### PR TITLE
feat: Try type inference, Go multi-return, and function reference syntax

### DIFF
--- a/.claude/skills/gala-code.md
+++ b/.claude/skills/gala-code.md
@@ -42,7 +42,7 @@ Design the implementation following GALA best practices:
 10. **Copy for updates** - Use `.Copy(field = newValue)` instead of mutation
 11. **String interpolation** - Use `s"Hello $name"` instead of `fmt.Sprintf("Hello %s", name)`. Use `f"$x%.2f"` for explicit format control. No `import "fmt"` needed.
 12. **Println/Print** - Use `Println(...)` and `Print(...)` instead of `fmt.Println(...)` / `fmt.Print(...)`. No import needed.
-13. **Try for Go errors** - Wrap Go functions that return `(T, error)` with `Try(() => f())`. Use `.OrElse` for independent fallbacks, `.FlatMap` for dependent chains. Never use sequential `if err == nil` blocks.
+13. **Try for Go errors** - Wrap Go functions that return `(T, error)` with `Try(f)` when f takes no args, or `Try(() => f(args))` when args are needed. Use `.OrElse` for independent fallbacks, `.FlatMap` for dependent chains. Never use sequential `if err == nil` blocks.
 14. **Option over sentinels** - Return `Option[T]` instead of sentinel values (`""`, `0`, `-1`, `nil`) to signal absence. Use `.GetOrElse`, `.Map`, or `match` on the caller side.
 
 ### Step 2: Write the Source Code
@@ -198,7 +198,7 @@ Before finishing, verify:
 - [ ] String interpolation (`s"..."` / `f"..."`) used instead of `fmt.Sprintf`
 - [ ] `Println`/`Print` used instead of `fmt.Println`/`fmt.Print`
 - [ ] No `import "fmt"` unless using functions beyond Println/Print/Sprintf (e.g., `fmt.Errorf`)
-- [ ] Go error returns wrapped with `Try(() => f())`, not `if err == nil` blocks
+- [ ] Go error returns wrapped with `Try(f)` (zero-arg) or `Try(() => f(args))`, not `if err == nil` blocks
 - [ ] Fallback patterns use `Try.OrElse`, not sequential if-err-nil
 - [ ] No sentinel return values (`""`, `0`, `-1`) — use `Option[T]` instead
 - [ ] Tests cover happy path, edge cases, and error cases

--- a/.claude/skills/gala-lint.md
+++ b/.claude/skills/gala-lint.md
@@ -55,8 +55,9 @@ Present findings in the output format specified at the end.
 | Get(0) after length check | `if x.Length() > 0 { x.Get(0) }` | `x.HeadOption()` or pattern match |
 | Unnecessary default on sealed | `case _ =>` when all sealed variants are covered | Remove `case _ =>`; exhaustive match is verified by the transpiler |
 | IsXxx() chains on sealed type | `if s.IsCircle() { ... } else if s.IsRectangle() { ... }` | `s match { case Circle(r) => ... case Rectangle(w, h) => ... }` |
-| If-err-nil on Go error return | `val x, err = f(); if err == nil { ... }` | Wrap with `Try(() => f())` then use `.Map`, `.GetOrElse`, or `match` |
-| Sequential if-err-nil fallback | Multiple `val x, err = f(); if err == nil { return x }` in sequence | `Try(() => f1()).OrElse(Try(() => f2()))` chain |
+| If-err-nil on Go error return | `val x, err = f(); if err == nil { ... }` | Wrap with `Try(f)` (if f takes no args) or `Try(() => f(args))` then use `.Map`, `.GetOrElse`, or `match` |
+| Sequential if-err-nil fallback | Multiple `val x, err = f(); if err == nil { return x }` in sequence | `Try(f1).OrElse(Try(f2))` chain (or `Try(() => f1(args)).OrElse(Try(() => f2(args)))` if args needed) |
+| Lambda wrapper for zero-arg func | `Try(() => f())` where f takes no arguments | `Try(f)` — pass function reference directly |
 
 ### 3. Sealed Types (HIGH priority)
 
