### PR TITLE
fix: handle escaped quotes inside string interpolation blocks

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1052,6 +1052,13 @@ gala_test(
     deps = ["//collection_immutable"],
 )
 
+# FIX-039: String interpolation with escaped quotes inside ${...}
+gala_test(
+    name = "interpolation_escaped_quotes",
+    src = "interpolation_escaped_quotes.gala",
+    expected = "interpolation_escaped_quotes.out",
+)
+
 gala_test(
     name = "type_alias",
     src = "type_alias.gala",

--- a/examples/interpolation_escaped_quotes.gala
+++ b/examples/interpolation_escaped_quotes.gala
@@ -1,0 +1,17 @@
+package main
+
+import (
+    "strings"
+)
+
+func main() {
+    // Escaped quotes inside ${} interpolation block
+    Println(s"result: ${strings.TrimSpace(\"  hello  \")}")
+
+    // Multiple escaped quotes in one expression
+    Println(s"replaced: ${strings.Replace(\"hello world\", \"world\", \"gala\", 1)}")
+
+    // Mixed: variable + escaped quotes in expression
+    val name = "GALA"
+    Println(s"$name says: ${strings.ToUpper(\"welcome\")}")
+}

--- a/examples/interpolation_escaped_quotes.out
+++ b/examples/interpolation_escaped_quotes.out
@@ -1,0 +1,3 @@
+result: hello
+replaced: hello gala
+GALA says: WELCOME

--- a/internal/parser/grammar/gala.g4
+++ b/internal/parser/grammar/gala.g4
@@ -242,8 +242,8 @@ FORMAT_STRING: 'f"' INTERP_BODY '"';
 
 fragment INTERP_BODY: (INTERP_CHAR | '\\' . | '${' BRACE_CONTENT '}')*;
 fragment INTERP_CHAR: ~["\r\n\\$] | '$' ~["{\r\n\\];
-fragment BRACE_CONTENT: (BRACE_CHAR | '"' (~["\r\n\\] | '\\' .)* '"' | '{' BRACE_CONTENT '}')*;
-fragment BRACE_CHAR: ~[{}"\r\n];
+fragment BRACE_CONTENT: (BRACE_CHAR | '\\' . | '"' (~["\r\n\\] | '\\' .)* '"' | '{' BRACE_CONTENT '}')*;
+fragment BRACE_CHAR: ~[{}"\r\n\\];
 
 IDENTIFIER: [a-zA-Z_] [a-zA-Z0-9_]*;
 INT_LIT: [0-9]+;

--- a/internal/transpiler/transformer/interpolation.go
+++ b/internal/transpiler/transformer/interpolation.go
@@ -217,7 +217,7 @@ func parseInterpolationParts(content string) []interpolationPart {
 				}
 			}
 
-			exprText := content[i+2 : j]
+			exprText := unescapeInterpolationExpr(content[i+2 : j])
 			j++ // skip closing }
 
 			// Check for format spec
@@ -268,6 +268,12 @@ func parseInterpolationParts(content string) []interpolationPart {
 	}
 
 	return parts
+}
+
+// unescapeInterpolationExpr converts escaped quotes inside ${} expression blocks
+// back to regular quotes so the expression can be re-parsed by the GALA parser.
+func unescapeInterpolationExpr(expr string) string {
+	return strings.ReplaceAll(expr, `\"`, `"`)
 }
 
 // extractFormatSpec extracts a Go printf format specifier starting at position i (which points to %).


### PR DESCRIPTION
## Summary

Fixes **FIX-039**: Escaped quotes inside `${}` interpolation blocks caused parse failures.

**Category**: TRANSPILER_BUG
**Priority**: P2
**Found in**: gala-server (BUG-034)

## Root Cause

Two issues combined: (1) ANTLR grammar's `BRACE_CONTENT` fragment didn't handle escape sequences — `\"` was consumed by `BRACE_CHAR` and the quote was misinterpreted. (2) The Go interpolation parser didn't unescape `\"` back to `"` before re-parsing expressions.

## Changes

- `internal/parser/grammar/gala.g4` — added `'\' .` alternative to `BRACE_CONTENT`, excluded `\` from `BRACE_CHAR`
- `internal/transpiler/transformer/interpolation.go` — added `unescapeInterpolationExpr()` function
- `examples/interpolation_escaped_quotes.gala` — verification example

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (214 tests)

## Repro (before fix)

```gala
// FAILS
Ok(s"${r.CtxGet(\"jwt-sub\").GetOrElse(\"none\")}")
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-034

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)