### PR TITLE
fix: resolve double package prefix and lost type param in Try[T] match

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1077,3 +1077,11 @@ gala_test(
     src = "some_type_inference.gala",
     expected = "some_type_inference.out",
 )
+
+# FIX-038 verification: Try match from function call (type inference + no double prefix)
+gala_test(
+    name = "try_match_from_func",
+    src = "try_match_from_func.gala",
+    expected = "try_match_from_func.out",
+    deps = ["//concurrent"],
+)

--- a/examples/try_match_from_func.gala
+++ b/examples/try_match_from_func.gala
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+import . "martianoff/gala/concurrent"
+
+type Handler func(string) Future[string]
+
+// Tests matching on Try[T] returned from a type-alias function variable
+func process(req string, next Handler) string {
+    val result = next(req).Await()
+    return result match {
+        case Success(s) => fmt.Sprintf("Got: %s", s)
+        case Failure(e) => fmt.Sprintf("Error: %s", e.Error())
+    }
+}
+
+func main() {
+    val handler Handler = (req string) => FutureOf[string](fmt.Sprintf("Hello %s", req))
+    fmt.Println(process("World", handler))
+}

--- a/examples/try_match_from_func.out
+++ b/examples/try_match_from_func.out
@@ -1,0 +1,1 @@
+Got: Hello World

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -887,6 +887,14 @@ func (t *galaASTTransformer) transformTypeDeclaration(ctx *grammar.TypeDeclarati
 			}
 		}
 
