### PR TITLE
fix: make test package sources available during test transpilation

### DIFF
--- a/gala.bzl
+++ b/gala.bzl
@@ -53,7 +53,7 @@ gala_exec_test = rule(
     },
 )
 
-def gala_transpile(name, src, out = None, package_files = []):
+def gala_transpile(name, src, out = None, package_files = [], extra_srcs = []):
     """Transpile a GALA source file to Go using the full gala binary.
 
     Args:
@@ -61,6 +61,7 @@ def gala_transpile(name, src, out = None, package_files = []):
         src: The .gala source file to transpile
         out: Output .go file name (optional)
         package_files: List of sibling .gala files in the same package for cross-file type resolution
+        extra_srcs: Additional GALA source files/filegroups to make available during transpilation
     """
     if not out:
         out = name + ".go"
@@ -73,7 +74,7 @@ def gala_transpile(name, src, out = None, package_files = []):
     # Use go.mod location to find the repository root for search path
     native.genrule(
         name = name,
-        srcs = [src] + package_files + [Label("//:all_gala_sources"), Label("//:go.mod")],
+        srcs = [src] + package_files + extra_srcs + [Label("//:all_gala_sources"), Label("//:go.mod")],
         outs = [out],
         cmd = "$(location {tool}) --input $(location {src}) --output $@ --search $$(dirname $(location {gomod})){pf}".format(
             tool = Label("//cmd/gala"),
@@ -352,6 +353,9 @@ def gala_go_test(name, srcs, deps = [], pkg = "main", embed = [], **kwargs):
         pkg = pkg,
     )
 
+    # Make test framework sources available during transpilation (for type resolution)
+    test_extra_srcs = [Label("//test:gala_sources")] if pkg != "test" else []
+
     # Transpile each test source file
     transpiled_srcs = []
     for i, src in enumerate(srcs):
@@ -363,6 +367,7 @@ def gala_go_test(name, srcs, deps = [], pkg = "main", embed = [], **kwargs):
             src = src,
             out = go_src,
             package_files = siblings,
+            extra_srcs = test_extra_srcs,
         )
         transpiled_srcs.append(go_src)
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,5 +1,14 @@
 load("//:gala.bzl", "gala_go_test", "gala_library")
 
+filegroup(
+    name = "gala_sources",
+    srcs = glob(
+        ["*.gala"],
+        exclude = ["*_test.gala"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
 gala_library(
     name = "test",
     srcs = [


### PR DESCRIPTION
## Summary

In Bazel sandboxed builds (Linux CI), the transpiler couldn't resolve types from dot-imported GALA packages when their `.gala` sources weren't declared as genrule inputs. This caused `named arguments only supported for struct construction (type: Case)` errors when transpiling `framework_test.gala`.

## Root Cause

`gala_transpile` genrules include `//:all_gala_sources` (std, collections, etc.) as inputs, making those packages' `.gala` files available in the sandbox for the transpiler's `analyzePackage()` to scan. The `test` package was missing from these inputs, so on Linux CI (where Bazel sandboxes restrict filesystem access to declared inputs only), `analyzePackage("test")` found no `.gala` files — the `Case` struct from `table.gala` was never analyzed, and named-argument construction failed.

On Windows, this worked because Bazel doesn't sandbox filesystem access.

## Changes

- **`gala.bzl`**: Added `extra_srcs` parameter to `gala_transpile` for additional source files/filegroups needed during transpilation. `gala_go_test` passes `//test:gala_sources` through this parameter (skipped when `pkg == "test"` to avoid circular deps).
- **`test/BUILD.bazel`**: Added `gala_sources` filegroup exposing the test framework's `.gala` files (excluding `*_test.gala`).

## Design Decision

Test sources are scoped to test targets only — they are **not** added to `//:all_gala_sources`, so `gala_library`, `gala_binary`, and example targets don't unnecessarily depend on the test package.

## Verification

- `bazel build //...` — 551 targets pass
- `bazel test //...` — 149/149 tests pass (including `//test:framework_test`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)