### PR TITLE
fix: transitive import tracking and gala_go_test gala_deps

### DIFF
--- a/gala.bzl
+++ b/gala.bzl
@@ -368,7 +368,7 @@ gala_go_test_gen = rule(
     },
 )
 
-def gala_go_test(name, srcs, deps = [], pkg = "main", embed = [], **kwargs):
+def gala_go_test(name, srcs, deps = [], gala_deps = [], pkg = "main", embed = [], **kwargs):
     """
     Creates a GALA test using Go-style conventions.
 
@@ -390,6 +390,8 @@ def gala_go_test(name, srcs, deps = [], pkg = "main", embed = [], **kwargs):
         name: The name of the test target.
         srcs: List of test source files (e.g., ["foo_test.gala"]).
         deps: Dependencies for the test.
+        gala_deps: GALA library dependency labels for cross-package type resolution.
+            Their source files are automatically included during transpilation.
         pkg: Package name for tests (default "main" for external tests).
         embed: Go source files to embed (for internal tests in same package).
         **kwargs: Additional arguments passed to the underlying rules.
@@ -417,6 +419,7 @@ def gala_go_test(name, srcs, deps = [], pkg = "main", embed = [], **kwargs):
             out = go_src,
             package_files = siblings,
             extra_srcs = test_extra_srcs,
+            gala_deps = gala_deps,
         )
         transpiled_srcs.append(go_src)
 
@@ -429,11 +432,11 @@ def gala_go_test(name, srcs, deps = [], pkg = "main", embed = [], **kwargs):
     all_srcs = transpiled_srcs + [main_go_src] + embed
 
     # Determine deps - skip //test and //std if testing those packages
-    final_deps = list(deps)
+    final_deps = list(deps) + list(gala_deps)
     if pkg != "test":
-        final_deps.append("//test")
+        final_deps.append(Label("//test"))
     if pkg != "std":
-        final_deps.append("//std")
+        final_deps.append(Label("//std"))
 
     go_binary(
         name = binary_name,

--- a/internal/transpiler/transformer/transformer.go
+++ b/internal/transpiler/transformer/transformer.go
@@ -31,6 +31,7 @@ type galaASTTransformer struct {
 	typeMetas             map[string]*transpiler.TypeMetadata
 	companionObjects      map[string]*transpiler.CompanionObjectMetadata // companion name -> metadata
 	importManager         *ImportManager                                 // unified import tracking
+	additionalImports     map[string]string                              // path -> alias for transitive imports needed by type inference
 	tempVarCount          int
 	inferer               *infer.Inferer
 	currentFuncReturnType transpiler.Type // return type of the function currently being transformed
@@ -82,6 +83,7 @@ func (t *galaASTTransformer) Transform(richAST *transpiler.RichAST) (fset *token
 		t.companionObjects = make(map[string]*transpiler.CompanionObjectMetadata)
 	}
 	t.importManager = NewImportManager()
+	t.additionalImports = make(map[string]string)
 	t.tempVarCount = 0
 	t.filePath = richAST.FilePath
 	if richAST.SourceContent != "" {
@@ -188,6 +190,52 @@ func (t *galaASTTransformer) Transform(richAST *transpiler.RichAST) (fset *token
 				},
 			}
 			// If std was added, it's at index 0. We want fmt to be there too.
+			file.Decls = append([]ast.Decl{importDecl}, file.Decls...)
+		}
+	}
+
+	// Add transitive imports needed by type inference (e.g., when lambda parameter
+	// types are inferred from a dependency's method signature and reference packages
+	// not explicitly imported in the current file).
+	for path, alias := range t.additionalImports {
+		// Skip if already imported explicitly
+		alreadyImported := false
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.IMPORT {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				importSpec, ok := spec.(*ast.ImportSpec)
+				if !ok {
+					continue
+				}
+				importPath := strings.Trim(importSpec.Path.Value, "\"")
+				if importPath == path {
+					alreadyImported = true
+					break
+				}
+				// Also check by alias — if the package is imported under a different path
+				if importSpec.Name != nil && importSpec.Name.Name == alias {
+					alreadyImported = true
+					break
+				}
+			}
+			if alreadyImported {
+				break
+			}
+		}
+		if !alreadyImported {
+			spec := &ast.ImportSpec{
+				Path: &ast.BasicLit{
+					Kind:  token.STRING,
+					Value: fmt.Sprintf("\"%s\"", path),
+				},
+			}
+			importDecl := &ast.GenDecl{
+				Tok:   token.IMPORT,
+				Specs: []ast.Spec{spec},
+			}
 			file.Decls = append([]ast.Decl{importDecl}, file.Decls...)
 		}
 	}

--- a/internal/transpiler/transformer/types.go
+++ b/internal/transpiler/transformer/types.go
@@ -198,6 +198,12 @@ func (t *galaASTTransformer) typeToExpr(typ transpiler.Type) ast.Expr {
 			if alias, ok := t.importManager.GetAlias(v.Package); ok {
 				pkgName = alias
 			}
+			// Track transitive import: if this package-qualified type is used but
+			// not explicitly imported in the source file, record the needed import
+			// so it can be added to the output file.
+			if path, ok := t.importManager.GetPath(v.Package); ok {
+				t.additionalImports[path] = pkgName
+			}
 			return &ast.SelectorExpr{
 				X:   ast.NewIdent(pkgName),
 				Sel: ast.NewIdent(v.Name),


### PR DESCRIPTION
## Summary
- **Transitive import tracking**: When type inference resolves lambda parameter types from a dependency's method signature (e.g., `httpcore.Request` from `server.GET()`), the transpiler now auto-adds the required `import` to the generated Go file. Previously this caused `undefined: httpcore` build failures.
- **`gala_go_test` `gala_deps` support**: Added `gala_deps` parameter for cross-package type resolution during test transpilation. Fixed `//test` and `//std` dep paths to use `Label()` for correct resolution in external repos.

## Repro (before fix)

```gala
// In an external project that depends on a GALA library:
package main
import . "martianoff/gala-server"

func main() {
    // Type inference resolves (req) as httpcore.Request from GET() signature
    val app = NewApp().GET("/", (req) => Ok("Hello!"))
}
```

**Before:** Generated Go code references `httpcore.Request` but doesn't import `httpcore` → build failure
**After:** `import "martianoff/gala-server/httpcore"` is automatically added

## Test plan
- [x] All 127 gala_simple tests pass (`bazel test //test/... //examples/...`)
- [x] gala-server builds successfully (`bazel build //...`)
- [x] gala-server tests pass (22/22 via `bazel run //:server_test_bin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)