### PR TITLE
fix: unify return types across all paths in block lambdas

### DIFF
--- a/docs/EXAMPLES.MD
+++ b/docs/EXAMPLES.MD
@@ -633,6 +633,47 @@ Recovered: -1
 Side effect!
 ```
 
+## Multiple Return Values (Using Tuples)
+
+GALA uses Tuple types instead of Go-style multi-value returns. Tuple destructuring provides clean syntax at the call site.
+
+```gala
+package main
+
+import . "martianoff/gala/std"
+
+// Return two values using Tuple
+func minMax(a int, b int) Tuple[int, int] {
+    if (a < b) {
+        return (a, b)
+    }
+    return (b, a)
+}
+
+// Return three values using Tuple3
+func divmod(a int, b int) Tuple3[int, int, string] {
+    if (b == 0) {
+        return (0, 0, "division by zero")
+    }
+    return (a / b, a % b, "ok")
+}
+
+func main() {
+    // Tuple destructuring (note parens around variable names)
+    val (lo, hi) = minMax(7, 3)
+    Println(s"min=$lo max=$hi")
+
+    val (q, r, status) = divmod(17, 5)
+    Println(s"$q remainder $r ($status)")
+}
+```
+
+Output:
+```
+min=3 max=7
+3 remainder 2 (ok)
+```
+
 ## More Examples
 
 You can find more examples in the `examples/` directory of the project:

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -1130,6 +1130,48 @@ val first = t.V1   // 1
 val second = t.V2  // "hello"
 ```
 
