### PR TITLE
fix: add return before IIFE when match is last expr in function block body

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -19,6 +19,7 @@ filegroup(
         "lib/generic.gala",
         "match_method_chain/main.gala",
         "match_method_chain/types.gala",
+        "match_return_iife.gala",
         "match_void_branches.gala",
         "mathlib/math.gala",
         "multi_file/greeter.gala",
@@ -498,6 +499,13 @@ gala_test(
     name = "match_type_inference",
     src = "match_type_inference.gala",
     expected = "match_type_inference.out",
+)
+
+# FIX-051: match as last expression in function block body auto-returns
+gala_test(
+    name = "match_return_iife",
+    src = "match_return_iife.gala",
+    expected = "match_return_iife.out",
 )
 
 gala_test(
@@ -1393,4 +1401,12 @@ gala_test(
     name = "if_expression_block",
     src = "if_expression_block.gala",
     expected = "if_expression_block.out",
+)
+
+# FIX-056 verification: lambda type inference produces concrete types, not any
+gala_test(
+    name = "lambda_any_fallback_verify",
+    src = "lambda_any_fallback_verify.gala",
+    expected = "lambda_any_fallback_verify.out",
+    deps = ["//collection_immutable"],
 )

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1402,11 +1402,3 @@ gala_test(
     src = "if_expression_block.gala",
     expected = "if_expression_block.out",
 )
-
-# FIX-056 verification: lambda type inference produces concrete types, not any
-gala_test(
-    name = "lambda_any_fallback_verify",
-    src = "lambda_any_fallback_verify.gala",
-    expected = "lambda_any_fallback_verify.out",
-    deps = ["//collection_immutable"],
-)

--- a/examples/match_return_iife.gala
+++ b/examples/match_return_iife.gala
@@ -1,0 +1,22 @@
+package main
+
+import (
+    "fmt"
+    . "martianoff/gala/std"
+)
+
+func classify(opt Option[int]) string {
+    val x = opt.GetOrElse(0)
+    x match {
+        case 0 => "zero"
+        case 1 => "one"
+        case _ => "other"
+    }
+}
+
+func main() {
+    fmt.Println(classify(Some(0)))
+    fmt.Println(classify(Some(1)))
+    fmt.Println(classify(Some(42)))
+    fmt.Println(classify(None[int]()))
+}

--- a/examples/match_return_iife.out
+++ b/examples/match_return_iife.out
@@ -1,0 +1,4 @@
+zero
+one
+other
+zero

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -79,6 +79,8 @@ go_test(
     # widen to "any" on CI while passing locally on Windows (no sandbox).
     data = [
         "//collection_immutable:gala_sources",
+        "//collection_mutable:gala_sources",
+        "//time_utils:gala_sources",
         "//std:gala_sources",
     ],
     deps = [

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -698,6 +698,16 @@ func (t *galaASTTransformer) transformFunctionDeclaration(ctx *grammar.FunctionD
 		if err != nil {
 			return nil, err
 		}
+		// Convert trailing IIFE expression statement to return statement for functions
+		// with a return type. This handles match expressions (compiled to IIFEs) that
+		// are the last expression in a function block body - same logic as lambdas.go.
+		if funcType.Results != nil && len(funcType.Results.List) > 0 && len(b.List) > 0 {
+			if exprStmt, ok := b.List[len(b.List)-1].(*ast.ExprStmt); ok {
+				if isIIFE(exprStmt.X) {
+					b.List[len(b.List)-1] = &ast.ReturnStmt{Results: []ast.Expr{exprStmt.X}}
+				}
+			}
+		}
 		body = b
 	} else if ctx.Expression() != nil {
 		expr, err := t.transformExpression(ctx.Expression())


### PR DESCRIPTION
## Summary

Fixes **FIX-051** / BUG-044: Missing `return` before IIFE in match-to-IIFE codegen.

**Category**: CODEGEN_BUG
**Priority**: P0 (blocks correct function return values)
**Found in**: gala-server

## Root Cause

When a function has a block body `{ ... }` and the last statement is a match expression (compiled to an IIFE), `transformBlock` creates an `ExprStmt` but never converts it to a `ReturnStmt`. The expression form `= expr` correctly wraps in `ReturnStmt`, but the block form did not.

## Changes

- `internal/transpiler/transformer/declarations.go` — Added IIFE-to-ReturnStmt conversion after `transformBlock`, matching existing logic in `lambdas.go`
- `examples/match_return_iife.gala` — Verification example

## Verification

- `examples/match_return_iife.gala` compiles and runs correctly
- `bazel build //...` passes
- `bazel test //...` passes

## Repro (before fix)

```gala
func classify(x int) string {
    val label = "test"
    x match {
        case 0 => "zero"
        case _ => s"other: $label"
    }
}
// Generated: func(obj int) string { ... }(x)  — missing return!
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-044 in gala-server TRANSPILER_NOTES.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)