### PR TITLE
fix: propagate dot imports across sibling files in same package

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -36,6 +36,7 @@ filegroup(
         "struct_field_unwrap/main.gala",
         "struct_field_unwrap/types.gala",
         "try_go_transitive_import.gala",
+        "use_cross_file_dot_import_lib.gala",
         "use_cross_file_unwrap_lib.gala",
         "wrapper_method_lambda/main.gala",
     ],
@@ -1123,6 +1124,30 @@ gala_test(
     ],
     expected = "cross_file_unwrap/cross_file_unwrap.out",
     deps = ["//go_interop"],
+)
+
+
+# FIX-062 verification: cross-file dot import propagation (library package)
+gala_library(
+    name = "cross_file_dot_import_lib",
+    srcs = [
+        "cross_file_dot_import_lib/ops.gala",
+        "cross_file_dot_import_lib/types.gala",
+    ],
+    importpath = "martianoff/gala/examples/cross_file_dot_import_lib",
+    visibility = ["//visibility:public"],
+    deps = ["//collection_immutable"],
+)
+
+# Consumer of cross_file_dot_import_lib
+gala_test(
+    name = "use_cross_file_dot_import_lib",
+    src = "use_cross_file_dot_import_lib.gala",
+    expected = "use_cross_file_dot_import_lib.out",
+    deps = [
+        ":cross_file_dot_import_lib",
+        "//collection_immutable",
+    ],
 )
 
 # FIX-GS-011 verification: cross-file struct field auto-unwrap (library package)

--- a/examples/cross_file_dot_import_lib/ops.gala
+++ b/examples/cross_file_dot_import_lib/ops.gala
@@ -1,0 +1,9 @@
+package crossdotlib
+
+// File B: does NOT import collection_immutable, but uses Registry
+// which has Array[string] fields from the sibling's dot import.
+// The generated Go for this file must include the collection_immutable import.
+
+func RegistrySize(r Registry) int = r.Count()
+
+func MakeRegistry(items ...string) Registry = NewRegistry(ArrayOf(items...))

--- a/examples/cross_file_dot_import_lib/types.gala
+++ b/examples/cross_file_dot_import_lib/types.gala
@@ -1,0 +1,10 @@
+package crossdotlib
+
+import . "martianoff/gala/collection_immutable"
+
+// File A: dot-imports collection_immutable and uses Array[T]
+struct Registry(Items Array[string])
+
+func NewRegistry(items Array[string]) Registry = Registry(Items = items)
+
+func (r Registry) Count() int = r.Items.Size()

--- a/examples/use_cross_file_dot_import_lib.gala
+++ b/examples/use_cross_file_dot_import_lib.gala
@@ -1,0 +1,9 @@
+package main
+
+import . "martianoff/gala/examples/cross_file_dot_import_lib"
+
+func main() {
+    val reg = MakeRegistry("a", "b", "c")
+    Println(s"size: ${reg.Count()}")
+    Println(s"via fn: ${RegistrySize(reg)}")
+}

--- a/examples/use_cross_file_dot_import_lib.out
+++ b/examples/use_cross_file_dot_import_lib.out
@@ -1,0 +1,2 @@
+size: 3
+via fn: 3

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -348,6 +348,25 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 	// std is always implicitly dot-imported
 	dotImportPkgs[registry.StdPackageName] = true
 
+	// Collect dot imports from sibling files for the transformer.
+	siblingDotImports := make(map[string]string)
+	for _, sib := range siblingTrees {
+		for _, impDecl := range sib.AllImportDeclaration() {
+			ctx := impDecl.(*grammar.ImportDeclarationContext)
+			for _, spec := range ctx.AllImportSpec() {
+				s := spec.(*grammar.ImportSpecContext)
+				isDotImport := s.Identifier() == nil && s.GetChildCount() > 1
+				if isDotImport {
+					path := strings.Trim(s.STRING().GetText(), "\"")
+					if pkgAlias, ok := richAST.Packages[path]; ok {
+						siblingDotImports[path] = pkgAlias
+					}
+				}
+			}
+		}
+	}
+	richAST.SiblingDotImports = siblingDotImports
+
 	// Set currentRichAST and dot-import tracking so resolveTypeWithParams can check
 	// already-known types (from dot-imported packages) before blindly qualifying with
 	// the current package name. This prevents e.g. Array from collection_immutable

