### PR TITLE
fix: include test framework in stdlib distribution

### DIFF
--- a/cmd/stdlib_gen/main.go
+++ b/cmd/stdlib_gen/main.go
@@ -30,6 +30,7 @@ func packageFromPath(path string) string {
 		"regex",
 		"io",
 		"json",
+		"test",
 		"std",
 	}
 
@@ -143,6 +144,7 @@ var PackageImportPaths = map[string]string{
 	"regex":                "martianoff/gala/regex",
 	"io":                   "martianoff/gala/io",
 	"json":                 "martianoff/gala/json",
+	"test":                 "martianoff/gala/test",
 }
 `)
 

--- a/internal/build/gomod.go
+++ b/internal/build/gomod.go
@@ -34,6 +34,7 @@ var StdlibPackages = []string{
 	"regex",
 	"io",
 	"json",
+	"test",
 }
 
 // StdlibImportPaths maps package names to their import paths.
@@ -50,6 +51,7 @@ var StdlibImportPaths = map[string]string{
 	"regex":                "martianoff/gala/regex",
 	"io":                   "martianoff/gala/io",
 	"json":                 "martianoff/gala/json",
+	"test":                 "martianoff/gala/test",
 }
 
 // GenerateGoMod generates a go.mod file content for the workspace.

--- a/internal/stdlib/BUILD.bazel
+++ b/internal/stdlib/BUILD.bazel
@@ -98,6 +98,16 @@ genrule(
         "//io:io_go",
         # io package - GALA source
         "//io:io.gala",
+        # test package - transpiled Go
+        "//test:assertions_go",
+        "//test:bench_go",
+        "//test:framework_go",
+        "//test:table_go",
+        # test package - GALA source
+        "//test:assertions.gala",
+        "//test:bench.gala",
+        "//test:framework.gala",
+        "//test:table.gala",
     ],
     outs = ["embedded_gen.go"],
     cmd = "$(location //cmd/stdlib_gen) -output $@ $(SRCS)",

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -134,6 +134,8 @@ func generatePackageGoMod(pkgName, importPath string) string {
 		content += "\tmartianoff/gala/std v0.0.0\n"
 		content += ")\n"
 		content += "\nreplace martianoff/gala/std => ../std\n"
+	case "test":
+		// test framework has no GALA stdlib dependencies (only Go stdlib: fmt, os, time)
 	case "json":
 		content += "\nrequire (\n"
 		content += "\tmartianoff/gala/std v0.0.0\n"

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,4 +1,11 @@
-load("//:gala.bzl", "gala_go_test", "gala_library")
+load("//:gala.bzl", "gala_go_test", "gala_library", "gala_bootstrap_transpile")
+
+exports_files([
+    "assertions.gala",
+    "bench.gala",
+    "framework.gala",
+    "table.gala",
+])
 
 filegroup(
     name = "gala_sources",
@@ -24,4 +31,33 @@ gala_library(
 gala_go_test(
     name = "framework_test",
     srcs = ["framework_test.gala"],
+)
+
+# Individual transpile rules for stdlib embedding (uses bootstrap to avoid circular dep)
+gala_bootstrap_transpile(
+    name = "assertions_go",
+    src = "assertions.gala",
+    out = "assertions.gen.go",
+    package_files = ["bench.gala", "framework.gala", "table.gala"],
+)
+
+gala_bootstrap_transpile(
+    name = "bench_go",
+    src = "bench.gala",
+    out = "bench.gen.go",
+    package_files = ["assertions.gala", "framework.gala", "table.gala"],
+)
+
+gala_bootstrap_transpile(
+    name = "framework_go",
+    src = "framework.gala",
+    out = "framework.gen.go",
+    package_files = ["assertions.gala", "bench.gala", "table.gala"],
+)
+
+gala_bootstrap_transpile(
+    name = "table_go",
+    src = "table.gala",
+    out = "table.gen.go",
+    package_files = ["assertions.gala", "bench.gala", "framework.gala"],
 )


### PR DESCRIPTION
## Summary

Fixes **FIX-043**: The `martianoff/gala/test` module was not included in the stdlib distribution.

**Category**: MISSING_FEATURE
**Priority**: P1
**Found in**: gala-server (BUG-038)

## Root Cause

The test framework existed in the repo at `test/` but was not included in the stdlib embedding pipeline (`cmd/stdlib_gen`, `internal/stdlib`, `internal/build/gomod.go`).

## Changes

- `cmd/stdlib_gen/main.go` — added `test` to packages list and `PackageImportPaths`
- `internal/build/gomod.go` — added `test` to `StdlibPackages` and `StdlibImportPaths`
- `internal/stdlib/stdlib.go` — added `test` case to `generatePackageGoMod()`
- `internal/stdlib/BUILD.bazel` — added transpiled Go + GALA source references
- `test/BUILD.bazel` — added `gala_bootstrap_transpile` rules for individual file transpilation

## Verification

- `bazel build //...` passes (including `//internal/stdlib:stdlib`)
- `bazel test //...` passes (214 tests)

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-038

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)