### PR TITLE
fix: reject '_' wildcard type in lambda params with explicit types

### DIFF
--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -31,7 +31,26 @@ func (t *galaASTTransformer) transformLambdaWithExpectedType(ctx *grammar.Lambda
 	paramsCtx := ctx.Parameters().(*grammar.ParametersContext)
 	fieldList := &ast.FieldList{}
 	if paramsCtx.ParameterList() != nil {
-		for i, pCtx := range paramsCtx.ParameterList().(*grammar.ParameterListContext).AllParameter() {
+		allParams := paramsCtx.ParameterList().(*grammar.ParameterListContext).AllParameter()
+		// Validate: reject `_` as a type annotation when other params have explicit types.
+		// `_` means "infer" but has no inference context in a standalone lambda.
+		hasExplicitType := false
+		hasWildcardType := false
+		for _, pCtx := range allParams {
+			paramCtx := pCtx.(*grammar.ParameterContext)
+			if paramCtx.Type_() != nil {
+				typeText := paramCtx.Type_().GetText()
+				if typeText == "_" {
+					hasWildcardType = true
+				} else {
+					hasExplicitType = true
+				}
+			}
+		}
+		if hasExplicitType && hasWildcardType {
+			return nil, galaerr.NewSemanticError("cannot use '_' as a parameter type when other parameters have explicit types — provide the type explicitly or omit all parameter types for inference")
+		}
+		for i, pCtx := range allParams {
 			paramCtx := pCtx.(*grammar.ParameterContext)
 			field, err := t.transformParameter(paramCtx)
 			if err != nil {


### PR DESCRIPTION
## Summary

Makes `_` as a parameter type a semantic error when other parameters have explicit types.

## Problem

```gala
val f = (method string, path string, status int, duration _) => s"$method $path $status"
```

The `_` wildcard was silently converted to `any`, generating `func(method string, path string, status int, duration any) string`. This compiled but produced wrong types at call sites.

## Fix

Reject mixed explicit/wildcard parameter types with a clear error message:

```
[SemanticError] cannot use '_' as a parameter type when other parameters have explicit types — provide the type explicitly or omit all parameter types for inference
```

`_` is only valid when ALL parameter types are omitted (fully inferred from calling context).

## Verification

- `bazel build //...` passes
- `bazel test //...` — 223 tests pass

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)