### PR TITLE
feat: add OrElse method to Option[T]

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -967,11 +967,29 @@ val msg = x match {
 // Monadic operations
 val result = x.Map((i int) => i * 2)
 
+// Safe value extraction
+val value = x.GetOrElse(0)
+val alternative = x.OrElse(Some(99))
+
 // Side-effect methods (return original value for chaining)
 x.OnSome((v) => { Println(s"Found: $v") })
  .OnNone(() => { Println("Not found") })
  .Map((i) => i * 2)
 ```
+
+#### Key Methods
+| Method | Description |
+|--------|-------------|
+| `IsDefined()` / `IsEmpty()` | Check the state |
+| `Get()` | Get value or panic |
+| `GetOrElse(default)` | Get value or return default |
+| `OrElse(alternative)` | Return this if Some, otherwise alternative |
+| `OnSome(f)` | Execute side-effect if Some, return original Option |
+| `OnNone(f)` | Execute side-effect if None, return original Option |
+| `ForEach(f)` | Apply procedure if nonempty |
+| `Map[U](f)` | Transform value if Some |
+| `FlatMap[U](f)` | Chain operations returning Option |
+| `Filter(predicate)` | Keep Some if predicate holds |
 
 ### Tuple
 `Tuple[A, B]` represents a pair of values. GALA supports concise parenthesis syntax for tuples (up to Tuple5).

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -122,6 +122,13 @@ gala_test(
     expected = "option_complex.out",
 )
 
+# Option.OrElse method verification
+gala_test(
+    name = "option_orelse_test",
+    src = "option_orelse_test.gala",
+    expected = "option_orelse_test.out",
+)
+
 gala_test(
     name = "match_method_return",
     src = "match_method_return.gala",

--- a/examples/option_orelse_test.gala
+++ b/examples/option_orelse_test.gala
@@ -1,0 +1,25 @@
+package main
+
+import "fmt"
+
+func main() {
+    // Test 1: Some.OrElse(other) returns the original Some
+    val some1 = Some(42)
+    val some2 = Some(99)
+    val result1 = some1.OrElse(some2)
+    fmt.Println("Some.OrElse(Some):", result1.Get())
+
+    // Test 2: None.OrElse(Some) returns the alternative Some
+    val none1 = None[int]()
+    val result2 = none1.OrElse(some1)
+    fmt.Println("None.OrElse(Some):", result2.Get())
+
+    // Test 3: None.OrElse(None) returns None
+    val none2 = None[int]()
+    val result3 = none1.OrElse(none2)
+    fmt.Println("None.OrElse(None) isEmpty:", result3.IsEmpty())
+
+    // Test 4: Chaining multiple OrElse calls
+    val result4 = None[string]().OrElse(None[string]()).OrElse(Some("found")).OrElse(Some("other"))
+    fmt.Println("Chained OrElse:", result4.Get())
+}

--- a/examples/option_orelse_test.out
+++ b/examples/option_orelse_test.out
@@ -1,0 +1,4 @@
+Some.OrElse(Some): 42
+None.OrElse(Some): 42
+None.OrElse(None) isEmpty: true
+Chained OrElse: found

--- a/std/option.gala
+++ b/std/option.gala
@@ -45,6 +45,14 @@ func (o Option[T]) GetOrElse(defaultValue T) T {
     return defaultValue
 }
 
+// OrElse returns this Option if it is Some, otherwise returns alternative.
+func (o Option[T]) OrElse(alternative Option[T]) Option[T] {
+    if o.isSome() {
+        return o
+    }
+    return alternative
+}
+
 // OnSome executes a callback with the value if this is Some,
 // returns the original Option unchanged (for chaining).
 func (o Option[T]) OnSome(f func(T)) Option[T] {


### PR DESCRIPTION
## Summary

- Adds `OrElse(alternative Option[T]) Option[T]` to `Option[T]`, consistent with `Try[T].OrElse` which already exists
- Returns the option if `Some`, otherwise returns the alternative

## Test plan

- [x] Verification example `examples/option_orelse_test.gala` covers Some.OrElse, None.OrElse, chaining
- [x] `bazel build //...` passes
- [x] `bazel test //...` passes (195 tests)
- [x] `docs/GALA.MD` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)