### PR TITLE
fix: sealed type named-arg construction in multi-file mode

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -791,3 +791,13 @@ gala_test(
     expected = "foldleft_method/foldleft_method.out",
     deps = ["//collection_immutable"],
 )
+
+# FIX-015 verification: sealed type named-arg construction in multi-file mode
+gala_test(
+    name = "named_arg_sealed",
+    srcs = [
+        "named_arg_sealed_model.gala",
+        "named_arg_sealed.gala",
+    ],
+    expected = "named_arg_sealed.out",
+)

--- a/examples/named_arg_sealed.gala
+++ b/examples/named_arg_sealed.gala
@@ -1,0 +1,23 @@
+package main
+
+import "fmt"
+
+// Constructs sealed type variants using named arguments from a DIFFERENT file.
+// Previously, this would silently drop all field values (BUG-DP-4).
+func makeSuccess() MyResult {
+    return MySuccess(SuccessValue = 42, SuccessMsg = "hello")
+}
+
+func makeFailure() MyResult {
+    return MyFailure(FailureCode = 500, FailureMsg = "error")
+}
+
+func describe(r MyResult) string = r match {
+    case MySuccess(v, msg) => fmt.Sprintf("Success: %d %s", v, msg)
+    case MyFailure(code, msg) => fmt.Sprintf("Failure: %d %s", code, msg)
+}
+
+func main() {
+    fmt.Println(describe(makeSuccess()))
+    fmt.Println(describe(makeFailure()))
+}

--- a/examples/named_arg_sealed.out
+++ b/examples/named_arg_sealed.out
@@ -1,0 +1,2 @@
+Success: 42 hello
+Failure: 500 error

--- a/examples/named_arg_sealed_model.gala
+++ b/examples/named_arg_sealed_model.gala
@@ -1,0 +1,10 @@
+package main
+
+// Defines a sealed type with multi-field variants in a separate file
+// from where it's constructed. Verifies named-arg construction works
+// across file boundaries (FIX-015 / BUG-DP-4).
+
+sealed type MyResult {
+    case MySuccess(SuccessValue int, SuccessMsg string)
+    case MyFailure(FailureCode int, FailureMsg string)
+}


### PR DESCRIPTION
## Summary

Fixes **FIX-015**: Sealed type named-argument construction silently drops ALL field values in multi-file mode

**Category**: TRANSPILER_BUG
**Priority**: P0 (CRITICAL — silent data corruption)
**Found in**: P6 (Concurrent Data Pipeline)

## Root Cause

`handleNamedArgsCall` in `calls.go` looked up field names from the `structFields` map, which stores `nil` for sealed variant companion types (they are empty structs — the actual fields live on the parent sealed type). The code looped over `nil` fields and produced an empty composite literal (e.g., `MySuccess{}` with all fields zeroed).

## Changes

- `internal/transpiler/transformer/calls.go`: Added sealed variant detection in `handleNamedArgsCall` — when `structFields` is empty but named args are provided, searches parent sealed types' `SealedVariants` metadata for field names, reorders named args to match Apply method parameter order, and generates correct `Apply()` call
- Added `findSealedVariantFields()` helper to search type metadata for variant field info
- `examples/named_arg_sealed.gala` + `named_arg_sealed_model.gala`: Multi-file verification test

## Verification

- `examples/named_arg_sealed` test passes
- `bazel build //...` passes (515 targets)
- `bazel test //...` passes (141 tests)

## Repro (before fix)

```gala
// model.gala
sealed type MyResult {
    case MySuccess(SuccessValue int, SuccessMsg string)
}

// other.gala (DIFFERENT FILE)
func makeResult() MyResult {
    return MySuccess(SuccessValue = 42, SuccessMsg = "hello")
    // Generated Go: return MySuccess{}  — ALL FIELDS LOST
}
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-DP-4

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)