### PR TITLE
feat: transpiler warning for dot-import symbol clashes

### DIFF
--- a/internal/transpiler/transformer/dot_import_test.go
+++ b/internal/transpiler/transformer/dot_import_test.go
@@ -1,10 +1,12 @@
 package transformer_test
 
 import (
+	"bytes"
 	"martianoff/gala/internal/transpiler"
 	"martianoff/gala/internal/transpiler/analyzer"
 	"martianoff/gala/internal/transpiler/generator"
 	"martianoff/gala/internal/transpiler/transformer"
+	"os"
 	"strings"
 	"testing"
 
@@ -57,4 +59,85 @@ func test() int {
 	}
 	assert.Equal(t, 0, regularImportCount,
 		"Should not have separate regular std import, got:\n%s", got)
+}
+
+func TestDotImportClashWarning(t *testing.T) {
+	// Capture stderr to detect the warning
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stderr = w
+
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	// Both go_interop and time_utils export Sleep and After
+	input := `package testpkg
+
+import (
+    . "martianoff/gala/go_interop"
+    . "martianoff/gala/time_utils"
+)
+
+func test() int {
+    return 42
+}
+`
+
+	_, _ = trans.Transpile(input, "")
+
+	// Read captured stderr
+	w.Close()
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	os.Stderr = oldStderr
+	stderrOutput := buf.String()
+
+	// Should have warnings about clashing symbols
+	assert.Contains(t, stderrOutput, "Warning: symbol")
+	assert.Contains(t, stderrOutput, "Sleep")
+	assert.Contains(t, stderrOutput, "After")
+	assert.Contains(t, stderrOutput, "go_interop")
+	assert.Contains(t, stderrOutput, "time_utils")
+}
+
+func TestDotImportNoClashWarning(t *testing.T) {
+	// Capture stderr — should be empty when no clash
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+	os.Stderr = w
+
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	// std and time_utils should not clash
+	input := `package testpkg
+
+import (
+    . "martianoff/gala/std"
+    . "martianoff/gala/time_utils"
+)
+
+func test() int {
+    return 42
+}
+`
+
+	_, _ = trans.Transpile(input, "")
+
+	w.Close()
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	os.Stderr = oldStderr
+	stderrOutput := buf.String()
+
+	// Should NOT have any symbol clash warnings
+	assert.NotContains(t, stderrOutput, "Warning: symbol")
 }

--- a/internal/transpiler/transpiler.go
+++ b/internal/transpiler/transpiler.go
@@ -52,6 +52,7 @@ type RichAST struct {
 	Functions        map[string]*FunctionMetadata
 	Packages         map[string]string                   // path -> pkgName
 	CompanionObjects map[string]*CompanionObjectMetadata // companion name -> metadata
+	GoExports        map[string][]string                 // pkgName -> exported symbol names (from Go-only packages)
 }
 
 // Merge combines metadata from another RichAST into this one.
@@ -82,6 +83,14 @@ func (r *RichAST) Merge(other *RichAST) {
 	}
 	for k, v := range other.CompanionObjects {
 		r.CompanionObjects[k] = v
+	}
+	if len(other.GoExports) > 0 {
+		if r.GoExports == nil {
+			r.GoExports = make(map[string][]string)
+		}
+		for pkg, symbols := range other.GoExports {
+			r.GoExports[pkg] = append(r.GoExports[pkg], symbols...)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Transpiler now warns when multiple dot-imported packages export symbols with the same name
- Analyzer scans Go-only packages for exported function/type names via regex
- Exports stored in `RichAST.GoExports` (separate from Types/Functions to avoid type resolution interference)
- Transformer compares dot-imported package symbols and emits stderr warnings

Example warning:
```
Warning: symbol "Sleep" is exported by multiple dot-imported packages: go_interop, time_utils. This will cause a Go compilation error. Use an aliased import for one of the packages.
```

Fixes BUG-KV-4 (warning component) from `examples/KVSTORE_REPORT.md`

## Test plan
- [x] `TestDotImportClashWarning` - verifies warning is emitted for clashing go_interop + time_utils
- [x] `TestDotImportNoClashWarning` - verifies no warning for non-clashing std + time_utils
- [x] All 118 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)