### PR TITLE
fix: support spread operator (...) in function/method calls

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -956,3 +956,11 @@ gala_test(
     src = "type_alias.gala",
     expected = "type_alias.out",
 )
+
+# FIX-GS-007 verification: spread operator (...) in function call arguments
+gala_test(
+    name = "spread_operator",
+    src = "spread_operator.gala",
+    expected = "spread_operator.out",
+    deps = ["//go_interop"],
+)

--- a/examples/spread_operator.gala
+++ b/examples/spread_operator.gala
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+import . "martianoff/gala/go_interop"
+
+func printAll(items ...string) {
+    for _, item := range items {
+        fmt.Println(item)
+    }
+}
+
+func wrap(items ...string) {
+    printAll(items...)
+}
+
+func main() {
+    val args = SliceOf("hello", "world", "spread")
+    printAll(args...)
+    wrap("a", "b", "c")
+}

--- a/examples/spread_operator.out
+++ b/examples/spread_operator.out
@@ -1,0 +1,6 @@
+hello
+world
+spread
+a
+b
+c

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "postfix.go",
         "scope.go",
         "sealed.go",
+        "spread.go",
         "statements.go",
         "transformer.go",
         "type_inference.go",

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -254,15 +254,15 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 					}
 					arg := argCtx.(*grammar.ArgumentContext)
 					pat := arg.Pattern()
-					ep, ok := pat.(*grammar.ExpressionPatternContext)
-					if !ok {
+					exprCtx, _, extractErr := extractArgExpression(pat)
+					if extractErr != nil {
 						continue
 					}
 					// Skip lambda and partial function arguments — can't infer types from them
-					if t.findLambdaInExpression(ep.Expression()) != nil || t.findPartialFunctionInExpression(ep.Expression()) != nil {
+					if t.findLambdaInExpression(exprCtx) != nil || t.findPartialFunctionInExpression(exprCtx) != nil {
 						continue
 					}
-					expr, err := t.transformExpression(ep.Expression())
+					expr, err := t.transformExpression(exprCtx)
 					if err != nil {
 						continue
 					}
@@ -291,12 +291,16 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 			}
 
 			var mArgs []ast.Expr
+			hasSpread := false
 			for i, argCtx := range argListCtx.AllArgument() {
 				arg := argCtx.(*grammar.ArgumentContext)
 				pat := arg.Pattern()
-				ep, ok := pat.(*grammar.ExpressionPatternContext)
-				if !ok {
-					return nil, galaerr.NewSemanticError("only expressions allowed as function arguments")
+				exprCtx, isSpread, extractErr := extractArgExpression(pat)
+				if extractErr != nil {
+					return nil, extractErr
+				}
+				if isSpread {
+					hasSpread = true
 				}
 
 				// Reuse pre-transformed expression if available (already processed during type inference)
@@ -311,7 +315,7 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 					expectedType = t.substituteTranspilerTypeParams(methodMeta.ParamTypes[i], typeSubst)
 				}
 
-				expr, err := t.transformArgumentWithExpectedType(ep.Expression(), expectedType)
+				expr, err := t.transformArgumentWithExpectedType(exprCtx, expectedType)
 				if err != nil {
 					return nil, err
 				}
@@ -362,8 +366,9 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 			}
 
 			return &ast.CallExpr{
-				Fun:  funExpr,
-				Args: append([]ast.Expr{receiver}, mArgs...),
+				Fun:      funExpr,
+				Args:     append([]ast.Expr{receiver}, mArgs...),
+				Ellipsis: ellipsisPos(hasSpread),
 			}, nil
 		}
 	}