+		// Store the underlying type for type alias resolution
+		// (e.g., Handler -> func(string) Future[string])
+		if targetType != nil {
+			if underlyingType := t.exprToType(targetType); !underlyingType.IsNil() {
+				t.typeAliases[name] = underlyingType
+			}
+		}
+
 		typeSpec := &ast.TypeSpec{
 			Name:       ast.NewIdent(name),
 			Assign:     1,

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -161,15 +161,23 @@ func (t *galaASTTransformer) inferMatchedTypeFromCases(caseClauses []grammar.ICa
 			continue
 		}
 
-		// Resolve the parent sealed type from companion metadata
-		targetTypeName := companion.TargetType
-		if companion.Package != "" {
-			targetTypeName = companion.Package + "." + targetTypeName
+		// Resolve the parent sealed type from companion metadata.
+		// companion.TargetType may already include the package prefix (e.g., "std.Try"
+		// from NamedType.BaseName()), so we must NOT blindly prepend companion.Package.
+		meta := t.getTypeMeta(companion.TargetType)
+		if meta == nil && companion.Package != "" {
+			// Only add package prefix if TargetType doesn't already contain one
+			if !strings.Contains(companion.TargetType, ".") {
+				meta = t.getTypeMeta(companion.Package + "." + companion.TargetType)
+			}
 		}
-		meta := t.getTypeMeta(targetTypeName)
 		if meta == nil {
-			// Try without package prefix (e.g., for dot-imported types)
-			meta = t.getTypeMeta(companion.TargetType)
+			// Last resort: strip any package prefix and try bare name
+			base := companion.TargetType
+			if idx := strings.LastIndex(base, "."); idx >= 0 {
+				base = base[idx+1:]
+			}
+			meta = t.getTypeMeta(base)
 		}
 		if meta == nil || !meta.IsSealed {
 			continue
@@ -180,7 +188,13 @@ func (t *galaASTTransformer) inferMatchedTypeFromCases(caseClauses []grammar.ICa
 		// from the case patterns alone.
 		var baseType transpiler.Type
 		if companion.Package != "" {
-			baseType = transpiler.NamedType{Package: companion.Package, Name: companion.TargetType}
+			// Strip package prefix from TargetType if it already contains one
+			// (e.g., "std.Try" -> "Try") to avoid double prefix "std.std.Try"
+			typeName := companion.TargetType
+			if strings.HasPrefix(typeName, companion.Package+".") {
+				typeName = typeName[len(companion.Package)+1:]
+			}
+			baseType = transpiler.NamedType{Package: companion.Package, Name: typeName}
 		} else {
 			baseType = transpiler.BasicType{Name: companion.TargetType}
 		}

--- a/internal/transpiler/transformer/transformer.go
+++ b/internal/transpiler/transformer/transformer.go
@@ -34,9 +34,10 @@ type galaASTTransformer struct {
 	additionalImports     map[string]string                              // path -> alias for transitive imports needed by type inference
 	tempVarCount          int
 	inferer               *infer.Inferer
-	currentFuncReturnType transpiler.Type // return type of the function currently being transformed
-	filePath              string           // source file path (for error reporting)
-	sourceLines           []string         // source lines (for error snippets)
+	currentFuncReturnType transpiler.Type            // return type of the function currently being transformed
+	typeAliases           map[string]transpiler.Type // type alias name -> underlying type (e.g., "Handler" -> func(string) Future[string])
+	filePath              string                     // source file path (for error reporting)
+	sourceLines           []string                   // source lines (for error snippets)
 }
 
 // NewGalaASTTransformer creates a new instance of ASTTransformer for GALA.
@@ -53,6 +54,7 @@ func NewGalaASTTransformer() transpiler.ASTTransformer {
 		companionObjects:  make(map[string]*transpiler.CompanionObjectMetadata),
 		importManager:     NewImportManager(),
 		inferer:           infer.NewInferer(),
+		typeAliases:       make(map[string]transpiler.Type),
 	}
 }
 
@@ -84,6 +86,7 @@ func (t *galaASTTransformer) Transform(richAST *transpiler.RichAST) (fset *token
 	}
 	t.importManager = NewImportManager()
 	t.additionalImports = make(map[string]string)
+	t.typeAliases = make(map[string]transpiler.Type)
 	t.tempVarCount = 0
 	t.filePath = richAST.FilePath
 	if richAST.SourceContent != "" {

--- a/internal/transpiler/transformer/type_inference.go
+++ b/internal/transpiler/transformer/type_inference.go
@@ -578,6 +578,14 @@ func (t *galaASTTransformer) getExprTypeNameManual(expr ast.Expr) transpiler.Typ
 				if funcType, ok := varType.(transpiler.FuncType); ok && len(funcType.Results) > 0 {
 					return funcType.Results[0]
 				}
+				// If the variable has a named type (e.g., Handler), check if it's a type alias
+				// for a function type and use the underlying function type's return type.
+				typeName := varType.BaseName()
+				if underlyingType, ok := t.typeAliases[typeName]; ok {
+					if funcType, ok := underlyingType.(transpiler.FuncType); ok && len(funcType.Results) > 0 {
+						return funcType.Results[0]
+					}
+				}
 			}
 
 			// Handle generic methods transformed to standalone functions: Receiver_Method


### PR DESCRIPTION
## Summary

Fixes **FIX-038**: Try[T] match generates `std.std.Try[any]` — double-prefixed qualified name and loses concrete type parameter.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1
**Found in**: gala-server (BUG-013)

## Root Cause

Two issues combined:
1. `companion.TargetType` from the analyzer already contained the package prefix (e.g., `"std.Try"` from `NamedType.BaseName()` which returns `String()` = `"pkg.Name"`). `inferMatchedTypeFromCases` in `match.go` blindly prepended `companion.Package + "."` again, producing `"std.std.Try"`.
2. When calling a variable whose type is a type alias (e.g., `Handler` = `func(string) Future[string]`), the transpiler stored it as `BasicType{Name: "Handler"}` and couldn't resolve the function's return type through the method chain, falling back to `any` for type params.

## Changes

- `match.go`: Strip existing package prefix from `TargetType` before constructing `NamedType`; try multiple lookup strategies for type meta
- `transformer.go`: Add `typeAliases map[string]transpiler.Type` field
- `declarations.go`: Populate `typeAliases` when processing type alias declarations
- `type_inference.go`: Resolve type aliases when inferring return type of function variable calls

## Verification

- `examples/try_match_from_func.gala` — exercises Try match on type-alias function variable return
- `bazel build //...` passes (pre-existing `mutable_collections` failure excluded)
- `bazel test //...` passes

## Repro (before fix)

```gala
type Handler func(string) Future[string]

func process(req string, next Handler) string {
    val result = next(req).Await()
    return result match {
        case Success(s) => s
        case Failure(e) => e.Error()
    }
}
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-013 (partially) in gala-server BUGS.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)