### PR TITLE
feat: add Slice, SliceFrom, SliceTo to go_interop

### DIFF
--- a/go_interop/types.go
+++ b/go_interop/types.go
@@ -56,7 +56,14 @@ func SliceRemoveAt[T any](s []T, index int) []T {
 	return s[:len(s)-1]
 }
 
+// Slice returns a sub-slice from index 'from' (inclusive) to 'to' (exclusive).
+// Equivalent to Go's s[from:to]. O(1).
+func Slice[T any](s []T, from int, to int) []T {
+	return s[from:to]
+}
+
 // SliceDrop returns a slice with the first n elements removed. O(1).
+// Equivalent to Go's s[n:].
 func SliceDrop[T any](s []T, n int) []T {
 	if n >= len(s) {
 		return nil
@@ -65,11 +72,24 @@ func SliceDrop[T any](s []T, n int) []T {
 }
 
 // SliceTake returns a slice with only the first n elements. O(1).
+// Equivalent to Go's s[:n].
 func SliceTake[T any](s []T, n int) []T {
 	if n >= len(s) {
 		return s
 	}
 	return s[:n]
+}
+
+// SliceFrom returns a sub-slice from index 'from' to the end. O(1).
+// Equivalent to Go's s[from:]. Same as SliceDrop but with a clearer name.
+func SliceFrom[T any](s []T, from int) []T {
+	return s[from:]
+}
+
+// SliceTo returns a sub-slice from the beginning to index 'to' (exclusive). O(1).
+// Equivalent to Go's s[:to]. Same as SliceTake but with a clearer name.
+func SliceTo[T any](s []T, to int) []T {
+	return s[:to]
 }
 
 // === Slice Creation Functions ===


### PR DESCRIPTION
## Summary

Adds slice sub-range functions to `go_interop` as the idiomatic GALA alternative to Go's slice expression syntax (`a[from:to]`).

**Category**: MISSING_FEATURE
**Priority**: P1
**Found in**: MicroGPT battle test (BUG-MG-2)

## Changes

- **`go_interop/types.go`**: Added three new functions:
  - `Slice(s, from, to)` — equivalent to `s[from:to]`
  - `SliceFrom(s, from)` — equivalent to `s[from:]`
  - `SliceTo(s, to)` — equivalent to `s[:to]`
  - Updated docs on existing `SliceDrop`/`SliceTake` noting their equivalence

## Usage

```gala
import . "martianoff/gala/go_interop"

val data = SliceOf(1, 2, 3, 4, 5)
val sub = Slice(data, 1, 3)       // [2, 3]
val tail = SliceFrom(data, 2)     // [3, 4, 5]
val head = SliceTo(data, 3)       // [1, 2, 3]
```

## Verification

- `bazel build //...` — 557 targets pass
- `bazel test //...` — 151/151 tests pass

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-MG-2

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)