### PR TITLE
fix: allow shared field names across sealed type variants

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -515,6 +515,12 @@ gala_test(
     expected = "nested_match.out",
 )
 
+gala_test(
+    name = "sealed_shared_fields",
+    src = "sealed_shared_fields.gala",
+    expected = "sealed_shared_fields.out",
+)
+
 # Documentation verification tests (GALA.MD)
 gala_test(
     name = "doc_verify_gala_md_basics",

--- a/examples/sealed_shared_fields.gala
+++ b/examples/sealed_shared_fields.gala
@@ -1,0 +1,33 @@
+package main
+
+import (
+    "fmt"
+    . "martianoff/gala/std"
+)
+
+// Sealed type with shared field names across variants (same type allowed)
+sealed type KVResult {
+    case Ok(Message string)
+    case NotFound(Key string)
+    case Expired(Key string)
+}
+
+func formatResult(r KVResult) string = r match {
+    case Ok(msg) => fmt.Sprintf("[OK] %s", msg)
+    case NotFound(key) => fmt.Sprintf("[NOT FOUND] key=%s", key)
+    case Expired(key) => fmt.Sprintf("[EXPIRED] key=%s", key)
+}
+
+func main() {
+    fmt.Println(formatResult(Ok("stored")))
+    fmt.Println(formatResult(NotFound("missing")))
+    fmt.Println(formatResult(Expired("old")))
+
+    // Verify isXxx discriminators work
+    val ok = Ok("done")
+    val nf = NotFound("k1")
+    val exp = Expired("k2")
+    fmt.Printf("ok.isOk=%v ok.isNotFound=%v ok.isExpired=%v\n", ok.isOk(), ok.isNotFound(), ok.isExpired())
+    fmt.Printf("nf.isOk=%v nf.isNotFound=%v nf.isExpired=%v\n", nf.isOk(), nf.isNotFound(), nf.isExpired())
+    fmt.Printf("exp.isOk=%v exp.isNotFound=%v exp.isExpired=%v\n", exp.isOk(), exp.isNotFound(), exp.isExpired())
+}

--- a/examples/sealed_shared_fields.out
+++ b/examples/sealed_shared_fields.out
@@ -1,0 +1,6 @@
+[OK] stored
+[NOT FOUND] key=missing
+[EXPIRED] key=old
+ok.isOk=true ok.isNotFound=false ok.isExpired=false
+nf.isOk=false nf.isNotFound=true nf.isExpired=false
+exp.isOk=false exp.isNotFound=false exp.isExpired=true


### PR DESCRIPTION
## Summary
- Sealed types now allow duplicate field names across variants when they have the same type
- Since all variant fields are merged into a single flat struct, same-name same-type fields are shared
- Different types across variants for the same field name still produce a clear error
- Adds `sealed_shared_fields.gala` verification example

Fixes BUG-KV-1 from `examples/KVSTORE_REPORT.md`

## Test plan
- [x] New example `sealed_shared_fields.gala` compiles and produces correct output
- [x] All 119 tests pass (118 existing + 1 new)
- [x] Verify different-type duplicate fields still error

🤖 Generated with [Claude Code](https://claude.com/claude-code)