### PR TITLE
fix: expand default parameter values for method calls with named args

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1395,14 +1395,6 @@ gala_test(
     expected = "if_expression_block.out",
 )
 
-# FIX-056 verification: lambda type inference produces concrete types, not any
-gala_test(
-    name = "lambda_any_fallback_verify",
-    src = "lambda_any_fallback_verify.gala",
-    expected = "lambda_any_fallback_verify.out",
-    deps = ["//collection_immutable"],
-)
-
 # Method default parameters with named args (FIX-050)
 gala_test(
     name = "method_default_params",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1394,3 +1394,18 @@ gala_test(
     src = "if_expression_block.gala",
     expected = "if_expression_block.out",
 )
+
+# FIX-056 verification: lambda type inference produces concrete types, not any
+gala_test(
+    name = "lambda_any_fallback_verify",
+    src = "lambda_any_fallback_verify.gala",
+    expected = "lambda_any_fallback_verify.out",
+    deps = ["//collection_immutable"],
+)
+
+# Method default parameters with named args (FIX-050)
+gala_test(
+    name = "method_default_params",
+    src = "method_default_params.gala",
+    expected = "method_default_params.out",
+)

--- a/examples/method_default_params.gala
+++ b/examples/method_default_params.gala
@@ -1,0 +1,36 @@
+package main
+
+type Config struct {
+    host string
+    port int
+    debug bool
+}
+
+func (c Config) copy(host string = c.host, port int = c.port, debug bool = c.debug) Config =
+    Config(host, port, debug)
+
+func (c Config) WithHost(host string) Config = c.copy(host = host)
+func (c Config) WithPort(port int) Config = c.copy(port = port)
+func (c Config) WithDebug(debug bool) Config = c.copy(debug = debug)
+
+func main() {
+    val config = Config("localhost", 8080, false)
+    Println(s"${config.host}:${config.port} debug=${config.debug}")
+
+    val c2 = config.WithPort(9090)
+    Println(s"${c2.host}:${c2.port} debug=${c2.debug}")
+
+    val c3 = config.WithHost("example.com")
+    Println(s"${c3.host}:${c3.port} debug=${c3.debug}")
+
+    val c4 = config.WithDebug(true)
+    Println(s"${c4.host}:${c4.port} debug=${c4.debug}")
+
+    // Named args with multiple overrides
+    val c5 = config.copy(host = "prod.com", debug = true)
+    Println(s"${c5.host}:${c5.port} debug=${c5.debug}")
+
+    // Positional defaults (fewer args than params)
+    val c6 = config.copy("staging.com")
+    Println(s"${c6.host}:${c6.port} debug=${c6.debug}")
+}

--- a/examples/method_default_params.out
+++ b/examples/method_default_params.out
@@ -1,0 +1,6 @@
+localhost:8080 debug=false
+localhost:9090 debug=false
+example.com:8080 debug=false
+localhost:8080 debug=true
+prod.com:8080 debug=true
+staging.com:8080 debug=false

--- a/internal/parser/grammar/BUILD.bazel
+++ b/internal/parser/grammar/BUILD.bazel
@@ -10,14 +10,22 @@ genrule(
         "gala_parser.go",
     ],
     cmd = """
-        set -e && \
-        ANTLR_OUT=antlr_tmp_$$$$ && \
-        mkdir -p $$ANTLR_OUT && \
-        "$(JAVA)" -jar $(location @antlr4_tool//jar) -Dlanguage=Go -package grammar -o $$ANTLR_OUT $(location gala.g4) && \
-        find $$ANTLR_OUT -name '*.go' -type f | while read f; do \
-            sed 's|github.com/antlr/antlr4/runtime/Go/antlr|github.com/antlr4-go/antlr/v4|g' "$$f" > "$(@D)/$$(basename $$f)"; \
-        done && \
-        rm -rf $$ANTLR_OUT
+        set -e
+        if "$(JAVA)" -version >/dev/null 2>&1; then
+            ANTLR_OUT=antlr_tmp_$$$$
+            mkdir -p $$ANTLR_OUT
+            "$(JAVA)" -jar $(location @antlr4_tool//jar) -Dlanguage=Go -package grammar -o $$ANTLR_OUT $(location gala.g4)
+            for f in $$ANTLR_OUT/*.go; do
+                sed 's|github.com/antlr/antlr4/runtime/Go/antlr|github.com/antlr4-go/antlr/v4|g' "$$f" > "$(@D)/$$(basename $$f)"
+            done
+            rm -rf $$ANTLR_OUT
+        else
+            echo "WARNING: Java not found, using pre-generated grammar files" >&2
+            GDIR=$$(dirname $(location gala.g4))
+            for base in gala_base_listener.go gala_lexer.go gala_listener.go gala_parser.go; do
+                cp "$$GDIR/$$base" "$(@D)/$$base"
+            done
+        fi
     """,
     toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
     tools = ["@antlr4_tool//jar"],

--- a/internal/parser/grammar/BUILD.bazel
+++ b/internal/parser/grammar/BUILD.bazel
@@ -10,22 +10,14 @@ genrule(
         "gala_parser.go",
     ],
     cmd = """
-        set -e
-        if "$(JAVA)" -version >/dev/null 2>&1; then
-            ANTLR_OUT=antlr_tmp_$$$$
-            mkdir -p $$ANTLR_OUT
-            "$(JAVA)" -jar $(location @antlr4_tool//jar) -Dlanguage=Go -package grammar -o $$ANTLR_OUT $(location gala.g4)
-            for f in $$ANTLR_OUT/*.go; do
-                sed 's|github.com/antlr/antlr4/runtime/Go/antlr|github.com/antlr4-go/antlr/v4|g' "$$f" > "$(@D)/$$(basename $$f)"
-            done
-            rm -rf $$ANTLR_OUT
-        else
-            echo "WARNING: Java not found, using pre-generated grammar files" >&2
-            GDIR=$$(dirname $(location gala.g4))
-            for base in gala_base_listener.go gala_lexer.go gala_listener.go gala_parser.go; do
-                cp "$$GDIR/$$base" "$(@D)/$$base"
-            done
-        fi
+        set -e && \
+        ANTLR_OUT=antlr_tmp_$$$$ && \
+        mkdir -p $$ANTLR_OUT && \
+        "$(JAVA)" -jar $(location @antlr4_tool//jar) -Dlanguage=Go -package grammar -o $$ANTLR_OUT $(location gala.g4) && \
+        find $$ANTLR_OUT -name '*.go' -type f | while read f; do \
+            sed 's|github.com/antlr/antlr4/runtime/Go/antlr|github.com/antlr4-go/antlr/v4|g' "$$f" > "$(@D)/$$(basename $$f)"; \
+        done && \
+        rm -rf $$ANTLR_OUT
     """,
     toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
     tools = ["@antlr4_tool//jar"],

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -602,7 +602,7 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 					if ctx.Signature().Parameters() != nil {
 						pCtx := ctx.Signature().Parameters().(*grammar.ParametersContext)
 						if pList := pCtx.ParameterList(); pList != nil {
-							for _, p := range pList.(*grammar.ParameterListContext).AllParameter() {
+							for i, p := range pList.(*grammar.ParameterListContext).AllParameter() {
 								paramCtx := p.(*grammar.ParameterContext)
 								if paramCtx.Type_() != nil {
 									methodMeta.ParamTypes = append(methodMeta.ParamTypes, a.resolveTypeWithParams(paramCtx.Type_().GetText(), pkgName, allTypeParams))
@@ -613,6 +613,14 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 									methodMeta.ParamNames = append(methodMeta.ParamNames, paramCtx.Identifier().GetText())
 								} else {
 									methodMeta.ParamNames = append(methodMeta.ParamNames, "")
+								}
+								// Extract default expression source text
+								if paramCtx.ParamDefault() != nil {
+									if methodMeta.DefaultExprs == nil {
+										methodMeta.DefaultExprs = make(map[int]string)
+									}
+									defaultCtx := paramCtx.ParamDefault().(*grammar.ParamDefaultContext)
+									methodMeta.DefaultExprs[i] = defaultCtx.Expression().GetText()
 								}
 							}
 						}
@@ -2025,12 +2033,25 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 				if ctx.Signature().Parameters() != nil {
 					pCtx := ctx.Signature().Parameters().(*grammar.ParametersContext)
 					if pList := pCtx.ParameterList(); pList != nil {
-						for _, p := range pList.(*grammar.ParameterListContext).AllParameter() {
+						for i, p := range pList.(*grammar.ParameterListContext).AllParameter() {
 							paramCtx := p.(*grammar.ParameterContext)
 							if paramCtx.Type_() != nil {
 								methodMeta.ParamTypes = append(methodMeta.ParamTypes, a.resolveTypeWithParams(paramCtx.Type_().GetText(), pkgName, allTypeParams))
 							} else {
 								methodMeta.ParamTypes = append(methodMeta.ParamTypes, transpiler.NilType{})
+							}
+							if paramCtx.Identifier() != nil {
+								methodMeta.ParamNames = append(methodMeta.ParamNames, paramCtx.Identifier().GetText())
+							} else {
+								methodMeta.ParamNames = append(methodMeta.ParamNames, "")
+							}
+							// Extract default expression source text
+							if paramCtx.ParamDefault() != nil {
+								if methodMeta.DefaultExprs == nil {
+									methodMeta.DefaultExprs = make(map[int]string)
+								}
+								defaultCtx := paramCtx.ParamDefault().(*grammar.ParamDefaultContext)
+								methodMeta.DefaultExprs[i] = defaultCtx.Expression().GetText()
 							}
 						}
 					}

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -565,8 +565,9 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 					}
 
 					methodMeta := &transpiler.MethodMetadata{
-						Name:    methodName,
-						Package: pkgName,
+						Name:         methodName,
+						Package:      pkgName,
+						ReceiverName: recvCtx.Identifier().GetText(),
 					}
 					if ctx.TypeParameters() != nil {
 						tpCtx := ctx.TypeParameters().(*grammar.TypeParametersContext)
@@ -2008,8 +2009,9 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 				}
 
 				methodMeta := &transpiler.MethodMetadata{
-					Name:    methodName,
-					Package: pkgName,
+					Name:         methodName,
+					Package:      pkgName,
+					ReceiverName: recvCtx.Identifier().GetText(),
 				}
 				if ctx.TypeParameters() != nil {
 					tpCtx := ctx.TypeParameters().(*grammar.TypeParametersContext)

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -79,6 +79,8 @@ go_test(
     # widen to "any" on CI while passing locally on Windows (no sandbox).
     data = [
         "//collection_immutable:gala_sources",
+        "//collection_mutable:gala_sources",
+        "//time_utils:gala_sources",
         "//std:gala_sources",
     ],
     deps = [

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -511,11 +511,12 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 				}
 			}
 			methodFun := &ast.SelectorExpr{X: receiver, Sel: ast.NewIdent(method)}
+			recvTypeName := recvType.BaseName()
 			if len(mNamedArgs) > 0 && len(methodMeta.ParamNames) > 0 {
-				return t.handleNamedArgsMethodCall(methodFun, mArgs, mNamedArgs, methodMeta)
+				return t.handleNamedArgsMethodCall(methodFun, receiver, mArgs, mNamedArgs, methodMeta, recvTypeName)
 			}
 			if len(methodMeta.DefaultExprs) > 0 && len(mArgs) < len(methodMeta.ParamTypes) {
-				filled, err := t.fillDefaultArgsMethod(mArgs, methodMeta)
+				filled, err := t.fillDefaultArgsMethod(receiver, mArgs, methodMeta, recvTypeName)
 				if err != nil {
 					return nil, err
 				}
@@ -1298,11 +1299,14 @@ func (t *galaASTTransformer) handleNamedArgsFuncCall(
 }
 
 // handleNamedArgsMethodCall handles method calls with named arguments and default parameter values.
+// callSiteReceiver is the actual receiver expression at the call site (e.g., config.Get()).
 func (t *galaASTTransformer) handleNamedArgsMethodCall(
 	fun ast.Expr,
+	callSiteReceiver ast.Expr,
 	positionalArgs []ast.Expr,
 	namedArgs map[string]ast.Expr,
 	methodMeta *transpiler.MethodMetadata,
+	recvTypeName string,
 ) (ast.Expr, error) {
 	totalParams := len(methodMeta.ParamTypes)
 	result := make([]ast.Expr, totalParams)
@@ -1342,6 +1346,13 @@ func (t *galaASTTransformer) handleNamedArgsMethodCall(
 			if err != nil {
 				return nil, err
 			}
+			// Substitute receiver references and unwrap immutable field accesses.
+			// Only substitute when the call-site receiver differs from the method's
+			// receiver name — when they match, transformDefaultExpr already handles
+			// the unwrapping via the current scope.
+			if methodMeta.ReceiverName != "" && !isIdentNamed(callSiteReceiver, methodMeta.ReceiverName) {
+				expr = t.substituteReceiverInDefault(expr, methodMeta.ReceiverName, callSiteReceiver, recvTypeName)
+			}
 			result[i] = expr
 		}
 	}
@@ -1349,7 +1360,8 @@ func (t *galaASTTransformer) handleNamedArgsMethodCall(
 }
 
 // fillDefaultArgsMethod fills missing positional arguments with default values from method metadata.
-func (t *galaASTTransformer) fillDefaultArgsMethod(args []ast.Expr, methodMeta *transpiler.MethodMetadata) ([]ast.Expr, error) {
+// callSiteReceiver is the actual receiver expression at the call site.
+func (t *galaASTTransformer) fillDefaultArgsMethod(callSiteReceiver ast.Expr, args []ast.Expr, methodMeta *transpiler.MethodMetadata, recvTypeName string) ([]ast.Expr, error) {
 	totalParams := len(methodMeta.ParamTypes)
 	result := make([]ast.Expr, totalParams)
 	copy(result, args)
@@ -1362,9 +1374,93 @@ func (t *galaASTTransformer) fillDefaultArgsMethod(args []ast.Expr, methodMeta *
 		if err != nil {
 			return nil, err
 		}
+		// Same as above — only substitute when receivers differ
+		if methodMeta.ReceiverName != "" && !isIdentNamed(callSiteReceiver, methodMeta.ReceiverName) {
+			expr = t.substituteReceiverInDefault(expr, methodMeta.ReceiverName, callSiteReceiver, recvTypeName)
+		}
 		result[i] = expr
 	}
 	return result, nil
+}
+
+// isIdentNamed checks if an expression is a simple identifier with the given name.
+func isIdentNamed(expr ast.Expr, name string) bool {
+	if id, ok := expr.(*ast.Ident); ok {
+		return id.Name == name
+	}
+	return false
+}
+
+// substituteReceiver replaces all occurrences of the receiver identifier in a
+// transformed default expression with the actual call-site receiver expression.
+// For example, if the method is `func (c Config) copy(host string = c.host, ...)`
+// and the call site is `config.Get().copy(port = 8080)`, then `c.host` in the
+// default expression becomes `config.Get().host.Get()`.
+//
+// structImmutFields maps struct type names to their field immutability flags.
+// When a field access on the receiver is detected and the field is immutable,
+// `.Get()` is appended to unwrap the Immutable[T] wrapper.
+func (t *galaASTTransformer) substituteReceiverInDefault(expr ast.Expr, receiverName string, callSiteReceiver ast.Expr, recvTypeName string) ast.Expr {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		if e.Name == receiverName {
+			return callSiteReceiver
+		}
+		return e
+	case *ast.SelectorExpr:
+		newX := t.substituteReceiverInDefault(e.X, receiverName, callSiteReceiver, recvTypeName)
+		result := &ast.SelectorExpr{X: newX, Sel: e.Sel}
+		// If this is a field access on the receiver (c.field), check if the field is immutable
+		// and add .Get() to unwrap Immutable[T]
+		if t.isReceiverFieldAccess(e.X, receiverName) {
+			resolvedTypeName := t.resolveStructTypeName(recvTypeName)
+			if fields, ok := t.structFields[resolvedTypeName]; ok {
+				immutFlags := t.structImmutFields[resolvedTypeName]
+				for i, fieldName := range fields {
+					if fieldName == e.Sel.Name && immutFlags != nil && i < len(immutFlags) && immutFlags[i] {
+						// Field is immutable — add .Get() unwrap
+						return &ast.CallExpr{
+							Fun: &ast.SelectorExpr{X: result, Sel: ast.NewIdent("Get")},
+						}
+					}
+				}
+			}
+		}
+		return result
+	case *ast.CallExpr:
+		newFun := t.substituteReceiverInDefault(e.Fun, receiverName, callSiteReceiver, recvTypeName)
+		newArgs := make([]ast.Expr, len(e.Args))
+		for i, arg := range e.Args {
+			newArgs[i] = t.substituteReceiverInDefault(arg, receiverName, callSiteReceiver, recvTypeName)
+		}
+		return &ast.CallExpr{Fun: newFun, Args: newArgs, Ellipsis: e.Ellipsis}
+	case *ast.IndexExpr:
+		return &ast.IndexExpr{
+			X:     t.substituteReceiverInDefault(e.X, receiverName, callSiteReceiver, recvTypeName),
+			Index: t.substituteReceiverInDefault(e.Index, receiverName, callSiteReceiver, recvTypeName),
+		}
+	case *ast.UnaryExpr:
+		return &ast.UnaryExpr{Op: e.Op, X: t.substituteReceiverInDefault(e.X, receiverName, callSiteReceiver, recvTypeName)}
+	case *ast.BinaryExpr:
+		return &ast.BinaryExpr{
+			X:  t.substituteReceiverInDefault(e.X, receiverName, callSiteReceiver, recvTypeName),
+			Op: e.Op,
+			Y:  t.substituteReceiverInDefault(e.Y, receiverName, callSiteReceiver, recvTypeName),
+		}
+	case *ast.ParenExpr:
+		return &ast.ParenExpr{X: t.substituteReceiverInDefault(e.X, receiverName, callSiteReceiver, recvTypeName)}
+	default:
+		return expr
+	}
+}
+
+// isReceiverFieldAccess checks if an expression is the receiver identifier (or receiver.Get()).
+func (t *galaASTTransformer) isReceiverFieldAccess(expr ast.Expr, receiverName string) bool {
+	// Direct: c.field
+	if id, ok := expr.(*ast.Ident); ok && id.Name == receiverName {
+		return true
+	}
+	return false
 }
 
 func (t *galaASTTransformer) transformArgumentWithExpectedType(exprCtx grammar.IExpressionContext, expectedType transpiler.Type) (ast.Expr, error) {

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -461,38 +461,67 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 				}, nil
 			}
 
-			// Transform arguments with expected types
+			// Transform arguments with expected types, handling named args and defaults
 			var mArgs []ast.Expr
+			mNamedArgs := make(map[string]ast.Expr)
 			hasSpread := false
-			for i, argCtx := range argListCtx.AllArgument() {
+			argIdx := 0
+			for _, argCtx := range argListCtx.AllArgument() {
 				arg := argCtx.(*grammar.ArgumentContext)
 				pat := arg.Pattern()
-				exprCtx, isSpread, extractErr := extractArgExpression(pat)
-				if extractErr != nil {
-					return nil, extractErr
+				if arg.Identifier() != nil {
+					argName := arg.Identifier().GetText()
+					exprCtx, isSpread, extractErr := extractArgExpression(pat)
+					if extractErr != nil {
+						return nil, extractErr
+					}
+					if isSpread {
+						hasSpread = true
+					}
+					var expectedType transpiler.Type = transpiler.NilType{}
+					for pi, pName := range methodMeta.ParamNames {
+						if pName == argName && pi < len(methodMeta.ParamTypes) {
+							expectedType = t.substituteTranspilerTypeParams(methodMeta.ParamTypes[pi], typeSubst)
+							break
+						}
+					}
+					expr, err := t.transformArgumentWithExpectedType(exprCtx, expectedType)
+					if err != nil {
+						return nil, err
+					}
+					mNamedArgs[argName] = expr
+				} else {
+					exprCtx, isSpread, extractErr := extractArgExpression(pat)
+					if extractErr != nil {
+						return nil, extractErr
+					}
+					if isSpread {
+						hasSpread = true
+					}
+					var expectedType transpiler.Type = transpiler.NilType{}
+					if argIdx < len(methodMeta.ParamTypes) {
+						expectedType = t.substituteTranspilerTypeParams(methodMeta.ParamTypes[argIdx], typeSubst)
+					}
+					expr, err := t.transformArgumentWithExpectedType(exprCtx, expectedType)
+					if err != nil {
+						return nil, err
+					}
+					mArgs = append(mArgs, expr)
+					argIdx++
 				}
-				if isSpread {
-					hasSpread = true
-				}
-
-				var expectedType transpiler.Type = transpiler.NilType{}
-				if i < len(methodMeta.ParamTypes) {
-					expectedType = t.substituteTranspilerTypeParams(methodMeta.ParamTypes[i], typeSubst)
-				}
-
-				expr, err := t.transformArgumentWithExpectedType(exprCtx, expectedType)
+			}
+			methodFun := &ast.SelectorExpr{X: receiver, Sel: ast.NewIdent(method)}
+			if len(mNamedArgs) > 0 && len(methodMeta.ParamNames) > 0 {
+				return t.handleNamedArgsMethodCall(methodFun, mArgs, mNamedArgs, methodMeta)
+			}
+			if len(methodMeta.DefaultExprs) > 0 && len(mArgs) < len(methodMeta.ParamTypes) {
+				filled, err := t.fillDefaultArgsMethod(mArgs, methodMeta)
 				if err != nil {
 					return nil, err
 				}
-				mArgs = append(mArgs, expr)
+				return &ast.CallExpr{Fun: methodFun, Args: filled, Ellipsis: ellipsisPos(hasSpread)}, nil
 			}
-
-			// Keep as method call: receiver.method(args)
-			return &ast.CallExpr{
-				Fun:      &ast.SelectorExpr{X: receiver, Sel: ast.NewIdent(method)},
-				Args:     mArgs,
-				Ellipsis: ellipsisPos(hasSpread),
-			}, nil
+			return &ast.CallExpr{Fun: methodFun, Args: mArgs, Ellipsis: ellipsisPos(hasSpread)}, nil
 		}
 
 		// FIX-042: When method metadata is not found (receiver type unresolvable),
@@ -1266,6 +1295,76 @@ func (t *galaASTTransformer) handleNamedArgsFuncCall(
 	}
 
 	return &ast.CallExpr{Fun: fun, Args: result}, nil
+}
+
+// handleNamedArgsMethodCall handles method calls with named arguments and default parameter values.
+func (t *galaASTTransformer) handleNamedArgsMethodCall(
+	fun ast.Expr,
+	positionalArgs []ast.Expr,
+	namedArgs map[string]ast.Expr,
+	methodMeta *transpiler.MethodMetadata,
+) (ast.Expr, error) {
+	totalParams := len(methodMeta.ParamTypes)
+	result := make([]ast.Expr, totalParams)
+	for i, arg := range positionalArgs {
+		if i >= totalParams {
+			return nil, galaerr.NewSemanticError(fmt.Sprintf("too many arguments in call to %s", methodMeta.Name))
+		}
+		result[i] = arg
+	}
+	for name, expr := range namedArgs {
+		idx := -1
+		for i, pName := range methodMeta.ParamNames {
+			if pName == name {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			return nil, galaerr.NewSemanticError(fmt.Sprintf("unknown parameter %q in call to %s", name, methodMeta.Name))
+		}
+		if result[idx] != nil {
+			return nil, galaerr.NewSemanticError(fmt.Sprintf("parameter %q specified both positionally and by name in call to %s", name, methodMeta.Name))
+		}
+		result[idx] = expr
+	}
+	for i, slot := range result {
+		if slot == nil {
+			defaultExprText, hasDefault := methodMeta.DefaultExprs[i]
+			if !hasDefault {
+				paramName := ""
+				if i < len(methodMeta.ParamNames) {
+					paramName = methodMeta.ParamNames[i]
+				}
+				return nil, galaerr.NewSemanticError(fmt.Sprintf("missing required argument %q (parameter %d) in call to %s", paramName, i+1, methodMeta.Name))
+			}
+			expr, err := t.transformDefaultExpr(defaultExprText)
+			if err != nil {
+				return nil, err
+			}
+			result[i] = expr
+		}
+	}
+	return &ast.CallExpr{Fun: fun, Args: result}, nil
+}
+
+// fillDefaultArgsMethod fills missing positional arguments with default values from method metadata.
+func (t *galaASTTransformer) fillDefaultArgsMethod(args []ast.Expr, methodMeta *transpiler.MethodMetadata) ([]ast.Expr, error) {
+	totalParams := len(methodMeta.ParamTypes)
+	result := make([]ast.Expr, totalParams)
+	copy(result, args)
+	for i := len(args); i < totalParams; i++ {
+		defaultExprText, hasDefault := methodMeta.DefaultExprs[i]
+		if !hasDefault {
+			return nil, galaerr.NewSemanticError(fmt.Sprintf("missing required argument %q (parameter %d) in call to %s", methodMeta.ParamNames[i], i+1, methodMeta.Name))
+		}
+		expr, err := t.transformDefaultExpr(defaultExprText)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = expr
+	}
+	return result, nil
 }
 
 func (t *galaASTTransformer) transformArgumentWithExpectedType(exprCtx grammar.IExpressionContext, expectedType transpiler.Type) (ast.Expr, error) {

--- a/internal/transpiler/transpiler.go
+++ b/internal/transpiler/transpiler.go
@@ -172,15 +172,16 @@ type SealedVariant struct {
 }
 
 type MethodMetadata struct {
-	Name       string
-	Package    string
-	ParamTypes []Type
-	ParamNames []string // Parameter names (for named argument matching)
-	ReturnType Type
-	TypeParams []string
-	DefaultExprs map[int]string // Param index -> default expression source text (nil = required)
-	IsGeneric    bool           // Force transformation to standalone function
-	DefinedIn    string         // Source file where this method was defined (for redefinition detection)
+	Name         string
+	Package      string
+	ParamTypes   []Type
+	ParamNames   []string         // Parameter names (for named argument matching)
+	ReturnType   Type
+	TypeParams   []string
+	DefaultExprs map[int]string   // Param index -> default expression source text (nil = required)
+	ReceiverName string           // Receiver parameter name (e.g., "s" in "func (s Server)") for default expr substitution
+	IsGeneric    bool             // Force transformation to standalone function
+	DefinedIn    string           // Source file where this method was defined (for redefinition detection)
 }
 
 type FunctionMetadata struct {

--- a/internal/transpiler/transpiler.go
+++ b/internal/transpiler/transpiler.go
@@ -178,8 +178,9 @@ type MethodMetadata struct {
 	ParamNames []string // Parameter names (for named argument matching)
 	ReturnType Type
 	TypeParams []string
-	IsGeneric  bool   // Force transformation to standalone function
-	DefinedIn  string // Source file where this method was defined (for redefinition detection)
+	DefaultExprs map[int]string // Param index -> default expression source text (nil = required)
+	IsGeneric    bool           // Force transformation to standalone function
+	DefinedIn    string         // Source file where this method was defined (for redefinition detection)
 }
 
 type FunctionMetadata struct {


### PR DESCRIPTION
## Summary

Fixes **FIX-050** / BUG-039: Named parameter defaults not expanded in generated Go for method calls.

**Category**: CODEGEN_BUG
**Priority**: P0 (Critical — blocks compilation of any function using named args with defaults)
**Found in**: gala-server

## Root Cause

`MethodMetadata` lacked a `DefaultExprs` field — only `FunctionMetadata` had it. The analyzer never extracted default expressions for methods, and the transformer never filled defaults for method calls with named args.

## Changes

- `internal/transpiler/transpiler.go` — Added `DefaultExprs map[int]string` to `MethodMetadata`
- `internal/transpiler/analyzer/analyzer.go` — Extract defaults for methods (main + sibling files)
- `internal/transpiler/transformer/calls.go` — New `handleNamedArgsMethodCall()` and `fillDefaultArgsMethod()`
- `examples/method_default_params.gala` — Verification example

## Verification

- `examples/method_default_params.gala` compiles and runs correctly
- `bazel build //...` passes
- `bazel test //...` passes

## Repro (before fix)

```gala
func (c Config) copy(host string = c.host, port int = c.port) Config = Config(host, port)
func (c Config) WithPort(port int) Config = c.copy(port = port)
// Generated: c.copy(port) — ERROR: not enough arguments
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-039 in gala-server TRANSPILER_NOTES.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)