### PR TITLE
fix: include non-test siblings when transpiling test files

### DIFF
--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -170,12 +170,15 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 							continue
 						}
 						otherPkgName := otherSF.PackageClause().(*grammar.PackageClauseContext).Identifier().GetText()
+						siblingIsTest := strings.HasSuffix(f.Name(), "_test.gala")
+						currentIsTest := strings.HasSuffix(filePath, "_test.gala")
 						// Allow _test.gala files to have different package names (like Go's _test.go convention)
-						isTestFile := strings.HasSuffix(f.Name(), "_test.gala") || strings.HasSuffix(filePath, "_test.gala")
-						if otherPkgName != pkgName && !isTestFile {
+						if otherPkgName != pkgName && !(siblingIsTest || currentIsTest) {
 							return nil, fmt.Errorf("multiple package names in directory %s: %s and %s", dirPath, pkgName, otherPkgName)
 						}
-						if otherPkgName == pkgName && !isTestFile {
+						// Include sibling if packages match AND (sibling is not test OR current is test)
+						// This follows Go semantics: test files see all package siblings during testing
+						if otherPkgName == pkgName && (!siblingIsTest || currentIsTest) {
 							siblingTrees = append(siblingTrees, otherSF)
 							siblingPaths = append(siblingPaths, otherPath)
 						}


### PR DESCRIPTION
## Summary

Fixes **FIX-067**: Test file lambda params fall back to `any` type because `_test.gala` siblings excluded from analysis.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1
**Found in**: gala-server (BUG-043 partial)

## Root Cause

In `analyzer.go`, `isTestFile` was true if EITHER sibling or current file was a test file. The inclusion check then excluded ALL siblings when the current file was a test, preventing type resolution.

## Changes

- `analyzer.go` — Split `isTestFile` into `siblingIsTest` and `currentIsTest`. Now follows Go semantics: test files see all same-package siblings, non-test files exclude test siblings.

## Verification

- `bazel build //...` passes  
- `bazel test //...` passes (222 tests)

## Dependencies

None — independent PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)