### PR TITLE
fix: detect unused match variables as compiler errors (FIX-002)

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -449,6 +449,22 @@ val desc = flag match {
 }
 ```
 
+**Unused variable rule:** All variables extracted in match patterns must be referenced in the branch body or guard expression. Unused variables cause a compiler error. Use `_` to explicitly discard values you don't need:
+
+```gala
+// ERROR: unused variable 'y' in match branch
+case Some(y) => "has value"
+
+// OK: use '_' to discard
+case Some(_) => "has value"
+
+// OK: variable is used in body
+case Some(y) => fmt.Sprintf("got %d", y)
+
+// OK: variable is used in guard
+case Some(y) if y > 0 => "positive"
+```
+
 #### Type-Based Pattern Matching
 GALA supports matching based on the type of an object. This is useful when working with `any` or interface types.
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -602,6 +602,13 @@ gala_test(
     deps = ["//time_utils"],
 )
 
+# Regression test for FIX-002: unused extracted variables in match branches
+gala_test(
+    name = "unused_match_vars",
+    src = "unused_match_vars.gala",
+    expected = "unused_match_vars.out",
+)
+
 gala_test(
     name = "kvstore",
     src = "kvstore.gala",

--- a/examples/unused_match_vars.gala
+++ b/examples/unused_match_vars.gala
@@ -2,9 +2,9 @@ package main
 
 import "fmt"
 
-// FIX-002 verification: unused extracted variables in match branches must not cause Go compile errors.
-// The transpiler generates variable bindings BEFORE the if-body, so without `_ = varName`
-// suppression, Go would reject any binding that is not referenced in the match body.
+// FIX-002 verification: GALA enforces that all extracted variables in match branches
+// must be used in the branch body or guard. Unused variables cause a compiler error.
+// Use '_' to explicitly discard values you don't need.
 
 sealed type Animal {
     case Dog(Name string, Age int)
@@ -12,60 +12,60 @@ sealed type Animal {
     case Fish()
 }
 
-// Case 1: Sealed type match - extract fields but only use some
+// Correct: use '_' to discard fields you don't need
 func animalCategory(a Animal) string = a match {
     case Dog(_, age) => if (age > 5) "old dog" else "young dog"
     case Cat(_, _) => "cat"
     case Fish() => "fish"
 }
 
-// Case 2: Option match - extract value but ignore it
+// Correct: use extracted value
 func hasValue(opt Option[int]) string = opt match {
-    case Some(v) => "yes"
+    case Some(v) => fmt.Sprintf("value=%d", v)
     case _ => "no"
 }
 
-// Case 3: Typed pattern match - extract but don't use
+// Correct: use '_' for typed patterns when you only need the type check
 func typeLabel(x any) string = x match {
-    case s: string => "string"
-    case i: int => "int"
+    case _: string => "string"
+    case _: int => "int"
     case _ => "other"
 }
 
-// Case 4: Tuple pattern match - extract but only use some
+// Correct: use all extracted tuple fields
 func tupleTest() string {
     val t = (1, "hello")
     return t match {
-        case (n, s) => fmt.Sprintf("n=%d", n)
+        case (n, s) => fmt.Sprintf("n=%d s=%s", n, s)
         case _ => "unknown"
     }
 }
 
-// Case 5: Variable binding - extract but ignore
-func alwaysForty(x int) int = x match {
-    case y => 40
+// Correct: use the bound variable
+func addOne(x int) int = x match {
+    case y => y + 1
     case _ => 0
 }
 
 func main() {
-    // Sealed type with unused extracted fields
+    // Sealed type: unused fields discarded with _
     fmt.Println(animalCategory(Dog("Rex", 3)))
     fmt.Println(animalCategory(Dog("Buddy", 8)))
     fmt.Println(animalCategory(Cat("Whiskers", 9)))
     fmt.Println(animalCategory(Fish()))
 
-    // Option with unused extracted value
+    // Option: extracted value is used
     fmt.Println(hasValue(Some(42)))
     fmt.Println(hasValue(None[int]()))
 
-    // Typed pattern with unused extracted value
+    // Typed pattern: discard value with _, keep type check
     fmt.Println(typeLabel("hello"))
     fmt.Println(typeLabel(42))
     fmt.Println(typeLabel(3.14))
 
-    // Tuple with partially-used extracted fields
+    // Tuple: all fields used
     fmt.Println(tupleTest())
 
-    // Variable binding, value ignored
-    fmt.Println(alwaysForty(99))
+    // Variable binding used in body
+    fmt.Println(addOne(99))
 }

--- a/examples/unused_match_vars.gala
+++ b/examples/unused_match_vars.gala
@@ -1,0 +1,71 @@
+package main
+
+import "fmt"
+
+// FIX-002 verification: unused extracted variables in match branches must not cause Go compile errors.
+// The transpiler generates variable bindings BEFORE the if-body, so without `_ = varName`
+// suppression, Go would reject any binding that is not referenced in the match body.
+
+sealed type Animal {
+    case Dog(Name string, Age int)
+    case Cat(Name string, Lives int)
+    case Fish()
+}
+
+// Case 1: Sealed type match - extract fields but only use some
+func animalCategory(a Animal) string = a match {
+    case Dog(_, age) => if (age > 5) "old dog" else "young dog"
+    case Cat(_, _) => "cat"
+    case Fish() => "fish"
+}
+
+// Case 2: Option match - extract value but ignore it
+func hasValue(opt Option[int]) string = opt match {
+    case Some(v) => "yes"
+    case _ => "no"
+}
+
+// Case 3: Typed pattern match - extract but don't use
+func typeLabel(x any) string = x match {
+    case s: string => "string"
+    case i: int => "int"
+    case _ => "other"
+}
+
+// Case 4: Tuple pattern match - extract but only use some
+func tupleTest() string {
+    val t = (1, "hello")
+    return t match {
+        case (n, s) => fmt.Sprintf("n=%d", n)
+        case _ => "unknown"
+    }
+}
+
+// Case 5: Variable binding - extract but ignore
+func alwaysForty(x int) int = x match {
+    case y => 40
+    case _ => 0
+}
+
+func main() {
+    // Sealed type with unused extracted fields
+    fmt.Println(animalCategory(Dog("Rex", 3)))
+    fmt.Println(animalCategory(Dog("Buddy", 8)))
+    fmt.Println(animalCategory(Cat("Whiskers", 9)))
+    fmt.Println(animalCategory(Fish()))
+
+    // Option with unused extracted value
+    fmt.Println(hasValue(Some(42)))
+    fmt.Println(hasValue(None[int]()))
+
+    // Typed pattern with unused extracted value
+    fmt.Println(typeLabel("hello"))
+    fmt.Println(typeLabel(42))
+    fmt.Println(typeLabel(3.14))
+
+    // Tuple with partially-used extracted fields
+    fmt.Println(tupleTest())
+
+    // Variable binding, value ignored
+    fmt.Println(alwaysForty(99))
+}

--- a/examples/unused_match_vars.out
+++ b/examples/unused_match_vars.out
@@ -2,10 +2,10 @@ young dog
 old dog
 cat
 fish
-yes
+value=42
 no
 string
 int
 other
-n=1
-40
+n=1 s=hello
+100

--- a/examples/unused_match_vars.out
+++ b/examples/unused_match_vars.out
@@ -1,0 +1,11 @@
+young dog
+old dog
+cat
+fish
+yes
+no
+string
+int
+other
+n=1
+40

--- a/internal/transpiler/transformer/match_test.go
+++ b/internal/transpiler/transformer/match_test.go
@@ -111,7 +111,6 @@ var x = std.NewImmutable(42)
 var res = std.NewImmutable(func(obj int) int {
 	{
 		y := obj
-		_ = y
 		if true {
 			return y + 1
 		}
@@ -144,7 +143,6 @@ var res = std.NewImmutable(func(obj std.Option[int]) int {
 		}
 		_ = _tmp_3
 		y := _tmp_3
-		_ = y
 		if _tmp_2 {
 			return y
 		}
@@ -177,7 +175,6 @@ var res = std.NewImmutable(func(obj std.Option[any]) string {
 		}
 		_ = _tmp_3
 		s, _tmp_4 := std.As[string](_tmp_3)
-		_ = s
 		if _tmp_2 && _tmp_4 {
 			return s
 		}
@@ -441,6 +438,42 @@ func describe(b bool) string = b match {
 	case false => "no"
 }`,
 			wantErr: true,
