### PR TITLE
feat: add gala test CLI command

### DIFF
--- a/cmd/gala/commands/BUILD.bazel
+++ b/cmd/gala/commands/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "project.go",
         "root.go",
         "run.go",
+        "test.go",
         "transpile.go",
         "version.go",
     ],

--- a/cmd/gala/commands/root.go
+++ b/cmd/gala/commands/root.go
@@ -22,6 +22,7 @@ This tool provides:
 Usage:
   gala build                    Build project to binary
   gala run                      Build and run project
+  gala test                     Run tests in project
   gala build -o myapp           Build with custom output name
   gala mod init                 Initialize gala.mod
   gala mod add <pkg>@<version>  Add a dependency
@@ -76,6 +77,7 @@ func init() {
 	rootCmd.AddCommand(buildCmd)
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(cleanCmd)
+	rootCmd.AddCommand(testCmd)
 
 	// Add global flags that mirror transpile flags for backward compatibility
 	rootCmd.Flags().StringVarP(&transpileInput, "input", "i", "", "Path to the input .gala file")

--- a/cmd/gala/commands/test.go
+++ b/cmd/gala/commands/test.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"martianoff/gala/internal/build"
+)
+
+var testVerbose bool
+
+var testCmd = &cobra.Command{
+	Use:   "test [directory]",
+	Short: "Run tests in a GALA project",
+	Long: `Test discovers and runs GALA test functions.
+
+This command:
+  1. Finds _test.gala files in the project directory
+  2. Transpiles source and test files together
+  3. Auto-discovers TestXxx(t T) T functions
+  4. Generates a test runner main
+  5. Builds and executes the test binary
+
+Test functions must have the signature: func TestXxx(t T) T
+where T is the test context from the test framework.
+
+For package main projects, source and test files are compiled together.
+For library packages, test files are compiled as package main and import
+the library under test.
+
+Examples:
+  gala test                     # Test current directory
+  gala test ./myproject         # Test specific directory
+  gala test -v                  # Verbose output`,
+	Args: cobra.MaximumNArgs(1),
+	Run:  runTest,
+}
+
+func init() {
+	testCmd.Flags().BoolVarP(&testVerbose, "verbose", "v", false, "Verbose output")
+}
+
+func runTest(cmd *cobra.Command, args []string) {
+	// Determine project directory
+	projectDir := "."
+	if len(args) > 0 {
+		projectDir = args[0]
+	}
+
+	absProjectDir, err := findProjectRoot(projectDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Run 'gala mod init' to create one.")
+		os.Exit(1)
+	}
+
+	// Create builder
+	builder, err := build.NewBuilder(absProjectDir, Version, testVerbose)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Run tests
+	if err := builder.Test(testVerbose); err != nil {
+		fmt.Fprintf(os.Stderr, "Test failed: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -2543,13 +2543,12 @@ GALA provides a comprehensive test framework with 22 assertions, panic recovery,
 
 ### Test File Convention
 
-Test files should be named with the `_test.gala` suffix or placed in a `tests/` subdirectory:
+Test files use the `_test.gala` suffix and are placed alongside source files:
 
 ```
 mypackage/
   mycode.gala
-  tests/
-    main.gala    # Test file with package main
+  mycode_test.gala    # Test file with package main
 ```
 
 ### Writing Tests
@@ -2805,12 +2804,30 @@ gala_test(
 
 ### Running Tests
 
-#### Prerequisites
+#### Using `gala test` (recommended)
+
+The `gala test` command automatically discovers `_test.gala` files, transpiles them, discovers `TestXxx` functions, generates a test runner, and executes tests — no manual wrappers or Bazel configuration needed.
+
+```bash
+gala test                     # Test current directory
+gala test ./myproject         # Test specific directory
+gala test -v                  # Verbose output
+```
+
+`gala test` handles both project types:
+- **`package main` projects**: source and test files are compiled together
+- **Library packages**: test files are compiled as `package main` and import the library under test
+
+#### Using Bazel
+
+For Bazel-based projects, use the `gala_go_test` and `gala_test` macros (see [BUILD.bazel Configuration](#buildbazel-configuration) above).
+
+##### Prerequisites
 
 - **Bazel** (via [Bazelisk](https://github.com/bazelbuild/bazelisk)): manages Bazel versions automatically
 - **Go SDK**: required for Go type inference (resolving function return types, struct fields, and method signatures from Go packages). Ensure `go` is on PATH or set the `GOROOT` environment variable.
 
-#### Commands
+##### Commands
 
 Build the entire project:
 ```bash

--- a/internal/build/BUILD.bazel
+++ b/internal/build/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "config.go",
         "deptranspiler.go",
         "gomod.go",
+        "testgen.go",
         "workspace.go",
     ],
     importpath = "martianoff/gala/internal/build",

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -678,6 +678,308 @@ func findGalaFilesRecursive(dir string) ([]string, error) {
 	return files, err
 }
 
+// Test runs the test flow: transpile source + test files, discover test functions,
+// generate a test main, build, and execute the test binary.
+// If verbose is true, passes -v-style output. Returns the exit code from the test run.
+func (b *Builder) Test(verbose bool) error {
+	// Step 1: Ensure workspace exists
+	if b.verbose {
+		fmt.Printf("Using workspace: %s\n", b.workspace.Dir)
+	}
+	if err := b.workspace.Ensure(); err != nil {
+		return fmt.Errorf("ensuring workspace: %w", err)
+	}
+
+	// Step 1.5: Invalidate workspace if gala version changed
+	versionFile := filepath.Join(b.workspace.Dir, ".gala-version")
+	if oldVer, err := os.ReadFile(versionFile); err != nil || string(oldVer) != b.stdlibVersion {
+		if b.verbose && err == nil {
+			fmt.Printf("GALA version changed (%s -> %s), invalidating workspace\n", string(oldVer), b.stdlibVersion)
+		}
+		os.RemoveAll(b.workspace.GenDir)
+		os.MkdirAll(b.workspace.GenDir, 0755)
+		os.RemoveAll(b.workspace.DepsDir)
+		os.MkdirAll(b.workspace.DepsDir, 0755)
+		os.Remove(filepath.Join(b.workspace.Dir, ".gala-source-hash"))
+		os.Remove(filepath.Join(b.workspace.Dir, ".gala-deps-hash"))
+		os.Remove(filepath.Join(b.workspace.Dir, "go.mod"))
+		os.Remove(filepath.Join(b.workspace.Dir, "go.sum"))
+		os.WriteFile(versionFile, []byte(b.stdlibVersion), 0644)
+	}
+
+	// Step 2: Ensure stdlib is extracted
+	if err := b.ensureStdlib(); err != nil {
+		return fmt.Errorf("ensuring stdlib: %w", err)
+	}
+
+	// Step 2.5: Fetch missing GALA dependencies
+	if err := b.ensureDeps(); err != nil {
+		return fmt.Errorf("fetching dependencies: %w", err)
+	}
+
+	// Step 2.6: Transpile GALA dependencies
+	if err := b.transpileDeps(); err != nil {
+		return fmt.Errorf("transpiling dependencies: %w", err)
+	}
+
+	// Step 3: Find source and test files
+	sourceFiles, err := findGalaFiles(b.workspace.ProjectDir)
+	if err != nil {
+		return fmt.Errorf("finding source files: %w", err)
+	}
+
+	testFiles, err := findGalaTestFiles(b.workspace.ProjectDir)
+	if err != nil {
+		return fmt.Errorf("finding test files: %w", err)
+	}
+
+	if len(testFiles) == 0 {
+		return fmt.Errorf("no _test.gala files found in %s", b.workspace.ProjectDir)
+	}
+
+	// Step 4: Determine package layout
+	// Test files in GALA are always package main and import the library under test.
+	// Source files can be package main (executable) or a library package.
+	// For package main projects: transpile source + test files together.
+	// For library projects: transpile source files as library, test files separately as main.
+	isLib := false
+	if len(sourceFiles) > 0 {
+		pkgName := detectPackageName(sourceFiles[0])
+		isLib = pkgName != "" && pkgName != "main"
+	}
+
+	// Always force-retranspile for tests (test files change independently)
+	if err := b.workspace.CleanGen(); err != nil {
+		return fmt.Errorf("cleaning gen dir: %w", err)
+	}
+
+	// Step 5: Transpile files
+	if isLib {
+		if err := b.transpileTestLibrary(sourceFiles, testFiles); err != nil {
+			return fmt.Errorf("transpiling: %w", err)
+		}
+	} else {
+		if err := b.transpileTestMain(sourceFiles, testFiles); err != nil {
+			return fmt.Errorf("transpiling: %w", err)
+		}
+	}
+
+	// Step 6: Generate go.mod
+	if err := b.generateGoMod(); err != nil {
+		return fmt.Errorf("generating go.mod: %w", err)
+	}
+
+	// Step 7: Discover test functions from .gala test files
+	var allTestFuncs []string
+	for _, tf := range testFiles {
+		funcs, err := FindTestFunctions(tf)
+		if err != nil {
+			return fmt.Errorf("scanning %s for test functions: %w", tf, err)
+		}
+		allTestFuncs = append(allTestFuncs, funcs...)
+	}
+
+	if len(allTestFuncs) == 0 {
+		return fmt.Errorf("no TestXxx functions found in test files")
+	}
+
+	if b.verbose {
+		fmt.Printf("Found %d test function(s): %s\n", len(allTestFuncs), strings.Join(allTestFuncs, ", "))
+	}
+
+	// Step 8: Generate test_main.go
+	testMainCode := GenerateTestMain(allTestFuncs)
+	if err := b.workspace.WriteGenFile("test_main.gen.go", []byte(testMainCode)); err != nil {
+		return fmt.Errorf("writing test_main.gen.go: %w", err)
+	}
+
+	if b.verbose {
+		fmt.Println("Generated test_main.gen.go")
+	}
+
+	// Step 9: Build the test binary
+	testBinary := filepath.Join(b.workspace.Dir, "test-binary")
+	if isWindows() {
+		testBinary += ".exe"
+	}
+
+	args := []string{"build", "-o", testBinary, "./gen/..."}
+	cmd := exec.Command("go", args...)
+	cmd.Dir = b.workspace.Dir
+	cmd.Env = append(os.Environ(), "GOMODCACHE="+b.config.GoPkgDir)
+
+	if b.verbose {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		fmt.Printf("Running: go %s\n", strings.Join(args, " "))
+	} else {
+		cmd.Stderr = os.Stderr
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("go build (test): %w", err)
+	}
+
+	// Step 10: Execute the test binary
+	if b.verbose {
+		fmt.Println("Running tests...")
+		fmt.Println()
+	}
+
+	execCmd := exec.Command(testBinary)
+	execCmd.Stdin = os.Stdin
+	execCmd.Stdout = os.Stdout
+	execCmd.Stderr = os.Stderr
+	execCmd.Dir = b.workspace.ProjectDir
+
+	if err := execCmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("tests failed (exit code %d)", exitErr.ExitCode())
+		}
+		return fmt.Errorf("running test binary: %w", err)
+	}
+
+	return nil
+}
+
+// transpileTestMain transpiles source + test files together for package main projects.
+// All files are transpiled into gen/ as package main.
+func (b *Builder) transpileTestMain(sourceFiles, testFiles []string) error {
+	allFiles := append(sourceFiles, testFiles...)
+	return b.transpileFiles(allFiles, allFiles)
+}
+
+// transpileTestLibrary transpiles source files as a library and test files as package main.
+// Source files go into gen/lib/ as the library package.
+// Test files go into gen/ as package main (they import the library).
+func (b *Builder) transpileTestLibrary(sourceFiles, testFiles []string) error {
+	// For library packages, test files are standalone package main files.
+	// They import the library via dot-import. We only need to transpile the test files
+	// into gen/ as package main. The library is already available as a dependency
+	// (either via stdlib, deps, or we transpile it into a subdirectory).
+
+	// Create lib subdirectory in gen
+	libDir := filepath.Join(b.workspace.GenDir, "lib")
+	if err := os.MkdirAll(libDir, 0755); err != nil {
+		return fmt.Errorf("creating lib dir: %w", err)
+	}
+
+	// Transpile source files into gen/lib/
+	if err := b.transpileFilesToDir(sourceFiles, sourceFiles, libDir); err != nil {
+		return fmt.Errorf("transpiling source files: %w", err)
+	}
+
+	// Transpile test files into gen/ (they are package main)
+	// Test files see source files as siblings for type resolution
+	allFiles := append(sourceFiles, testFiles...)
+	if err := b.transpileFilesToDir(testFiles, allFiles, b.workspace.GenDir); err != nil {
+		return fmt.Errorf("transpiling test files: %w", err)
+	}
+
+	return nil
+}
+
+// transpileFiles transpiles the given files into the workspace gen directory.
+// allSiblings is the full list of files for sibling-based type resolution.
+func (b *Builder) transpileFiles(files []string, allSiblings []string) error {
+	return b.transpileFilesToDir(files, allSiblings, b.workspace.GenDir)
+}
+
+// transpileFilesToDir transpiles the given files into the specified output directory.
+func (b *Builder) transpileFilesToDir(files []string, allSiblings []string, outDir string) error {
+	stdlibDir := b.config.StdlibVersionDir(b.stdlibVersion)
+	searchPaths := []string{b.workspace.ProjectDir, stdlibDir}
+
+	for _, req := range b.galaMod.GalaRequires() {
+		searchPaths = append(searchPaths, b.config.GalaModulePath(req.Path, req.Version))
+	}
+
+	p := transpiler.NewAntlrGalaParser()
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+
+	for _, galaFile := range files {
+		content, err := os.ReadFile(galaFile)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", galaFile, err)
+		}
+
+		var siblings []string
+		for _, other := range allSiblings {
+			if other != galaFile {
+				siblings = append(siblings, other)
+			}
+		}
+
+		var a transpiler.Analyzer
+		if len(siblings) > 0 {
+			a = analyzer.NewGalaAnalyzerWithPackageFiles(p, searchPaths, siblings)
+		} else {
+			a = analyzer.NewGalaAnalyzer(p, searchPaths)
+		}
+		t := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+		goCode, err := t.Transpile(string(content), galaFile)
+		if err != nil {
+			return fmt.Errorf("transpiling %s: %w", galaFile, err)
+		}
+
+		relPath, err := filepath.Rel(b.workspace.ProjectDir, galaFile)
+		if err != nil {
+			relPath = filepath.Base(galaFile)
+		}
+		outName := strings.TrimSuffix(relPath, ".gala") + ".gen.go"
+		outName = strings.ReplaceAll(outName, string(filepath.Separator), "_")
+
+		outPath := filepath.Join(outDir, outName)
+		if err := os.WriteFile(outPath, []byte(goCode), 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", outPath, err)
+		}
+
+		if b.verbose {
+			fmt.Printf("  %s -> %s\n", relPath, outName)
+		}
+	}
+
+	return nil
+}
+
+// detectPackageName reads the first line matching "package <name>" from a .gala file.
+func detectPackageName(galaFile string) string {
+	content, err := os.ReadFile(galaFile)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "package ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "package "))
+		}
+	}
+	return ""
+}
+
+// findGalaTestFiles finds all _test.gala files in the given directory (non-recursive).
+func findGalaTestFiles(dir string) ([]string, error) {
+	var files []string
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(entry.Name(), "_test.gala") {
+			files = append(files, filepath.Join(dir, entry.Name()))
+		}
+	}
+
+	return files, nil
+}
+
 // isWindows returns true if running on Windows.
 func isWindows() bool {
 	return os.PathSeparator == '\\'

--- a/internal/build/testgen.go
+++ b/internal/build/testgen.go
@@ -1,0 +1,74 @@
+package build
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// testFuncRegex matches GALA test function declarations that start with Test.
+// Pattern: func TestXxx(t T) T or func TestXxx(t test.T) test.T
+var testFuncRegex = regexp.MustCompile(`^\s*func\s+(Test\w+)\s*\(\s*\w+\s+(?:test\.)?T\s*\)\s+(?:test\.)?T`)
+
+// FindTestFunctions scans a .gala file for test function declarations.
+// It returns the names of all functions matching func TestXxx(t T) T.
+func FindTestFunctions(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var funcs []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		matches := testFuncRegex.FindStringSubmatch(line)
+		if len(matches) >= 2 {
+			funcs = append(funcs, matches[1])
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return funcs, nil
+}
+
+// GenerateTestMain generates a Go main() file that calls RunTests with all
+// discovered test functions. The generated code imports the test framework
+// and std library.
+func GenerateTestMain(testFuncs []string) string {
+	var sb strings.Builder
+
+	sb.WriteString("package main\n\n")
+
+	// Always import std for NewImmutable
+	sb.WriteString("import \"martianoff/gala/std\"\n")
+	sb.WriteString("import . \"martianoff/gala/test\"\n")
+	sb.WriteString("\n")
+
+	// Sort for deterministic output
+	sorted := make([]string, len(testFuncs))
+	copy(sorted, testFuncs)
+	sort.Strings(sorted)
+
+	sb.WriteString("func main() {\n")
+	sb.WriteString("\tRunTests(")
+
+	for i, funcName := range sorted {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(fmt.Sprintf("TestFunc{Name: std.NewImmutable(\"%s\"), F: std.NewImmutable(%s)}", funcName, funcName))
+	}
+
+	sb.WriteString(")\n")
+	sb.WriteString("}\n")
+
+	return sb.String()
+}


### PR DESCRIPTION
## Summary

- Adds `gala test` CLI command that discovers `_test.gala` files, transpiles them, auto-generates a test runner, and executes tests
- Eliminates the need for manual Go test harness wrappers (220+ `Test_X` wrappers in gala-server)
- Supports both `package main` projects and library packages

**Category**: USABILITY
**Priority**: P2
**Found in**: gala-server (USABILITY-001, USABILITY-005)

## Root Cause

GALA test functions use `func TestXxx(t T) T` which doesn't match Go's `func TestX(t *testing.T)`. Without a CLI test command, users needed either Bazel or manual Go wrapper functions for every test.

## Changes

- `cmd/gala/commands/test.go` — new `gala test` Cobra command with `-v` flag
- `cmd/gala/commands/root.go` — register test command, update help text
- `internal/build/testgen.go` — reusable test function discovery and main generation (extracted from `cmd/gala_test_gen`)
- `internal/build/builder.go` — `Test()` method, `transpileTestMain()`, `transpileTestLibrary()`, helpers
- `internal/build/BUILD.bazel` — add `testgen.go` to srcs
- `cmd/gala/commands/BUILD.bazel` — add `test.go` to srcs
- `docs/GALA.MD` — document `gala test` in Testing section

## Verification

- `bazel build //...` passes (820 targets)
- `bazel test //...` passes (218 tests)

## Usage

```bash
gala test                     # Test current directory
gala test ./myproject         # Test specific directory
gala test -v                  # Verbose output
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: USABILITY-001, USABILITY-005 in gala-server TRANSPILER_NOTES.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)