+#### Multiple Return Values
+
+GALA does not support Go-style multi-value returns `(A, B, error)`. Instead, use **Tuple types** to return multiple values from a function, and **tuple destructuring** at the call site.
+
+```gala
+// Return two values using Tuple[A, B]
+func swap(a int, b int) Tuple[int, int] = (b, a)
+
+// Return three values using Tuple3[A, B, C]
+func divmod(a int, b int) Tuple3[int, int, string] {
+    if (b == 0) {
+        return (0, 0, "division by zero")
+    }
+    return (a / b, a % b, "ok")
+}
+
+// Destructure at call site (note parentheses around variable names)
+val (x, y) = swap(3, 7)            // x = 7, y = 3
+val (q, r, status) = divmod(17, 5) // q = 3, r = 2, status = "ok"
+
+// Or use pattern matching
+val result = divmod(10, 3) match {
+    case (q, r, "ok") => s"$q remainder $r"
+    case (_, _, err)   => s"Error: $err"
+}
+```
+
+**Tuple type reference:**
+| Arity | Type | Construction |
+|-------|------|-------------|
+| 2 | `Tuple[A, B]` | `(a, b)` |
+| 3 | `Tuple3[A, B, C]` | `(a, b, c)` |
+| 4 | `Tuple4[A, B, C, D]` | `(a, b, c, d)` |
+| 5+ | `Tuple5[...]` ... `Tuple10[...]` | `(a, b, c, d, e, ...)` |
+
+**For Go interop** with functions that return `(T, error)`, use `var` to get raw Go values:
+```gala
+var data, err = goFunction()  // var avoids Immutable wrapping
+```
+
+See [Either](#either) for typed error handling, and [Try](#try-monad) for exception-safe error handling.
+
 ### Either
 `Either[A, B]` is a sealed type representing a value that can be one of two types. It is often used for error handling where `Left` is the error and `Right` is the success value.
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1417,3 +1417,10 @@ gala_test(
     src = "method_default_params.gala",
     expected = "method_default_params.out",
 )
+
+# Lambda multi-return type unification (FIX-058)
+gala_test(
+    name = "lambda_multi_return_unify",
+    src = "lambda_multi_return_unify.gala",
+    expected = "lambda_multi_return_unify.out",
+)

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1418,6 +1418,13 @@ gala_test(
     expected = "method_default_params.out",
 )
 
+# Multiple return values using Tuples (documentation example)
+gala_test(
+    name = "tuple_multi_return",
+    src = "tuple_multi_return.gala",
+    expected = "tuple_multi_return.out",
+)
+
 # Lambda multi-return type unification (FIX-058)
 gala_test(
     name = "lambda_multi_return_unify",

--- a/examples/lambda_multi_return_unify.gala
+++ b/examples/lambda_multi_return_unify.gala
@@ -1,0 +1,54 @@
+package main
+
+import (
+    "fmt"
+    . "martianoff/gala/std"
+)
+
+// Verify that block lambdas with multiple return paths
+// unify their return types correctly (BUG-047 / FIX-058).
+
+type Response struct {
+    code int
+    body string
+}
+
+func Unauthorized(msg string) Response = Response(code = 401, body = msg)
+func Ok(msg string) Response = Response(code = 200, body = msg)
+
+// Block lambda with multiple return paths returning the same concrete type.
+// Previously the transpiler only looked at the first return and missed nested returns.
+func processRequest(authorized bool) Response {
+    val handler = (flag bool) => {
+        if (flag) {
+            return Ok("success")
+        }
+        return Unauthorized("not authorized")
+    }
+    return handler(authorized)
+}
+
+// Block lambda returning Option — both paths return Option[int].
+func safeDivide(a int, b int) Option[int] {
+    val divider = (x int, y int) => {
+        if (y == 0) {
+            return None[int]()
+        }
+        return Some(x / y)
+    }
+    return divider(a, b)
+}
+
+func main() {
+    val r1 = processRequest(true)
+    fmt.Println(s"Authorized: code=${r1.code} body=${r1.body}")
+
+    val r2 = processRequest(false)
+    fmt.Println(s"Unauthorized: code=${r2.code} body=${r2.body}")
+
+    val d1 = safeDivide(10, 2)
+    fmt.Println(s"10/2 = ${d1.GetOrElse(0)}")
+
+    val d2 = safeDivide(10, 0)
+    fmt.Println(s"10/0 = ${d2.GetOrElse(-1)}")
+}

--- a/examples/lambda_multi_return_unify.out
+++ b/examples/lambda_multi_return_unify.out
@@ -1,0 +1,4 @@
+Authorized: code=200 body=success
+Unauthorized: code=401 body=not authorized
+10/2 = 5
+10/0 = -1

--- a/examples/tuple_multi_return.gala
+++ b/examples/tuple_multi_return.gala
@@ -1,0 +1,25 @@
+package main
+
+import . "martianoff/gala/std"
+
+func minMax(a int, b int) Tuple[int, int] {
+    if (a < b) {
+        return (a, b)
+    }
+    return (b, a)
+}
+
+func divmod(a int, b int) Tuple3[int, int, string] {
+    if (b == 0) {
+        return (0, 0, "division by zero")
+    }
+    return (a / b, a % b, "ok")
+}
+
+func main() {
+    val (lo, hi) = minMax(7, 3)
+    Println(s"min=$lo max=$hi")
+
+    val (q, r, status) = divmod(17, 5)
+    Println(s"$q remainder $r ($status)")
+}

--- a/examples/tuple_multi_return.out
+++ b/examples/tuple_multi_return.out
@@ -1,0 +1,2 @@
+min=3 max=7
+3 remainder 2 (ok)

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -424,29 +424,166 @@ func (t *galaASTTransformer) inferBlockReturnType(block *ast.BlockStmt) ast.Expr
 		}
 	}
 
