### PR TITLE
fix: infer companion Apply type param from return context

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1070,3 +1070,10 @@ gala_test(
     expected = "collection_lambda_inference.out",
     deps = ["//collection_immutable"],
 )
+
+# FIX-040 verification: Some(v) infers Option[string] not Option[any]
+gala_test(
+    name = "some_type_inference",
+    src = "some_type_inference.gala",
+    expected = "some_type_inference.out",
+)

--- a/examples/some_type_inference.gala
+++ b/examples/some_type_inference.gala
@@ -1,0 +1,41 @@
+package main
+
+import "fmt"
+
+// externalCall simulates an external Go function whose return type
+// the GALA transpiler cannot statically infer.
+func externalCall(key string) string {
+    return fmt.Sprintf("value_%s", key)
+}
+
+// FIX-040: Some(v) should infer Option[string] from the function return type
+// when the argument type cannot be determined from the expression.
+func findValue(name string) Option[string] {
+    val v = externalCall(name)
+    if v == "" {
+        return None[string]()
+    }
+    return Some(v)
+}
+
+// Also test with Either sealed type
+func classify(n int) Either[string, int] {
+    if n < 0 {
+        return Left(externalCall("negative"))
+    }
+    return Right(n)
+}
+
+func main() {
+    val result = findValue("test")
+    result match {
+        case Some(v) => Println(s"Found: $v")
+        case None() => Println("Not found")
+    }
+
+    val classified = classify(42)
+    classified match {
+        case Left(msg) => Println(s"Left: $msg")
+        case Right(n) => Println(s"Right: $n")
+    }
+}

--- a/examples/some_type_inference.out
+++ b/examples/some_type_inference.out
@@ -1,0 +1,2 @@
+Found: value_test
+Right: 42

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -678,36 +678,65 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 					isGeneric := methodMeta.IsGeneric || len(methodMeta.TypeParams) > 0
 
 					// If no explicit type args but type has type parameters, infer them from argument types
-					if !hasTypeArgs && len(typeMeta.TypeParams) > 0 && len(args) > 0 {
-						var inferredTypeArgs []ast.Expr
-						// Match Apply method parameter types with argument types
-						for i, arg := range args {
-							if i < len(methodMeta.ParamTypes) {
-								paramTypeStr := methodMeta.ParamTypes[i].String()
-								// Check if param type is one of the type parameters
-								for _, tp := range typeMeta.TypeParams {
-									if paramTypeStr == tp {
-										// Infer type from argument expression
-										argType := t.getExprTypeName(arg)
-										if argType != nil && !argType.IsNil() {
-											inferredTypeArgs = append(inferredTypeArgs, t.typeToExpr(argType))
-										} else {
-											inferredTypeArgs = append(inferredTypeArgs, ast.NewIdent("any"))
+					// and/or from the enclosing function's return type context (FIX-040).
+					if !hasTypeArgs && len(typeMeta.TypeParams) > 0 {
+						// Build a map from type param name to inferred concrete type
+						inferredMap := make(map[string]transpiler.Type)
+
+						// Step 1: Try to infer from Apply method arguments
+						if len(args) > 0 {
+							for i, arg := range args {
+								if i < len(methodMeta.ParamTypes) {
+									paramTypeStr := methodMeta.ParamTypes[i].String()
+									for _, tp := range typeMeta.TypeParams {
+										if paramTypeStr == tp {
+											argType := t.getExprTypeName(arg)
+											if argType != nil && !argType.IsNil() && !argType.IsAny() {
+												inferredMap[tp] = argType
+											}
+											break
 										}
-										break
 									}
 								}
 							}
 						}
-						// If we inferred all type args, use them
-						if len(inferredTypeArgs) == len(typeMeta.TypeParams) {
-							typeArgs = inferredTypeArgs
-							hasTypeArgs = true
-							// Update fun to include the type arguments
-							if len(typeArgs) == 1 {
-								fun = &ast.IndexExpr{X: baseExpr, Index: typeArgs[0]}
-							} else if len(typeArgs) > 1 {
-								fun = &ast.IndexListExpr{X: baseExpr, Indices: typeArgs}
+
+						// Step 2 (FIX-040): For any type params still unresolved, try to infer
+						// from the enclosing function's return type. For example, if we're in
+						// a function returning Option[string] and calling Some(v), unify the
+						// Apply method's return type (Option[T]) with Option[string] to get T=string.
+						if len(inferredMap) < len(typeMeta.TypeParams) && t.currentFuncReturnType != nil && !t.currentFuncReturnType.IsNil() {
+							if methodMeta.ReturnType != nil && !methodMeta.ReturnType.IsNil() {
+								returnInferred := make(map[string]transpiler.Type)
+								t.unifyForInference(methodMeta.ReturnType, t.currentFuncReturnType, typeMeta.TypeParams, returnInferred)
+								for tp, inferred := range returnInferred {
+									if _, alreadySet := inferredMap[tp]; !alreadySet {
+										inferredMap[tp] = inferred
+									}
+								}
+							}
+						}
+
+						// Build the inferred type args list
+						if len(inferredMap) == len(typeMeta.TypeParams) {
+							inferredTypeArgs := make([]ast.Expr, len(typeMeta.TypeParams))
+							allResolved := true
+							for i, tp := range typeMeta.TypeParams {
+								if inferred, ok := inferredMap[tp]; ok {
+									inferredTypeArgs[i] = t.typeToExpr(inferred)
+								} else {
+									allResolved = false
+									break
+								}
+							}
+							if allResolved {
+								typeArgs = inferredTypeArgs
+								hasTypeArgs = true
+								if len(typeArgs) == 1 {
+									fun = &ast.IndexExpr{X: baseExpr, Index: typeArgs[0]}
+								} else if len(typeArgs) > 1 {
+									fun = &ast.IndexListExpr{X: baseExpr, Indices: typeArgs}
+								}
 							}
 						}
 					}


### PR DESCRIPTION
## Summary

Fixes **FIX-040**: `Some(v)` infers `Option[any]` instead of `Option[string]` when function return type is `Option[string]`.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1
**Found in**: gala-server (BUG-016)

## Root Cause

When `Some(v)` is called and `v`'s type cannot be statically determined (e.g., `v` is assigned from an external Go function like `PathValue()`), `getExprTypeName()` returns `NilType`. The companion Apply type inference code in `calls.go` had no fallback, defaulting unresolvable type params to `any`, producing `Some[any]{}.Apply(v.Get())`.

## Changes

- `calls.go`: Added return-type-context inference for companion Apply calls. When argument type inference leaves type params unresolved, unifies the Apply method's return type (e.g., `Option[T]`) with `currentFuncReturnType` (e.g., `Option[string]`) to infer remaining params (e.g., `T = string`).

## Verification

- `examples/some_type_inference.gala` — exercises Option and Either companion Apply with implicit type params
- `bazel build //...` passes
- `bazel test //...` passes

## Repro (before fix)

```gala
func getParam(name string) Option[string] {
    val v = bridge.PathValue(name)
    if v == "" {
        return None[string]()
    }
    return Some(v)  // Generated Some[any] instead of Some[string]
}
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-016 in gala-server BUGS.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)