### PR TITLE
docs: modernize examples and add missing features

### DIFF
--- a/.claude/skills/gala-lint.md
+++ b/.claude/skills/gala-lint.md
@@ -145,8 +145,7 @@ func applyAll(handler Handler, filters ...Filter) Handler =
 import . "martianoff/gala/collection_immutable"
 
 val nums = ArrayOf(1, 2, 3, 4, 5)
-val evens = nums.Filter((x) => x % 2 == 0)
-val doubled = evens.Map((x) => x * 2)
+val evenDoubled = nums.Collect({ case n if n % 2 == 0 => n * 2 })
 val sum = nums.FoldLeft(0, (acc, x) => acc + x)
 ```
 
@@ -219,6 +218,9 @@ for _, x := range nums {
 | Manual accumulation | `var acc; for { acc = f(acc, x) }` | `list.FoldLeft(init, (acc, x) => f(acc, x))` |
 | Manual filter | `for { if cond { append } }` | `list.Filter(predicate)` |
 | Manual map | `for { result = append(result, f(x)) }` | `list.Map(f)` |
+| Filter then Map | `list.Filter(p).Map(f)` | `list.Collect({ case x if p(x) => f(x) })` |
+| Map then Filter (flatMap pattern) | `list.Map(f).Filter(p)` when f returns Option-like | `list.Collect({ case x if p(x) => f(x) })` |
+| FlatMap + Option for filter+transform | `list.FlatMap((x) => if p(x) { Some(f(x)) } else { None })` | `list.Collect({ case x if p(x) => f(x) })` |
 | Index-based iteration | `for i := 0; i < x.Length(); i++` | `x.ForEach(f)` or `for _, elem := range x` |
 | Option side effects | `if opt.IsDefined() { f(opt.Get()) }` | `opt.ForEach(f)` |
 | Reimplementing collection methods | Defining `Map`, `Filter`, `Fold` etc. with manual loops when wrapping a collection | Delegate to underlying collection's method |
@@ -228,6 +230,36 @@ for _, x := range nums {
 | Manual Reverse | `for i := len-1; i >= 0; i-- { append }` | `collection.Reverse()` |
 | Manual ZipWithIndex | `for i := 0; ...; result.Append((elem, i))` | `collection.ZipWithIndex()` |
 | Manual IndexOf | `for i := 0; ...; if elem == target { return i }` | `collection.IndexOfFirst(x => x == target)` |
+
+**Check**: Also search for `.Filter(` followed by `.Map(` on the same collection (chained or via intermediate val). These should use `.Collect` with a partial function instead.
+
+**Bad pattern** — Filter + Map chain:
+```gala
+// BAD: Two passes over the collection
+val evenDoubled = numbers.Filter((x) => x % 2 == 0).Map((x) => x * 2)
+
+// BAD: Filter + Map with intermediate val
+val adults = people.Filter((p) => p.Age >= 18)
+val names = adults.Map((p) => p.Name)
+
+// BAD: FlatMap with Option for conditional transform
+val results = items.FlatMap((x) => if x.IsValid() { Some(x.Transform()) } else { None[Output]() })
+```
+
+**Good pattern** — Collect with partial function:
+```gala
+// GOOD: Single pass, filter and transform together
+val evenDoubled = numbers.Collect({ case n if n % 2 == 0 => n * 2 })
+
+// GOOD: Collect with extractor
+val names = people.Collect({ case p if p.Age >= 18 => p.Name })
+
+// GOOD: Collect replaces FlatMap + Option
+val results = items.Collect({ case x if x.IsValid() => x.Transform() })
+
+// GOOD: Collect with sealed type extractor
+val values = options.Collect({ case Some(v) => v * 2 })
+```
 
 ### 8. Expression-Bodied Functions (MEDIUM priority)
 

--- a/collection_immutable/list.gala
+++ b/collection_immutable/list.gala
@@ -293,6 +293,19 @@ func (l List[T]) IndexOf(elem T) int {
     return -1
 }
 
+// LastIndexOf returns the index of the last occurrence of elem, or -1 if not found. O(n).
+func (l List[T]) LastIndexOf(elem T) int {
+    var result = -1
+    var current = l
+    for i := 0; !current.isEmpty; i++ {
+        if Equal(current.head, elem) {
+            result = i
+        }
+        current = *current.tail
+    }
+    return result
+}
+
 // Reverse returns a new list with elements in reverse order. O(n).
 func (l List[T]) Reverse() List[T] {
     return l.FoldLeft[List[T]](emptyList[T](), (acc List[T], elem T) => consList[T](elem, acc))

--- a/docs/CONCURRENT.MD
+++ b/docs/CONCURRENT.MD
@@ -40,29 +40,29 @@ val safe = async.GetOrElse(0)        // Returns int, default on failure
 ### Non-Blocking Callbacks
 
 ```gala
-async.OnSuccess((v int) => fmt.Println("Got:", v))
-async.OnFailure((e error) => fmt.Println("Error:", e))
-async.OnComplete((r Try[int]) => fmt.Println("Result:", r))
+async.OnSuccess((v) => Println(s"Got: $v"))
+async.OnFailure((e) => Println(s"Error: $e"))
+async.OnComplete((r) => Println(s"Result: $r"))
 ```
 
 ### Monadic Operations
 
 ```gala
-val doubled = async.Map[int]((v int) => v * 2)
-val chained = async.FlatMap[string]((v int) => fetchName(v))
+val doubled = async.Map((v) => v * 2)
+val chained = async.FlatMap((v) => fetchName(v))
 ```
 
 ### Error Recovery
 
 ```gala
-val recovered = failed.Recover((e error) => 0)
-val recoveredWith = failed.RecoverWith((e error) => FutureOf[int](0))
+val recovered = failed.Recover((e) => 0)
+val recoveredWith = failed.RecoverWith((e) => FutureOf[int](0))
 ```
 
 ### Combining Futures
 
 ```gala
-val zipped = f1.Zip[string](f2)      // Future[Tuple[int, string]]
+val zipped = f1.Zip(f2)               // Future[Tuple[int, string]]
 val first = f1.Fallback(f2)          // First success or last failure
 ```
 
@@ -77,22 +77,22 @@ val f = FutureOf[int](42)
 
 // With inferred type parameters (preferred)
 val msg = f match {
-    case Succeeded(v) => fmt.Sprintf("Got: %d", v)
-    case Failed(e) => fmt.Sprintf("Error: %s", e.Error())
+    case Succeeded(v) => s"Got: $v"
+    case Failed(e) => s"Error: ${e.Error()}"
     case _ => "Unknown"
 }
 
 // With explicit type parameters (when needed)
 val msg2 = f match {
-    case Succeeded[int](v) => fmt.Sprintf("Got: %d", v)
-    case Failed[int](e) => fmt.Sprintf("Error: %s", e.Error())
+    case Succeeded[int](v) => s"Got: $v"
+    case Failed[int](e) => s"Error: ${e.Error()}"
     case _ => "Unknown"
 }
 
 // Using Completed extractor with nested Try matching
 val msg3 = f match {
-    case Completed(Success(v)) => fmt.Sprintf("Success: %d", v)
-    case Completed(Failure(e)) => fmt.Sprintf("Failure: %s", e.Error())
+    case Completed(Success(v)) => s"Success: $v"
+    case Completed(Failure(e)) => s"Failure: ${e.Error()}"
     case _ => "Unknown"
 }
 ```
@@ -109,8 +109,8 @@ val all = Sequence[int](futures)     // Future[Array[int]]
 
 // Pattern matching on sequences
 val msg = futures match {
-    case AllSucceeded(values) => fmt.Sprintf("All: %v", values)
-    case AnyFailed(e) => fmt.Sprintf("Failed: %s", e.Error())
+    case AllSucceeded(values) => s"All: $values"
+    case AnyFailed(e) => s"Failed: ${e.Error()}"
     case _ => "Unknown"
 }
 
@@ -118,10 +118,10 @@ val msg = futures match {
 val first = FirstCompletedOf[int](futures)
 
 // Traverse: apply async function to each element
-val results = Traverse[int, string](items, (i int) => fetchAsync(i))
+val results = Traverse[int, string](items, (i) => fetchAsync(i))
 
 // Fold: reduce collection of Futures
-val sum = Fold[int, int](futures, 0, (acc int, v int) => acc + v)
+val sum = Fold[int, int](futures, 0, (acc, v) => acc + v)
 ```
 
 ---
@@ -158,8 +158,8 @@ val pool = NewFixedPoolEC(4)  // Worker pool with 4 goroutines
 val f2 = FutureApplyWith[int](() => compute(), pool)
 
 // Derived futures inherit EC from parent
-val f3 = f2.Map[string]((n int) => fmt.Sprintf("%d", n))  // uses pool
-val f4 = f3.FlatMap[int]((s string) => anotherFuture(s))  // uses pool
+val f3 = f2.Map((n) => s"$n")                             // uses pool
+val f4 = f3.FlatMap((s) => anotherFuture(s))              // uses pool
 
 // Cleanup
 pool.Shutdown()

--- a/docs/DEPENDENCY_MANAGEMENT.MD
+++ b/docs/DEPENDENCY_MANAGEMENT.MD
@@ -183,6 +183,8 @@ gala build -v
 2. Downloads Go dependencies to `~/.gala/go/pkg/mod/`
 3. Runs `go build` to produce the binary in your project directory
 
+**Auto-fetch**: `gala build` automatically downloads GALA dependencies listed in `gala.mod` that are not yet cached locally. No manual `gala mod download` step is needed.
+
 ### gala run
 
 Build and run a GALA project.
@@ -289,6 +291,8 @@ This command:
 - Removes unused dependencies
 - Marks indirect dependencies appropriately
 - **For Bazel projects**: Generates `go.mod` and `go.sum` with Go dependencies
+
+`gala mod tidy` handles both single-line and multi-line import blocks, and recognizes known GALA dependencies (like `std`, `collection_immutable`, etc.) automatically.
 
 ### gala mod graph
 

--- a/docs/EXAMPLES.MD
+++ b/docs/EXAMPLES.MD
@@ -9,7 +9,6 @@ The following example demonstrates many of GALA's features, including structs, i
 ```gala
 package main
 
-import "fmt"
 
 struct Point(X, Y int)
 
@@ -20,7 +19,7 @@ func main() {
     val p2 = moveX(p1, 5)
     
     val msg = if (p2.X > 10) "moved" else "static"
-    fmt.Println(msg, p2)
+    Println(msg, p2)
 }
 ```
 
@@ -29,7 +28,6 @@ func main() {
 ```gala
 package main
 
-import "fmt"
 
 func main() {
     val x = Some(10)
@@ -41,7 +39,7 @@ func main() {
         case _       => 0
     }
     
-    fmt.Println(res, z)
+    Println(res, z)
 }
 ```
 
@@ -50,7 +48,6 @@ func main() {
 ```gala
 package main
 
-import "fmt"
 
 type Box[T any] struct { Value T }
 
@@ -58,8 +55,8 @@ func (b Box[T]) Transform[U any](f func(T) U) Box[U] = Box[U](Value = f(b.Value)
 
 func main() {
     val b = Box[int](Value = 10)
-    val s = b.Transform((i int) => "Value is " + fmt.Sprintf("%d", i))
-    fmt.Println(s.Value)
+    val s = b.Transform((i int) => s"Value is $i")
+    Println(s.Value)
 }
 ```
 
@@ -68,16 +65,15 @@ func main() {
 ```gala
 package main
 
-import "fmt"
 
 struct Person(Name string, Age int)
 
 func main() {
-    val people = []Person{
+    val people = SliceOf(
         Person("Alice", 25),
         Person("Bob", 15),
         Person("Charlie", 70),
-    }
+    )
 
     for _, p := range people {
         val status = p match {
@@ -86,7 +82,7 @@ func main() {
             case Person(name, _)               => name + " is an adult"
             case _                             => "Unknown"
         }
-        fmt.Println(status)
+        Println(status)
     }
 }
 ```
@@ -96,7 +92,6 @@ func main() {
 ```gala
 package main
 
-import "fmt"
 
 type Even struct {}
 func (e Even) Unapply(i int) Option[int] = if (i % 2 == 0) Some(i) else None[int]()
@@ -105,19 +100,19 @@ func main() {
     val number = 42
     
     val description = number match {
-        case Even(n) => fmt.Sprintf("%d is an even number", n)
-        case _       => fmt.Sprintf("%d is odd", number)
+        case Even(n) => s"$n is an even number"
+        case _       => s"$number is odd"
     }
     
-    fmt.Println(description)
+    Println(description)
     
     // Nested patterns
     val opt = Some(10)
     opt match {
-        case Some(Even(n)) => fmt.Println("Found some even number", n)
-        case Some(n)       => fmt.Println("Found some odd number", n)
-        case None()        => fmt.Println("Nothing found")
-        case _             => fmt.Println("Other")
+        case Some(Even(n)) => Println("Found some even number", n)
+        case Some(n)       => Println("Found some odd number", n)
+        case None()        => Println("Nothing found")
+        case _             => Println("Other")
     }
 }
 ```
@@ -127,18 +122,17 @@ func main() {
 ```gala
 package main
 
-import "fmt"
 
 func main() {
     val x any = "hello"
     
     val res = x match {
-        case s: string => "string: " + s
-        case i: int    => fmt.Sprintf("int: %d", i)
+        case s: string => s"string: $s"
+        case i: int    => s"int: $i"
         case _         => "unknown"
     }
     
-    fmt.Println(res)
+    Println(res)
 }
 ```
 
@@ -147,7 +141,6 @@ func main() {
 ```gala
 package main
 
-import "fmt"
 
 type Wrap[T any] struct { Value T }
 func (w Wrap[T]) GetValue() any = w.Value
@@ -155,10 +148,10 @@ func (w Wrap[T]) GetValue() any = w.Value
 func main() {
     val w = Wrap[string](Value = "hello")
     val res = w match {
-        case w1: Wrap[_] => fmt.Sprintf("Matched Wrap[_]: %v", w1.GetValue())
+        case w1: Wrap[_] => s"Matched Wrap[_]: ${w1.GetValue()}"
         case _ => "Other"
     }
-    fmt.Println(res)
+    Println(res)
 }
 ```
 
@@ -167,7 +160,6 @@ func main() {
 ```gala
 package main
 
-import "fmt"
 
 // Define a generic type
 type Wrap[T any] struct {
@@ -186,28 +178,28 @@ func main() {
     // 1. Matching specific generic type
     val w1 = Wrap[int](Value = 42)
     val res1 = w1 match {
-        case w: Wrap[int] => fmt.Sprintf("Matched Wrap[int]: %d", w.Value)
+        case w: Wrap[int] => s"Matched Wrap[int]: ${w.Value}"
         case w: Wrap[string] => "Matched Wrap[string]: " + w.Value
         case _ => "Other"
     }
-    fmt.Println(res1)
+    Println(res1)
 
     // 2. Matching wildcard generic type
     val w2 = Wrap[string](Value = "hello")
     val res2 = w2 match {
-        case w: Wrap[_] => "Matched Wrap[_]: " + fmt.Sprintf("%v", w.Value)
+        case w: Wrap[_] => s"Matched Wrap[_]: ${w.Value}"
         case _          => "Other"
     }
-    fmt.Println(res2)
+    Println(res2)
 
     // 3. Using the generic extractor
     val w3 = Wrapper("GALA")
     val res3 = w3 match {
         case Wrapper(s: string) => "Extracted string: " + s
-        case Wrapper(i: int) => fmt.Sprintf("Extracted int: %d", i)
+        case Wrapper(i: int) => s"Extracted int: $i"
         case _ => "Other"
     }
-    fmt.Println(res3)
+    Println(res3)
 }
 ```
 
@@ -216,7 +208,6 @@ func main() {
 ```gala
 package main
 
-import "fmt"
 
 type Shaper interface {
     Area() float64
@@ -235,8 +226,8 @@ func main() {
     val s1 Shaper = r
     val s2 Shaper = c
     
-    fmt.Println("Area 1:", s1.Area())
-    fmt.Println("Area 2:", s2.Area())
+    Println("Area 1:", s1.Area())
+    Println("Area 2:", s2.Area())
 }
 ```
 
@@ -245,7 +236,6 @@ func main() {
 ```gala
 package main
 
-import "fmt"
 
 type Adder struct { Delta int }
 func (a Adder) Apply(x int) int = x + a.Delta
@@ -259,7 +249,7 @@ func main() {
     
     val res2 = Multiply(3, 4) // 12
     
-    fmt.Println(res1, res2)
+    Println(res1, res2)
 }
 ```
 
@@ -278,14 +268,11 @@ func Add(a int, b int) int = a + b
 ```gala
 package main
 
-import (
-    "fmt"
-    "martianoff/gala/examples/mathlib"
-)
+import "martianoff/gala/examples/mathlib"
 
 func main() {
     val sum = mathlib.Add(10, 20)
-    fmt.Println("Sum is", sum)
+    Println("Sum is", sum)
 }
 ```
 
@@ -296,7 +283,7 @@ import . "martianoff/gala/examples/mathlib"
 
 func main() {
     val sum = Add(10, 20)
-    fmt.Println("Sum is", sum)
+    Println("Sum is", sum)
 }
 ```
 
@@ -307,7 +294,6 @@ GALA uses the Hindley-Milner algorithm to infer types in complex scenarios, such
 ```gala
 package main
 
-import "fmt"
 
 func identity[T any](x T) T = x
 func getImm[T any](x T) Immutable[T] = NewImmutable(x)
@@ -315,7 +301,7 @@ func getImm[T any](x T) Immutable[T] = NewImmutable(x)
 func main() {
     // HM infers Immutable[int], which GALA then automatically unwraps to int
     var x = identity(getImm(42)) 
-    fmt.Printf("x: %d\n", x)
+    Println(s"x: $x")
 }
 ```
 
@@ -340,7 +326,7 @@ val opt = Some(42)
 
 // ForEach takes func(T) — void, no return needed
 opt.ForEach((x) => {
-    fmt.Println(x)
+    Println(x)
 })
 
 // Parameter type inferred from Option[int].Filter's signature
@@ -358,24 +344,84 @@ val s = S("hello")
 val hasVowel = s.Exists((r) => r == 'a' || r == 'e' || r == 'i' || r == 'o' || r == 'u')
 ```
 
+## Collect - Filter and Transform in One Pass
+
+`Collect` combines `Filter` and `Map` into a single operation using partial functions:
+
+```gala
+package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    val nums = ArrayOf(1, 2, 3, 4, 5, 6)
+
+    // Collect: filter and transform in one pass
+    val evenDoubled = nums.Collect({ case n if n % 2 == 0 => n * 2 })
+    Println(evenDoubled)  // Array(4, 8, 12)
+
+    // With sealed type extractors
+    val options = ArrayOf(Some(1), None[int](), Some(2), None[int](), Some(3))
+    val values = options.Collect({ case Some(v) => v * 10 })
+    Println(values)  // Array(10, 20, 30)
+}
+```
+
+## Option.OrElse - Fallback Options
+
+```gala
+package main
+
+func main() {
+    val primary = None[string]()
+    val fallback = Some("default")
+
+    val result = primary.OrElse(fallback)   // Some("default")
+    Println(result.Get())                    // "default"
+
+    val present = Some("actual")
+    val result2 = present.OrElse(fallback)  // Some("actual")
+    Println(result2.Get())                   // "actual"
+}
+```
+
+## Try with Function References
+
+When wrapping a zero-argument function, pass the function reference directly instead of wrapping in a lambda:
+
+```gala
+package main
+
+import "os"
+
+func main() {
+    // Function reference (preferred for zero-arg functions)
+    val dir = Try(os.TempDir)
+
+    // Lambda form (use when args needed)
+    val result = Try(() => os.MkdirAll("/tmp/test", 0755))
+
+    dir.OnSuccess((d) => Println(s"Temp dir: $d"))
+}
+```
+
 ## MkString - Joining Collection Elements
 
 ```gala
 package main
 
-import "fmt"
 import . "martianoff/gala/collection_immutable"
 
 func main() {
     val nums = ArrayOf(1, 2, 3, 4, 5)
-    fmt.Println(nums.MkString(", "))     // "1, 2, 3, 4, 5"
-    fmt.Println(nums.MkString(" | "))    // "1 | 2 | 3 | 4 | 5"
+    Println(nums.MkString(", "))     // "1, 2, 3, 4, 5"
+    Println(nums.MkString(" | "))    // "1 | 2 | 3 | 4 | 5"
 
     val words = ListOf("hello", "world")
-    fmt.Println(words.MkString(" "))     // "hello world"
+    Println(words.MkString(" "))     // "hello world"
 
     val empty = EmptyArray[int]()
-    fmt.Println(empty.MkString(", "))    // ""
+    Println(empty.MkString(", "))    // ""
 }
 ```
 
@@ -386,35 +432,34 @@ All collection types support `Sorted()`, `SortWith()`, and `SortBy()` for flexib
 ```gala
 package main
 
-import "fmt"
 import . "martianoff/gala/collection_immutable"
 
 func main() {
     // Array.Sorted - natural ordering
     val arr = ArrayOf(3, 1, 4, 1, 5, 9)
-    fmt.Println(arr.Sorted())                    // Array(1, 1, 3, 4, 5, 9)
+    Println(arr.Sorted())                    // Array(1, 1, 3, 4, 5, 9)
 
     // Array.SortWith - custom comparator (descending)
-    fmt.Println(arr.SortWith((a, b) => a > b))   // Array(9, 5, 4, 3, 1, 1)
+    Println(arr.SortWith((a, b) => a > b))   // Array(9, 5, 4, 3, 1, 1)
 
     // Array.SortBy - sort by key function
     val arr2 = ArrayOf(1, 9, 3, 7, 5)
-    fmt.Println(arr2.SortBy((x) => x))           // Array(1, 3, 5, 7, 9)
+    Println(arr2.SortBy((x) => x))           // Array(1, 3, 5, 7, 9)
 
     // List.Sorted
     val list = ListOf("banana", "apple", "cherry")
-    fmt.Println(list.Sorted())                   // List(apple, banana, cherry)
+    Println(list.Sorted())                   // List(apple, banana, cherry)
 
     // TreeSet.Sorted (already sorted)
     val tree = TreeSetOf(30, 10, 20)
-    fmt.Println(tree.Sorted())                   // Array(10, 20, 30)
+    Println(tree.Sorted())                   // Array(10, 20, 30)
 
     // HashSet.Sorted
     val set = HashSetOf(5, 3, 1)
-    fmt.Println(set.Sorted())                    // Array(1, 3, 5)
+    Println(set.Sorted())                    // Array(1, 3, 5)
 
     // Empty collection
-    fmt.Println(EmptyArray[int]().Sorted())      // Array()
+    Println(EmptyArray[int]().Sorted())      // Array()
 }
 ```
 
@@ -425,13 +470,12 @@ Type aliases create alternative names for existing types, useful for re-exportin
 ```gala
 package main
 
-import "fmt"
 
 type MyString string
 
 func main() {
     val s MyString = "hello"
-    fmt.Println(s)
+    Println(s)
 }
 ```
 

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -919,6 +919,8 @@ val evenDoubled = numbers.Collect({ case n if n % 2 == 0 => n * 2 })
 // Result: [4, 8]
 ```
 
+**Tip**: `Collect` is preferred over chaining `.Filter(p).Map(f)` as it combines both operations in a single pass.
+
 #### Extractors in Partial Functions
 When using extractors like `Some(n)`, the parameter type needs to be inferrable from context:
 
@@ -960,12 +962,12 @@ val y = None[int]()
 
 // Pattern matching (exhaustive - no case _ needed)
 val msg = x match {
-    case Some(v) => fmt.Sprintf("Got: %d", v)
+    case Some(v) => s"Got: $v"
     case None()  => "Empty"
 }
 
 // Monadic operations
-val result = x.Map((i int) => i * 2)
+val result = x.Map((i) => i * 2)
 
 // Safe value extraction
 val value = x.GetOrElse(0)
@@ -1004,7 +1006,7 @@ val t2 = Tuple[int, string](V1 = 1, V2 = "hello")
 
 // Pattern matching works with both
 val msg = t match {
-    case (a, b) => fmt.Sprintf("Got %d and %s", a, b)
+    case (a, b) => s"Got $a and $b"
     case _      => "Unknown"
 }
 
@@ -1029,18 +1031,18 @@ sealed type Either[A any, B any] {
 
 val e = Right[int, string]("success")
 val msg = e match {
-    case Left(code) => fmt.Sprintf("Error code: %d", code)
+    case Left(code) => s"Error code: $code"
     case Right(s)   => "Result: " + s
 }
 
 // Monadic operations are biased towards Right
-val length = e.Map((s string) => len(s))
+val length = e.Map((s) => len(s))
 
 // FlatMap chains computations that return Either
-val result = Right[string, int](5).FlatMap((x int) => Right[string, int](x + 100))
+val result = Right[string, int](5).FlatMap((x) => Right[string, int](x + 100))
 
 // Chaining Map and FlatMap
-val chained = Right[string, int](3).Map((x int) => x * 10).FlatMap((x int) => Right[string, int](x + 1))
+val chained = Right[string, int](3).Map((x) => x * 10).FlatMap((x) => Right[string, int](x + 1))
 
 // Side-effect methods (return original value for chaining)
 val logged = Right[string, int](42)
@@ -1073,17 +1075,17 @@ val answer = Try(getAnswer)             // works with GALA functions too
 
 // Pattern matching (exhaustive - no case _ needed)
 val msg = success match {
-    case Success(n) => fmt.Sprintf("Got: %d", n)
-    case Failure(e) => fmt.Sprintf("Error: %s", e.Error())
+    case Success(n) => s"Got: $n"
+    case Failure(e) => s"Error: ${e.Error()}"
 }
 
 // Monadic operations
-val doubled = success.Map[int]((n int) => n * 2)
-val result = success.FlatMap[int]((n int) => divide(n, 2))
+val doubled = success.Map((n) => n * 2)
+val result = success.FlatMap((n) => divide(n, 2))
 
 // Recovery
-val recovered = failure.Recover((e error) => 0)
-val recoveredWith = failure.RecoverWith((e error) => Success(0))
+val recovered = failure.Recover((e) => 0)
+val recoveredWith = failure.RecoverWith((e) => Success(0))
 
 // Side-effect methods (return original value for chaining)
 val logged = success
@@ -1166,13 +1168,13 @@ val result = async.Await()           // Returns Try[int]
 val value = async.GetOrElse(0)       // Returns int, default on failure
 
 // Monadic operations
-val doubled = async.Map[int]((v int) => v * 2)
-val chained = async.FlatMap[string]((v int) => fetchName(v))
+val doubled = async.Map((v) => v * 2)
+val chained = async.FlatMap((v) => fetchName(v))
 
 // Pattern matching
 val msg = async match {
-    case Succeeded(v) => fmt.Sprintf("Got: %d", v)
-    case Failed(e) => fmt.Sprintf("Error: %s", e.Error())
+    case Succeeded(v) => s"Got: $v"
+    case Failed(e) => s"Error: ${e.Error()}"
     case _ => "Unknown"
 }
 ```

--- a/docs/IMMUTABLE_COLLECTIONS.MD
+++ b/docs/IMMUTABLE_COLLECTIONS.MD
@@ -200,8 +200,8 @@ val list = ListOf(1, 2, 3, 4, 5)
 
 list.Take(3)                 // List(1, 2, 3)
 list.Drop(2)                 // List(3, 4, 5)
-list.TakeWhile((x int) => x < 4)  // List(1, 2, 3)
-list.DropWhile((x int) => x < 3)  // List(3, 4, 5)
+list.TakeWhile((x) => x < 4)  // List(1, 2, 3)
+list.DropWhile((x) => x < 3)  // List(3, 4, 5)
 list.SplitAt(2)              // Tuple(List(1, 2), List(3, 4, 5))
 ```
 
@@ -213,7 +213,7 @@ val list = ListOf(1, 2, 3, 4, 5)
 list.Contains(3)             // true
 list.IndexOf(3)              // 2
 list.IndexOf(10)             // -1
-list.Find((x int) => x > 3)  // Some(4)
+list.Find((x) => x > 3)  // Some(4)
 ```
 
 ### Transformations
@@ -222,18 +222,22 @@ list.Find((x int) => x > 3)  // Some(4)
 val list = ListOf(1, 2, 3)
 
 // Map
-list.Map[int]((x int) => x * 2)  // List(2, 4, 6)
+list.Map((x) => x * 2)  // List(2, 4, 6)
 
 // FlatMap
-list.FlatMap[int]((x int) => ListOf(x, x * 10))
+list.FlatMap((x) => ListOf(x, x * 10))
 // List(1, 10, 2, 20, 3, 30)
 
 // Filter
-list.Filter((x int) => x % 2 == 1)  // List(1, 3)
-list.FilterNot((x int) => x % 2 == 1)  // List(2)
+list.Filter((x) => x % 2 == 1)  // List(1, 3)
+list.FilterNot((x) => x % 2 == 1)  // List(2)
+
+// Collect - combines Filter and Map in a single pass using partial functions
+list.Collect({ case x if x % 2 == 1 => x * 10 })
+// List(10, 30)
 
 // Partition
-list.Partition((x int) => x > 2)
+list.Partition((x) => x > 2)
 // Tuple(List(3), List(1, 2))
 
 // Reverse
@@ -249,16 +253,16 @@ ListOf(1, 2, 2, 3, 1).Distinct()  // List(1, 2, 3)
 val list = ListOf(1, 2, 3, 4)
 
 // FoldLeft
-list.FoldLeft[int](0, (acc int, x int) => acc + x)  // 10
+list.FoldLeft(0, (acc, x) => acc + x)  // 10
 
 // FoldRight
-list.FoldRight[int](0, (x int, acc int) => x + acc)  // 10
+list.FoldRight(0, (x, acc) => x + acc)  // 10
 
 // Reduce
-list.Reduce((a int, b int) => a + b)  // 10
+list.Reduce((a, b) => a + b)  // 10
 
 // ReduceOption (safe for empty lists)
-list.ReduceOption((a int, b int) => a + b)  // Some(10)
+list.ReduceOption((a, b) => a + b)  // Some(10)
 ```
 
 ### Predicates
@@ -266,9 +270,9 @@ list.ReduceOption((a int, b int) => a + b)  // Some(10)
 ```gala
 val list = ListOf(2, 4, 6, 8)
 
-list.Exists((x int) => x == 4)  // true
-list.ForAll((x int) => x % 2 == 0)  // true
-list.Count((x int) => x > 4)  // 2
+list.Exists((x) => x == 4)  // true
+list.ForAll((x) => x % 2 == 0)  // true
+list.Count((x) => x > 4)  // 2
 ```
 
 ### Zipping
@@ -277,7 +281,7 @@ list.Count((x int) => x > 4)  // 2
 val nums = ListOf(1, 2, 3)
 val strs = ListOf("a", "b", "c")
 
-nums.Zip[string](strs)
+nums.Zip(strs)
 // List(Tuple(1, "a"), Tuple(2, "b"), Tuple(3, "c"))
 
 nums.ZipWithIndex()
@@ -330,8 +334,8 @@ val result = list match {
 ### ForEach (Side Effects)
 
 ```gala
-list.ForEach((x int) => {
-    fmt.Println(x)
+list.ForEach((x) => {
+    Println(x)
 })
 ```
 
@@ -355,7 +359,7 @@ val slice = SliceOf(1, 2, 3)
 val arr2 = ArrayFrom(slice)
 
 // Tabulate: compute each element from index (O(n) via arrayBuilder)
-val squares = ArrayTabulate(5, (i int) => i * i)
+val squares = ArrayTabulate(5, (i) => i * i)
 // squares == Array(0, 1, 4, 9, 16)
 
 // Fill: repeat the same value (O(n) via arrayBuilder)
@@ -429,8 +433,8 @@ val arr = ArrayOf(1, 2, 3, 4, 5)
 arr.Take(3)                  // Array(1, 2, 3)
 arr.Drop(2)                  // Array(3, 4, 5)
 arr.Slice(1, 4)              // Array(2, 3, 4)
-arr.TakeWhile((x int) => x < 4)   // Array(1, 2, 3)
-arr.DropWhile((x int) => x < 3)   // Array(3, 4, 5)
+arr.TakeWhile((x) => x < 4)   // Array(1, 2, 3)
+arr.DropWhile((x) => x < 3)   // Array(3, 4, 5)
 arr.SplitAt(2)               // Tuple(Array(1, 2), Array(3, 4, 5))
 ```
 
@@ -442,8 +446,8 @@ val arr = ArrayOf(1, 2, 3, 2, 1)
 arr.Contains(3)              // true
 arr.IndexOf(2)               // 1
 arr.LastIndexOf(2)           // 3
-arr.Find((x int) => x > 2)   // Some(3)
-arr.FindLast((x int) => x < 3)  // Some(1)
+arr.Find((x) => x > 2)   // Some(3)
+arr.FindLast((x) => x < 3)  // Some(1)
 ```
 
 ### Transformations
@@ -452,18 +456,22 @@ arr.FindLast((x int) => x < 3)  // Some(1)
 val arr = ArrayOf(1, 2, 3)
 
 // Map
-arr.Map[int]((x int) => x * 2)  // Array(2, 4, 6)
+arr.Map((x) => x * 2)  // Array(2, 4, 6)
 
 // FlatMap
-arr.FlatMap[int]((x int) => ArrayOf(x, x * 10))
+arr.FlatMap((x) => ArrayOf(x, x * 10))
 // Array(1, 10, 2, 20, 3, 30)
 
 // Filter
-arr.Filter((x int) => x % 2 == 1)  // Array(1, 3)
-arr.FilterNot((x int) => x % 2 == 1)  // Array(2)
+arr.Filter((x) => x % 2 == 1)  // Array(1, 3)
+arr.FilterNot((x) => x % 2 == 1)  // Array(2)
+
+// Collect - combines Filter and Map in a single pass using partial functions
+arr.Collect({ case x if x % 2 == 0 => x * 10 })
+// Array(20)
 
 // Partition
-arr.Partition((x int) => x > 2)
+arr.Partition((x) => x > 2)
 // Tuple(Array(3), Array(1, 2))
 
 // Reverse
@@ -478,10 +486,10 @@ ArrayOf(1, 2, 2, 3, 1).Distinct()  // Array(1, 2, 3)
 ```gala
 val arr = ArrayOf(1, 2, 3, 4)
 
-arr.FoldLeft[int](0, (acc int, x int) => acc + x)  // 10
-arr.FoldRight[int](0, (x int, acc int) => x + acc)  // 10
-arr.Reduce((a int, b int) => a + b)  // 10
-arr.ReduceOption((a int, b int) => a + b)  // Some(10)
+arr.FoldLeft(0, (acc, x) => acc + x)  // 10
+arr.FoldRight(0, (x, acc) => x + acc)  // 10
+arr.Reduce((a, b) => a + b)  // 10
+arr.ReduceOption((a, b) => a + b)  // Some(10)
 ```
 
 ### Predicates
@@ -489,9 +497,9 @@ arr.ReduceOption((a int, b int) => a + b)  // Some(10)
 ```gala
 val arr = ArrayOf(2, 4, 6, 8)
 
-arr.Exists((x int) => x == 4)  // true
-arr.ForAll((x int) => x % 2 == 0)  // true
-arr.Count((x int) => x > 4)  // 2
+arr.Exists((x) => x == 4)  // true
+arr.ForAll((x) => x % 2 == 0)  // true
+arr.Count((x) => x > 4)  // 2
 ```
 
 ### Zipping
@@ -500,7 +508,7 @@ arr.Count((x int) => x > 4)  // 2
 val nums = ArrayOf(1, 2, 3)
 val strs = ArrayOf("a", "b", "c")
 
-nums.Zip[string](strs)
+nums.Zip(strs)
 // Array(Tuple(1, "a"), Tuple(2, "b"), Tuple(3, "c"))
 
 nums.ZipWithIndex()
@@ -551,8 +559,8 @@ arr.MkString(", ")  // "1, 2, 3"
 ### ForEach (Side Effects)
 
 ```gala
-arr.ForEach((x int) => {
-    fmt.Println(x)
+arr.ForEach((x) => {
+    Println(x)
 })
 ```
 
@@ -666,15 +674,19 @@ HashSetOf(1, 2).SubsetOf(a)  // true
 val set = HashSetOf(1, 2, 3, 4, 5)
 
 // Filter
-set.Filter((x int) => x % 2 == 0)     // HashSet(2, 4)
-set.FilterNot((x int) => x % 2 == 0)  // HashSet(1, 3, 5)
+set.Filter((x) => x % 2 == 0)     // HashSet(2, 4)
+set.FilterNot((x) => x % 2 == 0)  // HashSet(1, 3, 5)
+
+// Collect - combines Filter and Map in a single pass using partial functions
+set.Collect({ case x if x % 2 == 0 => x * 10 })
+// HashSet(20, 40)
 
 // Partition
-set.Partition((x int) => x > 3)
+set.Partition((x) => x > 3)
 // Tuple(HashSet(4, 5), HashSet(1, 2, 3))
 
 // Map (use standalone function)
-MapHashSet[int, int](set, (x int) => x * 2)  // HashSet(2, 4, 6, 8, 10)
+MapHashSet[int, int](set, (x) => x * 2)  // HashSet(2, 4, 6, 8, 10)
 ```
 
 ### Folding and Reduction
@@ -683,13 +695,13 @@ MapHashSet[int, int](set, (x int) => x * 2)  // HashSet(2, 4, 6, 8, 10)
 val set = HashSetOf(1, 2, 3, 4, 5)
 
 // FoldLeft
-set.FoldLeft[int](0, (acc int, x int) => acc + x)  // 15
+set.FoldLeft(0, (acc, x) => acc + x)  // 15
 
 // Reduce
-set.Reduce((a int, b int) => a + b)  // 15
+set.Reduce((a, b) => a + b)  // 15
 
 // ReduceOption (safe for empty sets)
-set.ReduceOption((a int, b int) => a + b)  // Some(15)
+set.ReduceOption((a, b) => a + b)  // Some(15)
 ```
 
 ### Predicates
@@ -697,10 +709,10 @@ set.ReduceOption((a int, b int) => a + b)  // Some(15)
 ```gala
 val set = HashSetOf(2, 4, 6, 8)
 
-set.Exists((x int) => x > 5)           // true
-set.ForAll((x int) => x % 2 == 0)      // true
-set.Count((x int) => x > 4)            // 2
-set.Find((x int) => x > 5)             // Some(6) or Some(8)
+set.Exists((x) => x > 5)           // true
+set.ForAll((x) => x % 2 == 0)      // true
+set.Count((x) => x > 4)            // 2
+set.Find((x) => x > 5)             // Some(6) or Some(8)
 ```
 
 ### Sorting
@@ -730,8 +742,8 @@ set.MkString(", ")  // "1, 2, 3" (order not guaranteed)
 ### ForEach (Side Effects)
 
 ```gala
-set.ForEach((x int) => {
-    fmt.Println(x)
+set.ForEach((x) => {
+    Println(x)
 })
 ```
 
@@ -742,7 +754,7 @@ val set = HashSetOf(1, 2, 3)
 
 val result = set match {
     case s: HashSet[_] if s.IsEmpty() => "empty"
-    case s: HashSet[_] => fmt.Sprintf("has %d elements", s.Size())
+    case s: HashSet[_] => s"has ${s.Size()} elements"
     case _ => "unknown"
 }
 ```
@@ -888,15 +900,15 @@ TreeSetOf(1, 2).SubsetOf(a)  // true
 val set = TreeSetOf(1, 2, 3, 4, 5)
 
 // Filter
-set.Filter((x int) => x % 2 == 0)     // TreeSet(2, 4)
-set.FilterNot((x int) => x % 2 == 0)  // TreeSet(1, 3, 5)
+set.Filter((x) => x % 2 == 0)     // TreeSet(2, 4)
+set.FilterNot((x) => x % 2 == 0)  // TreeSet(1, 3, 5)
 
 // Partition
-set.Partition((x int) => x > 3)
+set.Partition((x) => x > 3)
 // Tuple(TreeSet(4, 5), TreeSet(1, 2, 3))
 
 // Map (use standalone function)
-MapTreeSet(set, (x int) => x * 2)  // TreeSet(2, 4, 6, 8, 10)
+MapTreeSet(set, (x) => x * 2)  // TreeSet(2, 4, 6, 8, 10)
 ```
 
 ### Folding and Reduction
@@ -905,13 +917,13 @@ MapTreeSet(set, (x int) => x * 2)  // TreeSet(2, 4, 6, 8, 10)
 val set = TreeSetOf(1, 2, 3, 4, 5)
 
 // FoldLeft - processes elements in sorted order!
-set.FoldLeft[int](0, (acc int, x int) => acc + x)  // 15
+set.FoldLeft(0, (acc, x) => acc + x)  // 15
 
 // Reduce
-set.Reduce((a int, b int) => a + b)  // 15
+set.Reduce((a, b) => a + b)  // 15
 
 // ReduceOption (safe for empty sets)
-set.ReduceOption((a int, b int) => a + b)  // Some(15)
+set.ReduceOption((a, b) => a + b)  // Some(15)
 ```
 
 ### Predicates
@@ -919,10 +931,10 @@ set.ReduceOption((a int, b int) => a + b)  // Some(15)
 ```gala
 val set = TreeSetOf(2, 4, 6, 8)
 
-set.Exists((x int) => x > 5)           // true
-set.ForAll((x int) => x % 2 == 0)      // true
-set.Count((x int) => x > 4)            // 2
-set.Find((x int) => x > 5)             // Some(6) - first in sorted order
+set.Exists((x) => x > 5)           // true
+set.ForAll((x) => x % 2 == 0)      // true
+set.Count((x) => x > 4)            // 2
+set.Find((x) => x > 5)             // Some(6) - first in sorted order
 ```
 
 ### Sorting
@@ -954,8 +966,8 @@ set.MkString(", ")  // "1, 2, 3" - sorted order
 
 ```gala
 // Elements processed in sorted order
-set.ForEach((x int) => {
-    fmt.Println(x)  // Prints: 1, 2, 3 (in order)
+set.ForEach((x) => {
+    Println(x)  // Prints: 1, 2, 3 (in order)
 })
 ```
 
@@ -966,7 +978,7 @@ val set = TreeSetOf(1, 2, 3)
 
 val result = set match {
     case s: TreeSet[_] if s.IsEmpty() => "empty"
-    case s: TreeSet[_] => fmt.Sprintf("has %d elements, min=%v", s.Size(), s.Min())
+    case s: TreeSet[_] => s"has ${s.Size()} elements, min=${s.Min()}"
     case _ => "unknown"
 }
 ```
@@ -1015,10 +1027,34 @@ m.Keys().ToArray()                            // Array (unordered)
 val m = HashMapOf(("a", 1), ("b", 2), ("c", 3))
 
 m.Filter((k, v) => v > 1)                    // HashMap(b -> 2, c -> 3)
-m.MapValues[int]((v) => v * 2)               // HashMap(a -> 2, b -> 4, c -> 6)
-m.FoldLeftKV[int](0, (acc, k, v) => acc + v) // 6
-m.FoldLeft[int](0, (acc int, entry Tuple[string, int]) => acc + entry.V2) // 6 — iterates as Tuple entries
+m.MapValues((v) => v * 2)                    // HashMap(a -> 2, b -> 4, c -> 6)
+m.FoldLeftKV(0, (acc, k, v) => acc + v)      // 6
+m.FoldLeft(0, (acc, entry) => acc + entry.V2) // 6 — iterates as Tuple entries
 m.Sorted()                                    // Array((a,1), (b,2), (c,3))
+
+// Collect - applies a partial function to each entry, returns Array[U]
+m.Collect({ case (k, v) if v > 1 => k })
+// Array("b", "c")
+
+// Filter by keys only
+m.FilterKeys((k) => k > "b")
+
+// Filter by values only
+m.FilterValues((v) => v > 1)
+```
+
+### ForEach (Side Effects)
+
+```gala
+m.ForEachKV((k, v) => {
+    Println(s"$k -> $v")
+})
+
+// Iterate keys only
+m.ForEachKey((k) => Println(k))
+
+// Iterate values only
+m.ForEachValue((v) => Println(v))
 ```
 
 ---
@@ -1112,10 +1148,10 @@ m.FilterKeys((k) => k > "b")       // TreeMap(c -> 3, d -> 4)
 m.FilterValues((v) => v > 2)       // TreeMap(c -> 3, d -> 4)
 
 // MapValues
-m.MapValues[int]((v) => v * 10)    // TreeMap(a -> 10, b -> 20, c -> 30, d -> 40)
+m.MapValues((v) => v * 10)    // TreeMap(a -> 10, b -> 20, c -> 30, d -> 40)
 
 // FoldLeftKV
-m.FoldLeftKV[int](0, (acc, k, v) => acc + v)  // 10
+m.FoldLeftKV(0, (acc, k, v) => acc + v)  // 10
 
 // Merge with combiner
 val m2 = TreeMapOf(("c", 30), ("e", 5))
@@ -1123,7 +1159,7 @@ m.Merge(m2, (v1, v2) => v1 + v2)
 // TreeMap(a -> 1, b -> 2, c -> 33, d -> 4, e -> 5)
 
 // Iteration (sorted key order)
-m.ForEachKV((k, v) => { fmt.Printf("%s=%d ", k, v) })
+m.ForEachKV((k, v) => { Println(s"$k=$v") })
 // a=1 b=2 c=3 d=4
 ```
 
@@ -1139,7 +1175,7 @@ m.Sorted()                              // Array((a,10), (b,20), (c,30))
 m.SortWith((a, b) => a.V2 < b.V2)      // Array((a,10), (b,20), (c,30))
 
 // Sort by extracted key (descending by value)
-m.SortBy[int]((e) => -e.V2)            // Array((c,30), (b,20), (a,10))
+m.SortBy((e) => -e.V2)            // Array((c,30), (b,20), (a,10))
 ```
 
 ### Conversion
@@ -1458,28 +1494,25 @@ bazel run //collection_immutable:perf_go
 ```gala
 package main
 
-import (
-    "fmt"
-    . "martianoff/gala/collection_immutable"
-)
+import . "martianoff/gala/collection_immutable"
 
 func main() {
     // Build a list of numbers
     val numbers = ListOf(1, 2, 3, 4, 5)
 
     // Transform: double each number
-    val doubled = numbers.Map[int]((x int) => x * 2)
+    val doubled = numbers.Map((x) => x * 2)
 
     // Filter: keep only values > 5
-    val filtered = doubled.Filter((x int) => x > 5)
+    val filtered = doubled.Filter((x) => x > 5)
 
     // Reduce: sum all values
-    val sum = filtered.Reduce((a int, b int) => a + b)
+    val sum = filtered.Reduce((a, b) => a + b)
 
-    fmt.Printf("Sum: %d\n", sum)  // Sum: 24 (6 + 8 + 10)
+    Println(s"Sum: $sum")  // Sum: 24 (6 + 8 + 10)
 
     // Original list is unchanged
-    fmt.Println("Original:", numbers.String())  // List(1, 2, 3, 4, 5)
+    Println(s"Original: ${numbers.String()}")  // List(1, 2, 3, 4, 5)
 }
 ```
 
@@ -1488,10 +1521,7 @@ func main() {
 ```gala
 package main
 
-import (
-    "fmt"
-    . "martianoff/gala/collection_immutable"
-)
+import . "martianoff/gala/collection_immutable"
 
 func main() {
     // Build array of 1000 elements
@@ -1501,13 +1531,13 @@ func main() {
     }
 
     // Random access - O(eC)
-    fmt.Printf("Element at 500: %d\n", arr.Get(500))
+    Println(s"Element at 500: ${arr.Get(500)}")
 
     // Update - O(eC)
     val updated = arr.Updated(500, 999999)
-    fmt.Printf("Updated element at 500: %d\n", updated.Get(500))
+    Println(s"Updated element at 500: ${updated.Get(500)}")
 
     // Original unchanged
-    fmt.Printf("Original element at 500: %d\n", arr.Get(500))
+    Println(s"Original element at 500: ${arr.Get(500)}")
 }
 ```

--- a/docs/MUTABLE_COLLECTIONS.MD
+++ b/docs/MUTABLE_COLLECTIONS.MD
@@ -252,17 +252,20 @@ arr.Reversed()           // new Array(5, 4, 3, 2, 1)
 var arr = ArrayOf(1, 2, 3, 4, 5)
 
 // Map - returns new Array
-var doubled = arr.Map[int]((x int) => x * 2)  // Array(2, 4, 6, 8, 10)
+var doubled = arr.Map((x) => x * 2)  // Array(2, 4, 6, 8, 10)
 
 // Filter - returns new Array
-var evens = arr.Filter((x int) => x % 2 == 0)  // Array(2, 4)
+var evens = arr.Filter((x) => x % 2 == 0)  // Array(2, 4)
+
+// Collect - combines Filter and Map in a single pass
+arr.Collect({ case x if x % 2 == 0 => x * 10 })
 
 // FoldLeft
-var sum = arr.FoldLeft[int](0, (acc int, x int) => acc + x)  // 15
+var sum = arr.FoldLeft(0, (acc, x) => acc + x)  // 15
 
 // FoldRight
-var result = arr.FoldRight[string]("", (x int, acc string) => {
-    return fmt.Sprintf("%d%s", x, acc)
+var result = arr.FoldRight("", (x, acc) => {
+    return s"${x}${acc}"
 })  // "12345"
 ```
 
@@ -274,10 +277,10 @@ var arr = ArrayOf(1, 2, 3, 2, 1)
 arr.Contains(3)              // true
 arr.IndexOf(2)               // 1
 arr.LastIndexOf(2)           // 3
-arr.Find((x int) => x > 2)   // Some(3)
-arr.Exists((x int) => x > 4) // true
-arr.ForAll((x int) => x > 0) // true
-arr.Count((x int) => x == 2) // 2
+arr.Find((x) => x > 2)      // Some(3)
+arr.Exists((x) => x > 4)    // true
+arr.ForAll((x) => x > 0)    // true
+arr.Count((x) => x == 2)    // 2
 ```
 
 ### Grouping
@@ -290,7 +293,7 @@ arr.Grouped(2)
 // Array(Array(1, 2), Array(3, 4), Array(5))
 
 // Group by key function
-arr.GroupBy[string]((x int) => {
+arr.GroupBy[string]((x) => {
     if x % 2 == 0 { return "even" }
     return "odd"
 })
@@ -335,8 +338,8 @@ arr.MkString(", ")  // "1, 2, 3"
 ### ForEach
 
 ```gala
-arr.ForEach((x int) => {
-    fmt.Println(x)
+arr.ForEach((x) => {
+    Println(x)
 })
 ```
 
@@ -429,16 +432,16 @@ list.AppendAll(ListOf(4, 5))    // [-1, 0, 1, 2, 3, 4, 5]
 var list = ListOf(1, 2, 3, 4, 5)
 
 // Map
-var doubled = list.Map[int]((x int) => x * 2)
+var doubled = list.Map((x) => x * 2)
 
 // Filter
-var evens = list.Filter((x int) => x % 2 == 0)
+var evens = list.Filter((x) => x % 2 == 0)
 
 // FoldLeft
-var sum = list.FoldLeft[int](0, (acc int, x int) => acc + x)
+var sum = list.FoldLeft(0, (acc, x) => acc + x)
 
 // FoldRight
-var result = list.FoldRight[string]("", foldHelper)
+var result = list.FoldRight("", foldHelper)
 ```
 
 ### Searching
@@ -449,10 +452,10 @@ var list = ListOf(1, 2, 3, 2, 1)
 list.Contains(3)              // true
 list.IndexOf(2)               // 1
 list.LastIndexOf(2)           // 3
-list.Find((x int) => x > 2)   // Some(3)
-list.Exists((x int) => x > 4) // true
-list.ForAll((x int) => x > 0) // true
-list.Count((x int) => x == 2) // 2
+list.Find((x) => x > 2)      // Some(3)
+list.Exists((x) => x > 4)    // true
+list.ForAll((x) => x > 0)    // true
+list.Count((x) => x == 2)    // 2
 ```
 
 ### Sorting
@@ -604,18 +607,18 @@ s1.Disjoint(s3)          // true: no common elements
 var s = HashSetOf(1, 2, 3, 4, 5, 6)
 
 // Filter - returns new HashSet
-var evens = s.Filter((x int) => x % 2 == 0)       // HashSet(2, 4, 6)
-var odds = s.FilterNot((x int) => x % 2 == 0)     // HashSet(1, 3, 5)
+var evens = s.Filter((x) => x % 2 == 0)       // HashSet(2, 4, 6)
+var odds = s.FilterNot((x) => x % 2 == 0)     // HashSet(1, 3, 5)
 
 // Partition - returns tuple of (matching, non-matching)
-var parts = s.Partition((x int) => x % 2 == 0)
+var parts = s.Partition((x) => x % 2 == 0)
 // parts.V1 = HashSet(2, 4, 6), parts.V2 = HashSet(1, 3, 5)
 
 // Map - returns new HashSet
-var doubled = s.Map[int]((x int) => x * 2)
+var doubled = s.Map((x) => x * 2)
 
 // FoldLeft
-var sum = s.FoldLeft[int](0, (acc int, x int) => acc + x)
+var sum = s.FoldLeft(0, (acc, x) => acc + x)
 ```
 
 ### Predicates
@@ -623,10 +626,10 @@ var sum = s.FoldLeft[int](0, (acc int, x int) => acc + x)
 ```gala
 var s = HashSetOf(1, 2, 3, 4, 5)
 
-s.Exists((x int) => x > 4)    // true: at least one > 4
-s.ForAll((x int) => x > 0)    // true: all are positive
-s.Count((x int) => x % 2 == 0) // 2: count of even numbers
-s.Find((x int) => x > 3)      // Some(4 or 5): first match (order not guaranteed)
+s.Exists((x) => x > 4)    // true: at least one > 4
+s.ForAll((x) => x > 0)    // true: all are positive
+s.Count((x) => x % 2 == 0) // 2: count of even numbers
+s.Find((x) => x > 3)      // Some(4 or 5): first match (order not guaranteed)
 ```
 
 ### Element Access
@@ -814,14 +817,14 @@ s2.SupersetOf(s1)        // true
 var s = TreeSetOf(3, 1, 4, 1, 5)
 
 // Iterate in sorted order
-s.ForEach((x int) => {
-    fmt.Println(x)       // prints 1, 3, 4, 5
+s.ForEach((x) => {
+    Println(x)           // prints 1, 3, 4, 5
     return nil
 })
 
 // Iterate in reverse order
-s.ForEachReverse((x int) => {
-    fmt.Println(x)       // prints 5, 4, 3, 1
+s.ForEachReverse((x) => {
+    Println(x)           // prints 5, 4, 3, 1
     return nil
 })
 ```
@@ -832,20 +835,20 @@ s.ForEachReverse((x int) => {
 var s = TreeSetOf(1, 2, 3, 4, 5, 6)
 
 // Filter
-var evens = s.Filter((x int) => x % 2 == 0)     // TreeSet(2, 4, 6)
+var evens = s.Filter((x) => x % 2 == 0)     // TreeSet(2, 4, 6)
 
 // Partition
-var parts = s.Partition((x int) => x % 2 == 0)
+var parts = s.Partition((x) => x % 2 == 0)
 // parts.V1 = TreeSet(2, 4, 6), parts.V2 = TreeSet(1, 3, 5)
 
 // Map - returns new TreeSet
-var doubled = s.Map[int]((x int) => x * 2)
+var doubled = s.Map((x) => x * 2)
 
 // FoldLeft (iterates in sorted order)
-var sum = s.FoldLeft[int](0, (acc int, x int) => acc + x)
+var sum = s.FoldLeft(0, (acc, x) => acc + x)
 
 // Reduce (uses sorted order)
-var sum2 = s.Reduce((a int, b int) => a + b)
+var sum2 = s.Reduce((a, b) => a + b)
 ```
 
 ### Predicates
@@ -853,10 +856,10 @@ var sum2 = s.Reduce((a int, b int) => a + b)
 ```gala
 var s = TreeSetOf(1, 2, 3, 4, 5)
 
-s.Exists((x int) => x > 4)    // true
-s.ForAll((x int) => x > 0)    // true
-s.Count((x int) => x % 2 == 0) // 2
-s.Find((x int) => x > 3)      // Some(4) - first in sorted order
+s.Exists((x) => x > 4)    // true
+s.ForAll((x) => x > 0)    // true
+s.Count((x) => x % 2 == 0) // 2
+s.Find((x) => x > 3)      // Some(4) - first in sorted order
 ```
 
 ### Sorting
@@ -913,7 +916,7 @@ m.Clear()                // removes all entries
 
 // Functional operations
 m.Filter((k, v) => v > 1)
-m.MapValues[int]((v) => v * 2)
+m.MapValues((v) => v * 2)
 m.Sorted()               // Array of entries sorted by key
 ```
 
@@ -1019,16 +1022,16 @@ var m = TreeMapOf(("a", 1), ("b", 2), ("c", 3), ("d", 4))
 m.Filter((k, v) => v % 2 == 0)      // TreeMap(b -> 2, d -> 4)
 
 // MapValues (returns new TreeMap)
-m.MapValues[int]((v) => v * 10)     // TreeMap(a -> 10, b -> 20, ...)
+m.MapValues((v) => v * 10)          // TreeMap(a -> 10, b -> 20, ...)
 
 // FoldLeftKV
-m.FoldLeftKV[int](0, (acc, k, v) => acc + v)  // 10
+m.FoldLeftKV(0, (acc, k, v) => acc + v)  // 10
 
 // FilterInPlace (modifies in-place)
 m.FilterInPlace((k, v) => v > 2)
 
 // Iteration (sorted key order)
-m.ForEachKV((k, v) => { fmt.Printf("%s=%d ", k, v) })
+m.ForEachKV((k, v) => { Println(s"$k=$v") })
 ```
 
 ### Sorted API
@@ -1038,7 +1041,7 @@ var m = TreeMapOf(("c", 30), ("a", 10), ("b", 20))
 
 m.Sorted()                              // Array((a,10), (b,20), (c,30))
 m.SortWith((a, b) => a.V2 < b.V2)      // Array((a,10), (b,20), (c,30))
-m.SortBy[int]((e) => -e.V2)            // Array((c,30), (b,20), (a,10))
+m.SortBy((e) => -e.V2)                  // Array((c,30), (b,20), (a,10))
 ```
 
 ### Conversion
@@ -1103,15 +1106,14 @@ GALA supports pattern matching on mutable collections. Since Array and List are 
 package main
 
 import (
-    "fmt"
     . "martianoff/gala/collection_mutable"
 )
 
 func describeArray[T any](arr *Array[T]) string {
     return arr match {
         case a: *Array[_] if a.IsEmpty() => "empty array"
-        case a: *Array[_] if a.Length() == 1 => fmt.Sprintf("single element: %v", a.Head())
-        case a: *Array[_] => fmt.Sprintf("array with %d elements", a.Length())
+        case a: *Array[_] if a.Length() == 1 => s"single element: ${a.Head()}"
+        case a: *Array[_] => s"array with ${a.Length()} elements"
         case _ => "unknown"
     }
 }
@@ -1121,9 +1123,9 @@ func main() {
     var single = ArrayOf(42)
     var multi = ArrayOf(1, 2, 3)
 
-    fmt.Println(describeArray[int](empty))   // "empty array"
-    fmt.Println(describeArray[int](single))  // "single element: 42"
-    fmt.Println(describeArray[int](multi))   // "array with 3 elements"
+    Println(describeArray[int](empty))   // "empty array"
+    Println(describeArray[int](single))  // "single element: 42"
+    Println(describeArray[int](multi))   // "array with 3 elements"
 }
 ```
 
@@ -1133,9 +1135,9 @@ func main() {
 func processNumbers(arr *Array[int]) string {
     return arr match {
         case a: *Array[int] if a.IsEmpty() => "no numbers"
-        case a: *Array[int] if a.ForAll((x int) => x > 0) => "all positive"
-        case a: *Array[int] if a.ForAll((x int) => x < 0) => "all negative"
-        case a: *Array[int] if a.Exists((x int) => x == 0) => "contains zero"
+        case a: *Array[int] if a.ForAll((x) => x > 0) => "all positive"
+        case a: *Array[int] if a.ForAll((x) => x < 0) => "all negative"
+        case a: *Array[int] if a.Exists((x) => x == 0) => "contains zero"
         case _ => "mixed numbers"
     }
 }
@@ -1145,9 +1147,9 @@ func processNumbers(arr *Array[int]) string {
 
 ```gala
 func findFirstEven(arr *Array[int]) string {
-    var found = arr.Find((x int) => x % 2 == 0)
+    var found = arr.Find((x) => x % 2 == 0)
     return found match {
-        case Some(value) => fmt.Sprintf("found even: %d", value)
+        case Some(value) => s"found even: $value"
         case None() => "no even numbers"
     }
 }
@@ -1159,7 +1161,7 @@ func getMiddleElement[T any](arr *Array[T]) string {
     var mid = arr.Length() / 2
     var opt = arr.GetOption(mid)
     return opt match {
-        case Some(v) => fmt.Sprintf("middle: %v", v)
+        case Some(v) => s"middle: $v"
         case None() => "no middle"
     }
 }
@@ -1179,7 +1181,7 @@ func describeList[T any](list *List[T]) string {
     return list match {
         case l: *List[_] if l.IsEmpty() => "empty list"
         case l: *List[_] if l.Length() == 1 => "singleton"
-        case l: *List[_] => fmt.Sprintf("list[%d]", l.Length())
+        case l: *List[_] => s"list[${l.Length()}]"
     }
 }
 ```
@@ -1193,7 +1195,7 @@ func analyzeArrays(a1 *Array[int], a2 *Array[int]) string {
         case (0, 0) => "both empty"
         case (0, _) => "first empty"
         case (_, 0) => "second empty"
-        case (n1, n2) if n1 == n2 => fmt.Sprintf("same size: %d", n1)
+        case (n1, n2) if n1 == n2 => s"same size: $n1"
         case (n1, n2) if n1 > n2 => "first is larger"
         case _ => "second is larger"
     }
@@ -1394,7 +1396,6 @@ bazel run //collection_mutable:perf_go
 package main
 
 import (
-    "fmt"
     . "martianoff/gala/collection_mutable"
 )
 
@@ -1408,13 +1409,13 @@ func main() {
     }
 
     // Transform: keep only values divisible by 4
-    var filtered = arr.Filter((x int) => x % 4 == 0)
+    var filtered = arr.Filter((x) => x % 4 == 0)
 
     // Sum all values
-    var sum = filtered.FoldLeft[int](0, (acc int, x int) => acc + x)
+    var sum = filtered.FoldLeft(0, (acc, x) => acc + x)
 
-    fmt.Printf("Sum of squares divisible by 4: %d\n", sum)
-    fmt.Printf("Count: %d\n", filtered.Length())
+    Println(s"Sum of squares divisible by 4: $sum")
+    Println(s"Count: ${filtered.Length()}")
 }
 ```
 
@@ -1424,7 +1425,6 @@ func main() {
 package main
 
 import (
-    "fmt"
     . "martianoff/gala/collection_mutable"
 )
 
@@ -1440,7 +1440,7 @@ func main() {
     // Dequeue (remove from front)
     for queue.NonEmpty() {
         var item = queue.RemoveFirst()
-        fmt.Printf("Processing: %s\n", item)
+        Println(s"Processing: $item")
     }
 }
 ```
@@ -1451,7 +1451,6 @@ func main() {
 package main
 
 import (
-    "fmt"
     . "martianoff/gala/collection_mutable"
     . "martianoff/gala/std"
 )
@@ -1473,7 +1472,7 @@ func main() {
 
     // Print each group
     for category, arr := range groups {
-        fmt.Printf("%s: %s\n", category, arr.String())
+        Println(s"$category: ${arr.String()}")
     }
 }
 ```
@@ -1484,7 +1483,6 @@ func main() {
 package main
 
 import (
-    "fmt"
     . "martianoff/gala/collection_mutable"
 )
 
@@ -1498,14 +1496,14 @@ func main() {
 
     // Find intersection (O(min(n,m)) average)
     var common = set1.Intersect(set2)
-    fmt.Printf("Common elements: %s\n", common.String())  // HashSet(5, 6, 7, 8)
+    Println(s"Common elements: ${common.String()}")  // HashSet(5, 6, 7, 8)
 
     // Find elements only in first dataset
     var onlyInFirst = set1.Diff(set2)
-    fmt.Printf("Only in first: %s\n", onlyInFirst.String())  // HashSet(1, 2, 3, 4)
+    Println(s"Only in first: ${onlyInFirst.String()}")  // HashSet(1, 2, 3, 4)
 
     // Check membership (O(1) average)
-    fmt.Printf("Contains 5: %t\n", set1.Contains(5))  // true
+    Println(s"Contains 5: ${set1.Contains(5)}")  // true
 }
 ```
 
@@ -1515,7 +1513,6 @@ func main() {
 package main
 
 import (
-    "fmt"
     . "martianoff/gala/collection_mutable"
 )
 
@@ -1532,7 +1529,7 @@ func main() {
     // Process in priority order
     for tasks.NonEmpty() {
         var priority = tasks.PopMin()  // O(log n)
-        fmt.Printf("Processing task with priority %d\n", priority)
+        Println(s"Processing task with priority $priority")
     }
     // Output: 1, 2, 3, 5
 }
@@ -1544,7 +1541,6 @@ func main() {
 package main
 
 import (
-    "fmt"
     . "martianoff/gala/collection_mutable"
 )
 
@@ -1554,14 +1550,14 @@ func main() {
 
     // Find passing grades (60+)
     var passing = grades.RangeFrom(60)
-    fmt.Printf("Passing: %s\n", passing.String())  // TreeSet(65, 72, 78, 85, 92, 98)
+    Println(s"Passing: ${passing.String()}")  // TreeSet(65, 72, 78, 85, 92, 98)
 
     // Find B grades (80-89)
     var bGrades = grades.Range(80, 89)
-    fmt.Printf("B grades: %s\n", bGrades.String())  // TreeSet(85)
+    Println(s"B grades: ${bGrades.String()}")  // TreeSet(85)
 
     // Find failing grades (<60)
     var failing = grades.RangeTo(59)
-    fmt.Printf("Failing: %s\n", failing.String())  // TreeSet(45, 55)
+    Println(s"Failing: ${failing.String()}")  // TreeSet(45, 55)
 }
 ```

--- a/docs/STREAM.MD
+++ b/docs/STREAM.MD
@@ -70,7 +70,7 @@ val naturals = From(1)              // 1, 2, 3, 4, ...
 val ones = Repeat(1)                // 1, 1, 1, 1, ...
 
 // Infinite iteration
-val powers = Iterate[int](1, (x int) => x * 2)  // 1, 2, 4, 8, 16, ...
+val powers = Iterate[int](1, (x) => x * 2)  // 1, 2, 4, 8, 16, ...
 
 // Infinite evaluation
 val randoms = Continually(() => rand.Int())     // random, random, ...
@@ -120,7 +120,7 @@ All transformation operations return new streams without forcing evaluation.
 Transform each element:
 
 ```gala
-val doubled = Of(1, 2, 3).Map[int]((x int) => x * 2)
+val doubled = Of(1, 2, 3).Map((x) => x * 2)
 // Result: 2, 4, 6
 ```
 
@@ -129,7 +129,7 @@ val doubled = Of(1, 2, 3).Map[int]((x int) => x * 2)
 Apply function returning stream, then flatten:
 
 ```gala
-val s = Of(1, 2, 3).FlatMap[int]((x int) => Of(x, x * 10))
+val s = Of(1, 2, 3).FlatMap((x) => Of(x, x * 10))
 // Result: 1, 10, 2, 20, 3, 30
 ```
 
@@ -138,10 +138,10 @@ val s = Of(1, 2, 3).FlatMap[int]((x int) => Of(x, x * 10))
 Keep elements matching (or not matching) predicate:
 
 ```gala
-val evens = Of(1, 2, 3, 4, 5).Filter((x int) => x % 2 == 0)
+val evens = Of(1, 2, 3, 4, 5).Filter((x) => x % 2 == 0)
 // Result: 2, 4
 
-val odds = Of(1, 2, 3, 4, 5).FilterNot((x int) => x % 2 == 0)
+val odds = Of(1, 2, 3, 4, 5).FilterNot((x) => x % 2 == 0)
 // Result: 1, 3, 5
 ```
 
@@ -153,7 +153,7 @@ Limit stream length:
 val first3 = Of(1, 2, 3, 4, 5).Take(3)
 // Result: 1, 2, 3
 
-val lessThan4 = Of(1, 2, 3, 4, 5).TakeWhile((x int) => x < 4)
+val lessThan4 = Of(1, 2, 3, 4, 5).TakeWhile((x) => x < 4)
 // Result: 1, 2, 3
 ```
 
@@ -165,7 +165,7 @@ Skip elements:
 val after2 = Of(1, 2, 3, 4, 5).Drop(2)
 // Result: 3, 4, 5
 
-val from3 = Of(1, 2, 3, 4, 5).DropWhile((x int) => x < 3)
+val from3 = Of(1, 2, 3, 4, 5).DropWhile((x) => x < 3)
 // Result: 3, 4, 5
 ```
 
@@ -176,7 +176,7 @@ Combine streams:
 ```gala
 val s1 = Of(1, 2, 3)
 val s2 = Of("a", "b", "c")
-val zipped = s1.Zip[string](s2)
+val zipped = s1.Zip(s2)
 // Result: (1, "a"), (2, "b"), (3, "c")
 
 val indexed = Of("a", "b", "c").ZipWithIndex()
@@ -225,7 +225,7 @@ val s = Of(0, 1, 2, 3, 4, 5).Slice(1, 4)
 Cumulative results:
 
 ```gala
-val s = Of(1, 2, 3).Scan[int](0, (acc int, x int) => acc + x)
+val s = Of(1, 2, 3).Scan(0, (acc, x) => acc + x)
 // Result: 0, 1, 3, 6
 ```
 
@@ -234,9 +234,7 @@ val s = Of(1, 2, 3).Scan[int](0, (acc int, x int) => acc + x)
 Apply partial function, keeping defined results:
 
 ```gala
-val s = Of(1, 2, 3, 4).Collect[int]((x int) => {
-    if (x % 2 == 0) Some(x * 10) else None[int]()
-})
+val s = Of(1, 2, 3, 4).Collect({ case x if x % 2 == 0 => x * 10 })
 // Result: 20, 40
 ```
 
@@ -249,10 +247,10 @@ val s = Of(1, 2, 3, 4, 5)
 val (first, rest) = s.SplitAt(2)  // (1, 2), (3, 4, 5)
 
 // Span: split at first non-matching
-val (matching, rest) = s.Span((x int) => x < 3)  // (1, 2), (3, 4, 5)
+val (matching, rest) = s.Span((x) => x < 3)  // (1, 2), (3, 4, 5)
 
 // Partition: split by predicate
-val (evens, odds) = s.Partition((x int) => x % 2 == 0)  // (2, 4), (1, 3, 5)
+val (evens, odds) = s.Partition((x) => x % 2 == 0)  // (2, 4), (1, 3, 5)
 ```
 
 ---
@@ -275,10 +273,10 @@ val list = Of(1, 2, 3).ToList()   // List[int]
 Aggregate values:
 
 ```gala
-val sum = Of(1, 2, 3, 4, 5).Fold[int](0, (acc int, x int) => acc + x)
+val sum = Of(1, 2, 3, 4, 5).Fold(0, (acc, x) => acc + x)
 // Result: 15
 
-val product = Of(1, 2, 3, 4).Reduce((a int, b int) => a * b)
+val product = Of(1, 2, 3, 4).Reduce((a, b) => a * b)
 // Result: Some(24)
 ```
 
@@ -287,7 +285,7 @@ val product = Of(1, 2, 3, 4).Reduce((a int, b int) => a * b)
 Apply side-effecting function:
 
 ```gala
-Of(1, 2, 3).ForEach((x int) => fmt.Println(x))
+Of(1, 2, 3).ForEach((x) => Println(x))
 ```
 
 ### Count / Length / Size
@@ -303,11 +301,11 @@ val n = Of(1, 2, 3).Count()  // 3
 Search and test:
 
 ```gala
-val found = Of(1, 2, 3, 4).Find((x int) => x > 2)  // Some(3)
+val found = Of(1, 2, 3, 4).Find((x) => x > 2)  // Some(3)
 
-val hasEven = Of(1, 2, 3).Exists((x int) => x % 2 == 0)  // true
+val hasEven = Of(1, 2, 3).Exists((x) => x % 2 == 0)  // true
 
-val allPositive = Of(1, 2, 3).ForAll((x int) => x > 0)   // true
+val allPositive = Of(1, 2, 3).ForAll((x) => x > 0)   // true
 ```
 
 ### Contains / IndexOf / IndexWhere
@@ -317,7 +315,7 @@ Search for elements:
 ```gala
 val hasTwo = Of(1, 2, 3).Contains(2)          // true
 val idx = Of(10, 20, 30).IndexOf(20)          // 1
-val idx2 = Of(1, 2, 3).IndexWhere((x int) => x > 1)  // 1
+val idx2 = Of(1, 2, 3).IndexWhere((x) => x > 1)  // 1
 ```
 
 ### MkString
@@ -364,11 +362,11 @@ Use `StreamCons` and `StreamNil` extractors for type-based matching:
 val result = myStream match {
     case StreamCons(head, tail) => {
         // head is T, tail is Stream[T]
-        fmt.Printf("Head: %v, Tail length: %d\n", head, tail.Count())
+        Println(s"Head: $head, Tail length: ${tail.Count()}")
         return head
     }
     case StreamNil() => {
-        fmt.Println("Empty stream")
+        Println("Empty stream")
         return defaultValue
     }
     case _ => defaultValue
@@ -385,7 +383,7 @@ val s = Of(1, 2, 3, 4, 5)
 val result = s match {
     // Match first two elements, rest goes into 'tail'
     case Stream(first, second, tail...) => {
-        fmt.Printf("First: %d, Second: %d, Rest size: %d\n", first, second, tail.Size())
+        Println(s"First: $first, Second: $second, Rest size: ${tail.Size()}")
         return first + second
     }
     // Match single element
@@ -430,9 +428,9 @@ val result = From(1).Take(10) match {
 ```gala
 val result = From(1)
     .Take(10)
-    .Filter((x int) => x % 2 == 0)
-    .Map[int]((x int) => x * x)
-    .Fold[int](0, (acc int, x int) => acc + x)
+    .Filter((x) => x % 2 == 0)
+    .Map((x) => x * x)
+    .Fold(0, (acc, x) => acc + x)
 // 2² + 4² + 6² + 8² + 10² = 220
 ```
 
@@ -443,7 +441,7 @@ func sieve(s Stream[int]) Stream[int] {
     val head = s.Head()
     if head.IsDefined() {
         val p = head.Get()
-        return NewCons[int](p, () => sieve(s.Tail().Filter((x int) => x % p != 0)))
+        return NewCons[int](p, () => sieve(s.Tail().Filter((x) => x % p != 0)))
     }
     return Empty[int]()
 }

--- a/docs/TODO.MD
+++ b/docs/TODO.MD
@@ -26,8 +26,9 @@
 - [x] Partial functions
 - [x] Restrict the GO map type declaration directly in GALA. Create required GO map functions inside std. Rewrite collections packages using std Maps. Leave ToGoMap functions for compatibility with GO apps
 - [x] Go pkg for go native primitives (maps, slices, channels etc)
-- [ ] Drop reflection usage for immutable vars for better performance
+- [x] Drop reflection usage for immutable vars for better performance
 - [ ] Official bazel module
 - [x] TreeMap
 - [x] Support expression syntax with match without return
 - [x] Compiler should provide better error messages, for example, "Type mismatch errors could be clearer about what the actual vs expected types are". Compiler must include line number and column number in error messages and may be code block highlighting for better readability
+- [ ] Level up Jetbrains plugin to support better syntax highlighting and code completion

--- a/docs/TYPE_INFERENCE.MD
+++ b/docs/TYPE_INFERENCE.MD
@@ -24,8 +24,9 @@ GALA implements a custom type inference and unwrapping system to handle its uniq
    - [Expression Unwrapping](#2-expression-unwrapping)
 7. [Type Resolution](#type-resolution)
 8. [Supported Expressions](#supported-expressions)
-9. [Limitations and Edge Cases](#limitations-and-edge-cases)
-10. [Key Files](#key-files)
+9. [Go Type Inference](#go-type-inference)
+10. [Limitations and Edge Cases](#limitations-and-edge-cases)
+11. [Key Files](#key-files)
 
 ---
 
@@ -297,6 +298,8 @@ Type resolution follows a 5-level precedence order (defined in `scope.go`):
 
 The `getType(name)` method in scope.go implements this resolution order.
 
+**Note**: Dot imports take precedence over aliased imports for unqualified name resolution. If both `. "collection_immutable"` and `cm "collection_mutable"` are imported, bare `Array` resolves to `collection_immutable.Array`.
+
 ---
 
 ## Supported Expressions
@@ -359,6 +362,20 @@ Lambda parameter inference works for:
 val sum = list.FoldLeft(0, (acc, x) => acc + x)        // acc inferred as int from 0
 val joined = list.FoldLeft("", (acc, x) => acc + x)     // acc inferred as string from ""
 ```
+
+---
+
+## Go Type Inference
+
+When the Go SDK is available (via `GOROOT` or `PATH`), the transpiler can infer types from Go standard library and third-party packages:
+
+- **Function return types**: `os.TempDir()` → inferred as `string`
+- **Method return types**: `strings.NewReader("hello").Read(buf)` → inferred from Go method signature
+- **Struct field types**: `req.URL.Host` → inferred as `string`
+
+This enables seamless interop without explicit type annotations when calling Go functions.
+
+Go type inference is optional — if the Go SDK is not found, transpilation still succeeds but Go type resolution is disabled (a warning is printed to stderr).
 
 ---
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -682,7 +682,10 @@ gala_test(
     name = "doc_verify_examples_md",
     src = "doc_verify/examples_md.gala",
     expected = "doc_verify/examples_md.out",
-    deps = ["//go_interop"],
+    deps = [
+        "//collection_immutable",
+        "//go_interop",
+    ],
 )
 
 gala_test(

--- a/examples/doc_verify/concurrent_md.gala
+++ b/examples/doc_verify/concurrent_md.gala
@@ -1,7 +1,6 @@
 package main
 
 import (
-    "fmt"
     . "martianoff/gala/std"
     . "martianoff/gala/concurrent"
 )
@@ -11,10 +10,10 @@ import (
 // Creating Futures (line 19-27)
 func testCreatingFutures() {
     val immediate = FutureOf[int](42)
-    fmt.Printf("Immediate value=%d\n", immediate.Get())
+    Println(s"Immediate value=${immediate.Get()}")
 
     val failed = FutureFailed[int](NoSuchElementError(Message = "oops"))
-    fmt.Printf("Failed isCompleted=%v\n", failed.IsCompleted())
+    Println(s"Failed isCompleted=${failed.IsCompleted()}")
 }
 
 // Blocking Operations (line 32-36)
@@ -22,32 +21,32 @@ func testBlockingOps() {
     val f = FutureOf[int](100)
 
     val result = f.Await()
-    fmt.Printf("Await=%v\n", result)
+    Println(s"Await=$result")
 
     val value = f.Get()
-    fmt.Printf("Get=%d\n", value)
+    Println(s"Get=$value")
 
     val safe = f.GetOrElse(0)
-    fmt.Printf("GetOrElse=%d\n", safe)
+    Println(s"GetOrElse=$safe")
 }
 
 // Monadic Operations (line 49-51)
 func testMonadicOps() {
     val f = FutureOf[int](10)
 
-    val doubled = f.Map[int]((v int) => v * 2)
-    fmt.Printf("Map=%d\n", doubled.Get())
+    val doubled = f.Map((v) => v * 2)
+    Println(s"Map=${doubled.Get()}")
 }
 
 // Error Recovery (line 55-57)
 func testErrorRecovery() {
     val failed = FutureFailed[int](NoSuchElementError(Message = "error"))
 
-    val recovered = failed.Recover((e error) => 0)
-    fmt.Printf("Recover=%d\n", recovered.Get())
+    val recovered = failed.Recover((e) => 0)
+    Println(s"Recover=${recovered.Get()}")
 
-    val recoveredWith = failed.RecoverWith((e error) => FutureOf[int](99))
-    fmt.Printf("RecoverWith=%d\n", recoveredWith.Get())
+    val recoveredWith = failed.RecoverWith((e) => FutureOf[int](99))
+    Println(s"RecoverWith=${recoveredWith.Get()}")
 }
 
 // Pattern Matching (line 75-88)
@@ -55,11 +54,11 @@ func testPatternMatch() {
     val f = FutureOf[int](42)
 
     val msg = f match {
-        case Succeeded(v) => fmt.Sprintf("Got: %d", v)
-        case Failed(e) => fmt.Sprintf("Error: %s", e.Error())
+        case Succeeded(v) => s"Got: $v"
+        case Failed(e) => s"Error: ${e.Error()}"
         case _ => "Unknown"
     }
-    fmt.Printf("Pattern match: %s\n", msg)
+    Println(s"Pattern match: $msg")
 }
 
 // Combining Futures (line 62-64)
@@ -67,9 +66,9 @@ func testCombiningFutures() {
     val f1 = FutureOf[int](10)
     val f2 = FutureOf[string]("hello")
 
-    val zipped = f1.Zip[string](f2)
+    val zipped = f1.Zip(f2)
     val result = zipped.Get()
-    fmt.Printf("Zip=(%d, %s)\n", result.V1, result.V2)
+    Println(s"Zip=(${result.V1}, ${result.V2})")
 }
 
 // Promise (line 132-142)
@@ -77,12 +76,12 @@ func testPromise() {
     val promise = NewPromise[int]()
     val future = promise.Future()
 
-    fmt.Printf("Before complete: isCompleted=%v\n", promise.IsCompleted())
+    Println(s"Before complete: isCompleted=${promise.IsCompleted()}")
 
     promise.Success(42)
 
-    fmt.Printf("After complete: isCompleted=%v\n", promise.IsCompleted())
-    fmt.Printf("Future value=%d\n", future.Get())
+    Println(s"After complete: isCompleted=${promise.IsCompleted()}")
+    Println(s"Future value=${future.Get()}")
 }
 
 func main() {

--- a/examples/doc_verify/examples_md.gala
+++ b/examples/doc_verify/examples_md.gala
@@ -1,14 +1,12 @@
 package main
 
-import (
-    "fmt"
-    . "martianoff/gala/std"
-    . "martianoff/gala/go_interop"
-)
+import . "martianoff/gala/collection_immutable"
+import . "martianoff/gala/go_interop"
+import "os"
 
 // Test examples from EXAMPLES.MD
 
-// Complete Example (line 9-24)
+// Complete Example
 struct Point(X int, Y int)
 
 func moveX(p Point, delta int) Point = p.Copy(X = p.X + delta)
@@ -18,13 +16,13 @@ func testCompleteExample() {
     val p2 = moveX(p1, 5)
 
     val msg = if (p2.X > 10) "moved" else "static"
-    fmt.Println(msg, p2)
+    Println(msg, p2)
 }
 
-// Option Monad Example (line 29-46)
+// Option Monad Example
 func testOptionMonad() {
     val x = Some(10)
-    val y = x.Map((v int) => v * 2)
+    val y = x.Map((v) => v * 2)
     val z = None[int]().GetOrElse(42)
 
     val res = y match {
@@ -32,21 +30,21 @@ func testOptionMonad() {
         case _       => 0
     }
 
-    fmt.Println(res, z)
+    Println(res, z)
 }
 
-// Generic Methods Example (line 51-64)
+// Generic Methods Example
 type Box[T any] struct { Value T }
 
 func (b Box[T]) Transform[U any](f func(T) U) Box[U] = Box[U](Value = f(b.Value))
 
 func testGenericMethods() {
     val b = Box[int](Value = 10)
-    val s = b.Transform((i int) => "Value is " + fmt.Sprintf("%d", i))
-    fmt.Println(s.Value)
+    val s = b.Transform((i int) => s"Value is $i")
+    Println(s.Value)
 }
 
-// Pattern Matching with Filters Example (line 68-92)
+// Pattern Matching with Filters Example
 struct Person(Name string, Age int)
 
 func testPatternFilters() {
@@ -63,11 +61,11 @@ func testPatternFilters() {
             case Person(name, _)               => name + " is an adult"
             case _                             => "Unknown"
         }
-        fmt.Println(status)
+        Println(status)
     }
 }
 
-// Custom Extractor Example (line 96-123)
+// Custom Extractor Example
 type Even struct {}
 func (e Even) Unapply(i int) Option[int] = if (i % 2 == 0) Some(i) else None[int]()
 
@@ -75,23 +73,36 @@ func testCustomExtractor() {
     val number = 42
 
     val description = number match {
-        case Even(n) => fmt.Sprintf("%d is an even number", n)
-        case _       => fmt.Sprintf("%d is odd", number)
+        case Even(n) => s"$n is an even number"
+        case _       => s"$number is odd"
     }
 
-    fmt.Println(description)
+    Println(description)
 
-    // Nested patterns - tested separately in match_extractors.gala
-    // Here we verify basic Option pattern matching
+    // Nested patterns
     val opt = Some(10)
     opt match {
-        case Some(n) => fmt.Println("Found some number", n)
-        case None()  => fmt.Println("Nothing found")
-        case _       => fmt.Println("Other")
+        case Some(Even(n)) => Println("Found some even number", n)
+        case Some(n)       => Println("Found some odd number", n)
+        case None()        => Println("Nothing found")
+        case _             => Println("Other")
     }
 }
 
-// Interface Example (line 216-241)
+// Type-Based Pattern Matching Example
+func testTypeMatch() {
+    val x any = "hello"
+
+    val res = x match {
+        case s: string => s"string: $s"
+        case i: int    => s"int: $i"
+        case _         => "unknown"
+    }
+
+    Println(res)
+}
+
+// Interface Example
 type Shaper interface {
     Area() float64
 }
@@ -109,11 +120,11 @@ func testInterface() {
     val s1 Shaper = r
     val s2 Shaper = c
 
-    fmt.Println("Area 1:", s1.Area())
-    fmt.Println("Area 2:", s2.Area())
+    Println("Area 1:", s1.Area())
+    Println("Area 2:", s2.Area())
 }
 
-// Apply Method Example (line 245-264)
+// Apply Method Example
 type Adder struct { Delta int }
 func (a Adder) Apply(x int) int = x + a.Delta
 
@@ -126,7 +137,80 @@ func testApplyMethod() {
 
     val res2 = Multiply(3, 4)
 
-    fmt.Println(res1, res2)
+    Println(res1, res2)
+}
+
+// Type Aliases Example
+type MyString string
+
+func testTypeAlias() {
+    val s MyString = "hello"
+    Println(s)
+}
+
+// Option.OrElse Example
+func testOrElse() {
+    val primary = None[string]()
+    val fallback = Some("default")
+
+    val result = primary.OrElse(fallback)
+    Println(result.Get())
+
+    val present = Some("actual")
+    val result2 = present.OrElse(fallback)
+    Println(result2.Get())
+}
+
+// Try with Function References Example
+func testTryFuncRef() {
+    val dir = Try(os.TempDir)
+    dir.OnSuccess((d) => Println(s"Temp dir success: ${d != ""}"))
+}
+
+// Collect Example
+func testCollect() {
+    val nums = ArrayOf(1, 2, 3, 4, 5, 6)
+
+    val evenDoubled = nums.Collect({ case n if n % 2 == 0 => n * 2 })
+    Println(evenDoubled)
+
+    val options = ArrayOf(Some(1), None[int](), Some(2), None[int](), Some(3))
+    val values = options.Collect({ case Some(v) => v * 10 })
+    Println(values)
+}
+
+// MkString Example
+func testMkString() {
+    val nums = ArrayOf(1, 2, 3, 4, 5)
+    Println(nums.MkString(", "))
+    Println(nums.MkString(" | "))
+
+    val words = ListOf("hello", "world")
+    Println(words.MkString(" "))
+
+    val empty = EmptyArray[int]()
+    Println(empty.MkString(", "))
+}
+
+// Sorted API Example
+func testSorted() {
+    val arr = ArrayOf(3, 1, 4, 1, 5, 9)
+    Println(arr.Sorted())
+    Println(arr.SortWith((a, b) => a > b))
+
+    val arr2 = ArrayOf(1, 9, 3, 7, 5)
+    Println(arr2.SortBy((x) => x))
+
+    val list = ListOf("banana", "apple", "cherry")
+    Println(list.Sorted())
+
+    val tree = TreeSetOf(30, 10, 20)
+    Println(tree.Sorted())
+
+    val set = HashSetOf(5, 3, 1)
+    Println(set.Sorted())
+
+    Println(EmptyArray[int]().Sorted())
 }
 
 func main() {
@@ -135,6 +219,13 @@ func main() {
     testGenericMethods()
     testPatternFilters()
     testCustomExtractor()
+    testTypeMatch()
     testInterface()
     testApplyMethod()
+    testTypeAlias()
+    testOrElse()
+    testTryFuncRef()
+    testCollect()
+    testMkString()
+    testSorted()
 }

--- a/examples/doc_verify/examples_md.out
+++ b/examples/doc_verify/examples_md.out
@@ -5,7 +5,25 @@ Alice is an adult
 Bob is a minor
 Charlie is a senior
 42 is an even number
-Found some number 10
+Found some even number 10
+string: hello
 Area 1: 50
 Area 2: 314.159
 15 12
+hello
+default
+actual
+Temp dir success: true
+Array(4, 8, 12)
+Array(10, 20, 30)
+1, 2, 3, 4, 5
+1 | 2 | 3 | 4 | 5
+hello world
+
+Array(1, 1, 3, 4, 5, 9)
+Array(9, 5, 4, 3, 1, 1)
+Array(1, 3, 5, 7, 9)
+List(apple, banana, cherry)
+Array(10, 20, 30)
+Array(1, 3, 5)
+Array()

--- a/examples/doc_verify/gala_md_monads.gala
+++ b/examples/doc_verify/gala_md_monads.gala
@@ -20,7 +20,7 @@ func testOption() {
     val x Option[int] = Some(10)
     val y Option[int] = None[int]()
 
-    val result = x.Map((i int) => i * 2)
+    val result = x.Map((i) => i * 2)
     fmt.Printf("Option mapped: %v\n", result.Get())
 
     val fallback = y.GetOrElse(42)
@@ -31,13 +31,13 @@ func testOption() {
 func testEither() {
     val e Either[int, string] = Right[int, string]("success")
     val msg = e match {
-        case Left(code) => fmt.Sprintf("Error code: %d", code)
+        case Left(code) => s"Error code: $code"
         case Right(s)   => "Result: " + s
         case _          => "Unknown"
     }
     fmt.Printf("Either match: %s\n", msg)
 
-    val length = e.Map((s string) => len(s))
+    val length = e.Map((s) => len(s))
     fmt.Printf("Either mapped: %v\n", length)
 }
 
@@ -47,16 +47,16 @@ func testTry() {
     val failure Try[int] = Failure[int](NoSuchElementError(Message = "not found"))
 
     val msg = success match {
-        case Success(n) => fmt.Sprintf("Got: %d", n)
-        case Failure(e) => fmt.Sprintf("Error: %s", e.Error())
+        case Success(n) => s"Got: $n"
+        case Failure(e) => s"Error: ${e.Error()}"
         case _          => "Unknown"
     }
     fmt.Printf("Try match: %s\n", msg)
 
-    val doubled = success.Map[int]((n int) => n * 2)
+    val doubled = success.Map((n) => n * 2)
     fmt.Printf("Try mapped: %d\n", doubled.Get())
 
-    val recovered = failure.Recover((e error) => 0)
+    val recovered = failure.Recover((e) => 0)
     fmt.Printf("Try recovered: %d\n", recovered.Get())
 
     val value = failure.GetOrElse(100)

--- a/examples/doc_verify/gala_md_patterns.gala
+++ b/examples/doc_verify/gala_md_patterns.gala
@@ -94,7 +94,7 @@ func testPatternWithFilter() {
 func testTupleMatch() {
     val t = (1, "hello")
     val msg = t match {
-        case (a, b) => fmt.Sprintf("Got %d and %s", a, b)
+        case (a, b) => s"Got $a and $b"
         case _      => "Unknown"
     }
     fmt.Printf("Tuple match: %s\n", msg)

--- a/examples/doc_verify/immutable_collections_md.gala
+++ b/examples/doc_verify/immutable_collections_md.gala
@@ -33,10 +33,10 @@ func testListHeadTail() {
 func testListTransformations() {
     val list = ListOf(1, 2, 3)
 
-    val mapped = list.Map[int]((x int) => x * 2)
+    val mapped = list.Map((x) => x * 2)
     fmt.Printf("Map=%s\n", mapped.String())
 
-    val filtered = list.Filter((x int) => x % 2 == 1)
+    val filtered = list.Filter((x) => x % 2 == 1)
     fmt.Printf("Filter=%s\n", filtered.String())
 
     val reversed = list.Reverse()
@@ -47,10 +47,10 @@ func testListTransformations() {
 func testListFolding() {
     val list = ListOf(1, 2, 3, 4)
 
-    val sum = list.FoldLeft[int](0, (acc int, x int) => acc + x)
+    val sum = list.FoldLeft(0, (acc, x) => acc + x)
     fmt.Printf("FoldLeft sum=%d\n", sum)
 
-    val reduced = list.Reduce((a int, b int) => a + b)
+    val reduced = list.Reduce((a, b) => a + b)
     fmt.Printf("Reduce=%d\n", reduced)
 }
 
@@ -59,7 +59,7 @@ func testListPatternMatch() {
     val list = ListOf(1, 2, 3)
 
     val result = list match {
-        case Cons(head, tail) => fmt.Sprintf("head=%d, tail.Length=%d", head, tail.Length())
+        case Cons(head, tail) => s"head=$head, tail.Length=${tail.Length()}"
         case Nil() => "empty"
         case _ => "other"
     }

--- a/examples/doc_verify/mutable_collections_md.gala
+++ b/examples/doc_verify/mutable_collections_md.gala
@@ -86,13 +86,13 @@ func testArrayStructural() {
 func testArrayFunctional() {
     var arr = ArrayOf(1, 2, 3, 4, 5)
 
-    var doubled = arr.Map[int]((x int) => x * 2)
+    var doubled = arr.Map((x) => x * 2)
     fmt.Printf("Map doubled=%s\n", doubled.String())
 
-    var evens = arr.Filter((x int) => x % 2 == 0)
+    var evens = arr.Filter((x) => x % 2 == 0)
     fmt.Printf("Filter evens=%s\n", evens.String())
 
-    var sum = arr.FoldLeft[int](0, (acc int, x int) => acc + x)
+    var sum = arr.FoldLeft(0, (acc, x) => acc + x)
     fmt.Printf("FoldLeft sum=%d\n", sum)
 }
 
@@ -103,10 +103,10 @@ func testArraySearching() {
     fmt.Printf("Contains(3)=%v\n", arr.Contains(3))
     fmt.Printf("IndexOf(2)=%d\n", arr.IndexOf(2))
     fmt.Printf("LastIndexOf(2)=%d\n", arr.LastIndexOf(2))
-    fmt.Printf("Find(>2).IsDefined=%v\n", arr.Find((x int) => x > 2).IsDefined())
-    fmt.Printf("Exists(>4)=%v\n", arr.Exists((x int) => x > 4))
-    fmt.Printf("ForAll(>0)=%v\n", arr.ForAll((x int) => x > 0))
-    fmt.Printf("Count(==2)=%d\n", arr.Count((x int) => x == 2))
+    fmt.Printf("Find(>2).IsDefined=%v\n", arr.Find((x) => x > 2).IsDefined())
+    fmt.Printf("Exists(>4)=%v\n", arr.Exists((x) => x > 4))
+    fmt.Printf("ForAll(>0)=%v\n", arr.ForAll((x) => x > 0))
+    fmt.Printf("Count(==2)=%d\n", arr.Count((x) => x == 2))
 }
 
 // Array Distinct (line 270-273)
@@ -171,9 +171,9 @@ func testListSearching() {
     fmt.Printf("List.Contains(3)=%v\n", list.Contains(3))
     fmt.Printf("List.IndexOf(2)=%d\n", list.IndexOf(2))
     fmt.Printf("List.LastIndexOf(2)=%d\n", list.LastIndexOf(2))
-    fmt.Printf("List.Exists(>4)=%v\n", list.Exists((x int) => x > 4))
-    fmt.Printf("List.ForAll(>0)=%v\n", list.ForAll((x int) => x > 0))
-    fmt.Printf("List.Count(==2)=%d\n", list.Count((x int) => x == 2))
+    fmt.Printf("List.Exists(>4)=%v\n", list.Exists((x) => x > 4))
+    fmt.Printf("List.ForAll(>0)=%v\n", list.ForAll((x) => x > 0))
+    fmt.Printf("List.Count(==2)=%d\n", list.Count((x) => x == 2))
 }
 
 // HashSet Construction (line 444-454)
@@ -244,9 +244,9 @@ func testHashSetRelationships() {
 func testHashSetPredicates() {
     var s = HashSetOf(1, 2, 3, 4, 5)
 
-    fmt.Printf("HashSet.Exists(>4)=%v\n", s.Exists((x int) => x > 4))
-    fmt.Printf("HashSet.ForAll(>0)=%v\n", s.ForAll((x int) => x > 0))
-    fmt.Printf("HashSet.Count(even)=%d\n", s.Count((x int) => x % 2 == 0))
+    fmt.Printf("HashSet.Exists(>4)=%v\n", s.Exists((x) => x > 4))
+    fmt.Printf("HashSet.ForAll(>0)=%v\n", s.ForAll((x) => x > 0))
+    fmt.Printf("HashSet.Count(even)=%d\n", s.Count((x) => x % 2 == 0))
 }
 
 // TreeSet Construction (line 618-628)
@@ -315,10 +315,10 @@ func testTreeSetOperations() {
 func testTreeSetPredicates() {
     var s = TreeSetOf(1, 2, 3, 4, 5)
 
-    fmt.Printf("TreeSet.Exists(>4)=%v\n", s.Exists((x int) => x > 4))
-    fmt.Printf("TreeSet.ForAll(>0)=%v\n", s.ForAll((x int) => x > 0))
-    fmt.Printf("TreeSet.Count(even)=%d\n", s.Count((x int) => x % 2 == 0))
-    fmt.Printf("TreeSet.Find(>3).IsDefined=%v\n", s.Find((x int) => x > 3).IsDefined())
+    fmt.Printf("TreeSet.Exists(>4)=%v\n", s.Exists((x) => x > 4))
+    fmt.Printf("TreeSet.ForAll(>0)=%v\n", s.ForAll((x) => x > 0))
+    fmt.Printf("TreeSet.Count(even)=%d\n", s.Count((x) => x % 2 == 0))
+    fmt.Printf("TreeSet.Find(>3).IsDefined=%v\n", s.Find((x) => x > 3).IsDefined())
 }
 
 func main() {

--- a/examples/doc_verify/stream_md_examples.gala
+++ b/examples/doc_verify/stream_md_examples.gala
@@ -1,7 +1,6 @@
 package main
 
 import (
-    "fmt"
     . "martianoff/gala/std"
     . "martianoff/gala/stream"
 )
@@ -15,7 +14,7 @@ func testFibonacci() {
         (state Tuple[int, int]) => Some((state.V1, (state.V2, state.V1 + state.V2))),
     )
     val first10 = fibs.Take(10).ToArray()
-    fmt.Printf("Fibonacci: %v\n", first10)
+    Println(s"Fibonacci: $first10")
 }
 
 // Test: Countdown (line 92-101)
@@ -29,56 +28,56 @@ func testCountdown() {
             return None[Tuple[int, int]]()
         },
     )
-    fmt.Printf("Countdown: %v\n", countdown.ToArray())
+    Println(s"Countdown: ${countdown.ToArray()}")
 }
 
 // Test: Of constructor (line 31)
 func testOf() {
     val s1 = Of(1, 2, 3, 4, 5)
-    fmt.Printf("Of: %v\n", s1.ToArray())
+    Println(s"Of: ${s1.ToArray()}")
 }
 
 // Test: Range (line 56-60)
 func testRange() {
     val s1 = Range(1, 10)
-    fmt.Printf("Range: %v\n", s1.ToArray())
+    Println(s"Range: ${s1.ToArray()}")
 }
 
 // Test: Iterate (line 73)
 func testIterate() {
-    val powers = Iterate[int](1, (x int) => x * 2)
-    fmt.Printf("Iterate: %v\n", powers.Take(5).ToArray())
+    val powers = Iterate[int](1, (x) => x * 2)
+    Println(s"Iterate: ${powers.Take(5).ToArray()}")
 }
 
 // Test: Map (line 123-124)
 func testMap() {
-    val doubled = Of(1, 2, 3).Map[int]((x int) => x * 2)
-    fmt.Printf("Map: %v\n", doubled.ToArray())
+    val doubled = Of(1, 2, 3).Map((x) => x * 2)
+    Println(s"Map: ${doubled.ToArray()}")
 }
 
 // Test: Filter (line 141-142)
 func testFilter() {
-    val evens = Of(1, 2, 3, 4, 5).Filter((x int) => x % 2 == 0)
-    fmt.Printf("Filter: %v\n", evens.ToArray())
+    val evens = Of(1, 2, 3, 4, 5).Filter((x) => x % 2 == 0)
+    Println(s"Filter: ${evens.ToArray()}")
 }
 
 // Test: Take (line 153)
 func testTake() {
     val first3 = Of(1, 2, 3, 4, 5).Take(3)
-    fmt.Printf("Take: %v\n", first3.ToArray())
+    Println(s"Take: ${first3.ToArray()}")
 }
 
 // Test: Fold (line 278-279)
 func testFold() {
-    val sum = Of(1, 2, 3, 4, 5).Fold[int](0, (acc int, x int) => acc + x)
-    fmt.Printf("Fold: %d\n", sum)
+    val sum = Of(1, 2, 3, 4, 5).Fold(0, (acc, x) => acc + x)
+    Println(s"Fold: $sum")
 }
 
 // Test: ZipWithIndex (line 182-183)
 func testZipWithIndex() {
     val indexed = Of("a", "b", "c").ZipWithIndex()
-    indexed.ForEach((t Tuple[string, int]) => {
-        fmt.Printf("ZipWithIndex: (%s, %d)\n", t.V1, t.V2)
+    indexed.ForEach((t) => {
+        Println(s"ZipWithIndex: (${t.V1}, ${t.V2})")
     })
 }
 


### PR DESCRIPTION
## Summary

- Replace `fmt.Println`/`fmt.Sprintf` with `Println`/`s"..."` string interpolation across all docs
- Remove explicit lambda param types where inferrable (e.g., `(x int) =>` → `(x) =>`)
- Remove unnecessary method type params (e.g., `.Map[int](` → `.Map(`)
- Add `Collect` method documentation to IMMUTABLE/MUTABLE_COLLECTIONS.MD
- Add `FilterKeys`/`FilterValues`/`ForEachKey`/`ForEachValue` to HashMap docs
- Add `Collect`, `Option.OrElse`, `Try(funcRef)` examples to EXAMPLES.MD
- Add Go type inference section to TYPE_INFERENCE.MD
- Add auto-fetch and multi-line import docs to DEPENDENCY_MANAGEMENT.MD
- Add `Collect` preference rules (Filter+Map → Collect) to gala-lint skill
- Add `List.LastIndexOf` to immutable collections
- Update all doc_verify test files to match current docs

## Test plan

- [x] `bazel test //...` — all 196 tests pass
- [x] All doc_verify examples updated and verified to compile
- [x] No transpiler changes included

🤖 Generated with [Claude Code](https://claude.com/claude-code)