### PR TITLE
fix: preserve generic type params in shorthand struct field types

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -9,6 +9,8 @@ filegroup(
         "cross_file_unwrap_lib/types.gala",
         "foldleft_method/main.gala",
         "lib/generic.gala",
+        "match_method_chain/main.gala",
+        "match_method_chain/types.gala",
         "mathlib/math.gala",
         "multi_file/greeter.gala",
         "multi_file/main.gala",
@@ -39,6 +41,13 @@ gala_library(
     name = "lib",
     src = "lib/generic.gala",
     importpath = "martianoff/gala/examples/lib",
+    visibility = ["//visibility:public"],
+)
+
+gala_library(
+    name = "match_lib",
+    src = "match_lib/store.gala",
+    importpath = "martianoff/gala/examples/match_lib",
     visibility = ["//visibility:public"],
 )
 
@@ -101,6 +110,25 @@ gala_test(
     name = "option_complex",
     src = "option_complex.gala",
     expected = "option_complex.out",
+)
+
+gala_test(
+    name = "match_method_return",
+    src = "match_method_return.gala",
+    expected = "match_method_return.out",
+)
+
+gala_test(
+    name = "match_method_return_generic",
+    src = "match_method_return_generic.gala",
+    expected = "match_method_return_generic.out",
+)
+
+gala_test(
+    name = "match_lib_test",
+    src = "match_lib_test.gala",
+    expected = "match_lib_test.out",
+    deps = [":match_lib"],
 )
 
 gala_test(
@@ -792,6 +820,16 @@ gala_test(
     expected = "multi_file_option/multi_file_option.out",
 )
 
+# BUG-013 verification: match on method return values (multi-file)
+gala_test(
+    name = "match_method_chain",
+    srcs = [
+        "match_method_chain/main.gala",
+        "match_method_chain/types.gala",
+    ],
+    expected = "match_method_chain/match_method_chain.out",
+)
+
 # Struct field auto-unwrapping when passed to functions (FIX-005 verification)
 gala_test(
     name = "struct_field_unwrap",
@@ -1023,4 +1061,12 @@ gala_test(
         ":cross_file_unwrap_lib",
         "//collection_immutable",
     ],
+)
+
+# BUG-014 verification: cross-package collection lambda type inference
+gala_test(
+    name = "collection_lambda_inference",
+    src = "collection_lambda_inference.gala",
+    expected = "collection_lambda_inference.out",
+    deps = ["//collection_immutable"],
 )

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -9,8 +9,6 @@ filegroup(
         "cross_file_unwrap_lib/types.gala",
         "foldleft_method/main.gala",
         "lib/generic.gala",
-        "match_method_chain/main.gala",
-        "match_method_chain/types.gala",
         "mathlib/math.gala",
         "multi_file/greeter.gala",
         "multi_file/main.gala",
@@ -41,13 +39,6 @@ gala_library(
     name = "lib",
     src = "lib/generic.gala",
     importpath = "martianoff/gala/examples/lib",
-    visibility = ["//visibility:public"],
-)
-
-gala_library(
-    name = "match_lib",
-    src = "match_lib/store.gala",
-    importpath = "martianoff/gala/examples/match_lib",
     visibility = ["//visibility:public"],
 )
 
@@ -110,25 +101,6 @@ gala_test(
     name = "option_complex",
     src = "option_complex.gala",
     expected = "option_complex.out",
-)
-
-gala_test(
-    name = "match_method_return",
-    src = "match_method_return.gala",
-    expected = "match_method_return.out",
-)
-
-gala_test(
-    name = "match_method_return_generic",
-    src = "match_method_return_generic.gala",
-    expected = "match_method_return_generic.out",
-)
-
-gala_test(
-    name = "match_lib_test",
-    src = "match_lib_test.gala",
-    expected = "match_lib_test.out",
-    deps = [":match_lib"],
 )
 
 gala_test(
@@ -820,16 +792,6 @@ gala_test(
     expected = "multi_file_option/multi_file_option.out",
 )
 
-# BUG-013 verification: match on method return values (multi-file)
-gala_test(
-    name = "match_method_chain",
-    srcs = [
-        "match_method_chain/main.gala",
-        "match_method_chain/types.gala",
-    ],
-    expected = "match_method_chain/match_method_chain.out",
-)
-
 # Struct field auto-unwrapping when passed to functions (FIX-005 verification)
 gala_test(
     name = "struct_field_unwrap",
@@ -1029,6 +991,7 @@ gala_test(
     deps = ["//go_interop"],
 )
 
+<<<<<<< HEAD
 # FIX-GS-011 verification: cross-file struct field auto-unwrap (multi-file binary)
 gala_test(
     name = "cross_file_unwrap",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -991,7 +991,6 @@ gala_test(
     deps = ["//go_interop"],
 )
 
-<<<<<<< HEAD
 # FIX-GS-011 verification: cross-file struct field auto-unwrap (multi-file binary)
 gala_test(
     name = "cross_file_unwrap",

--- a/examples/collection_lambda_inference.gala
+++ b/examples/collection_lambda_inference.gala
@@ -1,0 +1,35 @@
+package main
+
+import "fmt"
+import . "martianoff/gala/collection_immutable"
+
+struct Person(val name string, val age int)
+
+struct Server(val routes Array[Person])
+
+func main() {
+    val people = ArrayOf(Person("Alice", 30), Person("Bob", 25))
+
+    // ForEach with inferred lambda param type
+    people.ForEach((p) => {
+        fmt.Println(p.name)
+    })
+
+    // Map with inferred lambda param type
+    val names = people.Map((p) => p.name)
+    fmt.Println(names)
+
+    // FoldLeft with inferred lambda param types
+    val totalAge = people.FoldLeft(0, (acc, p) => acc + p.age)
+    fmt.Println(totalAge)
+
+    // Cross-package via struct field access
+    val server = Server(routes = people)
+    server.routes.ForEach((p) => {
+        fmt.Println(p.name)
+    })
+
+    // Filter with inferred lambda param type
+    val seniors = people.Filter((p) => p.age >= 30)
+    fmt.Println(seniors)
+}

--- a/examples/collection_lambda_inference.out
+++ b/examples/collection_lambda_inference.out
@@ -1,0 +1,7 @@
+Alice
+Bob
+Array(Alice, Bob)
+55
+Alice
+Bob
+Array({{Alice} {30}})

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -684,7 +684,7 @@ func (t *galaASTTransformer) transformStructShorthandDeclaration(ctx *grammar.St
 			var pType transpiler.Type = transpiler.NilType{}
 			if param.Type_() != nil {
 				typeExpr, _ := t.transformType(param.Type_())
-				pType = t.resolveType(t.getBaseTypeName(typeExpr))
+				pType = t.exprToType(typeExpr)
 			}
 			t.structFieldTypes[name][pName] = pType
 		}


### PR DESCRIPTION
## Summary

Fixes **BUG-014**: Lambda type inference fails for collection `ForEach`/`Map`/`FoldLeft` cross-package.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1 (blocks functional collection patterns cross-package)
**Found in**: gala-server

## Root Cause

`declarations.go` used `t.resolveType(t.getBaseTypeName(typeExpr))` for shorthand struct field types, which strips generic type parameters. `Array[Person]` became just `Array`, losing the element type info needed for lambda parameter inference in methods like `ForEach`, `Map`, `Filter`.

## Changes

- `internal/transpiler/transformer/declarations.go`: Changed to `t.exprToType(typeExpr)` which preserves full generic type including parameters

## Verification

- Added `examples/collection_lambda_inference.gala` + `.out` test
- `bazel build //...` passes
- `bazel test //...` passes

## Repro (before fix)

```gala
struct Routes(routes Array[Route])
// routes.ForEach((route) => { ... })
// Generated: func(route any) any — should be func(Route)
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-014 in gala-server BUGS.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)