### PR TITLE
fix: parenthesize composite literals in if/for conditions

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -628,6 +628,12 @@ gala_test(
 )
 
 gala_test(
+    name = "composite_lit_if_cond",
+    src = "composite_lit_if_cond.gala",
+    expected = "composite_lit_if_cond.out",
+)
+
+gala_test(
     name = "nested_match",
     src = "nested_match.gala",
     expected = "nested_match.out",

--- a/examples/composite_lit_if_cond.gala
+++ b/examples/composite_lit_if_cond.gala
@@ -1,0 +1,25 @@
+package main
+
+sealed type HttpMethod {
+    case GET()
+    case POST()
+    case OPTIONS()
+}
+
+func checkMethod(m HttpMethod) string {
+    // FIX-034: Composite literal in if condition must be parenthesized.
+    // OPTIONS{}.Apply() should not confuse Go parser's { detection.
+    if m == OPTIONS() {
+        return "options"
+    } else if m == GET() {
+        return "get"
+    } else {
+        return "other"
+    }
+}
+
+func main() {
+    Println(checkMethod(OPTIONS()))
+    Println(checkMethod(GET()))
+    Println(checkMethod(POST()))
+}

--- a/examples/composite_lit_if_cond.out
+++ b/examples/composite_lit_if_cond.out
@@ -1,0 +1,3 @@
+options
+get
+other

--- a/internal/transpiler/transformer/statements.go
+++ b/internal/transpiler/transformer/statements.go
@@ -258,6 +258,8 @@ func (t *galaASTTransformer) transformForStatement(ctx *grammar.ForStatementCont
 		if err != nil {
 			return nil, err
 		}
+		// FIX-034: Parenthesize composite literals in for conditions.
+		cond = parenthesizeCompositeLits(cond)
 		body, err := t.transformBlock(ctx.Block().(*grammar.BlockContext))
 		if err != nil {
 			return nil, err
@@ -358,6 +360,8 @@ func (t *galaASTTransformer) transformForStatement(ctx *grammar.ForStatementCont
 			if err != nil {
 				return nil, err
 			}
+			// FIX-034: Parenthesize composite literals in for conditions.
+			cond = parenthesizeCompositeLits(cond)
 		}
 
 		// Process post (can use init variables)
@@ -493,6 +497,9 @@ func (t *galaASTTransformer) transformIfStatement(ctx *grammar.IfStatementContex
 	if err != nil {
 		return nil, err
 	}
+	// FIX-034: Parenthesize composite literals in if conditions to avoid
+	// Go parser ambiguity where '{' is treated as the start of the if body.
+	cond = parenthesizeCompositeLits(cond)
 	body, err := t.transformBlock(ctx.Block(0).(*grammar.BlockContext))
 	if err != nil {
 		return nil, err

--- a/internal/transpiler/transformer/utils.go
+++ b/internal/transpiler/transformer/utils.go
@@ -213,6 +213,54 @@ func (t *galaASTTransformer) warnInference(format string, args ...interface{}) {
 	}
 }
 
+// parenthesizeCompositeLits wraps any ast.CompositeLit found in an expression
+// tree with ast.ParenExpr. This is needed because Go's parser treats '{' in
+// if/for/switch conditions as the start of the block body, making composite
+// literals like OPTIONS{}.Apply() ambiguous. Wrapping in parens resolves this.
+func parenthesizeCompositeLits(expr ast.Expr) ast.Expr {
+	if expr == nil {
+		return nil
+	}
+	switch e := expr.(type) {
+	case *ast.CompositeLit:
+		return &ast.ParenExpr{X: e}
+	case *ast.CallExpr:
+		e.Fun = parenthesizeCompositeLits(e.Fun)
+		for i, arg := range e.Args {
+			e.Args[i] = parenthesizeCompositeLits(arg)
+		}
+		return e
+	case *ast.SelectorExpr:
+		e.X = parenthesizeCompositeLits(e.X)
+		return e
+	case *ast.BinaryExpr:
+		e.X = parenthesizeCompositeLits(e.X)
+		e.Y = parenthesizeCompositeLits(e.Y)
+		return e
+	case *ast.UnaryExpr:
+		e.X = parenthesizeCompositeLits(e.X)
+		return e
+	case *ast.ParenExpr:
+		e.X = parenthesizeCompositeLits(e.X)
+		return e
+	case *ast.IndexExpr:
+		e.X = parenthesizeCompositeLits(e.X)
+		e.Index = parenthesizeCompositeLits(e.Index)
+		return e
+	case *ast.StarExpr:
+		e.X = parenthesizeCompositeLits(e.X)
+		return e
+	case *ast.TypeAssertExpr:
+		e.X = parenthesizeCompositeLits(e.X)
+		return e
+	case *ast.KeyValueExpr:
+		e.Value = parenthesizeCompositeLits(e.Value)
+		return e
+	default:
+		return expr
+	}
+}
+
 func findLeafIf(stmt ast.Stmt) *ast.IfStmt {
 	switch s := stmt.(type) {
 	case *ast.IfStmt:


### PR DESCRIPTION
## Summary

Fixes **FIX-034**: Sealed type variant constructors like `OPTIONS{}.Apply()` generate ambiguous Go code when used in if conditions.

**Category**: CODEGEN_BUG
**Priority**: P0
**Found in**: gala-server (BUG-029)

## Root Cause

Go's parser treats `{` in `if req.Method() == OPTIONS{}.Apply() {` as the start of the if body, not as a composite literal. The transpiler did not parenthesize composite literals in condition contexts.

## Changes

- `internal/transpiler/transformer/utils.go` — added `parenthesizeCompositeLits()` recursive AST walker
- `internal/transpiler/transformer/statements.go` — applied to if-conditions, for-conditions, and for-clause conditions
- `examples/composite_lit_if_cond.gala` — verification example

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (214 tests)
- New example `examples:composite_lit_if_cond` passes

## Repro (before fix)

```gala
// Generates invalid Go: if req.Method() == OPTIONS{}.Apply() {
// Now generates: if req.Method() == (OPTIONS{}).Apply() {
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-029

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)