@@ -401,12 +406,16 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 			// but still detect void function parameters for lambda return type stripping
 			if hasUnresolvedTypeParams {
 				var mArgs []ast.Expr
+				hasSpread := false
 				for i, argCtx := range argListCtx.AllArgument() {
 					arg := argCtx.(*grammar.ArgumentContext)
 					pat := arg.Pattern()
-					ep, ok := pat.(*grammar.ExpressionPatternContext)
-					if !ok {
-						return nil, galaerr.NewSemanticError("only expressions allowed as function arguments")
+					exprCtx, isSpread, extractErr := extractArgExpression(pat)
+					if extractErr != nil {
+						return nil, extractErr
+					}
+					if isSpread {
+						hasSpread = true
 					}
 					// Only pass void function types (avoids unresolved type params in return types)
 					var expectedType transpiler.Type = transpiler.NilType{}
@@ -415,26 +424,31 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 							expectedType = ft
 						}
 					}
-					expr, err := t.transformArgumentWithExpectedType(ep.Expression(), expectedType)
+					expr, err := t.transformArgumentWithExpectedType(exprCtx, expectedType)
 					if err != nil {
 						return nil, err
 					}
 					mArgs = append(mArgs, expr)
 				}
 				return &ast.CallExpr{
-					Fun:  &ast.SelectorExpr{X: receiver, Sel: ast.NewIdent(method)},
-					Args: mArgs,
+					Fun:      &ast.SelectorExpr{X: receiver, Sel: ast.NewIdent(method)},
+					Args:     mArgs,
+					Ellipsis: ellipsisPos(hasSpread),
 				}, nil
 			}
 
 			// Transform arguments with expected types
 			var mArgs []ast.Expr
+			hasSpread := false
 			for i, argCtx := range argListCtx.AllArgument() {
 				arg := argCtx.(*grammar.ArgumentContext)
 				pat := arg.Pattern()
-				ep, ok := pat.(*grammar.ExpressionPatternContext)
-				if !ok {
-					return nil, galaerr.NewSemanticError("only expressions allowed as function arguments")
+				exprCtx, isSpread, extractErr := extractArgExpression(pat)
+				if extractErr != nil {
+					return nil, extractErr
+				}
+				if isSpread {
+					hasSpread = true
 				}
 
 				var expectedType transpiler.Type = transpiler.NilType{}
@@ -442,7 +456,7 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 					expectedType = t.substituteTranspilerTypeParams(methodMeta.ParamTypes[i], typeSubst)
 				}
 
-				expr, err := t.transformArgumentWithExpectedType(ep.Expression(), expectedType)
+				expr, err := t.transformArgumentWithExpectedType(exprCtx, expectedType)
 				if err != nil {
 					return nil, err
 				}
@@ -451,8 +465,9 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 
 			// Keep as method call: receiver.method(args)
 			return &ast.CallExpr{
-				Fun:  &ast.SelectorExpr{X: receiver, Sel: ast.NewIdent(method)},
-				Args: mArgs,
+				Fun:      &ast.SelectorExpr{X: receiver, Sel: ast.NewIdent(method)},
+				Args:     mArgs,
+				Ellipsis: ellipsisPos(hasSpread),
 			}, nil
 		}
 
@@ -460,22 +475,27 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 		// still generate the method call directly instead of falling through to the
 		// regular function call handler which would lose the receiver.method structure.
 		var mArgs []ast.Expr
+		hasSpread := false
 		for _, argCtx := range argListCtx.AllArgument() {
 			arg := argCtx.(*grammar.ArgumentContext)
 			pat := arg.Pattern()
-			ep, ok := pat.(*grammar.ExpressionPatternContext)
-			if !ok {
-				return nil, galaerr.NewSemanticError("only expressions allowed as function arguments")
+			exprCtx, isSpread, extractErr := extractArgExpression(pat)
+			if extractErr != nil {
+				return nil, extractErr
 			}
-			expr, err := t.transformArgumentWithExpectedType(ep.Expression(), transpiler.NilType{})
+			if isSpread {
+				hasSpread = true
+			}
+			expr, err := t.transformArgumentWithExpectedType(exprCtx, transpiler.NilType{})
 			if err != nil {
 				return nil, err
 			}
 			mArgs = append(mArgs, expr)
 		}
 		return &ast.CallExpr{
-			Fun:  &ast.SelectorExpr{X: receiver, Sel: ast.NewIdent(method)},
-			Args: mArgs,
+			Fun:      &ast.SelectorExpr{X: receiver, Sel: ast.NewIdent(method)},
+			Args:     mArgs,
+			Ellipsis: ellipsisPos(hasSpread),
 		}, nil
 	}
 
@@ -509,6 +529,7 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 
 	var args []ast.Expr
 	namedArgs := make(map[string]ast.Expr)
