### PR TITLE
fix: map HM inference 'unit' type to VoidType in match expressions

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -19,6 +19,7 @@ filegroup(
         "lib/generic.gala",
         "match_method_chain/main.gala",
         "match_method_chain/types.gala",
+        "match_void_branches.gala",
         "mathlib/math.gala",
         "multi_file/greeter.gala",
         "multi_file/main.gala",
@@ -1216,4 +1217,11 @@ gala_test(
     src = "go_type_inference_cross_pkg.gala",
     expected = "go_type_inference_cross_pkg.out",
     deps = [":go_type_inference_lib"],
+)
+
+# FIX-046 verification: match with void function branches should not generate 'unit' type
+gala_test(
+    name = "match_void_branches",
+    src = "match_void_branches.gala",
+    expected = "match_void_branches.out",
 )

--- a/examples/match_void_branches.gala
+++ b/examples/match_void_branches.gala
@@ -1,0 +1,19 @@
+package main
+
+func greet(name string) {
+    Println(s"Hello, $name!")
+}
+
+func farewell(name string) {
+    Println(s"Goodbye, $name!")
+}
+
+func main() {
+    val result = Some("World")
+    result match {
+        case Some(name) => greet(name)
+        case None() => farewell("nobody")
+    }
+
+    Println("Done")
+}

--- a/examples/match_void_branches.out
+++ b/examples/match_void_branches.out
@@ -1,0 +1,2 @@
+Hello, World!
+Done

--- a/internal/transpiler/transformer/bridge.go
+++ b/internal/transpiler/transformer/bridge.go
@@ -75,6 +75,9 @@ func (t *galaASTTransformer) fromInferType(typ infer.Type) transpiler.Type {
 
 	switch v := typ.(type) {
 	case *infer.TypeConst:
+		if v.Name == "unit" {
+			return transpiler.VoidType{}
+		}
 		return transpiler.ParseType(v.Name)
 	case *infer.TypeVariable:
 		// Unresolved type variable - return NilType to signal inference failure


### PR DESCRIPTION
## Summary

Fixes **FIX-046**: Match expressions with void function branches generated `unit` as Go return type.

**Category**: TRANSPILER_BUG
**Priority**: P0
**Found in**: gala-playground (transpiler-016.md)

## Root Cause

`fromInferType` in `bridge.go` converted HM type inference's `TypeConst{Name: "unit"}` to `BasicType{Name: "unit"}` via `ParseType("unit")`. This is NOT recognized as `VoidType{}` by the match expression code, so the IIFE gets `unit` as its Go return type — which is undefined in Go.

## Changes

- `internal/transpiler/transformer/bridge.go`: Added check in `fromInferType` to map `TypeConst{Name: "unit"}` to `VoidType{}`
- `examples/match_void_branches.gala`: Verification example with void function branches in match

## Verification

- `examples/match_void_branches.gala` compiles and runs correctly
- `bazel build //...` passes
- `bazel test //...` passes (192/192)

## Repro (before fix)

```gala
findGala() match {
    case None() => Println("GALA binary not found.")
    case Some(galaBin) => startServer(galaBin)
}
```

Generated `func(obj std.Option[string]) unit { ... }` — `undefined: unit`

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: Issue 3 in transpiler-016.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)