+	// Collect return types from ALL return paths (including nested if/else blocks).
+	var returnTypes []ast.Expr
+	t.collectReturnTypes(block, valTypes, &returnTypes)
+
+	if len(returnTypes) == 0 {
+		return nil
+	}
+	if len(returnTypes) == 1 {
+		return returnTypes[0]
+	}
+
+	// Unify all collected return types.
+	return t.unifyBlockReturnTypes(returnTypes)
+}
+
+// collectReturnTypes recursively walks a block statement collecting inferred return
+// types from every return statement, including those nested inside if/else blocks.
+func (t *galaASTTransformer) collectReturnTypes(block *ast.BlockStmt, valTypes map[string]ast.Expr, out *[]ast.Expr) {
+	if block == nil {
+		return
+	}
 	for _, stmt := range block.List {
-		if retStmt, ok := stmt.(*ast.ReturnStmt); ok {
-			if len(retStmt.Results) > 0 {
-				result := retStmt.Results[0]
-				// Try to infer type using valTypes for .Get() calls anywhere in the expression
-				if typ := t.inferExprTypeWithValTypes(result, valTypes); typ != nil {
-					return typ
-				}
-				// Fallback to direct type inference
-				inferredType := t.getExprType(result)
-				if inferredType != nil {
-					if ident, ok := inferredType.(*ast.Ident); ok && ident.Name != "any" {
-						return inferredType
-					}
-					// For non-ident types (like generic types), also return them
-					if _, ok := inferredType.(*ast.Ident); !ok {
-						return inferredType
-					}
+		switch s := stmt.(type) {
+		case *ast.ReturnStmt:
+			if len(s.Results) > 0 {
+				if typ := t.inferReturnExprType(s.Results[0], valTypes); typ != nil {
+					*out = append(*out, typ)
 				}
 			}
+		case *ast.IfStmt:
+			// Recurse into if body and else branch
+			t.collectReturnTypes(s.Body, valTypes, out)
+			if s.Else != nil {
+				switch els := s.Else.(type) {
+				case *ast.BlockStmt:
+					t.collectReturnTypes(els, valTypes, out)
+				case *ast.IfStmt:
+					// else-if chain: wrap in a synthetic block for recursion
+					t.collectReturnTypes(&ast.BlockStmt{List: []ast.Stmt{els}}, valTypes, out)
+				}
+			}
+		case *ast.BlockStmt:
+			t.collectReturnTypes(s, valTypes, out)
 		}
 	}
-	return nil
+}
+
+// inferReturnExprType infers the type of a single return expression, trying
+// valTypes-based inference first, then falling back to getExprType.
+func (t *galaASTTransformer) inferReturnExprType(expr ast.Expr, valTypes map[string]ast.Expr) ast.Expr {
+	// Try to infer type using valTypes for .Get() calls anywhere in the expression
+	if typ := t.inferExprTypeWithValTypes(expr, valTypes); typ != nil {
+		return typ
+	}
+	// Fallback to direct type inference
+	inferredType := t.getExprType(expr)
+	if inferredType == nil {
+		return nil
+	}
+	if ident, ok := inferredType.(*ast.Ident); ok && ident.Name == "any" {
+		return nil
+	}
+	return inferredType
+}
+
+// unifyBlockReturnTypes takes a list of inferred return type expressions and attempts
+// to find a single unified type. If all types are identical, that type is returned.
+// If they differ only in generic type parameters, the most specific (non-primitive
+// inner parameter) type is preferred. Returns nil if unification is not possible.
+func (t *galaASTTransformer) unifyBlockReturnTypes(types []ast.Expr) ast.Expr {
+	if len(types) == 0 {
+		return nil
+	}
+
+	// Convert to transpiler types for structural comparison.
+	tTypes := make([]transpiler.Type, len(types))
+	for i, te := range types {
+		tTypes[i] = t.astTypeToTranspilerType(te)
+	}
+
+	// Start with the first type as candidate.
+	best := tTypes[0]
+	bestExpr := types[0]
+
+	for i := 1; i < len(tTypes); i++ {
+		cur := tTypes[i]
+		if best.String() == cur.String() {
+			continue // identical
+		}
+
+		// Try to pick the more specific type.
+		unified := t.pickMoreSpecificType(best, cur)
+		if unified != nil {
+			best = unified
+			bestExpr = t.typeToExpr(unified)
+			continue
+		}
+
+		// Types are incompatible — return the first non-primitive/non-simple type
+		// as a best-effort (matches the old behaviour of picking the first return).
+		// A future enhancement could emit a SemanticError here when we have access
+		// to the ANTLR context for position info.
+		return bestExpr
+	}
+
+	return bestExpr
+}
+
+// pickMoreSpecificType compares two types and returns the more specific one.
+// For generic types with the same base (e.g., Future[string] vs Future[Response]),
+// it picks the one whose inner type parameter is a non-primitive named type.
+// Returns nil if neither is clearly more specific or the types are incompatible.
+func (t *galaASTTransformer) pickMoreSpecificType(a, b transpiler.Type) transpiler.Type {
+	genA, aIsGen := a.(transpiler.GenericType)
+	genB, bIsGen := b.(transpiler.GenericType)
+
+	if aIsGen && bIsGen {
+		baseA := stripPackagePrefix(genA.Base.BaseName())
+		baseB := stripPackagePrefix(genB.Base.BaseName())
+		if baseA == baseB && len(genA.Params) == len(genB.Params) {
+			// Same generic base — compare each type parameter.
+			// Prefer the one with more specific (non-primitive) parameters.
+			aScore := 0
+			bScore := 0
+			for i := range genA.Params {
+				pa := genA.Params[i]
+				pb := genB.Params[i]
+				if pa.String() == pb.String() {
+					continue
+				}
+				if isSimpleOrPrimitive(pa) && !isSimpleOrPrimitive(pb) {
+					bScore++
+				} else if !isSimpleOrPrimitive(pa) && isSimpleOrPrimitive(pb) {
+					aScore++
+				}
+			}
+			if aScore >= bScore {
+				return a
+			}
+			return b
+		}
+	}
+
+	// If one is generic and the other is a basic/named type with the same base name,
+	// prefer the generic (more informative).
+	if aIsGen && !bIsGen && stripPackagePrefix(genA.Base.BaseName()) == stripPackagePrefix(b.BaseName()) {
+		return a
+	}
+	if bIsGen && !aIsGen && stripPackagePrefix(genB.Base.BaseName()) == stripPackagePrefix(a.BaseName()) {
+		return b
+	}
+
+	return nil // incompatible
+}
+
+// isSimpleOrPrimitive returns true for primitive types (int, string, bool, float64, etc.)
+// or types named "any".
+func isSimpleOrPrimitive(typ transpiler.Type) bool {
+	name := typ.BaseName()
+	return transpiler.IsPrimitiveType(name) || name == "any"
 }
 
 // inferExprTypeWithValTypes tries to infer the type of an expression,


### PR DESCRIPTION
## Summary

Fixes **FIX-058** / BUG-047: Lambda return type inference fails for complex multi-return bodies.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1 (High)
**Found in**: gala-server

## Root Cause

`inferBlockReturnType` only examined top-level return statements and used the first one found. Returns nested inside `if`/`else` blocks were invisible, causing wrong type inference for block lambdas with multiple return paths.

## Changes

- `internal/transpiler/transformer/lambdas.go`:
  - `collectReturnTypes` — recursively walks AST (including if/else bodies) to find all return types
  - `unifyBlockReturnTypes` — unifies collected types
  - `pickMoreSpecificType` — for generic types with same base, prefers non-primitive type params
- `examples/lambda_multi_return_unify.gala` — verification example
- `docs/GALA.MD` — documented multiple return values using Tuples
- `docs/EXAMPLES.MD` — added Tuple multi-return example
- `examples/tuple_multi_return.gala` — verified Tuple multi-return example

## Verification

- 218 tests pass
- `bazel build //...` passes
- `bazel test //...` passes

## Battle Test Report Reference

Originally reported as: BUG-047 in gala-server TRANSPILER_NOTES.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)