+	hasSpread := false
 
 	argIdx := 0
 	for _, argCtx := range argListCtx.AllArgument() {
@@ -519,20 +540,26 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 		if arg.Identifier() != nil {
 			// This is a named argument
 			argName := arg.Identifier().GetText()
-			ep, ok := pat.(*grammar.ExpressionPatternContext)
-			if !ok {
-				return nil, galaerr.NewSemanticError("only expressions allowed as function arguments")
+			exprCtx, isSpread, extractErr := extractArgExpression(pat)
+			if extractErr != nil {
+				return nil, extractErr
 			}
-			expr, err := t.transformExpression(ep.Expression())
+			if isSpread {
+				hasSpread = true
+			}
+			expr, err := t.transformExpression(exprCtx)
 			if err != nil {
 				return nil, err
 			}
 			namedArgs[argName] = expr
 		} else {
 			// Positional argument - use expected type if available
-			ep, ok := pat.(*grammar.ExpressionPatternContext)
-			if !ok {
-				return nil, galaerr.NewSemanticError("only expressions allowed as function arguments")
+			exprCtx, isSpread, extractErr := extractArgExpression(pat)
+			if extractErr != nil {
+				return nil, extractErr
+			}
+			if isSpread {
+				hasSpread = true
 			}
 			// Pass function types from metadata for lambda return type inference.
 			// For void function types, pass as-is.
@@ -567,7 +594,7 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 					expectedType = ft
 				}
 			}
-			expr, err := t.transformArgumentWithExpectedType(ep.Expression(), expectedType)
+			expr, err := t.transformArgumentWithExpectedType(exprCtx, expectedType)
 			if err != nil {
 				return nil, err
 			}
@@ -834,7 +861,7 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 		}
 	}
 
-	return &ast.CallExpr{Fun: fun, Args: args}, nil
+	return &ast.CallExpr{Fun: fun, Args: args, Ellipsis: ellipsisPos(hasSpread)}, nil
 }
 
 func (t *galaASTTransformer) handleNamedArgsCall(fun ast.Expr, args []ast.Expr, namedArgs map[string]ast.Expr) (ast.Expr, error) {

--- a/internal/transpiler/transformer/spread.go
+++ b/internal/transpiler/transformer/spread.go
@@ -1,0 +1,29 @@
+package transformer
+
+import (
+	"go/token"
+
+	"martianoff/gala/galaerr"
+	"martianoff/gala/internal/parser/grammar"
+)
+
+// extractArgExpression extracts the expression from a pattern in a function argument.
+// It handles both ExpressionPatternContext (regular args) and RestPatternContext (spread args like x...).
+// Returns the expression context, whether it's a spread argument, and an error if the pattern type is unsupported.
+func extractArgExpression(pat grammar.IPatternContext) (grammar.IExpressionContext, bool, error) {
+	if ep, ok := pat.(*grammar.ExpressionPatternContext); ok {
+		return ep.Expression(), false, nil
+	}
+	if rp, ok := pat.(*grammar.RestPatternContext); ok {
+		return rp.Expression(), true, nil
+	}
+	return nil, false, galaerr.NewSemanticError("only expressions allowed as function arguments")
+}
+
+// ellipsisPos returns a non-zero token.Pos if hasSpread is true, indicating variadic expansion.
+func ellipsisPos(hasSpread bool) token.Pos {
+	if hasSpread {
+		return token.Pos(1)
+	}
+	return token.NoPos
+}


### PR DESCRIPTION
## Summary

Fixes **BUG-007**: The spread operator `routes...` now works in function and method calls.

**Category**: TRANSPILER_BUG
**Priority**: P1
**Found in**: gala-server

## Root Cause

The grammar already supported spread via `RestPatternContext`, but the transformer's argument processing in `calls.go` only handled `ExpressionPatternContext` and rejected rest patterns with "only expressions allowed as function arguments".

## Changes

- `internal/transpiler/transformer/spread.go` (NEW) — Helper functions to extract expressions from both pattern types and detect spread
- `internal/transpiler/transformer/calls.go` — Updated 7 argument processing locations to use the new helpers and set `CallExpr.Ellipsis`
- `internal/transpiler/transformer/BUILD.bazel` — Added `spread.go`
- `examples/spread_operator.gala` + `.out` — Verification example

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (164/164)

## Dependencies

None — independent PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)