### PR TITLE
FIX-020: Upgrade dot-import collision to hard error + position info in SemanticError

### DIFF
--- a/docs/TODO.MD
+++ b/docs/TODO.MD
@@ -28,5 +28,6 @@
 - [x] Go pkg for go native primitives (maps, slices, channels etc)
 - [ ] Drop reflection usage for immutable vars for better performance
 - [ ] Official bazel module
-- [ ] Support expression syntax with match without return
 - [x] TreeMap
+- [x] Support expression syntax with match without return
+- [x] Compiler should provide better error messages, for example, "Type mismatch errors could be clearer about what the actual vs expected types are". Compiler must include line number and column number in error messages and may be code block highlighting for better readability

--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -47,6 +47,19 @@ func (e *SyntaxError) Error() string {
 // SemanticError represents an error during the transformation/transpilation phase.
 type SemanticError struct {
 	BaseError
+	Line     int
+	Column   int
+	FilePath string
+}
+
+func (e *SemanticError) Error() string {
+	if e.Line > 0 {
+		if e.FilePath != "" {
+			return fmt.Sprintf("[%s] %s:%d:%d %s", e.ErrType, e.FilePath, e.Line, e.Column, e.Msg)
+		}
+		return fmt.Sprintf("[%s] line %d:%d %s", e.ErrType, e.Line, e.Column, e.Msg)
+	}
+	return fmt.Sprintf("[%s] %s", e.ErrType, e.Msg)
 }
 
 // MultiError collects multiple GALA errors.
@@ -91,5 +104,30 @@ func NewSemanticError(msg string) *SemanticError {
 			Msg:     msg,
 			ErrType: TypeSemantic,
 		},
+	}
+}
+
+// NewSemanticErrorAt creates a SemanticError with line and column position.
+func NewSemanticErrorAt(line, column int, msg string) *SemanticError {
+	return &SemanticError{
+		BaseError: BaseError{
+			Msg:     msg,
+			ErrType: TypeSemantic,
+		},
+		Line:   line,
+		Column: column,
+	}
+}
+
+// NewSemanticErrorInFile creates a SemanticError with file path, line, and column position.
+func NewSemanticErrorInFile(filePath string, line, column int, msg string) *SemanticError {
+	return &SemanticError{
+		BaseError: BaseError{
+			Msg:     msg,
+			ErrType: TypeSemantic,
+		},
+		Line:     line,
+		Column:   column,
+		FilePath: filePath,
 	}
 }

--- a/galaerr/errors_test.go
+++ b/galaerr/errors_test.go
@@ -22,6 +22,30 @@ func TestSemanticError(t *testing.T) {
 	assert.Contains(t, err.Error(), "[SemanticError] undefined variable x")
 }
 
