### PR TITLE
fix: rename go_interop Sleep/After to avoid symbol clash

### DIFF
--- a/concurrent/execution_context.go
+++ b/concurrent/execution_context.go
@@ -38,5 +38,5 @@ var Spawn = go_interop.Spawn
 // Sleep pauses the current goroutine for the given duration.
 // Re-exported from go_interop for convenience with async operations.
 func Sleep(d time.Duration) {
-	go_interop.Sleep(d)
+	go_interop.GoSleep(d)
 }

--- a/go_interop/types.go
+++ b/go_interop/types.go
@@ -349,13 +349,15 @@ func SpawnWithRecover(f func() any, onPanic func(any) any) {
 	}()
 }
 
-// Sleep pauses the current goroutine for the specified duration.
-func Sleep(d time.Duration) {
+// GoSleep pauses the current goroutine for the specified duration.
+// Named GoSleep to avoid conflict with time_utils.Sleep when both packages are dot-imported.
+func GoSleep(d time.Duration) {
 	time.Sleep(d)
 }
 
-// After returns a channel that receives the current time after the duration.
-func After(d time.Duration) <-chan time.Time {
+// GoAfter returns a channel that receives the current time after the duration.
+// Named GoAfter to avoid conflict with time_utils.After when both packages are dot-imported.
+func GoAfter(d time.Duration) <-chan time.Time {
 	return time.After(d)
 }
 


### PR DESCRIPTION
## Summary
- Renames `go_interop.Sleep` → `go_interop.GoSleep` and `go_interop.After` → `go_interop.GoAfter`
- These names clashed with `time_utils.Sleep` and `time_utils.After` when both packages were dot-imported
- Updates the single caller in `concurrent/execution_context.go`

Fixes BUG-KV-4 (rename component) from `examples/KVSTORE_REPORT.md`

## Test plan
- [x] All 118 tests pass
- [x] Verified `concurrent/execution_context.go` updated to use `GoSleep`
- [x] No other callers of the old names exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)