### PR TITLE
fix: copy Go subpackages from GALA deps to transpiled output

### DIFF
--- a/internal/build/BUILD.bazel
+++ b/internal/build/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "build",
@@ -18,5 +18,15 @@ go_library(
         "//internal/transpiler/analyzer",
         "//internal/transpiler/generator",
         "//internal/transpiler/transformer",
+    ],
+)
+
+go_test(
+    name = "build_test",
+    srcs = ["deptranspiler_test.go"],
+    embed = [":build"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/build/deptranspiler.go
+++ b/internal/build/deptranspiler.go
@@ -198,6 +198,11 @@ func (dt *DepTranspiler) transpileSingleDep(dep mod.Require, transpiledDirs map[
 		}
 	}
 
+	// Copy non-.gala files (especially .go subpackages) from source to output
+	if err := copyNonGalaFiles(srcDir, outDir, dt.verbose); err != nil {
+		return "", fmt.Errorf("copying non-gala files for %s: %w", dep.Path, err)
+	}
+
 	// Generate go.mod for the dependency
 	if err := dt.generateDepGoMod(dep, outDir, transpiledDirs); err != nil {
 		return "", fmt.Errorf("generating go.mod for %s: %w", dep.Path, err)
@@ -320,4 +325,73 @@ func (dt *DepTranspiler) generateDepGoMod(dep mod.Require, outDir string, transp
 
 	goModPath := filepath.Join(outDir, "go.mod")
 	return os.WriteFile(goModPath, []byte(sb.String()), 0644)
+}
+
+// copyNonGalaFiles copies non-.gala files and subdirectories from srcDir to dstDir.
+// This ensures that pure Go subpackages within a GALA module are available in the
+// transpiled output directory alongside the generated .gen.go files.
+func copyNonGalaFiles(srcDir, dstDir string, verbose bool) error {
+	return filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip the root directory itself
+		if path == srcDir {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+
+		// Skip hidden directories, vendor, testdata, bazel dirs
+		if info.IsDir() {
+			name := info.Name()
+			if strings.HasPrefix(name, ".") || name == "vendor" ||
+				name == "testdata" || strings.HasPrefix(name, "bazel-") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Skip .gala files (already transpiled) and gala.mod
+		if strings.HasSuffix(info.Name(), ".gala") || info.Name() == "gala.mod" {
+			return nil
+		}
+
+		// Skip go.mod and go.sum from source (we generate our own)
+		if info.Name() == "go.mod" || info.Name() == "go.sum" {
+			return nil
+		}
+
+		dstPath := filepath.Join(dstDir, relPath)
+
+		// Ensure destination directory exists
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+			return fmt.Errorf("creating directory for %s: %w", relPath, err)
+		}
+
+		// Skip if destination already exists (don't overwrite .gen.go files)
+		if _, err := os.Stat(dstPath); err == nil {
+			return nil
+		}
+
+		// Copy the file
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+
+		if err := os.WriteFile(dstPath, data, 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", dstPath, err)
+		}
+
+		if verbose {
+			fmt.Printf("    copy: %s\n", relPath)
+		}
+
+		return nil
+	})
 }

--- a/internal/build/deptranspiler_test.go
+++ b/internal/build/deptranspiler_test.go
@@ -1,0 +1,82 @@
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyNonGalaFiles(t *testing.T) {
+	// Create source directory structure simulating a GALA module with Go subpackages
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	// Create source files
+	// Root .gala files (should be skipped - already transpiled)
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "server.gala"), []byte("package server"), 0644))
+	// Root .go file (should be copied)
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "helpers.go"), []byte("package server"), 0644))
+	// gala.mod (should be skipped)
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "gala.mod"), []byte("module test"), 0644))
+	// go.mod (should be skipped - we generate our own)
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "go.mod"), []byte("module test"), 0644))
+
+	// Go subpackage directory
+	httpcore := filepath.Join(srcDir, "httpcore")
+	require.NoError(t, os.MkdirAll(httpcore, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(httpcore, "httpcore.go"), []byte("package httpcore\n\nfunc Handler() {}"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(httpcore, "types.go"), []byte("package httpcore\n\ntype Request struct{}"), 0644))
+
+	// Nested Go subpackage
+	middleware := filepath.Join(srcDir, "httpcore", "middleware")
+	require.NoError(t, os.MkdirAll(middleware, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(middleware, "auth.go"), []byte("package middleware"), 0644))
+
+	// Hidden directory (should be skipped)
+	gitDir := filepath.Join(srcDir, ".git")
+	require.NoError(t, os.MkdirAll(gitDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(gitDir, "config"), []byte("git config"), 0644))
+
+	// Pre-existing .gen.go in dst (should NOT be overwritten)
+	require.NoError(t, os.WriteFile(filepath.Join(dstDir, "helpers.go"), []byte("GENERATED"), 0644))
+
+	// Run copyNonGalaFiles
+	err := copyNonGalaFiles(srcDir, dstDir, false)
+	require.NoError(t, err)
+
+	// Verify .gala files were NOT copied
+	assert.NoFileExists(t, filepath.Join(dstDir, "server.gala"))
+
+	// Verify gala.mod was NOT copied
+	assert.NoFileExists(t, filepath.Join(dstDir, "gala.mod"))
+
+	// Verify go.mod was NOT copied
+	content, err := os.ReadFile(filepath.Join(dstDir, "go.mod"))
+	assert.True(t, os.IsNotExist(err) || (err == nil && string(content) != "module test"),
+		"go.mod from source should not overwrite destination")
+
+	// Verify hidden dirs were NOT copied
+	assert.NoDirExists(t, filepath.Join(dstDir, ".git"))
+
+	// Verify Go subpackage files WERE copied
+	data, err := os.ReadFile(filepath.Join(dstDir, "httpcore", "httpcore.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "package httpcore")
+
+	data, err = os.ReadFile(filepath.Join(dstDir, "httpcore", "types.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "type Request struct{}")
+
+	// Verify nested subpackage was copied
+	data, err = os.ReadFile(filepath.Join(dstDir, "httpcore", "middleware", "auth.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "package middleware")
+
+	// Verify pre-existing file was NOT overwritten
+	data, err = os.ReadFile(filepath.Join(dstDir, "helpers.go"))
+	require.NoError(t, err)
+	assert.Equal(t, "GENERATED", string(data))
+}


### PR DESCRIPTION
## Summary

Fixes **FIX-038**: Go subpackages within external GALA modules not resolved during build

**Category**: CODEGEN_BUG
**Priority**: P0 (blocks compilation)
**Found in**: gala-playground

## Root Cause

When transpiling external GALA module dependencies, `transpileSingleDep()` only wrote `.gen.go` files from transpiled `.gala` sources. Pure Go subpackages (e.g., `httpcore/httpcore.go`) within the dependency were never copied to the output directory. The `replace` directive in `go.mod` pointed to a directory missing these subpackages, causing `package X is not in std` errors.

## Changes

- `internal/build/deptranspiler.go`: Added `copyNonGalaFiles()` function that recursively copies non-GALA files and subdirectories from the dependency source to the transpiled output directory. Skips `.gala` files (already transpiled), `gala.mod`, `go.mod`, `go.sum`, and hidden/vendor directories. Does not overwrite existing files (preserves `.gen.go` output).
- `internal/build/deptranspiler_test.go`: New test file with comprehensive test for `copyNonGalaFiles` — verifies Go subpackages are copied, hidden dirs skipped, `.gala`/mod files skipped, existing files not overwritten.
- `internal/build/BUILD.bazel`: Added `go_test` target for the new test.

## Verification

- `internal/build/deptranspiler_test.go` — `TestCopyNonGalaFiles`
- `bazel build //...` passes
- `bazel test //...` passes (187 tests + 1 new)

## Repro (before fix)

```gala
package main

import . "martianoff/gala-server"

func main() {
    NewServer().GET("/", (req) => Ok("hello")).Listen()
}
```

Where `gala-server` has a pure Go subpackage `httpcore/`:
```
deps/.../request.gen.go:6:8: package martianoff/gala-server/httpcore is not in std
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported in: `gala-playground/issues/build-go-subpackage-replace.md`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)