+func TestSemanticErrorAt(t *testing.T) {
+	err := galaerr.NewSemanticErrorAt(10, 5, "cannot assign to immutable variable x")
+	assert.Equal(t, galaerr.TypeSemantic, err.Type())
+	assert.Equal(t, 10, err.Line)
+	assert.Equal(t, 5, err.Column)
+	assert.Equal(t, "[SemanticError] line 10:5 cannot assign to immutable variable x", err.Error())
+}
+
+func TestSemanticErrorInFile(t *testing.T) {
+	err := galaerr.NewSemanticErrorInFile("main.gala", 10, 5, "undefined variable x")
+	assert.Equal(t, galaerr.TypeSemantic, err.Type())
+	assert.Equal(t, 10, err.Line)
+	assert.Equal(t, 5, err.Column)
+	assert.Equal(t, "main.gala", err.FilePath)
+	assert.Equal(t, "[SemanticError] main.gala:10:5 undefined variable x", err.Error())
+}
+
+func TestSemanticErrorNoPosition(t *testing.T) {
+	err := galaerr.NewSemanticError("undefined variable x")
+	assert.Equal(t, galaerr.TypeSemantic, err.Type())
+	assert.Equal(t, 0, err.Line)
+	assert.Equal(t, "[SemanticError] undefined variable x", err.Error())
+}
+
 func TestMultiError(t *testing.T) {
 	e1 := galaerr.NewSyntaxError(1, 1, "error 1")
 	e2 := galaerr.NewSyntaxError(2, 2, "error 2")

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -106,7 +106,7 @@ func (t *galaASTTransformer) transformValDeclaration(ctx *grammar.ValDeclaration
 		if isMultiReturnFromSingleExpr {
 			// multi-value from a single expression (e.g. function call)
 		} else {
-			return nil, galaerr.NewSemanticError("assignment mismatch")
+			return nil, t.semanticErrorAt(ctx, "assignment mismatch")
 		}
 	}
 
@@ -229,7 +229,7 @@ func (t *galaASTTransformer) transformValDeclaration(ctx *grammar.ValDeclaration
 		}
 
 		if t.isNoneCall(val) && ctx.Type_() == nil {
-			return nil, galaerr.NewSemanticError("variable assigned to None() must have an explicit type")
+			return nil, t.semanticErrorAt(ctx, "variable assigned to None() must have an explicit type")
 		}
 
 		var fun ast.Expr = t.stdIdent("NewImmutable")

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -565,7 +565,7 @@ func (t *galaASTTransformer) transformPartialFunctionLiteral(ctx *grammar.Partia
 	}
 
 	// Infer common inner result type T from all branches
-	innerResultType, err := t.inferCommonResultType(resultTypes, casePatterns)
+	innerResultType, err := t.inferCommonResultType(resultTypes, casePatterns, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -287,7 +287,7 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 	}
 
 	// Infer common result type from all branches
-	resultType, err := t.inferCommonResultType(resultTypes, casePatterns)
+	resultType, err := t.inferCommonResultType(resultTypes, casePatterns, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/transpiler/transformer/statements.go
+++ b/internal/transpiler/transformer/statements.go
@@ -49,7 +49,7 @@ func (t *galaASTTransformer) transformIncDecStmt(ctx *grammar.IncDecStmtContext)
 	// Check for mutability - get the name if it's an identifier
 	if ident, ok := expr.(*ast.Ident); ok {
 		if t.isVal(ident.Name) {
-			return nil, galaerr.NewSemanticError(fmt.Sprintf("cannot increment/decrement immutable variable %s", ident.Name))
+			return nil, t.semanticErrorAt(ctx, fmt.Sprintf("cannot increment/decrement immutable variable %s", ident.Name))
 		}
 	}
 
@@ -104,7 +104,7 @@ func (t *galaASTTransformer) transformAssignment(ctx *grammar.AssignmentContext)
 			if pc.Identifier() != nil {
 				name := pc.Identifier().GetText()
 				if t.isVal(name) {
-					return nil, galaerr.NewSemanticError(fmt.Sprintf("cannot assign to immutable variable %s", name))
+					return nil, t.semanticErrorAt(ctx, fmt.Sprintf("cannot assign to immutable variable %s", name))
 				}
 			}
 		}

--- a/internal/transpiler/transpiler.go
+++ b/internal/transpiler/transpiler.go
@@ -53,6 +53,8 @@ type RichAST struct {
 	Packages         map[string]string                   // path -> pkgName
 	CompanionObjects map[string]*CompanionObjectMetadata // companion name -> metadata
 	GoExports        map[string][]string                 // pkgName -> exported symbol names (from Go-only packages)
+	FilePath         string                              // source file path (for error reporting)
+	SourceContent    string                              // raw source text (for error snippets)
 }
 
 // Merge combines metadata from another RichAST into this one.
@@ -199,6 +201,8 @@ func (t *GalaToGoTranspiler) Transpile(input string, filePath string) (string, e
 	if err != nil {
 		return "", err
 	}
+	richAST.FilePath = filePath
+	richAST.SourceContent = input
 
 	fset, file, err := t.transformer.Transform(richAST)
 	if err != nil {


### PR DESCRIPTION
## Summary

- **Dot-import symbol collisions are now a hard compiler error** instead of a stderr warning, preventing confusing downstream Go compilation failures
- **SemanticError gains position info** (`Line`, `Column`, `FilePath` fields) with new constructors `NewSemanticErrorAt` and `NewSemanticErrorInFile`, while `NewSemanticError` remains fully backward-compatible
- **6 high-value error sites** now include line/column/file in their messages: match type inference, immutable variable assignment, inc/dec on immutables, assignment mismatch, and None() without explicit type
- **RichAST carries `FilePath` and `SourceContent`** as foundation for future source code snippet display in errors

## Test plan

- [x] `bazel build //...` passes (all 144 targets)
- [x] `bazel test //...` passes (all 144 tests)
- [x] New `TestSemanticErrorAt`, `TestSemanticErrorInFile`, `TestSemanticErrorNoPosition` tests verify error formatting
- [x] `TestDotImportClashError` verifies collision returns hard error (was `TestDotImportClashWarning`)
- [x] `TestDotImportNoClashNoError` verifies no false positives (was `TestDotImportNoClashWarning`)
- [x] Existing `TestSemanticError` still passes (backward-compatible format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)