--- a/internal/transpiler/transformer/codec.go
+++ b/internal/transpiler/transformer/codec.go
@@ -68,6 +68,7 @@ func (t *galaASTTransformer) finalizeCodecs(file *ast.File) {
 // Adds the import automatically.
 func (t *galaASTTransformer) collectionIdent(name string) ast.Expr {
 	if t.importManager.IsDotImported("collection_immutable") {
+		t.markDotImportUsed("collection_immutable")
 		return ast.NewIdent(name)
 	}
 	t.additionalImports["martianoff/gala/collection_immutable"] = "collection_immutable"

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -991,6 +991,9 @@ func (t *galaASTTransformer) transformTypeDeclaration(ctx *grammar.TypeDeclarati
 					} else if !t.importManager.IsDotImported(pkg) {
 						if alias, ok := t.importManager.GetAlias(pkg); ok {
 							targetType = &ast.SelectorExpr{X: ast.NewIdent(alias), Sel: ast.NewIdent(identName)}
+							if path, ok := t.importManager.GetPath(pkg); ok {
+								t.additionalImports[path] = alias
+							}
 						}
 					}
 				}
@@ -1235,8 +1238,12 @@ func (t *galaASTTransformer) transformFuncTypeSignature(ctx *grammar.SignatureCo
 						} else if t.importManager.IsDotImported(pkg) {
 							// Dot-imported package: use unqualified name
 							field.Type = ast.NewIdent(typeName)
+							t.markDotImportUsed(pkg)
 						} else if alias, ok := t.importManager.GetAlias(pkg); ok {
 							field.Type = &ast.SelectorExpr{X: ast.NewIdent(alias), Sel: ast.NewIdent(typeName)}
+							if path, ok := t.importManager.GetPath(pkg); ok {
+								t.additionalImports[path] = alias
+							}
 						} else {
 							field.Type = ast.NewIdent(typeName)
 						}

--- a/internal/transpiler/transformer/transformer.go
+++ b/internal/transpiler/transformer/transformer.go
@@ -45,6 +45,7 @@ type galaASTTransformer struct {
 	companionObjects      map[string]*transpiler.CompanionObjectMetadata // companion name -> metadata
 	importManager         *ImportManager                                 // unified import tracking
 	additionalImports     map[string]string                              // path -> alias for transitive imports needed by type inference
+	usedSiblingDotImports map[string]bool                                // paths of sibling dot imports actually referenced during transformation
 	tempVarCount          int
 	inferer               *infer.Inferer
 	currentFuncReturnType    transpiler.Type            // return type of the function currently being transformed
@@ -112,6 +113,7 @@ func (t *galaASTTransformer) Transform(richAST *transpiler.RichAST) (fset *token
 	}
 	t.importManager = NewImportManager()
 	t.additionalImports = make(map[string]string)
+	t.usedSiblingDotImports = make(map[string]bool)
 	t.typeAliases = make(map[string]transpiler.Type)
 	// Load type aliases from sibling files (extracted by analyzer)
 	for name, underlyingType := range richAST.TypeAliases {
@@ -134,6 +136,17 @@ func (t *galaASTTransformer) Transform(richAST *transpiler.RichAST) (fset *token
 
 	// Populate imports from richAST.Packages (includes implicit std import from analyzer)
 	t.importManager.AddFromPackages(richAST.Packages)
+
+	// Propagate dot imports from sibling files in the same package.
+	for path, pkgName := range richAST.SiblingDotImports {
+		if entry, exists := t.importManager.GetByPath(path); exists {
+			if !entry.IsDot {
+				t.importManager.Add(path, "", true, pkgName)
+			}
+		} else {
+			t.importManager.Add(path, "", true, pkgName)
+		}
+	}
 
 	// Populate metadata from RichAST
 	for typeName, meta := range richAST.Types {
@@ -301,6 +314,51 @@ func (t *galaASTTransformer) Transform(richAST *transpiler.RichAST) (fset *token
 		}
 	}
 
+	// Add dot imports from sibling files that are actually needed.
+	for path, pkgName := range richAST.SiblingDotImports {
+		needed := t.usedSiblingDotImports[path]
+		if !needed {
+			needed = t.astUsesDotImportedSymbols(file, pkgName, richAST)
+		}
+		if !needed {
+			continue
+		}
+		alreadyImported := false
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.IMPORT {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				importSpec, ok := spec.(*ast.ImportSpec)
+				if !ok {
+					continue
+				}
+				if strings.Trim(importSpec.Path.Value, "\"") == path {
+					alreadyImported = true
+					break
+				}
+			}
+			if alreadyImported {
+				break
+			}
+		}
+		if !alreadyImported {
+			spec := &ast.ImportSpec{
+				Name: ast.NewIdent("."),
+				Path: &ast.BasicLit{
+					Kind:  token.STRING,
+					Value: fmt.Sprintf("\"%s\"", path),
+				},
+			}
+			importDecl := &ast.GenDecl{
+				Tok:   token.IMPORT,
+				Specs: []ast.Spec{spec},
+			}
+			file.Decls = append([]ast.Decl{importDecl}, file.Decls...)
+		}
+	}
+
 	// Add import "embed" when embed val declarations with EmbeddedFS type are present.
 	// For string embeds, Go requires import _ "embed" (blank import).
 	if t.needsEmbedImport {
@@ -380,6 +438,47 @@ func (t *galaASTTransformer) Transform(richAST *transpiler.RichAST) (fset *token
 // It uses the ImportManager to resolve actual package names when they differ
 // from the last component of the import path (e.g., package "typealiaslib"
 // imported via path "martianoff/gala/examples/bug013_type_alias_lib").
+// astUsesDotImportedSymbols checks if the generated AST contains unqualified
+// identifiers that match exported symbols from a dot-imported package.
+func (t *galaASTTransformer) astUsesDotImportedSymbols(file *ast.File, pkgName string, richAST *transpiler.RichAST) bool {
+	exports := make(map[string]bool)
+	for _, meta := range richAST.Types {
+		if meta.Package == pkgName {
+			exports[meta.Name] = true
+		}
+	}
+	for _, meta := range richAST.Functions {
+		if meta.Package == pkgName {
+			exports[meta.Name] = true
+		}
+	}
+	for _, meta := range richAST.CompanionObjects {
+		if meta.Package == pkgName {
+			exports[meta.Name] = true
+		}
+	}
+	if goExports, ok := richAST.GoExports[pkgName]; ok {
+		for _, sym := range goExports {
+			exports[sym] = true
+		}
+	}
+	if len(exports) == 0 {
+		return false
+	}
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		if ident, ok := n.(*ast.Ident); ok && exports[ident.Name] {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
 func removeUnusedImports(file *ast.File, importMgr *ImportManager) {
 	usedPkgs := make(map[string]bool)
 	ast.Inspect(file, func(n ast.Node) bool {

--- a/internal/transpiler/transformer/types.go
+++ b/internal/transpiler/transformer/types.go
@@ -36,9 +36,12 @@ func (t *galaASTTransformer) transformType(ctx grammar.ITypeContext) (ast.Expr, 
 						ident = t.stdIdent(typeName)
 					} else {
 						// Check if this is a dot import - if so, don't qualify
-						if !t.importManager.IsDotImported(pkg) {
-							if alias, ok := t.importManager.GetAlias(pkg); ok {
-								ident = &ast.SelectorExpr{X: ast.NewIdent(alias), Sel: ast.NewIdent(typeName)}
+						if t.importManager.IsDotImported(pkg) {
+							t.markDotImportUsed(pkg)
+						} else if alias, ok := t.importManager.GetAlias(pkg); ok {
+							ident = &ast.SelectorExpr{X: ast.NewIdent(alias), Sel: ast.NewIdent(typeName)}
+							if path, ok := t.importManager.GetPath(pkg); ok {
+								t.additionalImports[path] = alias
 							}
 						}
 					}
@@ -163,6 +166,13 @@ func (t *galaASTTransformer) isKnownStdType(name string) bool {
 	return registry.IsStdType(name)
 }
 
+// markDotImportUsed records that a dot-imported package is actually referenced.
+func (t *galaASTTransformer) markDotImportUsed(pkgName string) {
+	if path, ok := t.importManager.GetPath(pkgName); ok {
+		t.usedSiblingDotImports[path] = true
+	}
+}
+
 func (t *galaASTTransformer) typeToExpr(typ transpiler.Type) ast.Expr {
 	if typ.IsNil() {
 		return ast.NewIdent("any")
@@ -187,6 +197,7 @@ func (t *galaASTTransformer) typeToExpr(typ transpiler.Type) ast.Expr {
 			}
 			// Check if this is a dot import - if so, use just the type name
 			if t.importManager.IsDotImported(v.Package) {
+				t.markDotImportUsed(v.Package)
 				return ast.NewIdent(v.Name)
 			}
 			// Check if this is the current package - if so, don't qualify with package name

--- a/internal/transpiler/transformer/utils.go
+++ b/internal/transpiler/transformer/utils.go
@@ -79,6 +79,7 @@ func (t *galaASTTransformer) ident(name string) ast.Expr {
 		}
 		// Check if it's dot-imported
 		if t.importManager.IsDotImported(pkg) {
+			t.markDotImportUsed(pkg)
 			return ast.NewIdent(base)
 		}
 		// Check if we have an alias for this actual package name

--- a/internal/transpiler/transpiler.go
+++ b/internal/transpiler/transpiler.go
@@ -66,10 +66,11 @@ type RichAST struct {
 	GoExports        map[string][]string                 // pkgName -> exported symbol names (from Go-only packages)
 	GoTypeInfo       *GoTypeInfo                         // type info extracted from Go source files and packages
 	TypeAliases      map[string]Type                     // type alias name -> underlying type (e.g., "Handler" -> func(Request) Future[Response])
-	EmbedDirectives  []EmbedDirective                    // embed val declarations
-	FilePath         string                              // source file path (for error reporting)
-	SourceContent    string                              // raw source text (for error snippets)
-	AnalysisWarnings []string                            // warnings from package analysis (e.g., unresolved GALA imports)
+	EmbedDirectives   []EmbedDirective  // embed val declarations
+	SiblingDotImports map[string]string // path -> pkgName for dot imports from sibling files in same package
+	FilePath          string            // source file path (for error reporting)
+	SourceContent     string            // raw source text (for error snippets)
+	AnalysisWarnings  []string          // warnings from package analysis (e.g., unresolved GALA imports)
 }
 
 // Merge combines metadata from another RichAST into this one.


### PR DESCRIPTION
## Summary
- **FIX-062**: When file A in a package has `import . "pkg"` and file B uses types/functions from that package, the generated Go for file B now correctly includes the dot import
- **FIX-063**: Sibling dot imports are only emitted when actually needed, preventing unused import errors (verified on `json` package which has sibling dot imports but some files don't use them)
- Added `SiblingDotImports` field to `RichAST` to pass sibling dot import info from analyzer to transformer
- Smart detection: combines explicit usage tracking (`markDotImportUsed`) with AST-level symbol scanning (`astUsesDotImportedSymbols`)

## Test plan
- [x] New verification example: `examples/cross_file_dot_import_lib` (2-file library where ops.gala uses collection_immutable types without importing)
- [x] Consumer test: `examples/use_cross_file_dot_import_lib` passes
- [x] Full test suite: all 220 tests pass
- [x] `json` package builds without unused import errors

Generated with [Claude Code](https://claude.com/claude-code)