### PR TITLE
fix: fail hard when stdlib packages cannot be resolved

### DIFF
--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -262,7 +262,10 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 					importedAST, err := a.analyzePackage(relPath)
 					if err != nil {
 						line := s.GetStart().GetLine()
-						fmt.Fprintf(os.Stderr, "Warning: failed to analyze package %s (imported at line %d): %v\n", relPath, line, err)
+						warnMsg := fmt.Sprintf("failed to analyze package %s (imported at line %d): %v", relPath, line, err)
+						fmt.Fprintf(os.Stderr, "Warning: %s
+", warnMsg)
+						richAST.AnalysisWarnings = append(richAST.AnalysisWarnings, warnMsg)
 					}
 					if err == nil {
 						a.analyzedPkgs[path] = importedAST

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -263,8 +263,7 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 					if err != nil {
 						line := s.GetStart().GetLine()
 						warnMsg := fmt.Sprintf("failed to analyze package %s (imported at line %d): %v", relPath, line, err)
-						fmt.Fprintf(os.Stderr, "Warning: %s
-", warnMsg)
+						fmt.Fprintf(os.Stderr, "Warning: %s\n", warnMsg)
 						richAST.AnalysisWarnings = append(richAST.AnalysisWarnings, warnMsg)
 					}
 					if err == nil {

--- a/internal/transpiler/transformer/transformer.go
+++ b/internal/transpiler/transformer/transformer.go
@@ -150,6 +150,20 @@ func (t *galaASTTransformer) Transform(richAST *transpiler.RichAST) (fset *token
 		}
 	}
 
+	// Fail hard if GALA package analysis had unresolved imports.
+	// Without resolved package metadata, type inference degrades to `any` and
+	// the generated Go code will not compile.
+	if len(richAST.AnalysisWarnings) > 0 {
+		var msgs []string
+		for _, w := range richAST.AnalysisWarnings {
+			msgs = append(msgs, "  - "+w)
+		}
+		return nil, nil, galaerr.NewSemanticError(
+			fmt.Sprintf("cannot transpile: %d imported package(s) could not be resolved:\n%s\n"+
+				"Hint: ensure all GALA dependencies are available via --search paths or gala.mod",
+				len(richAST.AnalysisWarnings), strings.Join(msgs, "\n")))
+	}
+
 	// Register EmbeddedFS method metadata (Go-defined type, not available from GALA analysis).
 	// This enables type inference for ReadString/ReadBytes calls on embedded filesystems.
 	t.registerEmbeddedFSMetadata()

--- a/internal/transpiler/transpiler.go
+++ b/internal/transpiler/transpiler.go
@@ -69,6 +69,7 @@ type RichAST struct {
 	EmbedDirectives  []EmbedDirective                    // embed val declarations
 	FilePath         string                              // source file path (for error reporting)
 	SourceContent    string                              // raw source text (for error snippets)
+	AnalysisWarnings []string                            // warnings from package analysis (e.g., unresolved GALA imports)
 }
 
 // Merge combines metadata from another RichAST into this one.


### PR DESCRIPTION
## Summary

Fixes **FIX-041**: `gala transpile` silently fell back to `any`/`string` types when it couldn't resolve stdlib packages, generating uncompilable code.

**Category**: TRANSPILER_BUG
**Priority**: P1
**Found in**: gala-server (BUG-036)

## Root Cause

The analyzer collected package resolution failures as warnings but the transformer proceeded with incomplete type information, falling back to `any` or incorrect types. Generated code was uncompilable.

## Changes

- `internal/transpiler/transpiler.go` — added `AnalysisWarnings []string` field to `RichAST`
- `internal/transpiler/analyzer/analyzer.go` — records warning messages into `richAST.AnalysisWarnings`
- `internal/transpiler/transformer/transformer.go` — checks `AnalysisWarnings` and returns `SemanticError` with all unresolved packages listed, with hint to use `--search` or `gala.mod`

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (214 tests)

## Repro (before fix)

```bash
gala transpile -i server.gala  # silently generates any/string types
# Now: error listing unresolved packages with actionable hint
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-036

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)