@@ -190,6 +191,7 @@ for _, x := range nums {
 | Redundant collection types | `ListOf[int](1, 2, 3)` | `ListOf(1, 2, 3)` |
 | Redundant single-param struct constructor | `Box[int](Value = 42)` | `Box(Value = 42)` (type inferred from named field value) |
 | Redundant generic function call type params | `Try[int](() => { return 1 })` | `Try(() => { return 1 })` (type inferred from lambda return) |
+| Unnecessary lambda for zero-arg func | `Try(() => os.TempDir())` | `Try(os.TempDir)` — pass function reference directly when func takes no args |
 | Redundant generic function call type params | `NewCons[int](head, tail)` | `NewCons(head, tail)` (type inferred from arguments) |
 | Redundant lambda param type | `list.Map((x int) => x * 2)` | `list.Map((x) => x * 2)` (type inferred from method signature) |
 | Redundant method type param | `list.Map[int]((x) => x * 2)` | `list.Map((x) => x * 2)` (Go infers from lambda) |
@@ -319,6 +321,13 @@ func findBinary() Option[string] =
     Try(() => exec.LookPath("gala"))
         .OrElse(Try(() => exec.LookPath("gala.exe")))
         .ToOption()
+```
+
+**Best pattern** — function reference when zero-arg:
+```gala
+// BEST: pass zero-arg function references directly (no lambda wrapper)
+val dir = Try(os.TempDir)                // same as Try(() => os.TempDir())
+val answer = Try(getAnswer)              // works with GALA functions too
 ```
 
 **When to use FlatMap vs OrElse**:

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -1035,8 +1035,12 @@ val success = Success(42)
 val failure = Failure[int](NoSuchElementError(Message = "not found"))
 
 // Try: safely execute code that may panic
-val result = Try[int](() => riskyDivide(10, 0))  // Failure (catches panic)
-val safe = Try[int](() => riskyDivide(10, 2))    // Success(5)
+val result = Try(() => riskyDivide(10, 0))  // Failure (catches panic)
+val safe = Try(() => riskyDivide(10, 2))    // Success(5)
+
+// Function reference sugar: pass a zero-arg function directly (no lambda needed)
+val dir = Try(os.TempDir)               // same as Try(() => os.TempDir())
+val answer = Try(getAnswer)             // works with GALA functions too
 
 // Pattern matching (exhaustive - no case _ needed)
 val msg = success match {
@@ -1080,6 +1084,7 @@ func processOrder(id int) Try[Receipt] =
 | Method | Description |
 |--------|-------------|
 | `Try[T](f)` | Execute f, catch panics as Failure |
+| `Try(funcRef)` | Pass a zero-arg function reference directly (sugar) |
 | `IsSuccess()` / `IsFailure()` | Check the state |
 | `Get()` | Get value or panic |
 | `GetOrElse(default)` | Get value or return default |

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -601,6 +601,12 @@ gala_test(
 )
 
 gala_test(
+    name = "try_func_ref",
+    src = "try_func_ref.gala",
+    expected = "try_func_ref.out",
+)
+
+gala_test(
     name = "sealed_types",
     src = "sealed_types.gala",
     expected = "sealed_types.out",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -595,6 +595,12 @@ gala_test(
 )
 
 gala_test(
+    name = "try_go_interop",
+    src = "try_go_interop.gala",
+    expected = "try_go_interop.out",
+)
+
+gala_test(
     name = "sealed_types",
     src = "sealed_types.gala",
     expected = "sealed_types.out",

--- a/examples/try_func_ref.gala
+++ b/examples/try_func_ref.gala
@@ -1,0 +1,25 @@
+package main
+
+import "os"
+
+func getAnswer() int = 42
+
+// Test: Try with function reference (no lambda wrapper needed)
+// Try(os.TempDir) should work the same as Try(() => os.TempDir())
+func main() {
+    // Go function reference
+    val result1 = Try(os.TempDir)
+    Println(result1.IsSuccess())
+
+    // Lambda syntax (existing)
+    val result2 = Try(() => os.TempDir())
+    Println(result2.IsSuccess())
+
+    // Both should produce the same result
+    Println(result1.Get() == result2.Get())
+
+    // GALA function reference (type inferred from function signature)
+    val result3 = Try(getAnswer)
+    Println(result3.IsSuccess())
+    Println(result3.Get())
+}

--- a/examples/try_func_ref.out
+++ b/examples/try_func_ref.out
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+42

--- a/examples/try_go_interop.gala
+++ b/examples/try_go_interop.gala
@@ -1,5 +1,6 @@
 package main
 
+import "net"
 import "os"
 import "strconv"
 
@@ -36,4 +37,18 @@ func main() {
         case Failure(_) => "failed"
     }
     Println(tmpResult)
+
+    // FIX-045 Tuple: Go function returning (string, string, error) -> Tuple[string, string]
+    val hostPort = Try(() => net.SplitHostPort("localhost:8080")) match {
+        case Success(hp) => s"host=${hp.V1} port=${hp.V2}"
+        case Failure(err) => s"Error: ${err.Error()}"
+    }
+    Println(hostPort)
+
+    // FIX-045 Tuple: error case
+    val badHostPort = Try(() => net.SplitHostPort("invalid")) match {
+        case Success(hp) => s"host=${hp.V1} port=${hp.V2}"
+        case Failure(_) => "split error caught"
+    }
+    Println(badHostPort)
 }

--- a/examples/try_go_interop.gala
+++ b/examples/try_go_interop.gala
@@ -1,0 +1,39 @@
+package main
+
+import "os"
+import "strconv"
+
+// Test FIX-044: Try type param inference from lambda return type
+// Test FIX-045: Go multi-return (T, error) inside Try lambda
+func main() {
+    // FIX-044: Try should infer T=string from lambda return type (single-return Go func)
+    val dirResult = Try(() => os.TempDir()) match {
+        case Success(_) => "ok"
+        case Failure(err) => s"Error: ${err.Error()}"
+    }
+    Println(dirResult)
+
+    // FIX-045: Try with Go function returning (int, error) - auto error panic wrapping
+    val intResult = Try(() => strconv.Atoi("42")) match {
+        case Success(n) => s"Parsed: $n"
+        case Failure(err) => s"Error: ${err.Error()}"
+    }
+    Println(intResult)
+
+    // FIX-045: Try with Go function returning (T, error) that actually fails
+    val failResult = Try(() => strconv.Atoi("not_a_number")) match {
+        case Success(n) => s"Parsed: $n"
+        case Failure(_) => "parse error caught"
+    }
+    Println(failResult)
+
+    // FIX-044+045: Try with os.MkdirTemp (string, error) - verify type inferred as string
+    val tmpResult = Try(() => os.MkdirTemp("", "gala-test-*")) match {
+        case Success(dir) => {
+            os.RemoveAll(dir)
+            return "temp dir created and cleaned"
+        }
+        case Failure(_) => "failed"
+    }
+    Println(tmpResult)
+}

--- a/examples/try_go_interop.out
+++ b/examples/try_go_interop.out
@@ -1,0 +1,4 @@
+ok
+Parsed: 42
+parse error caught
+temp dir created and cleaned

--- a/examples/try_go_interop.out
+++ b/examples/try_go_interop.out
@@ -2,3 +2,5 @@ ok
 Parsed: 42
 parse error caught
 temp dir created and cleaned
+host=localhost port=8080
+split error caught

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -682,19 +682,17 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 						// Build a map from type param name to inferred concrete type
 						inferredMap := make(map[string]transpiler.Type)
 
-						// Step 1: Try to infer from Apply method arguments
+						// Step 1: Try to infer from Apply method arguments using unification.
+						// This handles both simple cases (param is T, arg is string -> T=string)
+						// and complex cases (param is func() T, arg is func() string -> T=string).
+						// FIX-044: Use unifyForInference instead of direct string comparison
+						// so that FuncType params like func() T can be matched against lambda arg types.
 						if len(args) > 0 {
 							for i, arg := range args {
 								if i < len(methodMeta.ParamTypes) {
-									paramTypeStr := methodMeta.ParamTypes[i].String()
-									for _, tp := range typeMeta.TypeParams {
-										if paramTypeStr == tp {
-											argType := t.getExprTypeName(arg)
-											if argType != nil && !argType.IsNil() && !argType.IsAny() {
-												inferredMap[tp] = argType
-											}
-											break
-										}
+									argType := t.getExprTypeName(arg)
+									if argType != nil && !argType.IsNil() && !argType.IsAny() {
+										t.unifyForInference(methodMeta.ParamTypes[i], argType, typeMeta.TypeParams, inferredMap)
 									}
 								}
 							}

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -138,10 +138,13 @@ func (t *galaASTTransformer) transformLambdaWithExpectedType(ctx *grammar.Lambda
 					&ast.ExprStmt{X: expr},
 				},
 			}
-		} else if multiRetBody := t.tryWrapGoMultiReturnWithErrorPanic(expr); multiRetBody != nil {
-			// FIX-045: Go function returning (T, error) in expression lambda.
-			// Generate: _v, _err := expr; if _err != nil { panic(_err) }; return _v
+		} else if multiRetBody, multiRetType := t.tryWrapGoMultiReturnWithErrorPanic(expr); multiRetBody != nil {
+			// FIX-045: Go function returning (T, error) or (A, B, error) in expression lambda.
+			// Generate error-panic wrapper and update return type to match.
 			body = multiRetBody
+			if multiRetType != nil && !isConcreteExpectedType {
+				retType = multiRetType
+			}
 		} else {
 			body = &ast.BlockStmt{
 				List: []ast.Stmt{
@@ -172,18 +175,25 @@ func (t *galaASTTransformer) transformLambdaWithExpectedType(ctx *grammar.Lambda
 }
 
 // tryWrapGoMultiReturnWithErrorPanic checks if expr is a call to a Go function
-// returning (T, error). If so, generates a block that captures both returns,
-// panics on error, and returns the value. Returns nil if not applicable.
+// whose last return value is error. If so, generates a block that captures all
+// returns, panics on error, and returns the non-error values.
+//
+// Supported patterns:
+//   - (T, error)       -> returns T
+//   - (A, B, error)    -> returns Tuple[A, B]
+//   - (A, B, C, error) -> returns Tuple3[A, B, C]
+//   - etc. up to Tuple10
+//
 // This enables patterns like Try(() => os.MkdirTemp("", "prefix-*")) where
 // os.MkdirTemp returns (string, error) -- the error is converted to a panic
 // which Try catches as Failure.
-func (t *galaASTTransformer) tryWrapGoMultiReturnWithErrorPanic(expr ast.Expr) *ast.BlockStmt {
+func (t *galaASTTransformer) tryWrapGoMultiReturnWithErrorPanic(expr ast.Expr) (*ast.BlockStmt, ast.Expr) {
 	if t.goTypeInfo == nil {
-		return nil
+		return nil, nil
 	}
 	callExpr, ok := expr.(*ast.CallExpr)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	// Extract the qualified function name from the call
@@ -195,26 +205,83 @@ func (t *galaASTTransformer) tryWrapGoMultiReturnWithErrorPanic(expr ast.Expr) *
 		}
 	}
 	if qualifiedName == "" {
-		return nil
+		return nil, nil
 	}
 
 	sig := t.goTypeInfo.GetFuncSignature(qualifiedName)
-	if sig == nil || len(sig.Returns) != 2 {
-		return nil
+	if sig == nil || len(sig.Returns) < 2 {
+		return nil, nil
 	}
 
-	// Check that the second return is error
-	secondRet := sig.Returns[1]
-	if secondRet == nil || secondRet.String() != "error" {
-		return nil
+	// Check that the LAST return is error
+	lastRet := sig.Returns[len(sig.Returns)-1]
+	if lastRet == nil || lastRet.String() != "error" {
+		return nil, nil
 	}
 
-	// Generate: _v, _err := expr; if _err != nil { panic(_err) }; return _v
+	// Number of non-error return values
+	valueCount := len(sig.Returns) - 1
+
+	// Build LHS variable names: _v0, _v1, ... _vN, _err
+	var lhsExprs []ast.Expr
+	for i := 0; i < valueCount; i++ {
+		lhsExprs = append(lhsExprs, ast.NewIdent(fmt.Sprintf("_v%d", i)))
+	}
+	lhsExprs = append(lhsExprs, ast.NewIdent("_err"))
+
+	// Build the return expression and type
+	var returnExpr ast.Expr
+	var returnTypeExpr ast.Expr
+	if valueCount == 1 {
+		// (T, error) -> return _v0, type is T
+		returnExpr = ast.NewIdent("_v0")
+		returnTypeExpr = t.typeToExpr(sig.Returns[0])
+	} else {
+		// (A, B, error) -> return std.Tuple[A, B]{V1: _v0, V2: _v1}
+		// (A, B, C, error) -> return std.Tuple3[A, B, C]{V1: _v0, V2: _v1, V3: _v2}
+		// etc.
+		tupleName := "Tuple"
+		if valueCount > 2 {
+			tupleName = fmt.Sprintf("Tuple%d", valueCount)
+		}
+
+		// Build type args from the non-error return types
+		var typeArgs []ast.Expr
+		for i := 0; i < valueCount; i++ {
+			typeArgs = append(typeArgs, t.typeToExpr(sig.Returns[i]))
+		}
+
+		// Build tuple type expression: std.Tuple[A, B] or std.Tuple3[A, B, C]
+		var tupleType ast.Expr
+		tupleBase := t.stdIdent(tupleName)
+		if len(typeArgs) == 1 {
+			tupleType = &ast.IndexExpr{X: tupleBase, Index: typeArgs[0]}
+		} else {
+			tupleType = &ast.IndexListExpr{X: tupleBase, Indices: typeArgs}
+		}
+
+		// Build field key-value pairs: V1: _v0, V2: _v1, ...
+		var elts []ast.Expr
+		for i := 0; i < valueCount; i++ {
+			elts = append(elts, &ast.KeyValueExpr{
+				Key:   ast.NewIdent(fmt.Sprintf("V%d", i+1)),
+				Value: ast.NewIdent(fmt.Sprintf("_v%d", i)),
+			})
+		}
+
+		returnExpr = &ast.CompositeLit{
+			Type: tupleType,
+			Elts: elts,
+		}
+		returnTypeExpr = tupleType
+		t.needsStdImport = true
+	}
+
 	return &ast.BlockStmt{
 		List: []ast.Stmt{
-			// _v, _err := goFunc(args...)
+			// _v0, _v1, ..., _err := goFunc(args...)
 			&ast.AssignStmt{
-				Lhs: []ast.Expr{ast.NewIdent("_v"), ast.NewIdent("_err")},
+				Lhs: lhsExprs,
 				Tok: token.DEFINE,
 				Rhs: []ast.Expr{callExpr},
 			},
@@ -234,10 +301,10 @@ func (t *galaASTTransformer) tryWrapGoMultiReturnWithErrorPanic(expr ast.Expr) *
 					},
 				},
 			},
-			// return _v
-			&ast.ReturnStmt{Results: []ast.Expr{ast.NewIdent("_v")}},
+			// return _v0  (or std.Tuple[A,B]{V1: _v0, V2: _v1})
+			&ast.ReturnStmt{Results: []ast.Expr{returnExpr}},
 		},
-	}
+	}, returnTypeExpr
 }
 
 // inferBlockReturnType tries to infer the return type from a block's return statements.

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -138,6 +138,10 @@ func (t *galaASTTransformer) transformLambdaWithExpectedType(ctx *grammar.Lambda
 					&ast.ExprStmt{X: expr},
 				},
 			}
+		} else if multiRetBody := t.tryWrapGoMultiReturnWithErrorPanic(expr); multiRetBody != nil {
+			// FIX-045: Go function returning (T, error) in expression lambda.
+			// Generate: _v, _err := expr; if _err != nil { panic(_err) }; return _v
+			body = multiRetBody
 		} else {
 			body = &ast.BlockStmt{
 				List: []ast.Stmt{
@@ -165,6 +169,75 @@ func (t *galaASTTransformer) transformLambdaWithExpectedType(ctx *grammar.Lambda
 		Type: funcType,
 		Body: body,
 	}, nil
+}
+
+// tryWrapGoMultiReturnWithErrorPanic checks if expr is a call to a Go function
+// returning (T, error). If so, generates a block that captures both returns,
+// panics on error, and returns the value. Returns nil if not applicable.
+// This enables patterns like Try(() => os.MkdirTemp("", "prefix-*")) where
+// os.MkdirTemp returns (string, error) -- the error is converted to a panic
+// which Try catches as Failure.
+func (t *galaASTTransformer) tryWrapGoMultiReturnWithErrorPanic(expr ast.Expr) *ast.BlockStmt {
+	if t.goTypeInfo == nil {
+		return nil
+	}
+	callExpr, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return nil
+	}
+
+	// Extract the qualified function name from the call
+	qualifiedName := ""
+	switch fun := callExpr.Fun.(type) {
+	case *ast.SelectorExpr:
+		if id, ok := fun.X.(*ast.Ident); ok {
+			qualifiedName = id.Name + "." + fun.Sel.Name
+		}
+	}
+	if qualifiedName == "" {
+		return nil
+	}
+
+	sig := t.goTypeInfo.GetFuncSignature(qualifiedName)
+	if sig == nil || len(sig.Returns) != 2 {
+		return nil
+	}
+
+	// Check that the second return is error
+	secondRet := sig.Returns[1]
+	if secondRet == nil || secondRet.String() != "error" {
+		return nil
+	}
+
+	// Generate: _v, _err := expr; if _err != nil { panic(_err) }; return _v
+	return &ast.BlockStmt{
+		List: []ast.Stmt{
+			// _v, _err := goFunc(args...)
+			&ast.AssignStmt{
+				Lhs: []ast.Expr{ast.NewIdent("_v"), ast.NewIdent("_err")},
+				Tok: token.DEFINE,
+				Rhs: []ast.Expr{callExpr},
+			},
+			// if _err != nil { panic(_err) }
+			&ast.IfStmt{
+				Cond: &ast.BinaryExpr{
+					X:  ast.NewIdent("_err"),
+					Op: token.NEQ,
+					Y:  ast.NewIdent("nil"),
+				},
+				Body: &ast.BlockStmt{
+					List: []ast.Stmt{
+						&ast.ExprStmt{X: &ast.CallExpr{
+							Fun:  ast.NewIdent("panic"),
+							Args: []ast.Expr{ast.NewIdent("_err")},
+						}},
+					},
+				},
+			},
+			// return _v
+			&ast.ReturnStmt{Results: []ast.Expr{ast.NewIdent("_v")}},
+		},
+	}
 }
 
 // inferBlockReturnType tries to infer the return type from a block's return statements.

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -260,12 +260,16 @@ func (t *galaASTTransformer) tryWrapGoMultiReturnWithErrorPanic(expr ast.Expr) (
 			tupleType = &ast.IndexListExpr{X: tupleBase, Indices: typeArgs}
 		}
 
-		// Build field key-value pairs: V1: _v0, V2: _v1, ...
+		// Build field key-value pairs: V1: NewImmutable(_v0), V2: NewImmutable(_v1), ...
+		// Tuple fields are Immutable[T] (val fields)
 		var elts []ast.Expr
 		for i := 0; i < valueCount; i++ {
 			elts = append(elts, &ast.KeyValueExpr{
-				Key:   ast.NewIdent(fmt.Sprintf("V%d", i+1)),
-				Value: ast.NewIdent(fmt.Sprintf("_v%d", i)),
+				Key: ast.NewIdent(fmt.Sprintf("V%d", i+1)),
+				Value: &ast.CallExpr{
+					Fun:  t.stdIdent("NewImmutable"),
+					Args: []ast.Expr{ast.NewIdent(fmt.Sprintf("_v%d", i))},
+				},
 			})
 		}
 

--- a/internal/transpiler/transformer/type_inference.go
+++ b/internal/transpiler/transformer/type_inference.go
@@ -56,7 +56,20 @@ func (t *galaASTTransformer) getExprTypeNameManualUncached(expr ast.Expr) transp
 		if e.Name == "true" || e.Name == "false" {
 			return transpiler.BasicType{Name: "bool"}
 		}
-		return t.getType(e.Name)
+		if typ := t.getType(e.Name); !typ.IsNil() {
+			return typ
+		}
+		// Check if this is a reference to a known GALA function (e.g., passing getAnswer as func() int).
+		if fm, ok := t.functions[e.Name]; ok && len(fm.TypeParams) == 0 {
+			var params []transpiler.Type
+			params = append(params, fm.ParamTypes...)
+			var results []transpiler.Type
+			if fm.ReturnType != nil && !fm.ReturnType.IsNil() {
+				results = append(results, fm.ReturnType)
+			}
+			return transpiler.FuncType{Params: params, Results: results}
+		}
+		return transpiler.NilType{}
 	case *ast.IndexExpr:
 		xType := t.getExprTypeNameManual(e.X)
 		if arr, ok := xType.(transpiler.ArrayType); ok {
@@ -150,6 +163,15 @@ func (t *galaASTTransformer) getExprTypeNameManualUncached(expr ast.Expr) transp
 					}
 					if varType, ok := t.goTypeInfo.Variables[qualName]; ok && varType != nil {
 						return varType
+					}
+					// Check if this is a Go function reference (e.g., os.TempDir without parens).
+					// Return a FuncType so it can unify with expected func() T parameters.
+					if sig := t.goTypeInfo.GetFuncSignature(qualName); sig != nil {
+						var params []transpiler.Type
+						for _, p := range sig.Params {
+							params = append(params, p.Type)
+						}
+						return transpiler.FuncType{Params: params, Results: sig.Returns}
 					}
 				}
 				return transpiler.NamedType{Package: pkgName, Name: e.Sel.Name}


### PR DESCRIPTION
## Summary

- **FIX-044**: Fix type param inference for generic Apply methods — use `unifyForInference` instead of direct string comparison, enabling `func() T` params to unify with lambda arg types
- **FIX-045**: Support Go functions returning `(T, error)` and `(A, B, error)` in expression lambdas — auto-wrap with error-panic and Tuple construction
- **Function reference sugar**: `Try(os.TempDir)` and `Try(getAnswer)` now work without lambda wrappers — type is inferred from Go/GALA function signatures
- Documentation and lint/code skills updated to recommend `Try(f)` over `Try(() => f())` for zero-arg functions

## Test plan

- [x] `bazel build //...` passes
- [x] `bazel test //...` passes (191/191)
- [x] New example `try_func_ref.gala` — verifies Go + GALA function references
- [x] Updated `try_go_interop.gala` — verifies `(A, B, error)` multi-return with Tuple

🤖 Generated with [Claude Code](https://claude.com/claude-code)