### PR TITLE
fix: ensure dot-imported packages use unqualified references

### DIFF
--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -1232,6 +1232,9 @@ func (t *galaASTTransformer) transformFuncTypeSignature(ctx *grammar.SignatureCo
 					if pkg := resolvedType.GetPackage(); pkg != "" && pkg != t.packageName {
 						if pkg == registry.StdPackageName {
 							field.Type = t.stdIdent(typeName)
+						} else if t.importManager.IsDotImported(pkg) {
+							// Dot-imported package: use unqualified name
+							field.Type = ast.NewIdent(typeName)
 						} else if alias, ok := t.importManager.GetAlias(pkg); ok {
 							field.Type = &ast.SelectorExpr{X: ast.NewIdent(alias), Sel: ast.NewIdent(typeName)}
 						} else {

--- a/internal/transpiler/transformer/dot_import_test.go
+++ b/internal/transpiler/transformer/dot_import_test.go
@@ -120,6 +120,36 @@ func test() int {
 	assert.Contains(t, transpileErr.Error(), "pkg_b")
 }
 
+func TestDotImportNoQualifiedReferences(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	input := `package testpkg
+
+import . "martianoff/gala/std"
+
+func test() Option[int] {
+    val x = Some(42)
+    return x
+}
+`
+
+	got, err := trans.Transpile(input, "")
+	assert.NoError(t, err)
+
+	assert.NotContains(t, got, "std.Option",
+		"Dot-imported package should not produce qualified references, got:\n%s", got)
+	assert.NotContains(t, got, "std.Some",
+		"Dot-imported package should not produce qualified references, got:\n%s", got)
+	assert.NotContains(t, got, "std.Immutable",
+		"Dot-imported package should not produce qualified references, got:\n%s", got)
+	assert.Contains(t, got, "Option[int]",
+		"Should use unqualified type references with dot import, got:\n%s", got)
+}
+
 func TestDotImportNoClashNoError(t *testing.T) {
 	p := transpiler.NewAntlrGalaParser()
 	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())


### PR DESCRIPTION
## Summary

Fixes **FIX-052** / BUG-040: Dot imports not preserved — mixed qualified/unqualified references.

**Category**: CODEGEN_BUG
**Priority**: P1 (High — Go compilation error)
**Found in**: gala-server

## Root Cause

In `transformFuncTypeSignature`, function parameter types from dot-imported packages were incorrectly qualified (e.g., `collection_immutable.Array` instead of `Array`). The `IsDotImported` check was missing in that code path.

## Changes

- `internal/transpiler/transformer/declarations.go` — Added `IsDotImported` check in function type signature handler
- `internal/transpiler/transformer/dot_import_test.go` — New test `TestDotImportNoQualifiedReferences`
- `internal/transpiler/transpiler.go` — Added `DefaultExprs` to `MethodMetadata` (build dependency)

## Verification

- New test passes
- `bazel build //...` passes
- `bazel test //...` passes

## Repro (before fix)

```gala
import . "martianoff/gala/collection_immutable"
// Generated: collection_immutable.Array[...] — should be just Array[...]
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-040 in gala-server TRANSPILER_NOTES.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)