### PR TITLE
feat: default parameter values and named arguments

### DIFF
--- a/.claude/skills/gala-code.md
+++ b/.claude/skills/gala-code.md
@@ -40,10 +40,12 @@ Design the implementation following GALA best practices:
 8. **Implicit typing** - Omit type params where inferable: `Some(42)` not `Some[int](42)`, `(x) => x * 2` not `(x int) => x * 2`
 9. **Generics over reflection** - Use type parameters for reusable code
 10. **Copy for updates** - Use `.Copy(field = newValue)` instead of mutation
-11. **String interpolation** - Use `s"Hello $name"` instead of `fmt.Sprintf("Hello %s", name)`. Use `f"$x%.2f"` for explicit format control. No `import "fmt"` needed.
-12. **Println/Print** - Use `Println(...)` and `Print(...)` instead of `fmt.Println(...)` / `fmt.Print(...)`. No import needed.
-13. **Try for Go errors** - Wrap Go functions that return `(T, error)` with `Try(f)` when f takes no args, or `Try(() => f(args))` when args are needed. Use `.OrElse` for independent fallbacks, `.FlatMap` for dependent chains. Never use sequential `if err == nil` blocks.
-14. **Option over sentinels** - Return `Option[T]` instead of sentinel values (`""`, `0`, `-1`, `nil`) to signal absence. Use `.GetOrElse`, `.Map`, or `match` on the caller side.
+11. **Default parameters** - Use default values for optional params: `func connect(host string, port int = 8080)`. Callers can omit trailing defaults or use named args: `connect("localhost", tls = false)`
+12. **Named arguments** - Use named args for clarity: `divide(dividend = 20, divisor = 4)`. Works with any GALA function, not just structs
+13. **String interpolation** - Use `s"Hello $name"` instead of `fmt.Sprintf("Hello %s", name)`. Use `f"$x%.2f"` for explicit format control. No `import "fmt"` needed.
+14. **Println/Print** - Use `Println(...)` and `Print(...)` instead of `fmt.Println(...)` / `fmt.Print(...)`. No import needed.
+15. **Try for Go errors** - Wrap Go functions that return `(T, error)` with `Try(f)` when f takes no args, or `Try(() => f(args))` when args are needed. Use `.OrElse` for independent fallbacks, `.FlatMap` for dependent chains. Never use sequential `if err == nil` blocks.
+16. **Option over sentinels** - Return `Option[T]` instead of sentinel values (`""`, `0`, `-1`, `nil`) to signal absence. Use `.GetOrElse`, `.Map`, or `match` on the caller side.
 
 ### Step 2: Write the Source Code
 
@@ -194,6 +196,8 @@ Before finishing, verify:
 - [ ] GALA collections (`Array`, `List`) used instead of Go slices for internal logic
 - [ ] Variadic args converted with `ArrayOf(args...)` when functional processing is needed
 - [ ] Expression-bodied functions used for single-expression functions
+- [ ] Default parameter values used for optional parameters instead of overloads/options pattern
+- [ ] Named arguments used at call sites when it improves readability
 - [ ] Type parameters omitted where inferable
 - [ ] String interpolation (`s"..."` / `f"..."`) used instead of `fmt.Sprintf`
 - [ ] `Println`/`Print` used instead of `fmt.Println`/`fmt.Print`

