### PR TITLE
fix: add ImportPath to NamedType for transitive Go import resolution

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -19,7 +19,11 @@ filegroup(
         "lib/generic.gala",
         "match_method_chain/main.gala",
         "match_method_chain/types.gala",
+<<<<<<< HEAD
         "match_void_branches.gala",
+=======
+        "try_go_transitive_import.gala",
+>>>>>>> 8ced2cb (fix: add ImportPath to NamedType for transitive Go import resolution)
         "mathlib/math.gala",
         "multi_file/greeter.gala",
         "multi_file/main.gala",
@@ -1224,4 +1228,11 @@ gala_test(
     name = "match_void_branches",
     src = "match_void_branches.gala",
     expected = "match_void_branches.out",
+)
+
+# FIX-045 verification: transitive Go import for return types (e.g., io/fs from os.Stat)
+gala_test(
+    name = "try_go_transitive_import",
+    src = "try_go_transitive_import.gala",
+    expected = "try_go_transitive_import.out",
 )

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -19,11 +19,8 @@ filegroup(
         "lib/generic.gala",
         "match_method_chain/main.gala",
         "match_method_chain/types.gala",
-<<<<<<< HEAD
         "match_void_branches.gala",
-=======
         "try_go_transitive_import.gala",
->>>>>>> 8ced2cb (fix: add ImportPath to NamedType for transitive Go import resolution)
         "mathlib/math.gala",
         "multi_file/greeter.gala",
         "multi_file/main.gala",

--- a/examples/try_go_transitive_import.gala
+++ b/examples/try_go_transitive_import.gala
@@ -1,0 +1,11 @@
+package main
+
+import "os"
+
+func main() {
+    val result = Try(() => os.Stat("."))
+    result match {
+        case Success(_) => Println("Current directory exists")
+        case Failure(err) => Println(s"Error: $err")
+    }
+}

--- a/examples/try_go_transitive_import.out
+++ b/examples/try_go_transitive_import.out
@@ -1,0 +1,1 @@
+Current directory exists

--- a/internal/transpiler/analyzer/go_types.go
+++ b/internal/transpiler/analyzer/go_types.go
@@ -417,8 +417,9 @@ func goTypeToTranspilerType(t types.Type) transpiler.Type {
 			return goTypeToTranspilerType(types.Unalias(t))
 		}
 		return transpiler.NamedType{
-			Package: pkg.Name(),
-			Name:    obj.Name(),
+			Package:    pkg.Name(),
+			Name:       obj.Name(),
+			ImportPath: pkg.Path(),
 		}
 
 	case *types.Alias:

--- a/internal/transpiler/transformer/types.go
+++ b/internal/transpiler/transformer/types.go
@@ -203,6 +203,10 @@ func (t *galaASTTransformer) typeToExpr(typ transpiler.Type) ast.Expr {
 			// so it can be added to the output file.
 			if path, ok := t.importManager.GetPath(v.Package); ok {
 				t.additionalImports[path] = pkgName
+			} else if v.ImportPath != "" {
+				// Fallback: use the import path from Go type analysis
+				// (e.g., os.Stat returns fs.FileInfo — "io/fs" not in GALA imports)
+				t.additionalImports[v.ImportPath] = pkgName
 			}
 			return &ast.SelectorExpr{
 				X:   ast.NewIdent(pkgName),

--- a/internal/transpiler/types.go
+++ b/internal/transpiler/types.go
@@ -26,8 +26,9 @@ func (t BasicType) GetPackage() string { return "" }
 
 // NamedType represents a named type, potentially package-qualified.
 type NamedType struct {
-	Package string
-	Name    string
+	Package    string
+	Name       string
+	ImportPath string // Full Go import path (e.g., "io/fs"), used for transitive imports from Go type analysis
 }
 
 func (t NamedType) String() string {


### PR DESCRIPTION
## Summary

Fixes **FIX-045**: When Go functions return types from packages not directly imported in GALA source (e.g., `os.Stat` returns `fs.FileInfo` from `io/fs`), the import was silently dropped.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1
**Found in**: gala-playground (transpiler-016.md)

## Root Cause

`goTypeToTranspilerType` in `go_types.go` created `NamedType{Package: "fs"}` but didn't store the full import path `"io/fs"`. When `typeToExpr` tried to add a transitive import via `importManager.GetPath("fs")`, it failed because `"fs"` was never registered in the import manager.

## Changes

- `internal/transpiler/types.go`: Added `ImportPath` field to `NamedType`
- `internal/transpiler/analyzer/go_types.go`: Populated `ImportPath` with `pkg.Path()` in `goTypeToTranspilerType`
- `internal/transpiler/transformer/types.go`: Added fallback in `typeToExpr` to use `ImportPath` when import manager doesn't know the package
- `examples/try_go_transitive_import.gala`: Verification example using `os.Stat`

## Verification

- `examples/try_go_transitive_import.gala` compiles and runs correctly
- `bazel build //...` passes
- `bazel test //...` passes

## Repro (before fix)

```gala
val result = Try(() => os.Stat("."))
```

Generated `std.Try[fs.FileInfo]{}.Apply(...)` but missing `import "io/fs"` — `undefined: fs`

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: Issue 2 in transpiler-016.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)