### PR TITLE
fix: type inference for chained calls through type aliases and block lambda returns

### DIFF
--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -474,19 +474,28 @@ func (t *galaASTTransformer) collectReturnTypes(block *ast.BlockStmt, valTypes m
 // inferReturnExprType infers the type of a single return expression, trying
 // valTypes-based inference first, then falling back to getExprType.
 func (t *galaASTTransformer) inferReturnExprType(expr ast.Expr, valTypes map[string]ast.Expr) ast.Expr {
-	// Try to infer type using valTypes for .Get() calls anywhere in the expression
-	if typ := t.inferExprTypeWithValTypes(expr, valTypes); typ != nil {
-		return typ
-	}
-	// Fallback to direct type inference
+	// First try direct type inference (getExprTypeName) — this is the most reliable
+	// as it uses the full type inference pipeline.
 	inferredType := t.getExprType(expr)
-	if inferredType == nil {
-		return nil
+	if inferredType != nil {
+		if ident, ok := inferredType.(*ast.Ident); !ok || ident.Name != "any" {
+			return inferredType
+		}
 	}
-	if ident, ok := inferredType.(*ast.Ident); ok && ident.Name == "any" {
-		return nil
+	// Fallback: try to infer type using valTypes for .Get() calls on val variables.
+	// Only use this for top-level .Get() expressions (e.g., return result.Get()),
+	// NOT for nested .Get() calls inside other expressions — otherwise we'd return
+	// the inner val type instead of the outer expression type.
+	if callExpr, ok := expr.(*ast.CallExpr); ok && len(callExpr.Args) == 0 {
+		if selExpr, ok := callExpr.Fun.(*ast.SelectorExpr); ok && selExpr.Sel.Name == "Get" {
+			if ident, ok := selExpr.X.(*ast.Ident); ok {
+				if typ, ok := valTypes[ident.Name]; ok {
+					return typ
+				}
+			}
+		}
 	}
-	return inferredType
+	return nil
 }
 
 // unifyBlockReturnTypes takes a list of inferred return type expressions and attempts

--- a/internal/transpiler/transformer/type_inference_calls.go
+++ b/internal/transpiler/transformer/type_inference_calls.go
@@ -124,6 +124,24 @@ func (t *galaASTTransformer) inferCallExprType(e *ast.CallExpr) transpiler.Type 
 			if funcType, ok := funType.(transpiler.FuncType); ok && len(funcType.Results) > 0 {
 				return funcType.Results[0]
 			}
+			// If the result is a named type (e.g., Filter, Handler), resolve through
+			// type aliases to check if it's a function type alias.
+			// This handles chained calls like Logger()(req, handler) where Logger()
+			// returns Filter which is func(Request, Handler) Future[Response].
+			if !funType.IsNil() {
+				aliasKey := funType.BaseName()
+				if _, ok := t.typeAliases[aliasKey]; !ok {
+					if dotIdx := strings.LastIndex(aliasKey, "."); dotIdx != -1 {
+						aliasKey = aliasKey[dotIdx+1:]
+					}
+				}
+				if underlyingType, ok := t.typeAliases[aliasKey]; ok {
+					if funcType, ok := underlyingType.(transpiler.FuncType); ok && len(funcType.Results) > 0 {
+						t.traceType(e, funcType.Results[0], "chained-call-type-alias")
+						return funcType.Results[0]
+					}
+				}
+			}
 		}
 	}
 	return transpiler.NilType{}


### PR DESCRIPTION
## Summary

Fixes 5 type inference errors in gala-server test codegen (BUG-043 remaining issues).

## Root Causes & Fixes

### 1. Chained call type alias resolution (`type_inference_calls.go`)

**Problem:** `Logger()(req, handler)` returns a named type (`Filter`) which is a type alias for `func(Request, Handler) Future[Response]`. The chained call handler at `inferCallExprType` line 121 checked for `FuncType` directly but missed named types that are type aliases for function types.

**Fix:** After the direct FuncType check, resolve named types through `typeAliases` to find the underlying function type and extract its return type.

**Errors fixed:**
- CSRF Cookie tests: `Exists`/`Find` lambda params inferred as `any` instead of `Cookie`
- Filter composition: `Handler` return type inferred as `any`
- All downstream inference that depends on filter function return types

### 2. Block lambda return type inference (`lambdas.go`)

**Problem:** `inferReturnExprType` used `findValGetType` as the primary heuristic, which recursively searches for ANY `.Get()` call in the expression tree. For `return FutureOf(Ok(fmt.Sprintf("%s:%s", sub.Get(), iss.Get())))`, it found `sub.Get()` (type `string`) instead of the outer `FutureOf(Ok(...))` (type `Future[Response]`).

**Fix:** Prioritize `getExprType` (full type inference pipeline) over `findValGetType`. Only use `findValGetType` as a fallback for direct `val.Get()` return expressions.

**Errors fixed:**
- JWT test: lambda return type `string` instead of `Future[Response]`
- Handler type mismatch: `func(r Request) string` instead of `Handler`

## Verification

- `bazel build //...` passes
- `bazel test //...` — all 223 tests pass, 0 regressions
- gala-server test errors reduced from 10 → 5 remaining

## Remaining Errors (not type inference)

5 errors remain, all package visibility issues (not type inference):
- 3x unexported field access (`bridge`, `root`) — test package rewriting
- 2x unexported function (`applyFilters`, `makeBridgeHandler`) — same cause
- These are resolved by PR #111 (USABILITY-010: `go_test` with `embed`)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)