### PR TITLE
fix: rewrite project module imports for local subpackage resolution

### DIFF
--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -321,6 +321,12 @@ func (b *Builder) transpile() error {
 		return fmt.Errorf("copying local Go subpackages: %w", err)
 	}
 
+	// Rewrite imports that reference the project's Go module path to use the
+	// workspace module path instead, so local subpackages resolve correctly.
+	if err := b.rewriteProjectModuleImports(b.workspace.GenDir); err != nil {
+		return fmt.Errorf("rewriting project module imports: %w", err)
+	}
+
 	// Save source hash for next build
 	if currentHash != "" {
 		os.WriteFile(hashFile, []byte(currentHash), 0644)
@@ -401,6 +407,186 @@ func (b *Builder) copyEmbedFiles(patterns []string) error {
 	}
 
 	return nil
+}
+
+// rewriteProjectModuleImports rewrites import paths in all .go files under dir
+// that reference the project's Go module path, replacing them with the workspace
+// module path. This allows local Go subpackages (e.g., httpcore/) to be resolved
+// from the workspace gen/ directory instead of the remote registry.
+//
+// For example, if the project module is "github.com/user/project":
+//
+//	"github.com/user/project/httpcore" → "gala-build-workspace/gen/httpcore"
+//	"github.com/user/project"          → "gala-build-workspace/gen"
+func (b *Builder) rewriteProjectModuleImports(dir string) error {
+	projectModule := b.projectGoModulePath()
+	if projectModule == "" {
+		return nil // No module path known, nothing to rewrite
+	}
+
+	// Check if there are any local Go subdirectories worth rewriting for
+	hasSubDirs := false
+	entries, err := os.ReadDir(b.workspace.ProjectDir)
+	if err == nil {
+		for _, e := range entries {
+			if e.IsDir() && !strings.HasPrefix(e.Name(), ".") && e.Name() != "vendor" &&
+				!strings.HasPrefix(e.Name(), "bazel-") {
+				subPath := filepath.Join(b.workspace.ProjectDir, e.Name())
+				if hasGoFiles(subPath) {
+					hasSubDirs = true
+					break
+				}
+			}
+		}
+	}
+	if !hasSubDirs {
+		return nil // No local Go subpackages, skip rewriting
+	}
+
+	if b.verbose {
+		fmt.Printf("Rewriting project module imports: %s → gala-build-workspace/gen\n", projectModule)
+	}
+
+	return rewriteImportsInDir(dir, projectModule, "gala-build-workspace/gen", b.verbose)
+}
+
+// projectGoModulePath returns the project's Go module path by reading go.mod
+// or falling back to the gala.mod module declaration.
+func (b *Builder) projectGoModulePath() string {
+	// Try go.mod first (authoritative for Go imports)
+	goModPath := filepath.Join(b.workspace.ProjectDir, "go.mod")
+	if content, err := os.ReadFile(goModPath); err == nil {
+		if mod := parseGoModModulePath(string(content)); mod != "" {
+			return mod
+		}
+	}
+
+	// Fall back to gala.mod module path
+	if b.galaMod != nil && b.galaMod.Module.Path != "" {
+		return b.galaMod.Module.Path
+	}
+
+	return ""
+}
+
+// parseGoModModulePath extracts the module path from go.mod content.
+func parseGoModModulePath(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module "))
+		}
+	}
+	return ""
+}
+
+// hasGoFiles returns true if the directory contains any .go files.
+func hasGoFiles(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".go") {
+			return true
+		}
+	}
+	return false
+}
+
+// rewriteImportsInDir recursively scans all .go files in dir and rewrites
+// import paths that start with oldModule to use newModule instead.
+func rewriteImportsInDir(dir, oldModule, newModule string, verbose bool) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // Skip unreadable entries
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(info.Name(), ".go") {
+			return nil
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+
+		original := string(content)
+		rewritten := rewriteImportsInSource(original, oldModule, newModule)
+
+		if rewritten != original {
+			if verbose {
+				fmt.Printf("  rewrite imports: %s\n", path)
+			}
+			if err := os.WriteFile(path, []byte(rewritten), 0644); err != nil {
+				return fmt.Errorf("writing %s: %w", path, err)
+			}
+		}
+
+		return nil
+	})
+}
+
+// rewriteImportsInSource rewrites import paths in Go source code.
+// Replaces imports matching oldModule or oldModule/subpkg with newModule equivalents.
+func rewriteImportsInSource(source, oldModule, newModule string) string {
+	lines := strings.Split(source, "\n")
+	var result []string
+	inImportBlock := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "import (" {
+			inImportBlock = true
+			result = append(result, line)
+			continue
+		}
+		if inImportBlock && trimmed == ")" {
+			inImportBlock = false
+			result = append(result, line)
+			continue
+		}
+
+		if inImportBlock {
+			line = rewriteImportLine(line, oldModule, newModule)
+		} else if strings.HasPrefix(trimmed, "import ") && strings.Contains(trimmed, "\"") {
+			line = rewriteImportLine(line, oldModule, newModule)
+		}
+
+		result = append(result, line)
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// rewriteImportLine rewrites a single import line if it references oldModule.
+func rewriteImportLine(line, oldModule, newModule string) string {
+	// Find the quoted import path
+	start := strings.Index(line, "\"")
+	if start < 0 {
+		return line
+	}
+	end := strings.Index(line[start+1:], "\"")
+	if end < 0 {
+		return line
+	}
+	end += start + 1
+
+	importPath := line[start+1 : end]
+
+	// Check if this import matches the old module
+	if importPath == oldModule {
+		return line[:start+1] + newModule + line[end:]
+	}
+	if strings.HasPrefix(importPath, oldModule+"/") {
+		subPkg := strings.TrimPrefix(importPath, oldModule)
+		return line[:start+1] + newModule + subPkg + line[end:]
+	}
+
+	return line
 }
 
 // generateGoMod generates the go.mod file in the workspace and downloads Go dependencies.
@@ -880,6 +1066,11 @@ func (b *Builder) transpileTestLibrary(sourceFiles, testFiles []string) error {
 	// Copy local Go subpackages to gen/ so the library compiles
 	if err := copyNonGalaFiles(b.workspace.ProjectDir, b.workspace.GenDir, b.verbose); err != nil {
 		return fmt.Errorf("copying local Go subpackages: %w", err)
+	}
+
+	// Rewrite imports that reference the project's Go module path
+	if err := b.rewriteProjectModuleImports(b.workspace.GenDir); err != nil {
+		return fmt.Errorf("rewriting project module imports: %w", err)
 	}
 
 	// Create testgen/ directory for test files (separate from library in gen/)

--- a/internal/build/deptranspiler_test.go
+++ b/internal/build/deptranspiler_test.go
@@ -194,3 +194,214 @@ func TestSomething() {
 	require.NoError(t, err)
 	assert.Equal(t, "package server", string(data))
 }
+
+func TestRewriteImportsInSource(t *testing.T) {
+	tests := []struct {
+		name      string
+		source    string
+		oldModule string
+		newModule string
+		expected  string
+	}{
+		{
+			name: "import block with subpackage",
+			source: `package server
+
+import (
+	"fmt"
+	. "github.com/user/project/httpcore"
+	"martianoff/gala/std"
+)
+
+func main() {}`,
+			oldModule: "github.com/user/project",
+			newModule: "gala-build-workspace/gen",
+			expected: `package server
+
+import (
+	"fmt"
+	. "gala-build-workspace/gen/httpcore"
+	"martianoff/gala/std"
+)
+
+func main() {}`,
+		},
+		{
+			name: "single import with subpackage",
+			source: `package server
+
+import "github.com/user/project/httpcore"
+
+func main() {}`,
+			oldModule: "github.com/user/project",
+			newModule: "gala-build-workspace/gen",
+			expected: `package server
+
+import "gala-build-workspace/gen/httpcore"
+
+func main() {}`,
+		},
+		{
+			name: "import of root module",
+			source: `package httpcore
+
+import "github.com/user/project"
+
+func main() {}`,
+			oldModule: "github.com/user/project",
+			newModule: "gala-build-workspace/gen",
+			expected: `package httpcore
+
+import "gala-build-workspace/gen"
+
+func main() {}`,
+		},
+		{
+			name: "aliased import",
+			source: `package server
+
+import (
+	h "github.com/user/project/httpcore"
+)
+
+func main() {}`,
+			oldModule: "github.com/user/project",
+			newModule: "gala-build-workspace/gen",
+			expected: `package server
+
+import (
+	h "gala-build-workspace/gen/httpcore"
+)
+
+func main() {}`,
+		},
+		{
+			name: "no matching imports unchanged",
+			source: `package server
+
+import (
+	"fmt"
+	"github.com/other/module"
+)
+
+func main() {}`,
+			oldModule: "github.com/user/project",
+			newModule: "gala-build-workspace/gen",
+			expected: `package server
+
+import (
+	"fmt"
+	"github.com/other/module"
+)
+
+func main() {}`,
+		},
+		{
+			name: "multiple subpackages",
+			source: `package server
+
+import (
+	"github.com/user/project/httpcore"
+	"github.com/user/project/middleware"
+)
+
+func main() {}`,
+			oldModule: "github.com/user/project",
+			newModule: "gala-build-workspace/gen",
+			expected: `package server
+
+import (
+	"gala-build-workspace/gen/httpcore"
+	"gala-build-workspace/gen/middleware"
+)
+
+func main() {}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := rewriteImportsInSource(tt.source, tt.oldModule, tt.newModule)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRewriteImportsInDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a .gen.go file with project module imports
+	genCode := `package server
+
+import (
+	"fmt"
+	. "github.com/user/project/httpcore"
+)
+
+func main() { fmt.Println("hello") }
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "server.gen.go"), []byte(genCode), 0644))
+
+	// Write a Go subpackage file that references the project module
+	sub := filepath.Join(dir, "httpcore")
+	require.NoError(t, os.MkdirAll(sub, 0755))
+	subCode := `package httpcore
+
+import "github.com/user/project/httpcore/internal"
+
+func Handler() { internal.Do() }
+`
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "httpcore.go"), []byte(subCode), 0644))
+
+	// Write a non-.go file (should be untouched)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("github.com/user/project/httpcore"), 0644))
+
+	err := rewriteImportsInDir(dir, "github.com/user/project", "gala-build-workspace/gen", false)
+	require.NoError(t, err)
+
+	// Verify .gen.go was rewritten
+	data, err := os.ReadFile(filepath.Join(dir, "server.gen.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"gala-build-workspace/gen/httpcore"`)
+	assert.NotContains(t, string(data), `"github.com/user/project/httpcore"`)
+
+	// Verify subpackage .go file was rewritten
+	data, err = os.ReadFile(filepath.Join(sub, "httpcore.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"gala-build-workspace/gen/httpcore/internal"`)
+
+	// Verify non-.go file was NOT touched
+	data, err = os.ReadFile(filepath.Join(dir, "README.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "github.com/user/project/httpcore", string(data))
+}
+
+func TestParseGoModModulePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name:     "standard go.mod",
+			content:  "module github.com/user/project\n\ngo 1.22\n",
+			expected: "github.com/user/project",
+		},
+		{
+			name:     "with comment",
+			content:  "// generated\nmodule github.com/user/project\n",
+			expected: "github.com/user/project",
+		},
+		{
+			name:     "empty",
+			content:  "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, parseGoModModulePath(tt.content))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **FIX-068** / **USABILITY-006**: `gala build` workspace cannot resolve local Go subpackages

**Category**: USABILITY
**Priority**: P1
**Found in**: gala-server

## Root Cause

When `gala build` creates an isolated workspace, generated Go code imports local subpackages using the project's Go module path (e.g., `github.com/user/project/httpcore`). The workspace uses module `gala-build-workspace`, so Go couldn't resolve these imports locally and fell back to downloading the (possibly outdated) published version from the remote registry.

## Changes

- `internal/build/builder.go`:
  - Added `rewriteProjectModuleImports()` — scans gen/ after transpilation + file copy and rewrites import paths
  - Added `projectGoModulePath()` — reads module path from go.mod (preferred) or gala.mod (fallback)
  - Added `parseGoModModulePath()`, `hasGoFiles()` helpers
  - Added `rewriteImportsInDir()`, `rewriteImportsInSource()`, `rewriteImportLine()` — recursive import rewriting engine
  - Called from both `transpile()` (build) and `transpileTestLibrary()` (test)
- `internal/build/deptranspiler_test.go`:
  - Added `TestRewriteImportsInSource` — 6 cases (import blocks, single imports, aliases, root module, no-match, multiple subpackages)
  - Added `TestRewriteImportsInDir` — verifies recursive rewriting of .gen.go and copied .go files, non-.go files untouched
  - Added `TestParseGoModModulePath` — 3 cases

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (223 tests)

## Repro (before fix)

```
gala build   # in a project with local Go subpackage httpcore/
# go: found github.com/user/project/httpcore in github.com/user/project v0.0.0-old
# undefined: httpcore.NewFunction (not in the old published version)
```

## Dependencies

Depends on #107 (FIX-067). Merge FIX-067 first, then retarget this PR to master.

## Battle Test Report Reference

Originally reported as: USABILITY-006 and USABILITY-001 Issue B in gala-server TRANSPILER_NOTES.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)