### PR TITLE
fix: auto-prefix sealed type field names on cross-variant name conflicts

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -536,6 +536,12 @@ gala_test(
     expected = "sealed_recursive.out",
 )
 
+gala_test(
+    name = "sealed_field_clash",
+    src = "sealed_field_clash.gala",
+    expected = "sealed_field_clash.out",
+)
+
 # Documentation verification tests (GALA.MD)
 gala_test(
     name = "doc_verify_gala_md_basics",

--- a/examples/sealed_field_clash.gala
+++ b/examples/sealed_field_clash.gala
@@ -1,0 +1,33 @@
+package main
+
+import "fmt"
+
+// Sealed type where variants share field names with different types.
+// "Value" appears in IntVal (int) and StrVal (string) - requires prefixing.
+// "Label" appears only in Labeled - no conflict, no prefixing.
+sealed type Token {
+    case IntVal(Value int)
+    case StrVal(Value string)
+    case Labeled(Label string, Value float64)
+}
+
+func describe(t Token) string = t match {
+    case IntVal(v) => fmt.Sprintf("int:%d", v)
+    case StrVal(v) => fmt.Sprintf("str:%s", v)
+    case Labeled(lbl, v) => fmt.Sprintf("labeled:%s=%.1f", lbl, v)
+}
+
+func main() {
+    fmt.Println(describe(IntVal(42)))
+    fmt.Println(describe(StrVal("hello")))
+    fmt.Println(describe(Labeled("pi", 3.14)))
+
+    // Verify isXxx discriminators
+    val a = IntVal(1)
+    val b = StrVal("x")
+    val c = Labeled("y", 2.0)
+    fmt.Println(a.isIntVal())
+    fmt.Println(a.isStrVal())
+    fmt.Println(b.isStrVal())
+    fmt.Println(c.isLabeled())
+}

--- a/examples/sealed_field_clash.out
+++ b/examples/sealed_field_clash.out
@@ -1,0 +1,7 @@
+int:42
+str:hello
+labeled:pi=3.1
+true
+false
+true
+true

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -571,16 +571,19 @@ func (a *galaAnalyzer) analyzeSealedType(ctx *grammar.SealedTypeDeclarationConte
 		TypeParams: typeParams,
 	}
 
-	// Process each case to collect fields
+	// Process each case to collect fields (two passes: collect, then resolve conflicts)
+	type variantFieldInfo struct {
+		name     string
+		typeName string
+	}
 	type variantInfo struct {
 		name   string
-		fields []struct {
-			name     string
-			typeName string
-		}
+		fields []variantFieldInfo
 	}
 	var variants []variantInfo
 
+	// First pass: collect all variant fields
+	allFieldTypes := make(map[string]map[string]bool) // field name -> set of type texts
 	for _, caseCtx := range ctx.AllSealedCase() {
 		sc := caseCtx.(*grammar.SealedCaseContext)
 		variantName := sc.Identifier().GetText()
@@ -592,21 +595,45 @@ func (a *galaAnalyzer) analyzeSealedType(ctx *grammar.SealedTypeDeclarationConte
 				fc := fieldCtx.(*grammar.SealedCaseFieldContext)
 				fieldName := fc.Identifier().GetText()
 				fieldTypeStr := fc.Type_().GetText()
-				vi.fields = append(vi.fields, struct {
-					name     string
-					typeName string
-				}{fieldName, fieldTypeStr})
-
-				// Add to parent type fields
-				parentMeta.Fields[fieldName] = a.resolveTypeWithParams(fieldTypeStr, pkgName, typeParams)
-				parentMeta.FieldNames = append(parentMeta.FieldNames, fieldName)
-				// Self-referential fields use pointer indirection (not Immutable-wrapped)
-				isRecursive := fieldTypeStr == typeName || strings.HasPrefix(fieldTypeStr, typeName+"[")
-				parentMeta.ImmutFlags = append(parentMeta.ImmutFlags, !isRecursive)
+				vi.fields = append(vi.fields, variantFieldInfo{fieldName, fieldTypeStr})
+				if allFieldTypes[fieldName] == nil {
+					allFieldTypes[fieldName] = make(map[string]bool)
+				}
+				allFieldTypes[fieldName][fieldTypeStr] = true
 			}
 		}
 
 		variants = append(variants, vi)
+	}
+
+	// Detect field name conflicts: same name with different types requires prefixing
+	conflictingFields := make(map[string]bool)
+	for fieldName, typeSet := range allFieldTypes {
+		if len(typeSet) > 1 {
+			conflictingFields[fieldName] = true
+		}
+	}
+
+	// Second pass: register fields with correct struct field names (prefixed if conflicting)
+	addedFields := make(map[string]bool)
+	for _, vi := range variants {
+		for _, f := range vi.fields {
+			structFieldName := f.name
+			if conflictingFields[f.name] {
+				structFieldName = vi.name + f.name // e.g., "AddLeft", "SubLeft"
+			}
+
+			if addedFields[structFieldName] {
+				continue // shared field already added
+			}
+			addedFields[structFieldName] = true
+
+			parentMeta.Fields[structFieldName] = a.resolveTypeWithParams(f.typeName, pkgName, typeParams)
+			parentMeta.FieldNames = append(parentMeta.FieldNames, structFieldName)
+			// Self-referential fields use pointer indirection (not Immutable-wrapped)
+			isRecursive := f.typeName == typeName || strings.HasPrefix(f.typeName, typeName+"[")
+			parentMeta.ImmutFlags = append(parentMeta.ImmutFlags, !isRecursive)
+		}
 	}
 
 	// Add _variant field


### PR DESCRIPTION
## Summary

Fixes **FIX-003**: Sealed type variants cannot share field names across variants

**Category**: TRANSPILER_BUG
**Priority**: P2
**Found in**: Calculator battle test (BUG-CALC-3)

## Root Cause

Because sealed types are transpiled to a single flat Go struct with all variant fields merged, field names must be unique. When multiple variants want the same field name with different types (e.g., `Add(Left Expr)` and `Sub(Left int)`), the transpiler errored with "duplicate field name". Same-name-same-type fields are still shared as before.

## Changes

- `internal/transpiler/transformer/sealed.go`: Two-pass field processing — first pass detects conflicting names, second pass auto-prefixes conflicting fields with variant name (e.g., `AddLeft`, `SubLeft`). Apply/Unapply/String methods updated to use prefixed struct field names while keeping user-facing parameter names unchanged.
- `internal/transpiler/analyzer/analyzer.go`: Mirror the conflict detection in analyzer metadata
- `examples/sealed_field_clash.gala`: Verification example with same-name-different-type fields
- `examples/BUILD.bazel`: Add test entry

## Verification

- `examples/sealed_field_clash` test added and passing
- `bazel build //...` passes (444 targets)
- `bazel test //...` passes (121/121 tests)

## Repro (before fix)

```gala
sealed type Expr {
    case Num(Value float64)
    case Add(Left Expr, Right Expr)
    case Sub(Left Expr, Right Expr)  // Error: "Left" already used by Add
}
```

## Dependencies

Depends on #4 (FIX-001). Merge FIX-001 first, then retarget this PR to master.

## Battle Test Report Reference

Originally reported as: BUG-CALC-3

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)