### PR TITLE
fix: gala build/test handles local Go subpackages and library test packages

### DIFF
--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -315,6 +315,12 @@ func (b *Builder) transpile() error {
 		}
 	}
 
+	// Copy local Go subpackages (e.g., httpcore/) to the gen directory
+	// so they are available alongside generated .gen.go files
+	if err := copyNonGalaFiles(b.workspace.ProjectDir, b.workspace.GenDir, b.verbose); err != nil {
+		return fmt.Errorf("copying local Go subpackages: %w", err)
+	}
+
 	// Save source hash for next build
 	if currentHash != "" {
 		os.WriteFile(hashFile, []byte(currentHash), 0644)
@@ -752,6 +758,8 @@ func (b *Builder) Test(verbose bool) error {
 	if err := b.workspace.CleanGen(); err != nil {
 		return fmt.Errorf("cleaning gen dir: %w", err)
 	}
+	// Also clean testgen/ for library test runs
+	os.RemoveAll(filepath.Join(b.workspace.Dir, "testgen"))
 
 	// Step 5: Transpile files
 	if isLib {
@@ -788,8 +796,18 @@ func (b *Builder) Test(verbose bool) error {
 	}
 
 	// Step 8: Generate test_main.go
+	// For library packages, test files are in testgen/ (separate from gen/).
+	// For main packages, everything is in gen/.
+	testMainDir := b.workspace.GenDir
+	buildTarget := "./gen/..."
+	if isLib {
+		testMainDir = filepath.Join(b.workspace.Dir, "testgen")
+		buildTarget = "./testgen/..."
+	}
+
 	testMainCode := GenerateTestMain(allTestFuncs)
-	if err := b.workspace.WriteGenFile("test_main.gen.go", []byte(testMainCode)); err != nil {
+	testMainPath := filepath.Join(testMainDir, "test_main.gen.go")
+	if err := os.WriteFile(testMainPath, []byte(testMainCode), 0644); err != nil {
 		return fmt.Errorf("writing test_main.gen.go: %w", err)
 	}
 
@@ -803,7 +821,7 @@ func (b *Builder) Test(verbose bool) error {
 		testBinary += ".exe"
 	}
 
-	args := []string{"build", "-o", testBinary, "./gen/..."}
+	args := []string{"build", "-o", testBinary, buildTarget}
 	cmd := exec.Command("go", args...)
 	cmd.Dir = b.workspace.Dir
 	cmd.Env = append(os.Environ(), "GOMODCACHE="+b.config.GoPkgDir)
@@ -850,33 +868,139 @@ func (b *Builder) transpileTestMain(sourceFiles, testFiles []string) error {
 }
 
 // transpileTestLibrary transpiles source files as a library and test files as package main.
-// Source files go into gen/lib/ as the library package.
-// Test files go into gen/ as package main (they import the library).
+// Source files go into gen/ as their original library package.
+// Test files go into testgen/ and are rewritten to package main with a dot-import
+// of the library package, avoiding Go's "multiple packages in directory" conflict.
 func (b *Builder) transpileTestLibrary(sourceFiles, testFiles []string) error {
-	// For library packages, test files are standalone package main files.
-	// They import the library via dot-import. We only need to transpile the test files
-	// into gen/ as package main. The library is already available as a dependency
-	// (either via stdlib, deps, or we transpile it into a subdirectory).
-
-	// Create lib subdirectory in gen
-	libDir := filepath.Join(b.workspace.GenDir, "lib")
-	if err := os.MkdirAll(libDir, 0755); err != nil {
-		return fmt.Errorf("creating lib dir: %w", err)
-	}
-
-	// Transpile source files into gen/lib/
-	if err := b.transpileFilesToDir(sourceFiles, sourceFiles, libDir); err != nil {
+	// Transpile source files into gen/ as the library package
+	if err := b.transpileFilesToDir(sourceFiles, sourceFiles, b.workspace.GenDir); err != nil {
 		return fmt.Errorf("transpiling source files: %w", err)
 	}
 
-	// Transpile test files into gen/ (they are package main)
+	// Copy local Go subpackages to gen/ so the library compiles
+	if err := copyNonGalaFiles(b.workspace.ProjectDir, b.workspace.GenDir, b.verbose); err != nil {
+		return fmt.Errorf("copying local Go subpackages: %w", err)
+	}
+
+	// Create testgen/ directory for test files (separate from library in gen/)
+	testGenDir := filepath.Join(b.workspace.Dir, "testgen")
+	if err := os.MkdirAll(testGenDir, 0755); err != nil {
+		return fmt.Errorf("creating testgen dir: %w", err)
+	}
+
+	// Transpile test files into testgen/
 	// Test files see source files as siblings for type resolution
 	allFiles := append(sourceFiles, testFiles...)
-	if err := b.transpileFilesToDir(testFiles, allFiles, b.workspace.GenDir); err != nil {
+	if err := b.transpileFilesToDir(testFiles, allFiles, testGenDir); err != nil {
 		return fmt.Errorf("transpiling test files: %w", err)
 	}
 
+	// Rewrite generated test files: change package to "main" and add dot-import
+	// of the library package from gen/
+	if err := rewriteTestFilesAsMain(testGenDir); err != nil {
+		return fmt.Errorf("rewriting test files as package main: %w", err)
+	}
+
 	return nil
+}
+
+// rewriteTestFilesAsMain rewrites all .gen.go files in the given directory:
+// changes "package <name>" to "package main" and adds a dot-import of the
+// library from gala-build-workspace/gen.
+func rewriteTestFilesAsMain(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".gen.go") {
+			continue
+		}
+
+		filePath := filepath.Join(dir, entry.Name())
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", entry.Name(), err)
+		}
+
+		rewritten := rewritePackageToMain(string(content))
+		if err := os.WriteFile(filePath, []byte(rewritten), 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", entry.Name(), err)
+		}
+	}
+
+	return nil
+}
+
+// rewritePackageToMain changes the package declaration to "main" and injects
+// a dot-import of the library package (gala-build-workspace/gen).
+func rewritePackageToMain(code string) string {
+	lines := strings.Split(code, "\n")
+	var result []string
+	packageReplaced := false
+	importAdded := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Replace package declaration
+		if !packageReplaced && strings.HasPrefix(trimmed, "package ") {
+			result = append(result, "package main")
+			packageReplaced = true
+			continue
+		}
+
+		// After seeing import block, inject dot-import as first entry
+		if !importAdded && packageReplaced {
+			if trimmed == "import (" {
+				result = append(result, line)
+				result = append(result, "\t. \"gala-build-workspace/gen\"")
+				importAdded = true
+				continue
+			}
+			// Single import statement — convert to block with our dot-import
+			if strings.HasPrefix(trimmed, "import ") && strings.Contains(trimmed, "\"") {
+				start := strings.Index(trimmed, "\"")
+				end := strings.LastIndex(trimmed, "\"")
+				if start >= 0 && end > start {
+					impPath := trimmed[start+1 : end]
+					result = append(result, "import (")
+					result = append(result, "\t. \"gala-build-workspace/gen\"")
+					if strings.Contains(trimmed[:start], ".") {
+						result = append(result, fmt.Sprintf("\t. \"%s\"", impPath))
+					} else {
+						alias := strings.TrimSpace(trimmed[len("import "):start])
+						if alias != "" {
+							result = append(result, fmt.Sprintf("\t%s \"%s\"", alias, impPath))
+						} else {
+							result = append(result, fmt.Sprintf("\t\"%s\"", impPath))
+						}
+					}
+					result = append(result, ")")
+					importAdded = true
+					continue
+				}
+			}
+		}
+
+		result = append(result, line)
+	}
+
+	// If no import was found at all, add one after the package line
+	if !importAdded {
+		var final []string
+		for _, line := range result {
+			final = append(final, line)
+			if strings.TrimSpace(line) == "package main" {
+				final = append(final, "")
+				final = append(final, "import . \"gala-build-workspace/gen\"")
+			}
+		}
+		result = final
+	}
+
+	return strings.Join(result, "\n")
 }
 
 // transpileFiles transpiles the given files into the workspace gen directory.

--- a/internal/build/deptranspiler_test.go
+++ b/internal/build/deptranspiler_test.go
@@ -3,6 +3,7 @@ package build
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,4 +80,87 @@ func TestCopyNonGalaFiles(t *testing.T) {
 	data, err = os.ReadFile(filepath.Join(dstDir, "helpers.go"))
 	require.NoError(t, err)
 	assert.Equal(t, "GENERATED", string(data))
+}
+
+func TestRewritePackageToMain_ImportBlock(t *testing.T) {
+	input := `package server
+
+import (
+	"fmt"
+	"martianoff/gala/std"
+)
+
+func TestFoo() {
+	fmt.Println("hello")
+}`
+	result := rewritePackageToMain(input)
+	assert.True(t, strings.HasPrefix(result, "package main\n"))
+	assert.Contains(t, result, `. "gala-build-workspace/gen"`)
+	assert.Contains(t, result, `"fmt"`)
+	assert.Contains(t, result, `"martianoff/gala/std"`)
+}
+
+func TestRewritePackageToMain_SingleImport(t *testing.T) {
+	input := `package server
+
+import "fmt"
+
+func main() {}`
+	result := rewritePackageToMain(input)
+	assert.True(t, strings.HasPrefix(result, "package main\n"))
+	assert.Contains(t, result, `. "gala-build-workspace/gen"`)
+	assert.Contains(t, result, `"fmt"`)
+}
+
+func TestRewritePackageToMain_NoImport(t *testing.T) {
+	input := `package server
+
+func main() {}`
+	result := rewritePackageToMain(input)
+	assert.True(t, strings.HasPrefix(result, "package main\n"))
+	assert.Contains(t, result, `import . "gala-build-workspace/gen"`)
+}
+
+func TestRewritePackageToMain_DotImport(t *testing.T) {
+	input := `package server
+
+import . "martianoff/gala/std"
+
+func main() {}`
+	result := rewritePackageToMain(input)
+	assert.True(t, strings.HasPrefix(result, "package main\n"))
+	assert.Contains(t, result, `. "gala-build-workspace/gen"`)
+	assert.Contains(t, result, `. "martianoff/gala/std"`)
+}
+
+func TestRewriteTestFilesAsMain(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a test .gen.go file
+	testCode := `package server
+
+import "martianoff/gala/std"
+
+func TestSomething() {
+	_ = std.NewImmutable(42)
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "server_test.gen.go"), []byte(testCode), 0644))
+
+	// Write a non-.gen.go file (should not be touched)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "helper.go"), []byte("package server"), 0644))
+
+	err := rewriteTestFilesAsMain(dir)
+	require.NoError(t, err)
+
+	// Verify test file was rewritten
+	data, err := os.ReadFile(filepath.Join(dir, "server_test.gen.go"))
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(data), "package main\n"))
+	assert.Contains(t, string(data), `. "gala-build-workspace/gen"`)
+
+	// Verify non-.gen.go was NOT touched
+	data, err = os.ReadFile(filepath.Join(dir, "helper.go"))
+	require.NoError(t, err)
+	assert.Equal(t, "package server", string(data))
 }


### PR DESCRIPTION
## Summary

- **FIX-063 (USABILITY-006)**: `gala build` now copies local Go subpackages (e.g., `httpcore/`) to the build workspace alongside generated `.gen.go` files. Previously only dependencies got `copyNonGalaFiles`; now the main project does too.
- **FIX-065 (USABILITY-001)**: `gala test` for library packages no longer causes Go's "multiple packages in directory" error. Test files are now transpiled to a separate `testgen/` directory and rewritten to `package main` with a dot-import of the library from `gala-build-workspace/gen`.

## Changes

- `internal/build/builder.go`: Added `copyNonGalaFiles` call in `transpile()`; rewrote `transpileTestLibrary()` with `testgen/` separation; added `rewriteTestFilesAsMain()`, `rewritePackageToMain()`; updated test binary build target for library tests
- `internal/build/deptranspiler_test.go`: Added 5 tests for the package rewrite logic

## Test plan

- [x] `bazel build //cmd/gala:gala` passes
- [x] `bazel test //internal/build:build_test` passes (7 tests including 5 new)
- [x] `bazel test //internal/... //cmd/...` passes (14 tests)
- [ ] Manual: `gala test` on a library package project (e.g., gala-server)
- [ ] Manual: `gala build` on a project with local Go subpackages

🤖 Generated with [Claude Code](https://claude.com/claude-code)