### PR TITLE
fix: warn when sealed variant names collide with std auto-imports

### DIFF
--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -657,6 +657,14 @@ func (a *galaAnalyzer) analyzeSealedType(ctx *grammar.SealedTypeDeclarationConte
 		}
 
 		variants = append(variants, vi)
+
+		// Warn if variant name collides with a std auto-imported companion name.
+		// The variant creates a companion type that could shadow std companions
+		// (e.g., Success, Failure, Some, None, Left, Right).
+		if err := registry.CheckStdConflict(variantName, pkgName); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: sealed variant '%s' in type '%s' shadows %s; this may cause ambiguous symbols in generated Go code\n",
+				variantName, typeName, err.Error())
+		}
 	}
 
 	// Detect field name conflicts: same name with different types requires prefixing


### PR DESCRIPTION
## Summary

Fixes **FIX-040**: Sealed variant names silently collide with std auto-imports (Success, Failure, Some, None, Left, Right).

**Category**: USABILITY
**Priority**: P2
**Found in**: worker_pool (BUG-WP-4)

## Root Cause

`analyzeSealedType()` registered companion types for sealed variants without checking if the variant name collides with std library auto-imported companions. Names like `Success`, `Failure`, `Some`, `None`, `Left`, `Right` are auto-imported from `std` and creating sealed variants with these names causes ambiguous Go symbols at compile time with no warning at transpilation time.

## Changes

- `internal/transpiler/analyzer/analyzer.go`: Added `registry.CheckStdConflict()` call in sealed variant registration loop. Emits a warning to stderr when collision is detected. Prelude packages (like std itself) are exempted.

## Verification

- `bazel build //...` passes
- `bazel test //...` passes

## Repro (before fix)

```gala
sealed type TaskResult {
    case Success(TaskId int, Output string)  // collides with std Try[T].Success
    case Failure(TaskId int, Error string)   // collides with std Try[T].Failure
}
// No warning at transpilation; Go compilation fails
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)