### PR TITLE
fix: test codegen field unwrapping, stale module download, and junction handling

### DIFF
--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -1092,6 +1092,12 @@ func (b *Builder) transpileTestLibrary(sourceFiles, testFiles []string) error {
 		return fmt.Errorf("rewriting test files as package main: %w", err)
 	}
 
+	// Rewrite project module imports in testgen/ too, so go mod tidy doesn't
+	// try to fetch stale remote modules that have been replaced locally.
+	if err := b.rewriteProjectModuleImports(testGenDir); err != nil {
+		return fmt.Errorf("rewriting test project module imports: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/build/deptranspiler.go
+++ b/internal/build/deptranspiler.go
@@ -357,18 +357,30 @@ func copyNonGalaFiles(srcDir, dstDir string, verbose bool) error {
 			return nil
 		}
 
-		// Skip hidden directories, vendor, testdata, bazel dirs
-		if info.IsDir() {
-			name := info.Name()
-			if strings.HasPrefix(name, ".") || name == "vendor" ||
-				name == "testdata" || strings.HasPrefix(name, "bazel-") {
+		// Skip bazel directories/junctions regardless of how the OS reports them.
+		// On Windows, junctions may not have ModeDir set, so check the name
+		// before the IsDir() gate.
+		name := info.Name()
+		if strings.HasPrefix(name, "bazel-") {
+			if info.IsDir() {
 				return filepath.SkipDir
 			}
 			return nil
 		}
 
-		// Skip .gala files (already transpiled) and gala.mod
-		if strings.HasSuffix(info.Name(), ".gala") || info.Name() == "gala.mod" {
+		// Skip hidden directories, vendor, testdata
+		if info.IsDir() {
+			if strings.HasPrefix(name, ".") || name == "vendor" ||
+				name == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Skip .gala files (already transpiled), .gen.go files (stale transpiler
+		// output that may exist in the project dir), and gala.mod
+		if strings.HasSuffix(info.Name(), ".gala") || strings.HasSuffix(info.Name(), ".gen.go") ||
+			info.Name() == "gala.mod" {
 			return nil
 		}
 

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -77,6 +77,13 @@ func (t *galaASTTransformer) resolveFieldAccess(base ast.Expr, selName string) (
 	// Don't unwrap if we're accessing Immutable's own fields/methods
 	if !isImmutable || (selName != "Get" && selName != "value") {
 		base = t.unwrapImmutable(base)
+		// After unwrapping Immutable[T], update xType to T so that
+		// isImmutableField can look up the correct struct metadata.
+		if isImmutable {
+			if gen, ok := xType.(transpiler.GenericType); ok && len(gen.Params) > 0 {
+				xType = gen.Params[0]
+			}
+		}
 	}
 
 	// Also unwrap ConstPtr to access fields (but not ConstPtr's own methods)
@@ -137,6 +144,52 @@ func (t *galaASTTransformer) isImmutableField(xType transpiler.Type, selExpr *as
 		fieldType := t.getExprTypeName(selExpr)
 		if t.isImmutableType(fieldType) {
 			return true
+		}
+	}
+
+	// Fallback: when receiver type is unknown AND the base expression is a
+	// {val}.Get() call (indicating an Immutable-wrapped struct whose type
+	// inference didn't propagate), scan all known struct types for the field.
+	// Only unwrap if every struct that has this field agrees it's immutable.
+	if xTypeName == "" || xType.IsNil() {
+		isValGetCall := false
+		if ce, ok := selExpr.X.(*ast.CallExpr); ok && len(ce.Args) == 0 {
+			if se, ok := ce.Fun.(*ast.SelectorExpr); ok && se.Sel.Name == "Get" {
+				if id, ok := se.X.(*ast.Ident); ok && t.isVal(id.Name) {
+					isValGetCall = true
+				}
+			}
+		}
+		if isValGetCall {
+			foundField := false
+			allImmutable := true
+			// Check structImmutFields (current file types)
+			for tName, fields := range t.structFields {
+				for i, f := range fields {
+					if f == selName {
+						foundField = true
+						if i >= len(t.structImmutFields[tName]) || !t.structImmutFields[tName][i] {
+							allImmutable = false
+						}
+						break
+					}
+				}
+			}
+			// Check typeMetas (cross-package types)
+			for _, meta := range t.typeMetas {
+				for i, f := range meta.FieldNames {
+					if f == selName {
+						foundField = true
+						if i >= len(meta.ImmutFlags) || !meta.ImmutFlags[i] {
+							allImmutable = false
+						}
+						break
+					}
+				}
+			}
+			if foundField && allImmutable {
+				return true
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes **BUG-043 partial** and **USABILITY-009** from gala-server transpiler notes.

**Category**: USABILITY + TYPE_INFERENCE_BUG + BUILD_FIX
**Found in**: gala-server v2 development

## Changes

### 1. USABILITY-009: Stale remote module download during `gala test`
- **File**: `internal/build/builder.go`
- **Root cause**: `rewriteProjectModuleImports()` was called on `gen/` but not `testgen/`, so `go mod tidy` would still try to fetch remote modules that had been rewritten to local paths
- **Fix**: Also call `rewriteProjectModuleImports()` on `testgen/` in `transpileTestLibrary()`

### 2. BUG-043 partial: Immutable field not auto-unwrapped in test codegen
- **File**: `internal/transpiler/transformer/postfix.go`
- **Root cause**: Type inference for complex expression chains like `Logger()(r.Get(), handler.Get()).Get()` fails to propagate types in test context, leaving val types as `NilType` in scope. `isImmutableField` can't look up struct metadata without the receiver type.
- **Fix**: Added conservative fallback in `isImmutableField` — when receiver type is unknown AND the base expression is `{val}.Get()`, scans all known struct types. Only unwraps if every struct with that field agrees it's immutable.

### 3. BUG-043 partial: Stale `.gen.go` files contaminate workspace
- **File**: `internal/build/deptranspiler.go`
- **Root cause**: `copyNonGalaFiles` didn't skip `.gen.go` files from the project directory, so old pre-generated test files were copied to `gen/`, mixing stale code with freshly transpiled output
- **Fix**: Skip `.gen.go` files in `copyNonGalaFiles`

### 4. Windows junction handling
- **File**: `internal/build/deptranspiler.go`
- **Root cause**: Bazel junctions (`bazel-bin`, etc.) on Windows may not report `ModeDir`, bypassing the directory skip guard
- **Fix**: Check `bazel-` prefix before `IsDir()` gate

## Verification

- `bazel build //...` passes
- `bazel test //...` — all 223 tests pass, 0 regressions
- gala-server test errors: **34 → 10** (remaining 10 are deeper type inference issues for lambda params in test context)
- USABILITY-009 confirmed fixed: no more stale remote httpcore download during `gala test`

## Remaining Issues (not addressed)

10 errors remain in gala-server test codegen — these are deeper type inference failures:
- 1x unexported field access (`bridge` lowercase in cross-package test)
- 7x lambda param type inferred as `any` (receiver type unknown in expression chain)
- 2x lambda return type inferred as `any` (Handler type not resolved)

These require improving val type inference for complex expression chains — tracked separately.

## Battle Test Report Reference

Originally reported as: BUG-043 (partial), USABILITY-009 from `C:\Users\maxmr\GolandProjects\gala-server\TRANSPILER_NOTES.md`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)