### PR TITLE
fix: infer lambda param types from struct field definitions

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -936,6 +936,13 @@ gala_test(
     expected = "string_interpolation.out",
 )
 
+# FIX-GS-003 verification: struct lambda parameter type inference
+gala_test(
+    name = "struct_lambda_inference",
+    src = "struct_lambda_inference.gala",
+    expected = "struct_lambda_inference.out",
+)
+
 # String interpolation with nested string literals inside ${...}
 gala_test(
     name = "interpolation_nested_strings",

--- a/examples/struct_lambda_inference.gala
+++ b/examples/struct_lambda_inference.gala
@@ -1,0 +1,25 @@
+package main
+
+import "fmt"
+
+type Handler struct {
+    val Name string
+    val Fn func(string) string
+}
+
+type Processor struct {
+    val Transform func(int) int
+    val Combine func(int, int) int
+}
+
+func main() {
+    // Lambda (s) should infer type from Fn field: func(string) string
+    val h = Handler("greet", (s) => s"Hello, $s!")
+    fmt.Println(h.Name)
+    fmt.Println(h.Fn("World"))
+
+    // Multiple function fields with different signatures
+    val p = Processor((x) => x * 2, (a, b) => a + b)
+    fmt.Println(p.Transform(5))
+    fmt.Println(p.Combine(3, 7))
+}

--- a/examples/struct_lambda_inference.out
+++ b/examples/struct_lambda_inference.out
@@ -1,0 +1,4 @@
+greet
+Hello, World!
+10
+10

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -486,6 +486,27 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 		funcMeta = t.getFunction(funcName)
 	}
 
+	// Check if this call is struct construction — if so, use struct field types as expected types
+	// for lambda arguments. This must happen BEFORE argument transformation so that lambdas
+	// can infer parameter types from the struct field definitions.
+	var structFieldExpectedTypes []transpiler.Type
+	if funcName := t.extractFuncName(fun); funcName != "" {
+		typeMeta, resolvedTypeName := t.getTypeMetaResolved(funcName)
+		if typeMeta != nil {
+			resolved := t.resolveStructTypeName(resolvedTypeName)
+			if fields, ok := t.structFields[resolved]; ok {
+				if fieldTypes, ok := t.structFieldTypes[resolved]; ok {
+					structFieldExpectedTypes = make([]transpiler.Type, len(fields))
+					for i, fieldName := range fields {
+						if ft, ok := fieldTypes[fieldName]; ok {
+							structFieldExpectedTypes[i] = ft
+						}
+					}
+				}
+			}
+		}
+	}
+
 	var args []ast.Expr
 	namedArgs := make(map[string]ast.Expr)
 
@@ -538,6 +559,12 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 						// Non-generic function with concrete function param types - pass as-is
 						expectedType = ft
 					}
+				}
+			}
+			// If this is struct construction and we have field type info, use it as fallback
+			if expectedType.IsNil() && structFieldExpectedTypes != nil && argIdx < len(structFieldExpectedTypes) {
+				if ft, ok := structFieldExpectedTypes[argIdx].(transpiler.FuncType); ok {
+					expectedType = ft
 				}
 			}
 			expr, err := t.transformArgumentWithExpectedType(ep.Expression(), expectedType)


### PR DESCRIPTION
## Summary

Fixes **FIX-GS-003**: When constructing a struct with positional args like `Route("GET", "/", (req) => Ok("hello"))`, lambda parameter types are now inferred from the struct field type definitions instead of falling back to `any`.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1
**Found in**: gala-server (BUG-005)

## Root Cause

In `transformCallWithArgsCtx`, the argument transformation loop determines expected types using `funcMeta` (function metadata). For struct construction like `Route(...)`, `Route` is a type name, not a function, so `funcMeta` is nil and all args get `NilType{}` as expected type. The struct construction detection happened AFTER arg transformation, so lambda args never received expected type information from struct fields.

## Changes

- `internal/transpiler/transformer/calls.go` — Added struct field type pre-detection before the arg transformation loop. When a call target is a type with known struct fields, field types are extracted and used as expected types for lambda arguments.
- `examples/struct_lambda_inference.gala` + `.out` — Verification example with multiple lambda field types
- `examples/BUILD.bazel` — Added test target

## Verification

- `examples/struct_lambda_inference.gala` compiles and produces correct output
- `bazel build //...` passes
- `bazel test //...` passes (162/162)

## Repro (before fix)

```gala
type Handler struct {
    val Name string
    val Fn func(string) string
}
func main() {
    val h = Handler("greet", (s) => s"Hello, $s!")
    // ERROR: (s) inferred as `any` instead of `string`
}
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-005 in gala-server BUGS.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)