### PR TITLE
fix: prevent sibling import pollution for main/test packages

### DIFF
--- a/examples/mutable_collections.gala
+++ b/examples/mutable_collections.gala
@@ -185,10 +185,7 @@ func main() {
     var evens = squares.Filter((x int) => x % 2 == 0)
     fmt.Println("Even squares:", evens.String())  // Array(4, 16)
 
-    var doubled = ArrayOf[int]()
-    for i := 0; i < squares.Length(); i++ {
-        doubled.Append(squares.Get(i) * 2)
-    }
+    var doubled = squares.Map[int]((x int) => x * 2)
     fmt.Println("Doubled:", doubled.String())  // Array(2, 8, 18, 32, 50)
     fmt.Println()
 

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -139,8 +139,11 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 			siblingTrees = append(siblingTrees, otherSF)
 			siblingPaths = append(siblingPaths, pf)
 		}
-	} else if filePath != "" {
-		// Directory-discovered siblings (existing behavior)
+	} else if filePath != "" && pkgName != "main" && pkgName != "test" {
+		// Directory-discovered siblings (only for library packages, not main/test).
+		// For main/test packages, directory-discovered siblings are independent programs
+		// that happen to share a directory (e.g., examples/). Scanning their imports
+		// would pollute the current file's type resolution with unrelated packages.
 		dirPath := filepath.Dir(filePath)
 		absDirPath, err := filepath.Abs(dirPath)
 		if err == nil && !a.checkedDirs[absDirPath] {


### PR DESCRIPTION
## Summary

- Fixes cross-package generic method resolution generating wrong package references (e.g., `collection_immutable.Array_Map` instead of `Array_Map`)
- Root cause: analyzer scanned ALL sibling files' imports in `examples/` directory, polluting `dotImportPkgs` with packages from unrelated files
- Restores `mutable_collections.gala` to use `squares.Map[int]()` instead of manual loop workaround

## Root Cause

When analyzing a `package main` file in `examples/`, the analyzer discovered ALL other `.gala` files in the same directory as siblings (since they're all `package main`). It then scanned their imports via `scanImports()` and built `dotImportPkgs` from all siblings — including files that dot-import `collection_immutable`. This caused `findKnownTypePackage("Array", "main")` to non-deterministically resolve `Array` to `collection_immutable.Array` instead of `collection_mutable.Array`.

## Changes

- `internal/transpiler/analyzer/analyzer.go`: Skip directory-discovered sibling scanning for `main`/`test` packages. Multi-file packages use explicit `--package-files` instead.
- `examples/mutable_collections.gala`: Restore `squares.Map[int]((x int) => x * 2)` call (remove manual loop workaround)

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (all 174 tests)
- Generated code for `mutable_collections` now correctly generates `Array_Map[int, int](squares, ...)` without wrong package prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)