### PR TITLE
fix: auto-destructure (T, error) Go returns in val declarations

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1233,3 +1233,10 @@ gala_test(
     src = "try_go_transitive_import.gala",
     expected = "try_go_transitive_import.out",
 )
+
+# FIX-044 verification: auto-destructure (T, error) Go returns in val declarations
+gala_test(
+    name = "try_val_destructure",
+    src = "try_val_destructure.gala",
+    expected = "try_val_destructure.out",
+)

--- a/examples/try_val_destructure.gala
+++ b/examples/try_val_destructure.gala
@@ -1,0 +1,19 @@
+package main
+
+import (
+    "os"
+    "path/filepath"
+)
+
+func main() {
+    val tmpDir = os.MkdirTemp("", "gala-test-*")
+    val path = filepath.Join(tmpDir, "test.txt")
+    val f = os.Create(path)
+    f.WriteString("hello from gala")
+    f.Close()
+
+    val data = os.ReadFile(path)
+    Println(string(data))
+
+    os.RemoveAll(tmpDir)
+}

--- a/examples/try_val_destructure.out
+++ b/examples/try_val_destructure.out
@@ -1,0 +1,1 @@
+hello from gala

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -326,6 +326,10 @@ func (t *galaASTTransformer) transformValDeclaration(ctx *grammar.ValDeclaration
 			val = &ast.IndexExpr{X: t.unwrapImmutable(rhsExprs[0]), Index: &ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", i)}}
 		}
 
+		// Auto-destructure Go functions returning (T, error): wrap in IIFE that
+		// panics on error and returns only the non-error value.
+		val = t.wrapGoMultiReturnAsIIFE(val)
+
 		if t.isNoneCall(val) && ctx.Type_() == nil {
 			return nil, t.semanticErrorAt(ctx, "variable assigned to None() must have an explicit type")
 		}

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -311,6 +311,31 @@ func (t *galaASTTransformer) tryWrapGoMultiReturnWithErrorPanic(expr ast.Expr) (
 	}, returnTypeExpr
 }
 
+// wrapGoMultiReturnAsIIFE wraps a Go function call returning (T, error) in an IIFE
+// that destructures the return, panics on error, and returns the non-error value.
+// If the expression is not a multi-return Go call, returns the original expression unchanged.
+//
+// Example: os.Create(path) which returns (*os.File, error) becomes:
+//
+//	func() *os.File { _v0, _err := os.Create(path); if _err != nil { panic(_err) }; return _v0 }()
+func (t *galaASTTransformer) wrapGoMultiReturnAsIIFE(expr ast.Expr) ast.Expr {
+	block, returnTypeExpr := t.tryWrapGoMultiReturnWithErrorPanic(expr)
+	if block == nil {
+		return expr
+	}
+	// Wrap in IIFE: func() T { ... }()
+	return &ast.CallExpr{
+		Fun: &ast.FuncLit{
+			Type: &ast.FuncType{
+				Results: &ast.FieldList{
+					List: []*ast.Field{{Type: returnTypeExpr}},
+				},
+			},
+			Body: block,
+		},
+	}
+}
+
 // inferBlockReturnType tries to infer the return type from a block's return statements.
 // Returns nil if no concrete type can be inferred.
 func (t *galaASTTransformer) inferBlockReturnType(block *ast.BlockStmt) ast.Expr {

--- a/internal/transpiler/transformer/statements.go
+++ b/internal/transpiler/transformer/statements.go
@@ -212,6 +212,9 @@ func (t *galaASTTransformer) transformShortVarDeclWithMutability(ctx *grammar.Sh
 			val = &ast.IndexExpr{X: t.unwrapImmutable(rhsExprs[0]), Index: &ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", i)}}
 		}
 
+		// Auto-destructure Go functions returning (T, error)
+		val = t.wrapGoMultiReturnAsIIFE(val)
+
 		if t.isNoneCall(val) {
 			return nil, galaerr.NewSemanticError("variable assigned to None() must have an explicit type")
 		}


### PR DESCRIPTION
## Summary

Fixes **FIX-044**: `val` assignments calling Go functions that return `(T, error)` now properly destructure the multi-return, panicking on error and keeping only the non-error value.

**Category**: TRANSPILER_BUG
**Priority**: P0
**Found in**: gala-playground (transpiler-016.md)

## Root Cause

`transformValDeclaration` treated `val f = os.Create(path)` as a single-value expression and wrapped the entire `(T, error)` return in `NewImmutable(os.Create(...))`, causing `too many arguments` compilation errors.

The `tryWrapGoMultiReturnWithErrorPanic` logic only ran for expression lambdas, not for `val` statements inside block lambdas.

## Changes

- `internal/transpiler/transformer/lambdas.go`: Added `wrapGoMultiReturnAsIIFE` helper that wraps `(T, error)` calls in `func() T { _v0, _err := ...; if _err != nil { panic(_err) }; return _v0 }()`
- `internal/transpiler/transformer/declarations.go`: Call `wrapGoMultiReturnAsIIFE` before `NewImmutable` wrapping
- `internal/transpiler/transformer/statements.go`: Same for short var declarations
- `examples/try_val_destructure.gala`: Verification using `os.MkdirTemp`, `os.Create`, `os.ReadFile`

## Verification

- `examples/try_val_destructure.gala` compiles and runs correctly
- `bazel build //...` passes
- `bazel test //...` passes (192/192)

## Repro (before fix)

```gala
val f = os.Create(path)  // os.Create returns (*os.File, error)
```

Generated `var f = std.NewImmutable(os.Create(path))` — `too many arguments in call to std.NewImmutable`

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: Issue 1 in transpiler-016.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)