### PR TITLE
fix: prevent double function call with val multi-return destructuring

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -768,3 +768,10 @@ gala_test(
     ],
     expected = "struct_field_unwrap/struct_field_unwrap.out",
 )
+
+# FIX-004 verification: val multi-return from single Go function call
+gala_test(
+    name = "val_multi_return",
+    src = "val_multi_return.gala",
+    expected = "val_multi_return.out",
+)

--- a/examples/val_multi_return.gala
+++ b/examples/val_multi_return.gala
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+import "strconv"
+
+func main() {
+    // FIX-004 verification: val with Go multi-return function
+    // strconv.Atoi returns (int, error) - should be called exactly once
+    val num, err = strconv.Atoi("42")
+    fmt.Println("num:", num, "err:", err)
+
+    // Verify with an error case too
+    val num2, err2 = strconv.Atoi("not_a_number")
+    fmt.Println("num2:", num2, "err2:", err2)
+}

--- a/examples/val_multi_return.out
+++ b/examples/val_multi_return.out
@@ -1,0 +1,2 @@
+num: 42 err: <nil>
+num2: 0 err2: strconv.Atoi: parsing "not_a_number": invalid syntax


### PR DESCRIPTION
## Summary

Fixes **BUG-011**: Go multi-return with `val` wraps in `NewImmutable`, calling function twice

**Category**: CODEGEN_BUG
**Priority**: P1
**Found in**: HTTP Echo Server (P1)

## Root Cause

In `transformValDeclaration`, when a single RHS expression produces multiple values (Go multi-return), each `val` variable was independently wrapping the RHS expression in `NewImmutable()`. This caused the function to be called once per variable instead of once total.

For example, `val data, err = io.ReadAll(r.Body)` generated:
```go
var data = std.NewImmutable(io.ReadAll(r.Body))
var err = std.NewImmutable(io.ReadAll(r.Body))  // SECOND call!
```

## Changes

- `internal/transpiler/transformer/declarations.go`: Added multi-return detection in `transformValDeclaration`. When `len(rhsExprs) == 1 && len(namesCtx) > 1`, generates a temp variable to capture all return values first, then wraps each in `NewImmutable`.
- `internal/transpiler/transformer/multi_var_test.go`: Unit test for multi-return val destructuring.
- `examples/val_multi_return.gala`: Verification example.

## Generated code (after fix)

```go
var __multiret_0, __multiret_1 = io.ReadAll(r.Body)  // Single call
var data = std.NewImmutable(__multiret_0)
var err = std.NewImmutable(__multiret_1)
```

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (136 tests)
- `examples/val_multi_return` compiles and runs correctly

## Repro (before fix)

```gala
val data, err = io.ReadAll(r.Body)  // Calls ReadAll TWICE
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-011, BUG-HTTP-7

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)