### PR TITLE
feat: support library package compilation in gala build

### DIFF
--- a/cmd/gala/commands/build.go
+++ b/cmd/gala/commands/build.go
@@ -17,12 +17,15 @@ var (
 var buildCmd = &cobra.Command{
 	Use:   "build [directory]",
 	Short: "Build a GALA project",
-	Long: `Build compiles GALA source files into an executable binary.
+	Long: `Build compiles GALA source files.
+
+For executable projects (package main), produces a binary.
+For library packages, performs a compile check without producing a binary.
 
 This command:
   1. Reads dependencies from gala.mod
   2. Transpiles .gala files to Go code (in a build workspace)
-  3. Runs go build to produce a binary
+  3. Runs go build to produce a binary (or compile-check for libraries)
 
 The binary is placed in the current directory by default.
 No go.mod or generated files are created in your project directory.
@@ -30,7 +33,7 @@ No go.mod or generated files are created in your project directory.
 Examples:
   gala build                    # Build current directory
   gala build ./myproject        # Build specific directory
-  gala build -o myapp           # Custom output name
+  gala build -o myapp           # Custom output name (executables only)
   gala build -v                 # Verbose output`,
 	Args: cobra.MaximumNArgs(1),
 	Run:  runBuild,
@@ -69,5 +72,10 @@ func runBuild(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Built: %s\n", outputPath)
+	if outputPath == "" {
+		// Library package — compile check succeeded, no binary produced
+		fmt.Println("ok (library compiled successfully)")
+	} else {
+		fmt.Printf("Built: %s\n", outputPath)
+	}
 }

--- a/cmd/gala/commands/run.go
+++ b/cmd/gala/commands/run.go
@@ -84,6 +84,12 @@ func runRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	if outputPath == "" {
+		fmt.Fprintln(os.Stderr, "Error: cannot run a library package. Only 'package main' projects can be run.")
+		fmt.Fprintln(os.Stderr, "Use 'gala build' to compile-check library packages.")
+		os.Exit(1)
+	}
+
 	// Execute the built binary
 	execCmd := exec.Command(outputPath, programArgs...)
 	execCmd.Stdin = os.Stdin

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -63,6 +63,7 @@ func NewBuilder(projectDir string, stdlibVersion string, verbose bool) (*Builder
 // Build executes the full build process and returns the path to the output binary.
 // If outputPath is empty, uses the module name. If it's an absolute path, uses it directly.
 // Otherwise, treats it as relative to the project directory.
+// For library packages (non-main), Build performs a compile check and returns "" with no error.
 func (b *Builder) Build(outputPath string) (string, error) {
 	// Step 1: Ensure workspace exists
 	if b.verbose {
@@ -115,12 +116,19 @@ func (b *Builder) Build(outputPath string) (string, error) {
 		return "", fmt.Errorf("generating go.mod: %w", err)
 	}
 
-	// Step 4.5: Check that the project is an executable (package main)
-	if err := b.checkIsExecutable(); err != nil {
-		return "", err
+	// Step 4.5: Check if library package — if so, compile-check only
+	isLib, pkgName := b.isLibraryPackage()
+	if isLib {
+		if b.verbose {
+			fmt.Printf("Package %q is a library, running compile check...\n", pkgName)
+		}
+		if err := b.goCompileCheck(); err != nil {
+			return "", fmt.Errorf("go build (compile check): %w", err)
+		}
+		return "", nil
 	}
 
-	// Step 5: Run go build
+	// Step 5: Run go build (executable)
 	finalPath, err := b.goBuild(outputPath)
 	if err != nil {
 		return "", fmt.Errorf("go build: %w", err)
@@ -436,12 +444,12 @@ func (b *Builder) generateGoMod() error {
 	return nil
 }
 
-// checkIsExecutable verifies that the generated code contains package main.
-// Library packages (non-main) cannot be built into executables.
-func (b *Builder) checkIsExecutable() error {
+// isLibraryPackage checks whether the generated code is a library (non-main) package.
+// Returns (true, packageName) for libraries, (false, "") for executables.
+func (b *Builder) isLibraryPackage() (bool, string) {
 	genFiles, err := b.workspace.GenFiles()
 	if err != nil {
-		return fmt.Errorf("listing generated files: %w", err)
+		return false, ""
 	}
 
 	// Read the first generated file to determine the package name
@@ -464,12 +472,33 @@ func (b *Builder) checkIsExecutable() error {
 	}
 
 	if pkgName != "" && pkgName != "main" {
-		return fmt.Errorf("cannot build executable: package %q is a library, not an executable\n"+
-			"Only 'package main' projects can be built with 'gala build' or 'gala run'.\n"+
-			"To use this package as a library, import it from a 'package main' project.", pkgName)
+		return true, pkgName
 	}
 
-	return nil
+	return false, ""
+}
+
+// goCompileCheck runs `go build ./...` in the workspace without producing a binary.
+// This verifies that library packages compile correctly.
+func (b *Builder) goCompileCheck() error {
+	if b.verbose {
+		fmt.Println("Running go build (compile check)...")
+	}
+
+	cmd := exec.Command("go", "build", "./gen/...")
+	cmd.Dir = b.workspace.Dir
+	cmd.Env = append(os.Environ(),
+		"GOMODCACHE="+b.config.GoPkgDir,
+	)
+
+	if b.verbose {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	} else {
+		cmd.Stderr = os.Stderr
+	}
+
+	return cmd.Run()
 }
 
 // goBuild runs `go build` in the workspace and returns the output path.


### PR DESCRIPTION
## Summary

Fixes **FIX-042**: `gala build` now supports library packages by compile-checking instead of erroring.

**Category**: MISSING_FEATURE
**Priority**: P1
**Found in**: gala-server (BUG-037)

## Root Cause

`gala build` called `checkIsExecutable()` which rejected any non-main package. There was no way to compile-check a GALA library without Bazel.

## Changes

- `internal/build/builder.go` — replaced `checkIsExecutable()` with `isLibraryPackage()` returning `(bool, string)`; added `goCompileCheck()` method running `go build ./gen/...` for libraries
- `cmd/gala/commands/build.go` — prints "ok (library compiled successfully)" for library builds
- `cmd/gala/commands/run.go` — rejects library packages with helpful error

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (214 tests)

## Repro (before fix)

```bash
gala build  # in a library package
# Error: cannot build executable: package "server" is a library
# Now: compile-checks and prints "ok (library compiled successfully)"
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-037

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)