### PR TITLE
fix: improve match expression type inference for Go types and blocks

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -483,6 +483,18 @@ gala_test(
 )
 
 gala_test(
+    name = "match_type_inference",
+    src = "match_type_inference.gala",
+    expected = "match_type_inference.out",
+)
+
+gala_test(
+    name = "match_block_branch",
+    src = "match_block_branch.gala",
+    expected = "match_block_branch.out",
+)
+
+gala_test(
     name = "tuple_shorthand_generic",
     src = "tuple_shorthand_generic.gala",
     expected = "tuple_shorthand_generic.out",

--- a/examples/match_block_branch.gala
+++ b/examples/match_block_branch.gala
@@ -1,0 +1,34 @@
+package main
+
+import . "martianoff/gala/std"
+
+// Test match with block branch that computes a value
+func process(opt Option[int]) string {
+    return opt match {
+        case Some(n) => {
+            val doubled = n * 2
+            return s"doubled: $doubled"
+        }
+        case None() => "nothing"
+    }
+}
+
+// Test match with block branch in default/wildcard case
+func classify(n int) string {
+    return n match {
+        case 0 => "zero"
+        case 1 => "one"
+        case _ => {
+            val label = s"other: $n"
+            return label
+        }
+    }
+}
+
+func main() {
+    Println(process(Some(21)))
+    Println(process(None[int]()))
+    Println(classify(0))
+    Println(classify(1))
+    Println(classify(42))
+}

--- a/examples/match_block_branch.out
+++ b/examples/match_block_branch.out
@@ -1,0 +1,5 @@
+doubled: 42
+nothing
+zero
+one
+other: 42

--- a/examples/match_type_inference.gala
+++ b/examples/match_type_inference.gala
@@ -1,0 +1,28 @@
+package main
+
+import "os"
+
+// Case 4: Match on string for val assignment with string literal and identifier branches
+func getPort() string {
+    val envPort = os.Getenv("PORT")
+    val port = envPort match {
+        case "" => "3000"
+        case _ => envPort
+    }
+    return port
+}
+
+// Case: Match with all branches returning string literals
+func describeEnv(key string) string {
+    return key match {
+        case "HOME" => "home directory"
+        case "PATH" => "executable search path"
+        case _ => "unknown"
+    }
+}
+
+func main() {
+    Println(getPort())
+    Println(describeEnv("HOME"))
+    Println(describeEnv("OTHER"))
+}

--- a/examples/match_type_inference.out
+++ b/examples/match_type_inference.out
@@ -1,0 +1,3 @@
+3000
+home directory
+unknown

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -264,8 +264,14 @@ func (t *galaASTTransformer) transformMatchClauses(ctx grammar.IExpressionContex
 				}
 				defaultBody = b.List
 				if len(b.List) > 0 {
-					if ret, ok := b.List[len(b.List)-1].(*ast.ReturnStmt); ok && len(ret.Results) > 0 {
+					lastStmt := b.List[len(b.List)-1]
+					if ret, ok := lastStmt.(*ast.ReturnStmt); ok && len(ret.Results) > 0 {
 						resultTypes = append(resultTypes, t.inferResultType(ret.Results[0]))
+						casePatterns = append(casePatterns, "case _")
+					} else if exprStmt, ok := lastStmt.(*ast.ExprStmt); ok {
+						// Block's last expression statement becomes the return value
+						defaultBody[len(defaultBody)-1] = &ast.ReturnStmt{Results: []ast.Expr{exprStmt.X}}
+						resultTypes = append(resultTypes, t.inferResultType(exprStmt.X))
 						casePatterns = append(casePatterns, "case _")
 					}
 				}
@@ -566,6 +572,12 @@ func (t *galaASTTransformer) inferCommonResultType(types []transpiler.Type, patt
 		}
 		// VoidType is compatible with any type (for mixed match where some branches are void)
 		if _, isVoid := typ.(transpiler.VoidType); isVoid {
+			continue
+		}
+		// NilType means inference failed for this branch — treat as compatible
+		// when at least one other branch has a concrete type. The Go compiler
+		// will catch any real type mismatch downstream.
+		if typ.IsNil() {
 			continue
 		}
 		// Note: NilType (from nil literal) is allowed and checked in typesCompatible

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -261,8 +261,14 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 				}
 				defaultBody = b.List
 				if len(b.List) > 0 {
-					if ret, ok := b.List[len(b.List)-1].(*ast.ReturnStmt); ok && len(ret.Results) > 0 {
+					lastStmt := b.List[len(b.List)-1]
+					if ret, ok := lastStmt.(*ast.ReturnStmt); ok && len(ret.Results) > 0 {
 						resultTypes = append(resultTypes, t.inferResultType(ret.Results[0]))
+						casePatterns = append(casePatterns, "case _")
+					} else if exprStmt, ok := lastStmt.(*ast.ExprStmt); ok {
+						// Block's last expression statement becomes the return value
+						defaultBody[len(defaultBody)-1] = &ast.ReturnStmt{Results: []ast.Expr{exprStmt.X}}
+						resultTypes = append(resultTypes, t.inferResultType(exprStmt.X))
 						casePatterns = append(casePatterns, "case _")
 					}
 				}

--- a/internal/transpiler/transformer/type_inference.go
+++ b/internal/transpiler/transformer/type_inference.go
@@ -1139,6 +1139,33 @@ var knownGoStdlibReturnTypes = map[string]transpiler.Type{
 	"math.Ceil":  transpiler.BasicType{Name: "float64"},
 	"math.Round": transpiler.BasicType{Name: "float64"},
 	"math.Sqrt":  transpiler.BasicType{Name: "float64"},
+	// os package
+	"os.Getenv":     transpiler.BasicType{Name: "string"},
+	"os.Hostname":   transpiler.BasicType{Name: "string"},
+	"os.Getwd":      transpiler.BasicType{Name: "string"},
+	"os.TempDir":    transpiler.BasicType{Name: "string"},
+	"os.UserHomeDir": transpiler.BasicType{Name: "string"},
+	"os.Executable": transpiler.BasicType{Name: "string"},
+	// os/exec package
+	"exec.Command":        transpiler.PointerType{Elem: transpiler.NamedType{Package: "exec", Name: "Cmd"}},
+	"exec.CommandContext":  transpiler.PointerType{Elem: transpiler.NamedType{Package: "exec", Name: "Cmd"}},
+	"exec.LookPath":       transpiler.BasicType{Name: "string"},
+	// runtime package
+	"runtime.GOOS":   transpiler.BasicType{Name: "string"},
+	"runtime.GOARCH": transpiler.BasicType{Name: "string"},
+	// filepath package
+	"filepath.Join":    transpiler.BasicType{Name: "string"},
+	"filepath.Dir":     transpiler.BasicType{Name: "string"},
+	"filepath.Base":    transpiler.BasicType{Name: "string"},
+	"filepath.Ext":     transpiler.BasicType{Name: "string"},
+	"filepath.Abs":     transpiler.BasicType{Name: "string"},
+	"filepath.Clean":   transpiler.BasicType{Name: "string"},
+	// path package
+	"path.Join":  transpiler.BasicType{Name: "string"},
+	"path.Dir":   transpiler.BasicType{Name: "string"},
+	"path.Base":  transpiler.BasicType{Name: "string"},
+	"path.Ext":   transpiler.BasicType{Name: "string"},
+	"path.Clean": transpiler.BasicType{Name: "string"},
 	// len is a builtin, but handle it if needed
 }
 


### PR DESCRIPTION
## Summary

Fixes **FIX-040**: Match expressions used as val assignments or return values now correctly infer result types when branches return Go interop types, use block bodies, or return string literals.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1
**Found in**: gala-playground

## Root Cause

Three separate issues combined to cause match expression type inference failures:

1. **NilType intolerance**: `inferCommonResultType` treated NilType branches (where inference failed) as type mismatches, even when other branches had concrete types. Now NilType branches are skipped during compatibility checking.

2. **Block wildcard branches**: Wildcard/default cases with block bodies didn't extract the result type from the last expression. The non-wildcard handler already converted `ExprStmt` to `ReturnStmt`, but the wildcard handler only checked for existing `ReturnStmt`.

3. **Missing Go stdlib types**: Common Go functions (`exec.Command`, `os.Getenv`, `runtime.GOOS`, etc.) weren't in the `knownGoStdlibReturnTypes` map, causing NilType for all branches.

## Changes

- `internal/transpiler/transformer/match.go` — NilType tolerance in `inferCommonResultType`; block body type extraction for wildcard cases
- `internal/transpiler/transformer/postfix.go` — Matching block body fix for postfix match expressions
- `internal/transpiler/transformer/type_inference.go` — Extended `knownGoStdlibReturnTypes` with `os`, `os/exec`, `runtime`, `filepath`, `path` entries

## Verification

- `examples/match_type_inference.gala` — Tests string match with `os.Getenv`, string literals, identifiers
- `examples/match_block_branch.gala` — Tests Option match with block branches, int match with block default
- `bazel build //...` passes
- `bazel test //...` passes (184/184 — 2 new example tests)

## Repro (before fix)

```gala
val port = os.Getenv("PORT") match {
    case "" => "3000"
    case _ => envPort
}
// Error: cannot infer result type of match expression
```

## Dependencies

None — this PR can be reviewed and merged independently.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)