### PR TITLE
fix: .Copy() no longer generates self-qualified struct literal (BUG-017)

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1092,3 +1092,17 @@ gala_test(
     src = "block_lambda_match.gala",
     expected = "block_lambda_match.out",
 )
+
+# BUG-013 repro: Try match extractor values typed as any
+gala_test(
+    name = "bug013_try_match_extractor",
+    src = "bug013_try_match_extractor.gala",
+    expected = "bug013_try_match_extractor.out",
+    deps = ["//concurrent"],
+)
+
+# BUG-017 repro: .Copy() generates self-qualified struct literal
+gala_library(
+    name = "bug017_copy_self_qualify",
+    srcs = ["bug017_copy/lib.gala"],
+)

--- a/examples/bug013_try_match_extractor.gala
+++ b/examples/bug013_try_match_extractor.gala
@@ -1,0 +1,33 @@
+package main
+
+import (
+    . "martianoff/gala/std"
+    . "martianoff/gala/concurrent"
+)
+
+struct Response(Code int, Body string)
+
+func doWork() Future[Response] = FutureOf(Response(Code = 200, Body = "OK"))
+
+// Test 1: match on Try[Response] from Future.Await()
+func handleFuture(f Future[Response]) string {
+    val result = f.Await()
+    return result match {
+        case Success(resp) => s"Code: ${resp.Code}, Body: ${resp.Body}"
+        case Failure(err) => s"Error: $err"
+    }
+}
+
+// Test 2: match on Try[Response] directly
+func handleTry(result Try[Response]) string {
+    return result match {
+        case Success(resp) => resp.Body
+        case Failure(err) => s"Error: $err"
+    }
+}
+
+func main() {
+    val f = doWork()
+    Println(handleFuture(f))
+    Println(handleTry(Success(Response(Code = 404, Body = "Not Found"))))
+}

--- a/examples/bug013_try_match_extractor.out
+++ b/examples/bug013_try_match_extractor.out
@@ -1,0 +1,2 @@
+Code: 200, Body: OK
+Not Found

--- a/examples/bug017_copy/lib.gala
+++ b/examples/bug017_copy/lib.gala
@@ -1,0 +1,8 @@
+package mylib
+
+import . "martianoff/gala/std"
+
+struct Config(Host string, Port int, Name string)
+
+func (c Config) WithPort(port int) Config = c.Copy(Port = port)
+func (c Config) WithName(name string) Config = c.Copy(Name = name)

--- a/internal/transpiler/transformer/methods.go
+++ b/internal/transpiler/transformer/methods.go
@@ -124,7 +124,7 @@ func (t *galaASTTransformer) transformCopyCall(receiver ast.Expr, argListCtx *gr
 	}
 
 	return &ast.CompositeLit{
-		Type: ast.NewIdent(typeName),
+		Type: t.ident(typeName),
 		Elts: elts,
 	}, nil
 }


### PR DESCRIPTION
## Summary

- Fixes `.Copy(field = value)` generating `mylib.Config{...}` inside `package mylib` (invalid Go)
- Adds verification examples for BUG-013 (Try match extractors — confirmed working) and BUG-017

## Root Cause

`transformCopyCall` in `methods.go` used `ast.NewIdent(typeName)` where `typeName` was fully qualified (e.g., `"mylib.Config"`). This generated `mylib.Config{}` inside package `mylib`, which is invalid Go — you can't self-qualify a type with your own package name.

## Changes

- `internal/transpiler/transformer/methods.go`: Replace `ast.NewIdent(typeName)` with `t.ident(typeName)` which strips the current package prefix and handles dot imports
- `examples/bug017_copy/lib.gala`: Verification example
- `examples/bug013_try_match_extractor.gala`: Verification that Try match extractors work correctly

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (177 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)