### PR TITLE
test: add verification test for tuple literal return type inference

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -892,3 +892,10 @@ gala_test(
     src = "scientific_notation.gala",
     expected = "scientific_notation.out",
 )
+
+# FIX-042 verification: tuple literal return type should not widen first element to any
+gala_test(
+    name = "tuple_return_widen",
+    src = "tuple_return_widen.gala",
+    expected = "tuple_return_widen.out",
+)

--- a/examples/tuple_return_widen.gala
+++ b/examples/tuple_return_widen.gala
@@ -1,0 +1,48 @@
+package main
+
+import (
+    "fmt"
+    . "martianoff/gala/std"
+)
+
+func getName() string {
+    return "world"
+}
+
+// FIX-042 verification: tuple literal return type should not widen element to any.
+// Case 1: val variable as first element in tuple literal with return type
+func case1() Tuple[string, int] {
+    val name = "hello"
+    return (name, 42)
+}
+
+// Case 2: function call in first position
+func case2() Tuple[string, int] {
+    return (getName(), 42)
+}
+
+// Case 3: string concatenation expression in first position
+func case3() Tuple[string, int] {
+    val prefix = "val"
+    return (prefix + "=10", 10)
+}
+
+// Case 4: local variable tuple (no return type fallback)
+func case4() {
+    val s = "local"
+    var pair = (s, 99)
+    fmt.Println(pair.V1, pair.V2)
+}
+
+func main() {
+    var r1 = case1()
+    fmt.Println(r1.V1, r1.V2)
+
+    var r2 = case2()
+    fmt.Println(r2.V1, r2.V2)
+
+    var r3 = case3()
+    fmt.Println(r3.V1, r3.V2)
+
+    case4()
+}

--- a/examples/tuple_return_widen.out
+++ b/examples/tuple_return_widen.out
@@ -1,0 +1,4 @@
+hello 42
+world 42
+val=10 10
+local 99


### PR DESCRIPTION
## Summary

**FIX-042**: Adds regression test verifying that tuple literal return types infer concrete types (e.g., `Tuple[string, int]`) instead of widening to `Tuple[any, int]`.

**Category**: TEST
**Priority**: P2
**Found in**: table_formatter

## Changes

- `examples/tuple_return_widen.gala`: New verification test covering val variables, function calls, string concatenation, and local variable tuples
- `examples/tuple_return_widen.out`: Expected output
- `examples/BUILD.bazel`: New test target

## Verification

- `bazel build //...` passes
- `bazel test //...` passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)