### PR TITLE
fix: playground transpiler issues (FIX-041, FIX-042, FIX-043)

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -3,11 +3,19 @@ load("//:gala.bzl", "gala_binary", "gala_library", "gala_test")
 filegroup(
     name = "gala_sources",
     srcs = [
+        "bug013_cross_pkg/corelib/corelib.gala",
+        "bug013_cross_pkg/main.gala",
+        "bug013_type_alias_lib/processor.gala",
+        "bug013_type_alias_lib/types.gala",
+        "bug013_type_alias_lib_test.gala",
         "cross_file_unwrap/main.gala",
         "cross_file_unwrap/types.gala",
         "cross_file_unwrap_lib/ops.gala",
         "cross_file_unwrap_lib/types.gala",
         "foldleft_method/main.gala",
+        "go_type_inference_lib/textutil.gala",
+        "go_type_inference_multifile/helpers.gala",
+        "go_type_inference_multifile/main.gala",
         "lib/generic.gala",
         "match_method_chain/main.gala",
         "match_method_chain/types.gala",
@@ -20,20 +28,12 @@ filegroup(
         "multi_file_option/main.gala",
         "multi_file_types/main.gala",
         "multi_file_types/model.gala",
+        "slice_unwrap/main.gala",
+        "slice_unwrap/model.gala",
         "struct_field_unwrap/main.gala",
         "struct_field_unwrap/types.gala",
         "use_cross_file_unwrap_lib.gala",
         "wrapper_method_lambda/main.gala",
-        "slice_unwrap/main.gala",
-        "slice_unwrap/model.gala",
-        "bug013_cross_pkg/corelib/corelib.gala",
-        "bug013_cross_pkg/main.gala",
-        "bug013_type_alias_lib/types.gala",
-        "bug013_type_alias_lib/processor.gala",
-        "bug013_type_alias_lib_test.gala",
-        "go_type_inference_lib/textutil.gala",
-        "go_type_inference_multifile/helpers.gala",
-        "go_type_inference_multifile/main.gala",
     ],
     visibility = ["//visibility:public"],
 )
@@ -489,6 +489,12 @@ gala_test(
     name = "match_type_inference",
     src = "match_type_inference.gala",
     expected = "match_type_inference.out",
+)
+
+gala_test(
+    name = "match_go_constant",
+    src = "match_go_constant.gala",
+    expected = "match_go_constant.out",
 )
 
 gala_test(
@@ -1133,7 +1139,10 @@ gala_test(
     name = "bug013_cross_pkg",
     src = "bug013_cross_pkg/main.gala",
     expected = "bug013_cross_pkg/main.out",
-    deps = ["//concurrent", ":bug013_cross_pkg_corelib"],
+    deps = [
+        ":bug013_cross_pkg_corelib",
+        "//concurrent",
+    ],
 )
 
 # BUG-013 repro: type alias for func type in library package + match through alias
@@ -1142,8 +1151,8 @@ gala_test(
 gala_library(
     name = "bug013_type_alias_lib",
     srcs = [
-        "bug013_type_alias_lib/types.gala",
         "bug013_type_alias_lib/processor.gala",
+        "bug013_type_alias_lib/types.gala",
     ],
     importpath = "martianoff/gala/examples/bug013_type_alias_lib",
     visibility = ["//visibility:public"],
@@ -1196,4 +1205,3 @@ gala_test(
     expected = "go_type_inference_cross_pkg.out",
     deps = [":go_type_inference_lib"],
 )
-

--- a/examples/match_go_constant.gala
+++ b/examples/match_go_constant.gala
@@ -1,0 +1,13 @@
+package main
+
+import "runtime"
+
+func main() {
+    val compiler = runtime.Compiler
+    val label = compiler match {
+        case "gc" => "standard"
+        case "gccgo" => "gcc-based"
+        case _ => "other"
+    }
+    Println(label)
+}

--- a/examples/match_go_constant.out
+++ b/examples/match_go_constant.out
@@ -1,0 +1,1 @@
+standard

--- a/internal/stdlib/BUILD.bazel
+++ b/internal/stdlib/BUILD.bazel
@@ -20,6 +20,7 @@ genrule(
         "//std:constptr_go",
         "//std:types.go",
         "//std:interfaces.go",
+        "//std:embedded_fs.go",
         # std package - GALA source (for analyzer)
         "//std:option.gala",
         "//std:immutable.gala",

--- a/internal/transpiler/analyzer/go_types.go
+++ b/internal/transpiler/analyzer/go_types.go
@@ -384,7 +384,26 @@ func goTypeToTranspilerType(t types.Type) transpiler.Type {
 
 	switch t := t.(type) {
 	case *types.Basic:
-		return transpiler.BasicType{Name: t.Name()}
+		name := t.Name()
+		// Untyped constants (e.g., "untyped string", "untyped int") should
+		// resolve to their concrete Go type for code generation purposes.
+		if t.Info()&types.IsUntyped != 0 {
+			switch t.Kind() {
+			case types.UntypedBool:
+				name = "bool"
+			case types.UntypedInt:
+				name = "int"
+			case types.UntypedRune:
+				name = "rune"
+			case types.UntypedFloat:
+				name = "float64"
+			case types.UntypedComplex:
+				name = "complex128"
+			case types.UntypedString:
+				name = "string"
+			}
+		}
+		return transpiler.BasicType{Name: name}
 
 	case *types.Named:
 		obj := t.Obj()

--- a/internal/transpiler/module/resolver.go
+++ b/internal/transpiler/module/resolver.go
@@ -161,6 +161,10 @@ func (r *Resolver) ResolvePackagePath(importPath string) (string, error) {
 	// GALA modules are provided via --search (e.g., gala + gala-server).
 	for _, sp := range r.searchPaths {
 		spModRoot, spModName := FindModuleRoot(sp)
+		// Also try gala.mod if go.mod wasn't found (pure GALA packages may not have go.mod)
+		if spModName == "" {
+			spModRoot, spModName = findGalaModuleRoot(sp)
+		}
 		if spModName == "" || spModRoot == r.moduleRoot {
 			continue // skip primary module (already handled in Strategy 1)
 		}
@@ -254,6 +258,10 @@ func (r *Resolver) IsGalaPackage(importPath string) bool {
 	// Check if any search path is a module root whose name matches
 	for _, sp := range r.searchPaths {
 		spModRoot, spModName := FindModuleRoot(sp)
+		// Also try gala.mod if go.mod wasn't found (pure GALA packages may not have go.mod)
+		if spModName == "" {
+			spModRoot, spModName = findGalaModuleRoot(sp)
+		}
 		if spModName == "" || spModName == r.moduleName {
 			continue
 		}
@@ -494,6 +502,33 @@ func FindModuleRoot(startPath string) (moduleRoot, moduleName string) {
 			break
 		}
 		dir = parent
+	}
+
+	return "", ""
+}
+
+// findGalaModuleRoot looks for gala.mod in the given directory (not walking up)
+// and extracts the module name from it. Used as fallback when go.mod is not found
+// (pure GALA packages that don't have a go.mod).
+func findGalaModuleRoot(startPath string) (moduleRoot, moduleName string) {
+	dir := startPath
+	if info, err := os.Stat(dir); err == nil && !info.IsDir() {
+		dir = filepath.Dir(dir)
+	}
+
+	modPath := filepath.Join(dir, "gala.mod")
+	content, err := os.ReadFile(modPath)
+	if err != nil {
+		return "", ""
+	}
+
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "module ") {
+			moduleName = strings.TrimSpace(strings.TrimPrefix(line, "module "))
+			return dir, moduleName
+		}
 	}
 
 	return "", ""

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -384,7 +384,6 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 		if typeMeta != nil {
 			methodMeta = typeMeta.Methods[method]
 		}
-
 		if methodMeta != nil {
 			// Build type substitution map from receiver's type arguments
 			typeSubst := make(map[string]string)

--- a/internal/transpiler/transformer/type_inference.go
+++ b/internal/transpiler/transformer/type_inference.go
@@ -136,6 +136,17 @@ func (t *galaASTTransformer) getExprTypeNameManualUncached(expr ast.Expr) transp
 				if actual, ok := t.importManager.ResolveAlias(pkgName); ok {
 					pkgName = actual
 				}
+				// Check if this is a Go constant or variable (not a type)
+				// e.g., runtime.GOOS is a string constant, not a type
+				qualName := pkgName + "." + e.Sel.Name
+				if t.goTypeInfo != nil {
+					if constType, ok := t.goTypeInfo.Constants[qualName]; ok {
+						return constType
+					}
+					if varType, ok := t.goTypeInfo.Variables[qualName]; ok {
+						return varType
+					}
+				}
 				return transpiler.NamedType{Package: pkgName, Name: e.Sel.Name}
 			}
 		}

--- a/internal/transpiler/transformer/type_inference.go
+++ b/internal/transpiler/transformer/type_inference.go
@@ -25,6 +25,11 @@ func (t *galaASTTransformer) getExprTypeNameManual(expr ast.Expr) transpiler.Typ
 		return cached
 	}
 	result := t.getExprTypeNameManualUncached(expr)
+	// Guard against nil interface value (not NilType{}) which can happen when
+	// called functions return nil instead of NilType{}.
+	if result == nil {
+		return transpiler.NilType{}
+	}
 	// Only cache non-nil results; failed lookups may succeed later as more scope info becomes available.
 	if !result.IsNil() {
 		t.exprTypeCache[expr] = result
@@ -140,10 +145,10 @@ func (t *galaASTTransformer) getExprTypeNameManualUncached(expr ast.Expr) transp
 				// e.g., runtime.GOOS is a string constant, not a type
 				qualName := pkgName + "." + e.Sel.Name
 				if t.goTypeInfo != nil {
-					if constType, ok := t.goTypeInfo.Constants[qualName]; ok {
+					if constType, ok := t.goTypeInfo.Constants[qualName]; ok && constType != nil {
 						return constType
 					}
-					if varType, ok := t.goTypeInfo.Variables[qualName]; ok {
+					if varType, ok := t.goTypeInfo.Variables[qualName]; ok && varType != nil {
 						return varType
 					}
 				}


### PR DESCRIPTION
## Summary

Fixes three transpiler issues found during GALA playground testing:

- **FIX-041**: Match expressions using Go constants (e.g., `runtime.GOOS`) as subjects generated `func(obj runtime.GOOS)` instead of `func(obj string)`. Fixed by checking `GoTypeInfo.Constants` and `GoTypeInfo.Variables` before defaulting to NamedType in type inference.

- **FIX-042**: Lambda parameters typed as `any` instead of concrete types when the method comes from a dot-imported external GALA package (e.g., `gala-server`). Root cause: module resolver only looked for `go.mod` but pure GALA packages only have `gala.mod`. Added `findGalaModuleRoot()` fallback.

- **FIX-043**: `std.NewEmbeddedFS` was undefined when using `gala build` because `embedded_fs.go` was missing from the `generate_embedded` genrule srcs in the stdlib BUILD file.

## Changes

- `internal/transpiler/transformer/type_inference.go` — Check GoTypeInfo constants/variables for selector types; nil guard for uncached type inference
- `internal/transpiler/analyzer/go_types.go` — Map untyped Go constant kinds to concrete types (committed earlier)
- `internal/transpiler/module/resolver.go` — Added `findGalaModuleRoot()` for pure GALA packages without `go.mod`
- `internal/stdlib/BUILD.bazel` — Added `//std:embedded_fs.go` to generate_embedded srcs
- `examples/match_go_constant.gala` + `.out` — Verification example for FIX-041

## Verification

- `bazel build //...` passes
- `bazel test //...` — all 189 tests pass
- Playground generated code verified: `func(req Request)` (was `func(req any)`), `func(obj string)` (was `func(obj runtime.GOOS)`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)