### PR TITLE
feat: add side-effect chaining methods to Try, Either, Option

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -966,6 +966,11 @@ val msg = x match {
 
 // Monadic operations
 val result = x.Map((i int) => i * 2)
+
+// Side-effect methods (return original value for chaining)
+x.OnSome((v) => { Println(s"Found: $v") })
+ .OnNone(() => { Println("Not found") })
+ .Map((i) => i * 2)
 ```
 
 ### Tuple
@@ -1018,6 +1023,12 @@ val result = Right[string, int](5).FlatMap((x int) => Right[string, int](x + 100
 
 // Chaining Map and FlatMap
 val chained = Right[string, int](3).Map((x int) => x * 10).FlatMap((x int) => Right[string, int](x + 1))
+
+// Side-effect methods (return original value for chaining)
+val logged = Right[string, int](42)
+    .OnRight((v) => { Println(s"Success: $v") })
+    .OnLeft((e) => { Println(s"Error: $e") })
+    .Map((x) => x * 2)
 ```
 
 ### Try Monad
@@ -1052,6 +1063,12 @@ val result = success.FlatMap[int]((n int) => divide(n, 2))
 val recovered = failure.Recover((e error) => 0)
 val recoveredWith = failure.RecoverWith((e error) => Success(0))
 
+// Side-effect methods (return original value for chaining)
+val logged = success
+    .OnSuccess((n) => { Println(s"Got: $n") })
+    .OnFailure((e) => { Println(s"Error: ${e.Error()}") })
+    .Map((x) => x * 2)
+
 // Safe value extraction
 val value = failure.GetOrElse(0)
 val alternative = failure.OrElse(Success(100))
@@ -1084,6 +1101,8 @@ func processOrder(id int) Try[Receipt] =
 | `Get()` | Get value or panic |
 | `GetOrElse(default)` | Get value or return default |
 | `OrElse(alternative)` | Return this if Success, otherwise alternative |
+| `OnSuccess(f)` | Execute side-effect if Success, return original Try |
+| `OnFailure(f)` | Execute side-effect if Failure, return original Try |
 | `Map[U](f)` | Transform value if Success |
 | `FlatMap[U](f)` | Chain operations returning Try |
 | `Filter(predicate)` | Keep Success if predicate holds |

--- a/std/either.gala
+++ b/std/either.gala
@@ -61,6 +61,24 @@ func (e Either[A, B]) Swap() Either[B, A] {
     return Left[B, A](e.RightValue)
 }
 
+// OnRight executes a callback with the right value if this is a Right,
+// returns the original Either unchanged (for chaining).
+func (e Either[A, B]) OnRight(f func(B)) Either[A, B] {
+    if e.isRight() {
+        f(e.RightValue)
+    }
+    return e
+}
+
+// OnLeft executes a callback with the left value if this is a Left,
+// returns the original Either unchanged (for chaining).
+func (e Either[A, B]) OnLeft(f func(A)) Either[A, B] {
+    if e.isLeft() {
+        f(e.LeftValue)
+    }
+    return e
+}
+
 // Fold applies f1 to the left value or f2 to the right value.
 func (e Either[A, B]) Fold[C any](f1 func(A) C, f2 func(B) C) C {
     if e.isLeft() {

--- a/std/option.gala
+++ b/std/option.gala
@@ -45,6 +45,24 @@ func (o Option[T]) GetOrElse(defaultValue T) T {
     return defaultValue
 }
 
+// OnSome executes a callback with the value if this is Some,
+// returns the original Option unchanged (for chaining).
+func (o Option[T]) OnSome(f func(T)) Option[T] {
+    if o.isSome() {
+        f(o.Value)
+    }
+    return o
+}
+
+// OnNone executes a callback if this is None,
+// returns the original Option unchanged (for chaining).
+func (o Option[T]) OnNone(f func()) Option[T] {
+    if o.isNone() {
+        f()
+    }
+    return o
+}
+
 // ForEach applies the given procedure f to the option's value, if it is nonempty.
 // f: the procedure to apply.
 func (o Option[T]) ForEach(f func(T)) {

--- a/std/try.gala
+++ b/std/try.gala
@@ -55,6 +55,24 @@ func (t Try[T]) OrElse(alternative Try[T]) Try[T] {
     return alternative
 }
 
+// OnSuccess executes a callback with the value if this is a Success,
+// returns the original Try unchanged (for chaining).
+func (t Try[T]) OnSuccess(f func(T)) Try[T] {
+    if t.isSuccess() {
+        f(t.Value)
+    }
+    return t
+}
+
+// OnFailure executes a callback with the error if this is a Failure,
+// returns the original Try unchanged (for chaining).
+func (t Try[T]) OnFailure(f func(error)) Try[T] {
+    if t.isFailure() {
+        f(t.Err)
+    }
+    return t
+}
+
 // ForEach applies the given procedure f to the value if this is a Success.
 func (t Try[T]) ForEach(f func(T)) {
     if t.isSuccess() {


### PR DESCRIPTION
## Summary

- Add `OnSuccess(f)` / `OnFailure(f)` to **Try[T]** — execute side-effect callbacks that return the original Try unchanged for chaining
- Add `OnRight(f)` / `OnLeft(f)` to **Either[A, B]** — same pattern for Either's two variants
- Add `OnSome(f)` / `OnNone(f)` to **Option[T]** — same pattern for Option's two variants
- Document new methods in `docs/GALA.MD` with inline examples and key methods table

## Motivation

Enables ergonomic side-effect insertion (logging, metrics, debugging) in functional pipelines without breaking the chain:

```gala
Try[int](() => riskyCompute())
    .OnSuccess((v) => { Println(s"Got: $v") })
    .OnFailure((e) => { metrics.IncrementErrorCount() })
    .Map((x) => x * 2)
    .GetOrElse(0)
```

Follows the same pattern already established by `Future[T].OnSuccess/OnFailure` in the `concurrent` package.

## Test plan

- [x] `bazel build //...` passes
- [x] `bazel test //...` passes (190/190)
- [x] No breaking changes — new methods only

🤖 Generated with [Claude Code](https://claude.com/claude-code)