### PR TITLE
fix: gala_go_test supports internal package tests via go_test + embed

### DIFF
--- a/cmd/gala_test_gen/main.go
+++ b/cmd/gala_test_gen/main.go
@@ -96,6 +96,12 @@ func generateMainFile(pkgName string, testFuncs map[string][]string) string {
 	if pkgName != "test" {
 		sb.WriteString("import . \"martianoff/gala/test\"\n")
 	}
+
+	// For non-main packages (internal tests), generate TestMain for go_test compatibility.
+	// go_test requires TestMain(m *testing.M) as the entry point.
+	if pkgName != "main" {
+		sb.WriteString("import \"testing\"\n")
+	}
 	sb.WriteString("\n")
 
 	// Collect all functions sorted for deterministic output
@@ -105,7 +111,13 @@ func generateMainFile(pkgName string, testFuncs map[string][]string) string {
 	}
 	sort.Strings(allFuncs)
 
-	sb.WriteString("func main() {\n")
+	if pkgName == "main" {
+		// External tests: generate func main() for go_binary
+		sb.WriteString("func main() {\n")
+	} else {
+		// Internal tests: generate TestMain(m *testing.M) for go_test
+		sb.WriteString("func TestMain(m *testing.M) {\n")
+	}
 	sb.WriteString("\tRunTests(")
 
 	for i, funcName := range allFuncs {

--- a/gala.bzl
+++ b/gala.bzl
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 def _gala_test_impl(ctx):
     binary = ctx.executable.binary
@@ -461,10 +461,6 @@ def gala_go_test(name, srcs, deps = [], gala_deps = [], pkg = "main", embed = []
     # Use the output from gala_go_test_gen directly
     main_go_src = ":" + gen_name
 
-    # Build the test binary
-    binary_name = name + "_bin"
-    all_srcs = transpiled_lib_srcs + transpiled_srcs + [main_go_src] + embed
-
     # Determine deps - skip //test and //std if testing those packages
     final_deps = list(deps) + list(gala_deps)
     if pkg != "test":
@@ -472,19 +468,47 @@ def gala_go_test(name, srcs, deps = [], gala_deps = [], pkg = "main", embed = []
     if pkg != "std":
         final_deps.append(Label("//std"))
 
-    go_binary(
-        name = binary_name,
-        srcs = all_srcs,
-        deps = final_deps,
-        **kwargs
-    )
+    if pkg == "main":
+        # External tests: use go_binary (all sources are package main)
+        binary_name = name + "_bin"
+        all_srcs = transpiled_lib_srcs + transpiled_srcs + [main_go_src] + embed
 
-    # Create the test rule
-    gala_internal_unit_test(
-        name = name,
-        binary = ":" + binary_name,
-        is_windows = select({
-            "@platforms//os:windows": True,
-            "//conditions:default": False,
-        }),
-    )
+        go_binary(
+            name = binary_name,
+            srcs = all_srcs,
+            deps = final_deps,
+            **kwargs
+        )
+
+        # Create the test rule
+        gala_internal_unit_test(
+            name = name,
+            binary = ":" + binary_name,
+            is_windows = select({
+                "@platforms//os:windows": True,
+                "//conditions:default": False,
+            }),
+        )
+    else:
+        # Internal tests: use go_library + go_test with embed.
+        # This avoids the go_binary package-main requirement that conflicts
+        # with internal test packages (USABILITY-010).
+        lib_name = name + "_lib"
+        if transpiled_lib_srcs or embed:
+            go_library(
+                name = lib_name,
+                srcs = transpiled_lib_srcs + embed,
+                deps = final_deps,
+                importpath = pkg,
+            )
+            test_embed = [":" + lib_name]
+        else:
+            test_embed = []
+
+        go_test(
+            name = name,
+            srcs = transpiled_srcs + [main_go_src],
+            embed = test_embed,
+            deps = final_deps,
+            **kwargs
+        )


### PR DESCRIPTION
## Summary

Fixes **USABILITY-010**: `gala_go_test` Bazel macro cannot build internal package tests.

**Category**: USABILITY
**Priority**: High — blocks all Bazel test targets that use `lib_srcs` with non-main packages
**Found in**: gala-server v2 development

## Root Cause

`gala_go_test` used `go_binary` for all tests, which requires all source files to be `package main`. For internal tests (same package as the library, e.g. `package server`), this creates an unsolvable conflict:
- Library files are `package server`
- Generated harness is `package main`
- `go_binary` can't mix packages

## Changes

- **`gala.bzl`**: For `pkg != "main"` (internal tests), use `go_library` + `go_test` + `embed` instead of `go_binary`. This lets test files use the same package as the library under test.
- **`cmd/gala_test_gen/main.go`**: Generate `TestMain(m *testing.M)` instead of `func main()` for non-main packages, making the harness compatible with `go_test`.

External tests (`pkg="main"`) are unchanged — they continue to use `go_binary` + `gala_internal_unit_test`.

## Verification

- `bazel build //...` passes
- `bazel test //...` — all 223 tests pass (existing tests all use `pkg="main"`, unaffected)
- The internal test path is architecturally ready but requires a `gala_go_test(..., pkg="server", ...)` invocation to exercise

## Usage

```starlark
# Internal test (same package as library):
gala_go_test(
    name = "server_test",
    srcs = ["server_test.gala"],
    pkg = "server",
    lib_srcs = ["server.gala", "filter.gala", ...],
    deps = ["//httpcore"],
)
```

## Battle Test Report Reference

Originally reported as: USABILITY-010 from `C:\Users\maxmr\GolandProjects\gala-server\TRANSPILER_NOTES.md`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)