+		},
+		{
+			name: "Unused match variable is a compiler error",
+			input: `package main
+
+val x = 42
+val res = x match {
+	case y => 0
+	case _ => 0
+}`,
+			wantErr: true,
+		},
+		{
+			name: "Unused match variable with guard referencing it is allowed",
+			input: `package main
+
+val x = 42
+val res = x match {
+	case y if y > 10 => 1
+	case _ => 0
+}`,
+			expected: `package main
+
+import "martianoff/gala/std"
+
+var x = std.NewImmutable(42)
+var res = std.NewImmutable(func(obj int) int {
+	{
+		y := obj
+		if true && y > 10 {
+			return 1
+		}
+	}
+	return 0
+}(x.Get()))
+`,
 		},
 		{
 			name: "Bool with redundant default is allowed",

--- a/internal/transpiler/transformer/match_test.go
+++ b/internal/transpiler/transformer/match_test.go
@@ -111,6 +111,7 @@ var x = std.NewImmutable(42)
 var res = std.NewImmutable(func(obj int) int {
 	{
 		y := obj
+		_ = y
 		if true {
 			return y + 1
 		}
@@ -141,7 +142,9 @@ var res = std.NewImmutable(func(obj std.Option[int]) int {
 		if _tmp_2 {
 			_tmp_3 = _tmp_1.Get()
 		}
+		_ = _tmp_3
 		y := _tmp_3
+		_ = y
 		if _tmp_2 {
 			return y
 		}
@@ -172,7 +175,9 @@ var res = std.NewImmutable(func(obj std.Option[any]) string {
 		if _tmp_2 {
 			_tmp_3 = _tmp_1.Get()
 		}
+		_ = _tmp_3
 		s, _tmp_4 := std.As[string](_tmp_3)
+		_ = s
 		if _tmp_2 && _tmp_4 {
 			return s
 		}

--- a/internal/transpiler/transformer/tuple_either_test.go
+++ b/internal/transpiler/transformer/tuple_either_test.go
@@ -27,11 +27,13 @@ func TestTupleEither(t *testing.T) {
 			name: "Tuple extraction",
 			input: `package main
 
+import "fmt"
+
 func main() {
     val t = Tuple[int, string](V1 = 1, V2 = "hello")
     val res = t match {
-        case Tuple(a, b) => a
-        case _ => 0
+        case Tuple(a, b) => fmt.Sprintf("%d %s", a, b)
+        case _ => ""
     }
 }`,
 			expected: []string{
@@ -179,11 +181,13 @@ func main() {
 			name: "Tuple3 pattern matching",
 			input: `package main
 
+import "fmt"
+
 func main() {
     val t = (42, "hello", true)
     val res = t match {
-        case Tuple3(a, b, c) => a
-        case _ => 0
+        case Tuple3(a, b, c) => fmt.Sprintf("%d %s %v", a, b, c)
+        case _ => ""
     }
 }`,
 			expected: []string{
@@ -194,14 +198,16 @@ func main() {
 			},
 		},
 		{
-			name: "Tuple pattern matching with pair",
+			name: "Tuple pattern matching with pair - all vars used",
 			input: `package main
+
+import "fmt"
 
 func main() {
     val pair = (1, "world")
     val res = pair match {
-        case Tuple(x, y) => x
-        case _ => 0
+        case Tuple(x, y) => fmt.Sprintf("%d %s", x, y)
+        case _ => ""
     }
 }`,
 			expected: []string{
@@ -211,14 +217,32 @@ func main() {
 			},
 		},
 		{
-			name: "Tuple pattern matching with parentheses syntax",
+			name: "Tuple pattern matching with pair - unused var uses wildcard",
 			input: `package main
 
 func main() {
     val pair = (1, "world")
     val res = pair match {
-        case (x, y) => x
+        case Tuple(x, _) => x
         case _ => 0
+    }
+}`,
+			expected: []string{
+				"std.Tuple[int, string]",
+				"obj.V1.Get()",
+			},
+		},
+		{
+			name: "Tuple pattern matching with parentheses syntax",
+			input: `package main
+
+import "fmt"
+
+func main() {
+    val pair = (1, "world")
+    val res = pair match {
+        case (x, y) => fmt.Sprintf("%d %s", x, y)
+        case _ => ""
     }
 }`,
 			expected: []string{
@@ -231,11 +255,13 @@ func main() {
 			name: "Tuple3 pattern matching with parentheses syntax",
 			input: `package main
 
+import "fmt"
+
 func main() {
     val triple = (1, "hello", true)
     val res = triple match {
-        case (a, b, c) => a
-        case _ => 0
+        case (a, b, c) => fmt.Sprintf("%d %s %v", a, b, c)
+        case _ => ""
     }
 }`,
 			expected: []string{


### PR DESCRIPTION
## Summary

Reworks **FIX-002** to detect unused match variables as GALA compiler errors instead of silently suppressing them with `_ = varName`.

**Category**: TRANSPILER_BUG
**Priority**: P1
**Found in**: Calculator battle test (BUG-CALC-2)

## Approach

Instead of suppressing Go's "declared and not used" error by generating `_ = varName` after every pattern extraction, the transpiler now detects unused pattern variables at the GALA level and emits a clear, actionable error:

```
unused variable 'l' in match branch — use '_' to discard this value
```

This follows Go's philosophy: unused variables are a programming mistake, not something to hide.

## How It Works

In `transformCaseClauseWithType`, pattern bindings are generated BEFORE the body is transformed. After body transformation, the transpiler:

1. Extracts user-defined pattern variable names from bindings (skipping `_tmp_*` temps and `_`)
2. Walks the Go AST body + guard expression to collect all referenced identifiers
3. Reports an error for any user pattern variable not found in the reference set

## Changes

- **`internal/transpiler/transformer/patterns.go`**: Removed `suppressUnused` function and all user-var call sites. Replaced with `blankAssignTempVar` only for internal `_tmp_*` temp vars
- **`internal/transpiler/transformer/match.go`**: Added `extractUserPatternVarNames`, `collectReferencedIdents`, and unused variable check in `transformCaseClauseWithType`
- **`internal/transpiler/transformer/match_test.go`**: Removed `_ = y`/`_ = s` from expected output, added tests for unused variable error and guard-referenced variable
- **`internal/transpiler/transformer/tuple_either_test.go`**: Updated tests to use all extracted variables or `_` wildcards
- **`examples/unused_match_vars.gala`**: Rewritten to demonstrate correct `_` usage
- **`docs/GALA.MD`**: Added "Unused variable rule" to Match Expression section

## Edge Cases

| Pattern | Result |
|---------|--------|
| `case Add(l, r) => l + r` | OK — both used |
| `case Add(l, _) => l * 2` | OK — `l` used, `_` discarded |
| `case Add(_, _) => false` | OK — both discarded |
| `case Add(l, r) => false` | ERROR — `l` unused |
| `case Add(l, r) if l > 0 => true` | ERROR — `r` unused (but `l` OK via guard) |
| `case n => n + 1` | OK — simple binding used |

## Verification

- `bazel build //...` passes (441 targets)
- `bazel test //...` passes (120/120 tests)
- `examples/unused_match_vars` compiles with correct `_` usage
- Documentation updated in `docs/GALA.MD`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)