### PR TITLE
chore: move Go SDK env vars to .bazelrc and document test setup

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,3 +9,9 @@ build:linux --workspace_status_command=tools/workspace_status.sh
 build:macos --workspace_status_command=tools/workspace_status.sh
 
 #startup --windows_enable_symlinks
+
+# Go type inference: pass GOROOT and PATH to genrules so the transpiler
+# can use go/importer to resolve Go package types (function signatures,
+# struct fields, method sets, etc.).
+build --action_env=GOROOT
+build --action_env=PATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           repository-cache: true
 
       - name: Build
-        run: bazel build //... --action_env=GOROOT --action_env=PATH
+        run: bazel build //...
 
       - name: Test
-        run: bazel test //... --test_output=errors --verbose_failures --action_env=GOROOT --action_env=PATH
+        run: bazel test //... --test_output=errors --verbose_failures

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -41,12 +41,30 @@ GALA is a programming language that transpiles to Go. Build system: Bazel.
 |------|---------|
 | Build | `bazel build //...` |
 | Test | `bazel test //...` |
+| Test (verbose) | `bazel test //... --test_output=errors --verbose_failures` |
+| Test single target | `bazel test //examples:match_type_inference` |
 | Generate BUILD files | `bazel run //:gazelle` |
 
 **Update Go dependencies (run in order):**
 ```shell
 go mod tidy && bazel run //:gazelle && bazel run //:gazelle-update-repos && bazel run //:gazelle && bazel mod tidy
 ```
+
+### Prerequisites
+
+- **Bazel** (via Bazelisk): install from https://github.com/bazelbuild/bazelisk
+- **Go SDK**: required for Go type inference. Ensure `go` is on PATH or set `GOROOT`.
+
+### How Bazel finds the Go SDK
+
+The `.bazelrc` file includes `--action_env=GOROOT` and `--action_env=PATH` so that
+transpilation genrules can access the Go SDK for type inference (resolving function
+return types, struct fields, method signatures from Go packages). The genrules also
+use `tags = ["no-sandbox"]` in `gala.bzl` to allow filesystem access to the SDK.
+
+If the Go SDK is not found, transpilation still succeeds but Go type inference is
+disabled (a warning is printed to stderr). This only affects type resolution for
+Go stdlib/third-party packages — GALA's own type system works without it.
 
 ---
 

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -2403,15 +2403,50 @@ gala_test(
 
 ### Running Tests
 
+#### Prerequisites
+
+- **Bazel** (via [Bazelisk](https://github.com/bazelbuild/bazelisk)): manages Bazel versions automatically
+- **Go SDK**: required for Go type inference (resolving function return types, struct fields, and method signatures from Go packages). Ensure `go` is on PATH or set the `GOROOT` environment variable.
+
+#### Commands
+
+Build the entire project:
+```bash
+bazel build //...
+```
+
 Run all tests:
 ```bash
 bazel test //...
 ```
 
-Run specific tests:
+Run with verbose output (shows error details on failure):
+```bash
+bazel test //... --test_output=errors --verbose_failures
+```
+
+Run a specific test:
 ```bash
 bazel test //mypackage:mycode_test
 ```
+
+Run a specific example:
+```bash
+bazel test //examples:match_type_inference
+```
+
+#### Bazel Configuration
+
+The project's `.bazelrc` includes settings required for both Linux and Windows:
+
+```
+build --action_env=GOROOT    # Pass Go SDK root to transpiler genrules
+build --action_env=PATH      # Allow genrules to find the Go binary
+```
+
+Transpilation genrules in `gala.bzl` use `tags = ["no-sandbox"]` to allow the transpiler filesystem access to the Go SDK for type inference via `go/importer`.
+
+If the Go SDK is not found, transpilation still succeeds but Go type inference is disabled — a warning is printed to stderr. This only affects type resolution for Go stdlib and third-party packages; GALA's own type system works without it.
 
 ## 16. Best Practices
 


### PR DESCRIPTION
## Summary
- Move `--action_env=GOROOT` and `--action_env=PATH` from CI workflow into `.bazelrc` so they apply on all platforms (Linux, Windows, macOS) without requiring users to pass special flags
- Simplify CI workflow — no longer needs explicit `--action_env` flags
- Document prerequisites (Bazel, Go SDK) and Bazel configuration in both `CLAUDE.md` and `docs/GALA.MD`

## Test plan
- [x] `bazel build //...` passes locally (187 targets)
- [x] `bazel test //...` passes locally (187 tests)
- [ ] CI passes on Linux (ubuntu-latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)