--- a/.claude/skills/gala-lint.md
+++ b/.claude/skills/gala-lint.md
@@ -181,7 +181,22 @@ for _, x := range nums {
 
 **Acceptable `fmt` uses**: `fmt.Errorf`, `fmt.Fprintf`, `fmt.Fscan*`, `fmt.Stringer` interface implementation, and any `fmt` function not covered by interpolation.
 
-### 6. Type Inference (MEDIUM priority)
+### 6. Default Parameters and Named Arguments (MEDIUM priority)
+
+| Issue | Pattern to Flag | Recommended Fix |
+|-------|-----------------|-----------------|
+| Options pattern instead of defaults | Struct with `WithPort`, `WithTimeout` option functions | Use default parameter values: `func connect(host string, port int = 8080)` |
+| Multiple wrapper functions | `func NewFoo()`, `func NewFooWithBar()`, `func NewFooWithBarAndBaz()` | Single function with defaults: `func NewFoo(bar int = 0, baz string = "")` |
+| Boolean flag parameter without name | `connect("localhost", 8080, true)` where `true` is ambiguous | Use named arg: `connect("localhost", tls = true)` |
+| Positional args reducing readability | `createUser("Alice", 30, "admin", true, false)` | Use named args for clarity: `createUser(name = "Alice", age = 30, role = "admin")` |
+| Default after required without default | `func f(a int = 1, b int, c string = "x")` | Defaults must be contiguous at end: `func f(b int, a int = 1, c string = "x")` |
+
+**Check**: Search for the functional options pattern (structs named `*Option` or `*Config` with `With*` functions), multiple function overloads with incremental parameters, and call sites with 3+ positional boolean/int literal arguments where named args would clarify intent.
+
+**Acceptable patterns**: Go interop functions that must match Go signatures cannot use defaults.
+
+### 7. Type Inference (MEDIUM priority)
+<!-- Note: sections below renumbered after inserting rule 6 -->
 
 | Issue | Pattern to Flag | Recommended Fix |
 |-------|-----------------|-----------------|

--- a/docs/EXAMPLES.MD
+++ b/docs/EXAMPLES.MD
@@ -23,6 +23,67 @@ func main() {
 }
 ```
 
+## Named Arguments
+
+Function calls support named arguments in any order. The compiler reorders them to match the function signature.
+
+```gala
+package main
+
+func describe(name string, age int, role string) string =
+    s"$name ($role, age $age)"
+
+func main() {
+    Println(describe("Alice", 30, "engineer"))                   // positional
+    Println(describe(role = "designer", name = "Bob", age = 25)) // named, any order
+}
+```
+
+## Default Parameter Values
+
+Functions can have default parameter values. Callers can omit trailing defaults or use named arguments to skip specific parameters.
+
+```gala
+package main
+
+func greet(name string, greeting string = "Hello", punctuation string = "!") string =
+    s"$greeting, $name$punctuation"
+
+func add(a int, b int = 10) int = a + b
+
+func main() {
+    Println(greet("World"))                     // Hello, World!
+    Println(greet("World", "Hi"))               // Hi, World!
+    Println(greet("World", "Hey", "..."))       // Hey, World...
+    Println(greet("World", punctuation = "?"))  // Hello, World?
+    Println(greet(name = "World", greeting = "Yo")) // Yo, World!
+    Println(add(5))                             // 15
+    Println(add(5, 20))                         // 25
+}
+```
+
+Default expressions are evaluated at each call site:
+
+```gala
+package main
+
+var counter = 0
+
+func nextId() int {
+    counter = counter + 1
+    return counter
+}
+
+func createItem(name string, id int = nextId()) string =
+    s"$name#$id"
+
+func main() {
+    Println(createItem("A"))      // A#1
+    Println(createItem("B"))      // B#2
+    Println(createItem("C", 99))  // C#99
+}
+```
+
 ## Option Monad Example
 
 ```gala

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -9,6 +9,8 @@ GALA (Go Alternative LAnguage) is a modern programming language that transpiles 
 1. [Project Structure](#1-project-structure)
 2. [Variable Declarations](#2-variable-declarations)
 3. [Functions](#3-functions)
+   - [Named Arguments](#named-arguments)
+   - [Default Parameter Values](#default-parameter-values)
 4. [Types and Structs](#4-types-and-structs)
    - [Sealed Types (ADTs)](#sealed-types-algebraic-data-types)
    - [Type Aliases](#type-aliases)
@@ -147,6 +149,58 @@ func process(val data string, var count int) {
     count = count + 1 // OK
 }
 ```
+
+### Named Arguments
+
+Function calls support named arguments. Named arguments can appear in any order — the compiler reorders them to match the function signature.
+
+```gala
+func divide(dividend int, divisor int) int = dividend / divisor
+
+divide(divisor = 4, dividend = 20)  // 5 — reordered to divide(20, 4)
+divide(20, 4)                        // 5 — positional works too
+```
+
+Named arguments work with struct construction, `Copy()` method overrides, and regular function calls.
+
+### Default Parameter Values
+
+Parameters can have default values. When a function is called without providing a defaulted argument, the default expression is injected at the call site. Default parameters must come after required parameters.
+
+```gala
+func connect(host string, port int = 8080, tls bool = true) Connection {
+    // ...
+}
+
+// Positional: omit trailing defaults
+connect("localhost")                    // port=8080, tls=true
+connect("localhost", 3000)              // tls=true
+connect("localhost", 3000, false)       // all explicit
+
+// Named arguments + defaults: skip any defaulted parameter
+connect("localhost", tls = false)       // port=8080
+connect(host = "localhost", port = 443) // tls=true
+```
+
+Default expressions are evaluated at each call site (not once at definition time):
+
+```gala
+func log(msg string, timestamp time.Time = time.Now()) {
+    Println(s"[$timestamp] $msg")
+}
+log("starting")  // timestamp = current time at each call
+```
+
+Expression functions also support defaults:
+
+```gala
+func greet(name string, greeting string = "Hello") string = s"$greeting, $name!"
+```
+
+The compiler validates defaults at compile time:
+- Default expression type must match the parameter type (e.g., `x int = "hello"` is a compile error)
+- Parameters with defaults must be contiguous at the end of the parameter list
+- Missing required arguments produce a clear error pointing to the GALA source line
 
 ### Function Type Parameters (Higher-Order Functions)
 GALA supports functions as first-class values. You can pass functions as parameters and return them from other functions.

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -20,7 +20,6 @@ filegroup(
         "match_method_chain/main.gala",
         "match_method_chain/types.gala",
         "match_void_branches.gala",
-        "try_go_transitive_import.gala",
         "mathlib/math.gala",
         "multi_file/greeter.gala",
         "multi_file/main.gala",
@@ -34,6 +33,7 @@ filegroup(
         "slice_unwrap/model.gala",
         "struct_field_unwrap/main.gala",
         "struct_field_unwrap/types.gala",
+        "try_go_transitive_import.gala",
         "use_cross_file_unwrap_lib.gala",
         "wrapper_method_lambda/main.gala",
     ],
@@ -1270,4 +1270,25 @@ gala_test(
     src = "iterate_lambda_infer.gala",
     expected = "iterate_lambda_infer.out",
     deps = ["//stream"],
+)
+
+# Named arguments for function calls — reorder to match parameter order
+gala_test(
+    name = "named_args",
+    src = "named_args.gala",
+    expected = "named_args.out",
+)
+
+# Default parameter values with positional and named argument call-site injection
+gala_test(
+    name = "default_params",
+    src = "default_params.gala",
+    expected = "default_params.out",
+)
+
+# Default parameter values with expression defaults (evaluated at call time)
+gala_test(
+    name = "default_params_expr",
+    src = "default_params_expr.gala",
+    expected = "default_params_expr.out",
 )

--- a/examples/default_params.gala
+++ b/examples/default_params.gala
@@ -1,0 +1,21 @@
+package main
+
+func greet(name string, greeting string = "Hello", punctuation string = "!") string =
+    s"$greeting, $name$punctuation"
+
+func add(a int, b int = 10) int = a + b
+
+func main() {
+    // Positional args - skip defaults
+    Println(greet("World"))
+    Println(greet("World", "Hi"))
+    Println(greet("World", "Hey", "..."))
+
+    // Named args with defaults
+    Println(greet("World", punctuation = "?"))
+    Println(greet(name = "World", greeting = "Yo"))
+
+    // Simple default
+    Println(add(5))
+    Println(add(5, 20))
+}

--- a/examples/default_params.out
+++ b/examples/default_params.out
@@ -1,0 +1,7 @@
+Hello, World!
+Hi, World!
+Hey, World...
+Hello, World?
+Yo, World!
+15
+25

--- a/examples/default_params_expr.gala
+++ b/examples/default_params_expr.gala
@@ -1,0 +1,25 @@
+package main
+
+var counter = 0
+
+func nextId() int {
+    counter = counter + 1
+    return counter
+}
+
+func createItem(name string, id int = nextId()) string =
+    s"$name#$id"
+
+func withFlag(label string, enabled bool = true) string =
+    if (enabled) s"$label: ON" else s"$label: OFF"
+
+func main() {
+    // Expression defaults: nextId() is called each time
+    Println(createItem("A"))
+    Println(createItem("B"))
+    Println(createItem("C", 99))
+
+    // Boolean defaults
+    Println(withFlag("feature"))
+    Println(withFlag("debug", false))
+}

--- a/examples/default_params_expr.out
+++ b/examples/default_params_expr.out
@@ -1,0 +1,5 @@
+A#1
+B#2
+C#99
+feature: ON
+debug: OFF

--- a/examples/named_args.gala
+++ b/examples/named_args.gala
@@ -1,0 +1,20 @@
+package main
+
+func describe(name string, age int, role string) string =
+    s"$name ($role, age $age)"
+
+func divide(dividend int, divisor int) int = dividend / divisor
+
+func main() {
+    // Positional
+    Println(describe("Alice", 30, "engineer"))
+
+    // Named, any order
+    Println(describe(role = "designer", name = "Bob", age = 25))
+
+    // Named reordering
+    Println(divide(divisor = 4, dividend = 20))
+
+    // All named, same order
+    Println(divide(dividend = 100, divisor = 10))
+}

--- a/examples/named_args.out
+++ b/examples/named_args.out
@@ -1,0 +1,4 @@
+Alice (engineer, age 30)
+Bob (designer, age 25)
+5
+10

--- a/internal/parser/grammar/gala.g4
+++ b/internal/parser/grammar/gala.g4
@@ -68,7 +68,9 @@ parameterList: parameter (',' parameter)*;
 // - Named with type: "x int", "val x int", "x ...int"
 // - Named without type: "x" (type inferred)
 // - Type only (for function types): "int", "Option[T]", "...int"
-parameter: (VAL | VAR)? (identifier ELLIPSIS? type? | ELLIPSIS? type);
+// - With default value: "x int = 42", "host string = \"localhost\""
+parameter: (VAL | VAR)? (identifier ELLIPSIS? type? paramDefault? | ELLIPSIS? type);
+paramDefault: '=' expression;
 
 ELLIPSIS: '...';
 

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -607,6 +607,11 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 								} else {
 									methodMeta.ParamTypes = append(methodMeta.ParamTypes, transpiler.NilType{})
 								}
+								if paramCtx.Identifier() != nil {
+									methodMeta.ParamNames = append(methodMeta.ParamNames, paramCtx.Identifier().GetText())
+								} else {
+									methodMeta.ParamNames = append(methodMeta.ParamNames, "")
+								}
 							}
 						}
 					}
@@ -669,15 +674,33 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 				if ctx.Signature().Parameters() != nil {
 					pCtx := ctx.Signature().Parameters().(*grammar.ParametersContext)
 					if pList := pCtx.ParameterList(); pList != nil {
-						for _, p := range pList.(*grammar.ParameterListContext).AllParameter() {
+						for i, p := range pList.(*grammar.ParameterListContext).AllParameter() {
 							paramCtx := p.(*grammar.ParameterContext)
 							if paramCtx.Type_() != nil {
 								funcMeta.ParamTypes = append(funcMeta.ParamTypes, a.resolveTypeWithParams(paramCtx.Type_().GetText(), pkgName, funcMeta.TypeParams))
 							} else {
 								funcMeta.ParamTypes = append(funcMeta.ParamTypes, transpiler.NilType{})
 							}
+							// Extract parameter name
+							if paramCtx.Identifier() != nil {
+								funcMeta.ParamNames = append(funcMeta.ParamNames, paramCtx.Identifier().GetText())
+							} else {
+								funcMeta.ParamNames = append(funcMeta.ParamNames, "")
+							}
+							// Extract default expression source text
+							if paramCtx.ParamDefault() != nil {
+								if funcMeta.DefaultExprs == nil {
+									funcMeta.DefaultExprs = make(map[int]string)
+								}
+								defaultCtx := paramCtx.ParamDefault().(*grammar.ParamDefaultContext)
+								funcMeta.DefaultExprs[i] = defaultCtx.Expression().GetText()
+							}
 						}
 					}
+				}
+				// Validate default parameter rules
+				if err := validateDefaultParams(funcMeta, ctx.GetStart().GetLine(), filePath); err != nil {
+					return nil, err
 				}
 				richAST.Functions[fullFuncName] = funcMeta
 			}
@@ -2049,12 +2072,24 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 					if ctx.Signature().Parameters() != nil {
 						pCtx := ctx.Signature().Parameters().(*grammar.ParametersContext)
 						if pList := pCtx.ParameterList(); pList != nil {
-							for _, p := range pList.(*grammar.ParameterListContext).AllParameter() {
+							for i, p := range pList.(*grammar.ParameterListContext).AllParameter() {
 								paramCtx := p.(*grammar.ParameterContext)
 								if paramCtx.Type_() != nil {
 									funcMeta.ParamTypes = append(funcMeta.ParamTypes, a.resolveTypeWithParams(paramCtx.Type_().GetText(), pkgName, funcMeta.TypeParams))
 								} else {
 									funcMeta.ParamTypes = append(funcMeta.ParamTypes, transpiler.NilType{})
+								}
+								if paramCtx.Identifier() != nil {
+									funcMeta.ParamNames = append(funcMeta.ParamNames, paramCtx.Identifier().GetText())
+								} else {
+									funcMeta.ParamNames = append(funcMeta.ParamNames, "")
+								}
+								if paramCtx.ParamDefault() != nil {
+									if funcMeta.DefaultExprs == nil {
+										funcMeta.DefaultExprs = make(map[int]string)
+									}
+									defaultCtx := paramCtx.ParamDefault().(*grammar.ParamDefaultContext)
+									funcMeta.DefaultExprs[i] = defaultCtx.Expression().GetText()
 								}
 							}
 						}
@@ -2067,5 +2102,136 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 	return nil
 }
 
+
+// validateDefaultParams checks that default parameter values follow the rules:
+// 1. Parameters with defaults must come after all required parameters
+// 2. Variadic parameters cannot have defaults
+// 3. Default expression types must be compatible with parameter types (for literals)
+func validateDefaultParams(funcMeta *transpiler.FunctionMetadata, line int, filePath string) error {
+	if len(funcMeta.DefaultExprs) == 0 {
+		return nil
+	}
+
+	// Check ordering: once a default is seen, all subsequent params must have defaults (or be variadic)
+	seenDefault := false
+	for i := range funcMeta.ParamTypes {
+		_, hasDefault := funcMeta.DefaultExprs[i]
+		if hasDefault {
+			seenDefault = true
+		} else if seenDefault {
+			paramName := ""
+			if i < len(funcMeta.ParamNames) {
+				paramName = funcMeta.ParamNames[i]
+			}
+			return fmt.Errorf("%s:%d: parameter %q has no default value but follows parameter with default in function %s (parameters with defaults must be contiguous at end of parameter list)",
+				filePath, line, paramName, funcMeta.Name)
+		}
+	}
+
+	// Check literal type compatibility
+	for i, defaultText := range funcMeta.DefaultExprs {
+		if i >= len(funcMeta.ParamTypes) {
+			continue
+		}
+		paramType := funcMeta.ParamTypes[i].String()
+		if paramType == "" || paramType == "<nil>" {
+			continue
+		}
+		literalType := inferLiteralType(defaultText)
+		if literalType == "" {
+			continue // non-literal expression, can't validate statically
+		}
+		if !typesCompatibleForDefault(paramType, literalType) {
+			paramName := ""
+			if i < len(funcMeta.ParamNames) {
+				paramName = funcMeta.ParamNames[i]
+			}
+			return fmt.Errorf("%s:%d: default value for parameter %q has type %s, but parameter type is %s",
+				filePath, line, paramName, literalType, paramType)
+		}
+	}
+
+	return nil
+}
+
+// inferLiteralType returns the type of a literal expression, or "" if not a literal.
+func inferLiteralType(expr string) string {
+	if expr == "true" || expr == "false" {
+		return "bool"
+	}
+	if expr == "nil" {
+		return "" // nil is compatible with many types
+	}
+	if len(expr) >= 2 && expr[0] == '"' && expr[len(expr)-1] == '"' {
+		return "string"
+	}
+	if len(expr) >= 2 && expr[0] == '\'' && expr[len(expr)-1] == '\'' {
+		return "rune"
+	}
+	// Check for float (contains . or e/E)
+	if isNumericLiteral(expr) {
+		for _, c := range expr {
+			if c == '.' || c == 'e' || c == 'E' {
+				return "float64"
+			}
+		}
+		return "int"
+	}
+	return ""
+}
+
+// isNumericLiteral checks if a string looks like a numeric literal.
+func isNumericLiteral(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	start := 0
+	if s[0] == '-' || s[0] == '+' {
+		start = 1
+	}
+	if start >= len(s) {
+		return false
+	}
+	hasDigit := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if c >= '0' && c <= '9' {
+			hasDigit = true
+		} else if c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-' {
+			// valid in float literals
+		} else {
+			return false
+		}
+	}
+	return hasDigit
+}
+
+// typesCompatibleForDefault checks if a literal type is compatible with a parameter type.
+func typesCompatibleForDefault(paramType, literalType string) bool {
+	if paramType == literalType {
+		return true
+	}
+	// Numeric widening: int literal can be used for int, int8, int16, int32, int64, uint*, float*
+	if literalType == "int" {
+		switch paramType {
+		case "int", "int8", "int16", "int32", "int64",
+			"uint", "uint8", "uint16", "uint32", "uint64",
+			"float32", "float64", "byte", "rune":
+			return true
+		}
+	}
+	// Float literal can be used for float32, float64
+	if literalType == "float64" {
+		switch paramType {
+		case "float32", "float64":
+			return true
+		}
+	}
+	// any accepts everything
+	if paramType == "any" || paramType == "interface{}" {
+		return true
+	}
+	return false
+}
 
 var _ transpiler.Analyzer = (*galaAnalyzer)(nil)

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -5,6 +5,8 @@ import (
 	"go/ast"
 	"strings"
 
+	"github.com/antlr4-go/antlr/v4"
+
 	"martianoff/gala/galaerr"
 	"martianoff/gala/internal/parser/grammar"
 	"martianoff/gala/internal/transpiler"
@@ -146,6 +148,16 @@ func (t *galaASTTransformer) applyCallSuffix(base ast.Expr, suffix *grammar.Post
 			}
 		}
 
+		// Zero-argument call — check if function has default params that need injection
+		if funcName := t.extractFuncName(base); funcName != "" {
+			if funcMeta := t.getFunction(funcName); funcMeta != nil && len(funcMeta.DefaultExprs) > 0 && len(funcMeta.ParamTypes) > 0 {
+				filled, err := t.fillDefaultArgs(nil, funcMeta)
+				if err != nil {
+					return nil, err
+				}
+				return &ast.CallExpr{Fun: base, Args: filled}, nil
+			}
+		}
 		return &ast.CallExpr{Fun: base, Args: nil}, nil
 	}
 
@@ -621,9 +633,21 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 		}
 	}
 
-	// If we have named args, this might be struct construction
+	// If we have named args, try function call with named args + defaults first
 	if len(namedArgs) > 0 {
+		if funcMeta != nil && len(funcMeta.ParamNames) > 0 {
+			return t.handleNamedArgsFuncCall(fun, args, namedArgs, funcMeta)
+		}
 		return t.handleNamedArgsCall(fun, args, namedArgs)
+	}
+
+	// If fewer positional args than expected and function has defaults, inject default values
+	if funcMeta != nil && len(funcMeta.DefaultExprs) > 0 && len(args) < len(funcMeta.ParamTypes) {
+		filled, err := t.fillDefaultArgs(args, funcMeta)
+		if err != nil {
+			return nil, err
+		}
+		args = filled
 	}
 
 	// Check if the function being called is a type with an Apply method
@@ -1074,6 +1098,119 @@ func (t *galaASTTransformer) findSealedVariantFields(variantName string) []strin
 		}
 	}
 	return nil
+}
+
+// parseDefaultExpr parses a GALA expression string (from a default parameter value)
+// into an ANTLR expression context that can be transformed by the normal pipeline.
+func (t *galaASTTransformer) parseDefaultExpr(exprText string) (grammar.IExpressionContext, error) {
+	input := antlr.NewInputStream(exprText)
+	lexer := grammar.NewgalaLexer(input)
+	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
+	p := grammar.NewgalaParser(stream)
+	p.RemoveErrorListeners()
+	return p.Expression(), nil
+}
+
+// transformDefaultExpr parses and transforms a default expression string into a Go AST expression.
+func (t *galaASTTransformer) transformDefaultExpr(exprText string) (ast.Expr, error) {
+	exprCtx, err := t.parseDefaultExpr(exprText)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse default expression %q: %w", exprText, err)
+	}
+	return t.transformExpression(exprCtx)
+}
+
+// fillDefaultArgs fills missing positional arguments with default values from function metadata.
+// Called when a function has defaults and fewer args were provided than parameters.
+func (t *galaASTTransformer) fillDefaultArgs(args []ast.Expr, funcMeta *transpiler.FunctionMetadata) ([]ast.Expr, error) {
+	totalParams := len(funcMeta.ParamTypes)
+	result := make([]ast.Expr, totalParams)
+
+	// Copy provided positional args
+	copy(result, args)
+
+	// Fill missing positions with defaults
+	for i := len(args); i < totalParams; i++ {
+		defaultExprText, hasDefault := funcMeta.DefaultExprs[i]
+		if !hasDefault {
+			return nil, galaerr.NewSemanticError(fmt.Sprintf(
+				"missing required argument %q (parameter %d) in call to %s",
+				funcMeta.ParamNames[i], i+1, funcMeta.Name))
+		}
+		expr, err := t.transformDefaultExpr(defaultExprText)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = expr
+	}
+
+	return result, nil
+}
+
+// handleNamedArgsFuncCall handles function calls with named arguments and default parameter values.
+// Reorders named args to match parameter order and fills gaps with defaults.
+func (t *galaASTTransformer) handleNamedArgsFuncCall(
+	fun ast.Expr,
+	positionalArgs []ast.Expr,
+	namedArgs map[string]ast.Expr,
+	funcMeta *transpiler.FunctionMetadata,
+) (ast.Expr, error) {
+	totalParams := len(funcMeta.ParamTypes)
+	result := make([]ast.Expr, totalParams)
+
+	// Place positional args first
+	for i, arg := range positionalArgs {
+		if i >= totalParams {
+			return nil, galaerr.NewSemanticError(fmt.Sprintf(
+				"too many arguments in call to %s: expected %d, got %d positional + %d named",
+				funcMeta.Name, totalParams, len(positionalArgs), len(namedArgs)))
+		}
+		result[i] = arg
+	}
+
+	// Place named args at their correct positions
+	for name, expr := range namedArgs {
+		idx := -1
+		for i, pName := range funcMeta.ParamNames {
+			if pName == name {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			return nil, galaerr.NewSemanticError(fmt.Sprintf(
+				"unknown parameter %q in call to %s", name, funcMeta.Name))
+		}
+		if result[idx] != nil {
+			return nil, galaerr.NewSemanticError(fmt.Sprintf(
+				"parameter %q specified both positionally and by name in call to %s",
+				name, funcMeta.Name))
+		}
+		result[idx] = expr
+	}
+
+	// Fill remaining gaps with defaults
+	for i, slot := range result {
+		if slot == nil {
+			defaultExprText, hasDefault := funcMeta.DefaultExprs[i]
+			if !hasDefault {
+				paramName := ""
+				if i < len(funcMeta.ParamNames) {
+					paramName = funcMeta.ParamNames[i]
+				}
+				return nil, galaerr.NewSemanticError(fmt.Sprintf(
+					"missing required argument %q (parameter %d) in call to %s",
+					paramName, i+1, funcMeta.Name))
+			}
+			expr, err := t.transformDefaultExpr(defaultExprText)
+			if err != nil {
+				return nil, err
+			}
+			result[i] = expr
+		}
+	}
+
+	return &ast.CallExpr{Fun: fun, Args: result}, nil
 }
 
 func (t *galaASTTransformer) transformArgumentWithExpectedType(exprCtx grammar.IExpressionContext, expectedType transpiler.Type) (ast.Expr, error) {

--- a/internal/transpiler/transpiler.go
+++ b/internal/transpiler/transpiler.go
@@ -174,6 +174,7 @@ type MethodMetadata struct {
 	Name       string
 	Package    string
 	ParamTypes []Type
+	ParamNames []string // Parameter names (for named argument matching)
 	ReturnType Type
 	TypeParams []string
 	IsGeneric  bool   // Force transformation to standalone function
@@ -181,11 +182,13 @@ type MethodMetadata struct {
 }
 
 type FunctionMetadata struct {
-	Name       string
-	Package    string
-	ParamTypes []Type
-	ReturnType Type
-	TypeParams []string
+	Name          string
+	Package       string
+	ParamTypes    []Type
+	ParamNames    []string         // Parameter names (for named argument matching and default injection)
+	ReturnType    Type
+	TypeParams    []string
+	DefaultExprs  map[int]string   // Param index -> default expression source text (nil = required)
 }
 
 // CompanionObjectMetadata stores information about companion objects that can be used

--- a/website/docs/examples.md
+++ b/website/docs/examples.md
@@ -34,6 +34,67 @@ func main() {
 }
 ```
 
+## Named Arguments
+
+Function calls support named arguments in any order. The compiler reorders them to match the function signature.
+
+```gala
+package main
+
+func describe(name string, age int, role string) string =
+    s"$name ($role, age $age)"
+
+func main() {
+    Println(describe("Alice", 30, "engineer"))                   // positional
+    Println(describe(role = "designer", name = "Bob", age = 25)) // named, any order
+}
+```
+
+## Default Parameter Values
+
+Functions can have default parameter values. Callers can omit trailing defaults or use named arguments to skip specific parameters.
+
+```gala
+package main
+
+func greet(name string, greeting string = "Hello", punctuation string = "!") string =
+    s"$greeting, $name$punctuation"
+
+func add(a int, b int = 10) int = a + b
+
+func main() {
+    Println(greet("World"))                     // Hello, World!
+    Println(greet("World", "Hi"))               // Hi, World!
+    Println(greet("World", "Hey", "..."))       // Hey, World...
+    Println(greet("World", punctuation = "?"))  // Hello, World?
+    Println(greet(name = "World", greeting = "Yo")) // Yo, World!
+    Println(add(5))                             // 15
+    Println(add(5, 20))                         // 25
+}
+```
+
+Default expressions are evaluated at each call site:
+
+```gala
+package main
+
+var counter = 0
+
+func nextId() int {
+    counter = counter + 1
+    return counter
+}
+
+func createItem(name string, id int = nextId()) string =
+    s"$name#$id"
+
+func main() {
+    Println(createItem("A"))      // A#1
+    Println(createItem("B"))      // B#2
+    Println(createItem("C", 99))  // C#99
+}
+```
+
 ## Option Monad Example
 
 ```gala

--- a/website/docs/language-reference.md
+++ b/website/docs/language-reference.md
@@ -142,6 +142,55 @@ func process(val data string, var count int) {
 }
 ```
 
+### Named Arguments
+
+Function calls support named arguments. Named arguments can appear in any order — the compiler reorders them to match the function signature.
+
+```gala
+func divide(dividend int, divisor int) int = dividend / divisor
+
+divide(divisor = 4, dividend = 20)  // 5 — reordered to divide(20, 4)
+divide(20, 4)                        // 5 — positional works too
+```
+
+Named arguments work with struct construction, `Copy()` method overrides, and regular function calls.
+
+### Default Parameter Values
+
+Parameters can have default values. When a function is called without providing a defaulted argument, the default expression is injected at the call site. Default parameters must come after required parameters.
+
+```gala
+func connect(host string, port int = 8080, tls bool = true) {
+    Println(s"Connecting to $host:$port (tls=$tls)")
+}
+
+connect("localhost")                    // port=8080, tls=true
+connect("localhost", 3000)              // tls=true
+connect("localhost", 3000, false)       // all explicit
+
+// Named arguments + defaults: skip any defaulted parameter
+connect("localhost", tls = false)       // port=8080
+connect(host = "localhost", port = 443) // tls=true
+```
+
+Default expressions are evaluated at each call site (not once at definition time):
+
+```gala
+func log(msg string, ts time.Time = time.Now()) {
+    Println(s"[$ts] $msg")
+}
+```
+
+Expression functions also support defaults:
+
+```gala
+func greet(name string, greeting string = "Hello") string = s"$greeting, $name!"
+```
+
+The compiler validates defaults at compile time:
+- Default expression type must match the parameter type
+- Parameters with defaults must be contiguous at the end of the parameter list
+
 ### Higher-Order Functions
 Functions are first-class values:
 

--- a/website/vs-go.md
+++ b/website/vs-go.md
@@ -221,6 +221,46 @@ GALA also provides `Println` and `Print` as built-in functions -- no `fmt` impor
 
 ---
 
+## 7. Default Parameter Values
+
+Go has no default parameters. The common workaround is the "functional options" pattern, which requires a struct, variadic functions, and option types. GALA adds defaults directly to the function signature.
+
+<div class="comparison">
+<div>
+<p><strong>GALA</strong></p>
+<pre><code>func connect(
+    host string,
+    port int = 8080,
+    tls bool = true,
+) Connection {
+    // ...
+}
+
+connect("localhost")
+connect("db", tls = false)</code></pre>
+</div>
+<div>
+<p><strong>Go</strong></p>
+<pre><code>type ConnectOption func(*connectOpts)
+type connectOpts struct {
+    port int; tls bool
+}
+func WithPort(p int) ConnectOption { ... }
+func WithTLS(t bool) ConnectOption { ... }
+
+func Connect(host string,
+    opts ...ConnectOption,
+) Connection { ... }
+
+Connect("localhost")
+Connect("db", WithTLS(false))</code></pre>
+</div>
+</div>
+
+Named arguments let callers skip parameters with defaults. The compiler validates default types at compile time and gives clear errors for mismatches.
+
+---
+
 ## When to Choose GALA
 
 GALA is a strong fit when you want:
@@ -229,6 +269,7 @@ GALA is a strong fit when you want:
 - **Monadic error handling** -- `Option[T]`, `Either[A,B]`, `Try[T]` instead of `if err != nil`
 - **Immutability by default** -- `val` bindings and auto-generated `Copy()` / `Equal()`
 - **Functional collection pipelines** -- `Map`, `Filter`, `FoldLeft`, `Collect` on immutable data structures
+- **Default parameter values** -- named arguments, call-site defaults, no "functional options" boilerplate
 - **Concise syntax** -- expression functions, lambda type inference, string interpolation
 - **Full Go compatibility** -- every Go library works, no wrappers needed
 


### PR DESCRIPTION
## Summary

- **Default parameter values**: `func connect(host string, port int = 8080, tls bool = true)` — callers can omit trailing defaults
- **Named arguments for function calls**: `connect("localhost", tls = false)` — skip defaulted params or reorder args for clarity
- **Call-site injection**: defaults injected directly into generated Go calls — clean output, no wrappers
- **Compile-time validation**: type mismatches, non-contiguous defaults, and missing required args produce clear GALA-level errors

## Changes

| Area | Files | What |
|------|-------|------|
| Grammar | `gala.g4` | `paramDefault: '=' expression;` on parameter rule |
| Metadata | `transpiler.go` | `ParamNames`, `DefaultExprs` on FunctionMetadata/MethodMetadata |
| Analyzer | `analyzer.go` | Extract names/defaults at 3 sites + validation |
| Transformer | `calls.go` | `fillDefaultArgs`, `handleNamedArgsFuncCall`, `parseDefaultExpr` |
| Examples | 3 new `.gala` + `.out` files | `default_params`, `default_params_expr`, `named_args` |
| Docs | GALA.MD, EXAMPLES.MD, language-reference.md, examples.md, vs-go.md | Full documentation |

## Test plan

- [x] `bazel test examples:default_params` — positional + named args with defaults
- [x] `bazel test examples:default_params_expr` — expression defaults evaluated per-call
- [x] `bazel test examples:named_args` — named arg reordering without defaults
- [x] `bazel test internal/transpiler/...` — all transpiler unit tests pass
- [x] `bazel test examples/...` — all 177 existing example tests pass
- [x] Type mismatch error: `func bad(x int = "hello")` → compile error
- [x] Ordering error: `func bad(a int = 1, b int)` → compile error
- [x] Missing required arg: `greet()` when `name` has no default → compile error

🤖 Generated with [Claude Code](https://claude.com/claude-code)