### PR TITLE
fix: support trailing commas in parameter lists

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1367,3 +1367,10 @@ gala_test(
     expected = "qualified_lambda_infer.out",
     deps = ["//io"],
 )
+
+# FIX-033: trailing commas in multi-line function/struct parameter lists
+gala_test(
+    name = "trailing_comma_params",
+    src = "trailing_comma_params.gala",
+    expected = "trailing_comma_params.out",
+)

--- a/examples/trailing_comma_params.gala
+++ b/examples/trailing_comma_params.gala
@@ -1,0 +1,28 @@
+package main
+
+// Multi-line function with trailing comma
+func greetMultiline(
+    name string,
+    greeting string = "Hello",
+    punctuation string = "!",
+) string =
+    s"$greeting, $name$punctuation"
+
+// Multi-line struct with trailing comma
+struct Config(
+    Host string,
+    Port int,
+    Debug bool,
+)
+
+func NewConfig() Config = Config("localhost", 8080, true)
+
+func main() {
+    Println(greetMultiline("World"))
+    Println(greetMultiline("World", "Hi", "?"))
+
+    val cfg = NewConfig()
+    Println(cfg.Host)
+    Println(cfg.Port)
+    Println(cfg.Debug)
+}

--- a/examples/trailing_comma_params.out
+++ b/examples/trailing_comma_params.out
@@ -1,0 +1,5 @@
+Hello, World!
+Hi, World?
+localhost
+8080
+true

--- a/internal/parser/grammar/gala.g4
+++ b/internal/parser/grammar/gala.g4
@@ -22,7 +22,7 @@ structShorthandDeclaration: 'struct' identifier parameters;
 
 sealedTypeDeclaration: SEALED 'type' identifier (typeParameters)? '{' sealedCase+ '}';
 sealedCase: CASE identifier '(' sealedCaseFieldList? ')';
-sealedCaseFieldList: sealedCaseField (',' sealedCaseField)*;
+sealedCaseFieldList: sealedCaseField (',' sealedCaseField)* ','?;
 sealedCaseField: identifier type;
 
 declaration
@@ -63,7 +63,7 @@ receiver: '(' (VAL | VAR)? identifier type ')';
 signature: parameters (type)?;
 
 parameters: '(' parameterList? ')';
-parameterList: parameter (',' parameter)*;
+parameterList: parameter (',' parameter)* ','?;
 // Parameters can be:
 // - Named with type: "x int", "val x int", "x ...int"
 // - Named without type: "x" (type inferred)


### PR DESCRIPTION
## Summary

Fixes **FIX-033**: Multi-line function and struct parameter lists failed to parse when they had a trailing comma before the closing paren.

**Category**: TRANSPILER_BUG
**Priority**: P1
**Found in**: gala-server (BUG-028)

## Root Cause

The grammar rules `parameterList` and `sealedCaseFieldList` did not allow an optional trailing comma. When multi-line parameter lists included a trailing comma (e.g., `"SAMEORIGIN",\n)`), the parser saw `,` followed by `)` which did not match `, parameter`, causing "extraneous input ')'" error.

## Changes

- `internal/parser/grammar/gala.g4` — added `','?` to `parameterList` and `sealedCaseFieldList` rules (matching existing `argumentList` pattern)
- `examples/trailing_comma_params.gala` — verification example with multi-line params

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (214 tests)
- New example `examples:trailing_comma_params` passes

## Repro (before fix)

```gala
// FAILS: parser emits "extraneous input ')'"
func SecureWithConfig(
    xssProtection string = "1; mode=block",
    contentTypeNosniff string = "nosniff",
) Filter = ...
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-028

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)