### PR TITLE
fix: void lambda type detection, Void type, and FromError

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -22,7 +22,6 @@ filegroup(
         "match_method_chain/types.gala",
         "match_return_iife.gala",
         "match_void_branches.gala",
-        "newimmutable_nil.gala",
         "mathlib/math.gala",
         "multi_file/greeter.gala",
         "multi_file/main.gala",
@@ -32,6 +31,7 @@ filegroup(
         "multi_file_option/main.gala",
         "multi_file_types/main.gala",
         "multi_file_types/model.gala",
+        "newimmutable_nil.gala",
         "slice_unwrap/main.gala",
         "slice_unwrap/model.gala",
         "struct_field_unwrap/main.gala",
@@ -939,7 +939,10 @@ gala_test(
     name = "foldleft_spread_type",
     src = "foldleft_spread_type.gala",
     expected = "foldleft_spread_type.out",
-    deps = ["//collection_immutable", "//go_interop"],
+    deps = [
+        "//collection_immutable",
+        "//go_interop",
+    ],
 )
 
 # FIX-015 verification: sealed type named-arg construction in multi-file mode
@@ -1456,8 +1459,8 @@ gala_test(
 gala_library(
     name = "cross_file_import_lib",
     srcs = [
-        "cross_file_import_lib/types.gala",
         "cross_file_import_lib/ops.gala",
+        "cross_file_import_lib/types.gala",
     ],
     importpath = "martianoff/gala/examples/cross_file_import_lib",
     deps = ["//collection_immutable"],
@@ -1470,5 +1473,33 @@ gala_test(
     deps = [
         "//collection_immutable",
         "//examples:cross_file_import_lib",
+    ],
+)
+
+# BUG-047 repro: Lambda return type inference with multiple return paths
+gala_test(
+    name = "lambda_multi_return_type",
+    src = "lambda_multi_return_type.gala",
+    expected = "lambda_multi_return_type.out",
+    deps = [
+        "//concurrent",
+    ],
+)
+
+# FIX-076 verification: FromError and Unit type
+gala_test(
+    name = "from_error",
+    src = "from_error.gala",
+    expected = "from_error.out",
+)
+
+# FIX-075 verification: Lambda passed to Go func expecting func() should be void
+gala_test(
+    name = "go_func_void_lambda",
+    src = "go_func_void_lambda.gala",
+    expected = "go_func_void_lambda.out",
+    deps = [
+        "//concurrent",
+        "//go_interop",
     ],
 )

--- a/examples/from_error.gala
+++ b/examples/from_error.gala
@@ -22,9 +22,9 @@ func main() {
     val fail = FromError(os.Remove("/tmp/gala-nonexistent-dir-12345"))
     fmt.Println(fail.IsFailure())
 
-    // Chain with OnFailure
+    // Chain with OnFailure — just check it fires
     FromError(os.Remove("/tmp/gala-nonexistent-dir-12345"))
-        .OnFailure((err) => fmt.Println(s"expected error: $err"))
+        .OnFailure((err) => fmt.Println("error handled"))
 
     // Void type
     val u = Void{}

--- a/examples/from_error.gala
+++ b/examples/from_error.gala
@@ -1,0 +1,32 @@
+package main
+
+import (
+    "fmt"
+    . "martianoff/gala/std"
+    "os"
+)
+
+// Verify FromError converts Go error returns to Try[Void],
+// and that Void type works correctly.
+
+func main() {
+    // FromError with a successful operation
+    val result = FromError(os.Mkdir("/tmp/gala-test-from-error", 0755))
+    fmt.Println(result.IsSuccess())
+
+    // Clean up — also via FromError
+    val cleanup = FromError(os.Remove("/tmp/gala-test-from-error"))
+    fmt.Println(cleanup.IsSuccess())
+
+    // FromError with an error (remove non-existent dir)
+    val fail = FromError(os.Remove("/tmp/gala-nonexistent-dir-12345"))
+    fmt.Println(fail.IsFailure())
+
+    // Chain with OnFailure
+    FromError(os.Remove("/tmp/gala-nonexistent-dir-12345"))
+        .OnFailure((err) => fmt.Println(s"expected error: $err"))
+
+    // Void type
+    val u = Void{}
+    fmt.Println(u.Equal(Void{}))
+}

--- a/examples/from_error.out
+++ b/examples/from_error.out
@@ -1,5 +1,5 @@
 true
 true
 true
-expected error: remove /tmp/gala-nonexistent-dir-12345: The system cannot find the file specified.
+error handled
 true

--- a/examples/from_error.out
+++ b/examples/from_error.out
@@ -1,0 +1,5 @@
+true
+true
+true
+expected error: remove /tmp/gala-nonexistent-dir-12345: The system cannot find the file specified.
+true

--- a/examples/go_func_void_lambda.gala
+++ b/examples/go_func_void_lambda.gala
@@ -1,0 +1,49 @@
+package main
+
+import (
+    "fmt"
+    "net"
+    "time"
+    . "martianoff/gala/std"
+    "martianoff/gala/go_interop"
+)
+
+// FIX-075: Lambda passed to Go function expecting func() should generate func(),
+// not func() <return-type-of-body>. This verifies that the transpiler correctly
+// detects void function parameters from Go type info.
+
+func main() {
+    // Case 1: go_interop.Spawn with block lambda (already worked via FIX-073)
+    go_interop.Spawn(() => {
+        fmt.Println("block lambda spawn")
+    })
+    time.Sleep(50 * time.Millisecond)
+
+    // Case 2: go_interop.Spawn with expression lambda
+    // Before FIX-075, this generated func() int (from Println return type)
+    go_interop.Spawn(() => fmt.Println("expression lambda spawn"))
+    time.Sleep(50 * time.Millisecond)
+
+    // Case 3: SpawnWithRecover via qualified call
+    // First param func() is void, second param func(any) is also void
+    go_interop.SpawnWithRecover(
+        () => fmt.Println("spawn with recover"),
+        (err any) => fmt.Println(s"recovered: $err"),
+    )
+    time.Sleep(50 * time.Millisecond)
+
+    // Case 4: Spawn with FromError — the idiomatic GALA pattern for
+    // Go functions returning error in void context
+    go_interop.Spawn(() => {
+        // net.Listen returns (net.Listener, error) — Try handles (T, error)
+        // For error-only functions, use FromError
+        val listener = Try(() => net.Listen("tcp", "127.0.0.1:0"))
+        listener.OnSuccess((l net.Listener) => {
+            FromError(l.Close()).OnFailure((err) => fmt.Println(s"close error: $err"))
+            fmt.Println("listener opened and closed")
+        }).OnFailure((err) => fmt.Println(s"listen error: $err"))
+    })
+    time.Sleep(50 * time.Millisecond)
+
+    Println("done")
+}

--- a/examples/go_func_void_lambda.out
+++ b/examples/go_func_void_lambda.out
@@ -1,0 +1,5 @@
+block lambda spawn
+expression lambda spawn
+spawn with recover
+listener opened and closed
+done

--- a/examples/lambda_multi_return_type.gala
+++ b/examples/lambda_multi_return_type.gala
@@ -1,0 +1,38 @@
+package main
+
+import (
+    "fmt"
+    . "martianoff/gala/std"
+    . "martianoff/gala/concurrent"
+)
+
+// BUG-047 repro attempt: Lambda return type inference with multiple return paths.
+// Result: The multi-return type inference works correctly for same-package types.
+
+type MyResponse struct {
+    Status int
+    Body string
+}
+
+func Unauthorized(msg string) MyResponse = MyResponse(Status = 401, Body = msg)
+func Ok(body string) MyResponse = MyResponse(Status = 200, Body = body)
+
+func middleware(next func(string) Future[MyResponse]) func(string) Future[MyResponse] =
+    (req string) => {
+        if (req == "bad") {
+            return FutureOf(Unauthorized("unauthorized"))
+        }
+        return next(req)
+    }
+
+func handler(req string) Future[MyResponse] =
+    FutureOf(Ok(s"hello $req"))
+
+func main() {
+    val mw = middleware((req string) => handler(req))
+    val result = mw("good").Await()
+    fmt.Println(result.Get().Body)
+
+    val result2 = mw("bad").Await()
+    fmt.Println(result2.Get().Body)
+}

--- a/examples/lambda_multi_return_type.out
+++ b/examples/lambda_multi_return_type.out
@@ -1,0 +1,2 @@
+hello good
+unauthorized

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -1592,8 +1592,7 @@ func (a *galaAnalyzer) analyzePackage(relPath string) (*transpiler.RichAST, erro
 		}
 	}
 
-	// For Go-only packages (no .gala files), scan .go files for exported symbols.
-	// This enables the transpiler to warn when two dot-imported packages export the same symbol.
+	// Scan .go files for exported symbols and type information.
 	hasGalaFiles := false
 	for _, f := range files {
 		if !f.IsDir() && filepath.Ext(f.Name()) == ".gala" {
@@ -1602,15 +1601,18 @@ func (a *galaAnalyzer) analyzePackage(relPath string) (*transpiler.RichAST, erro
 		}
 	}
 	if !hasGalaFiles {
+		// For Go-only packages, also extract exported symbol names for collision warnings.
 		a.extractGoFileExports(files, dirPath, relPath, pkgAST)
-		// Also extract full type information from local Go files
-		goInfo := AnalyzeGoFiles(dirPath)
-		if len(goInfo.Functions) > 0 || len(goInfo.Types) > 0 || len(goInfo.Variables) > 0 || len(goInfo.TypeAliases) > 0 {
-			if pkgAST.GoTypeInfo == nil {
-				pkgAST.GoTypeInfo = transpiler.NewGoTypeInfo()
-			}
-			pkgAST.GoTypeInfo.Merge(goInfo)
+	}
+	// Always extract Go type information from .go files, even in mixed GALA+Go packages.
+	// This ensures Go-defined functions and variables (e.g., concurrent.Spawn) are available
+	// for type inference when GALA code calls them (FIX-075).
+	goInfo := AnalyzeGoFiles(dirPath)
+	if len(goInfo.Functions) > 0 || len(goInfo.Types) > 0 || len(goInfo.Variables) > 0 || len(goInfo.TypeAliases) > 0 {
+		if pkgAST.GoTypeInfo == nil {
+			pkgAST.GoTypeInfo = transpiler.NewGoTypeInfo()
 		}
+		pkgAST.GoTypeInfo.Merge(goInfo)
 	}
 
 	return pkgAST, nil

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -560,6 +560,16 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 		funcMeta = t.getFunction(funcName)
 	}
 
+	// FIX-075: When GALA function metadata is not available, try Go type info.
+	// This handles Go-defined functions and variables with function types (e.g., concurrent.Spawn)
+	// that are called from GALA code via dot imports or qualified references.
+	var goFuncParamTypes []transpiler.Type
+	if funcMeta == nil && t.goTypeInfo != nil {
+		if funcName := t.extractFuncName(fun); funcName != "" {
+			goFuncParamTypes = t.resolveGoFuncParamTypes(funcName)
+		}
+	}
+
 	// Check if this call is struct construction — if so, use struct field types as expected types
 	// for lambda arguments. This must happen BEFORE argument transformation so that lambdas
 	// can infer parameter types from the struct field definitions.
@@ -687,6 +697,12 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 						// Void function type or non-generic function — pass as-is
 						expectedType = ft
 					}
+				}
+			}
+			// FIX-075: Fall back to Go type info for lambda expected types
+			if expectedType.IsNil() && goFuncParamTypes != nil && argIdx < len(goFuncParamTypes) {
+				if ft, ok := goFuncParamTypes[argIdx].(transpiler.FuncType); ok {
+					expectedType = ft
 				}
 			}
 			// If this is struct construction and we have field type info, use it as fallback
@@ -1767,4 +1783,76 @@ func (t *galaASTTransformer) inferFuncTypeSubstFromArgs(funcMeta *transpiler.Fun
 		result[k] = v.String()
 	}
 	return result
+}
+
+// resolveGoFuncParamTypes resolves parameter types for a Go-defined function or
+// function-typed variable using GoTypeInfo. This is used when GALA function metadata
+// is not available (e.g., Go functions/vars in mixed GALA+Go packages like concurrent.Spawn).
+// It checks GoTypeInfo.Functions first, then GoTypeInfo.Variables for function-typed vars.
+// For bare names (from dot imports), it tries each dot-imported package as a qualifier.
+func (t *galaASTTransformer) resolveGoFuncParamTypes(funcName string) []transpiler.Type {
+	if t.goTypeInfo == nil {
+		return nil
+	}
+
+	// Helper: extract param types from a Go function signature
+	sigToParams := func(sig *transpiler.GoFuncSignature) []transpiler.Type {
+		params := make([]transpiler.Type, len(sig.Params))
+		for i, p := range sig.Params {
+			params[i] = p.Type
+		}
+		return params
+	}
+
+	// Try direct lookup (qualified name like pkg.Func)
+	if sig := t.goTypeInfo.GetFuncSignature(funcName); sig != nil {
+		return sigToParams(sig)
+	}
+	// Try as a variable with function type
+	if varType, ok := t.goTypeInfo.Variables[funcName]; ok {
+		if ft, ok := varType.(transpiler.FuncType); ok {
+			return ft.Params
+		}
+	}
+
+	// For bare names, try each dot-imported package as qualifier
+	for _, entry := range t.importManager.dotImports {
+		qualName := entry.PkgName + "." + funcName
+		if sig := t.goTypeInfo.GetFuncSignature(qualName); sig != nil {
+			return sigToParams(sig)
+		}
+		if varType, ok := t.goTypeInfo.Variables[qualName]; ok {
+			if ft, ok := varType.(transpiler.FuncType); ok {
+				return ft.Params
+			}
+		}
+	}
+
+	// For qualified calls (alias.Func), resolve the alias to the actual package name
+	if parts := splitQualifiedName(funcName); len(parts) == 2 {
+		alias, name := parts[0], parts[1]
+		if entry, ok := t.importManager.GetByAlias(alias); ok && entry.PkgName != alias {
+			qualName := entry.PkgName + "." + name
+			if sig := t.goTypeInfo.GetFuncSignature(qualName); sig != nil {
+				return sigToParams(sig)
+			}
+			if varType, ok := t.goTypeInfo.Variables[qualName]; ok {
+				if ft, ok := varType.(transpiler.FuncType); ok {
+					return ft.Params
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// splitQualifiedName splits "pkg.Name" into ["pkg", "Name"], or returns nil for bare names.
+func splitQualifiedName(name string) []string {
+	for i, c := range name {
+		if c == '.' {
+			return []string{name[:i], name[i+1:]}
+		}
+	}
+	return nil
 }

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -106,6 +106,18 @@ func (t *galaASTTransformer) transformLambdaWithExpectedType(ctx *grammar.Lambda
 		if err != nil {
 			return nil, err
 		}
+		// Reject block lambdas in void context that discard error returns.
+		// Check each expression statement for Go calls returning error.
+		if isVoidExpected {
+			for _, stmt := range b.List {
+				if exprStmt, ok := stmt.(*ast.ExprStmt); ok {
+					if funcName := t.goCallReturnsErrorOnly(exprStmt.X); funcName != "" {
+						return nil, galaerr.NewSemanticError(
+							fmt.Sprintf("cannot discard error return from %s in void lambda — use FromError(%s) to handle the error", funcName, funcName))
+					}
+				}
+			}
+		}
 		// When void is expected, strip any trailing "return nil" (legacy pattern)
 		if isVoidExpected && len(b.List) > 0 {
 			if ret, ok := b.List[len(b.List)-1].(*ast.ReturnStmt); ok && len(ret.Results) == 1 {
@@ -163,6 +175,12 @@ func (t *galaASTTransformer) transformLambdaWithExpectedType(ctx *grammar.Lambda
 		if body != nil {
 			// Already set (e.g., expression lambda `() => nil` treated as void)
 		} else if isVoidExpected {
+			// Reject expression lambdas in void context that discard error returns.
+			// Users must handle errors explicitly, e.g., FromError(goCall()).OnFailure(...)
+			if funcName := t.goCallReturnsErrorOnly(expr); funcName != "" {
+				return nil, galaerr.NewSemanticError(
+					fmt.Sprintf("cannot discard error return from %s in void lambda — use FromError(%s) to handle the error", funcName, funcName))
+			}
 			// For void functions, the expression is just a statement, not a return
 			body = &ast.BlockStmt{
 				List: []ast.Stmt{
@@ -203,6 +221,50 @@ func (t *galaASTTransformer) transformLambdaWithExpectedType(ctx *grammar.Lambda
 		Type: funcType,
 		Body: body,
 	}, nil
+}
+
+// goCallReturnsErrorOnly checks if expr is a call to a Go function whose sole return
+// type is `error`. Returns the function name for the error message, or "" otherwise.
+// This only catches error-only returns (e.g., Close(), ListenAndServe()), NOT multi-return
+// functions like fmt.Println() which return (int, error) — those are handled by
+// tryWrapGoMultiReturnWithErrorPanic in non-void contexts.
+func (t *galaASTTransformer) goCallReturnsErrorOnly(expr ast.Expr) string {
+	if t.goTypeInfo == nil {
+		return ""
+	}
+	callExpr, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return ""
+	}
+
+	var sig *transpiler.GoFuncSignature
+	var funcName string
+	switch fun := callExpr.Fun.(type) {
+	case *ast.SelectorExpr:
+		if id, ok := fun.X.(*ast.Ident); ok {
+			funcName = id.Name + "." + fun.Sel.Name
+			sig = t.goTypeInfo.GetFuncSignature(funcName)
+			if sig == nil {
+				sig = t.resolveMethodSignatureOnExpr(fun.X, fun.Sel.Name)
+			}
+		} else {
+			sig = t.resolveMethodSignatureOnExpr(fun.X, fun.Sel.Name)
+			if sel, ok := fun.X.(*ast.SelectorExpr); ok {
+				funcName = sel.Sel.Name + "." + fun.Sel.Name
+			} else {
+				funcName = fun.Sel.Name
+			}
+		}
+	}
+	if sig == nil {
+		return ""
+	}
+
+	// Only reject when the sole return type is error
+	if len(sig.Returns) == 1 && sig.Returns[0] != nil && sig.Returns[0].String() == "error" {
+		return funcName
+	}
+	return ""
 }
 
 // tryWrapGoMultiReturnWithErrorPanic checks if expr is a call to a Go function

--- a/std/try.gala
+++ b/std/try.gala
@@ -183,3 +183,24 @@ func FromEitherError[T any](e Either[error, T]) Try[T] {
 // Returns Success[T] with the result if f completes normally.
 // Returns Failure[T] with the panic value as error if f panics.
 func TryApply[T any](f func() T) Try[T] = tryRecover[T](f)
+
+// Void represents the absence of a meaningful value, similar to Scala's Void.
+// Used as the type parameter for Try[Void] when converting Go error returns.
+type Void struct {}
+
+// FromError converts a Go error return into a Try[Void].
+// Returns Success[Void] if err is nil, Failure[Void] otherwise.
+//
+// For Go functions returning (T, error), use Try(() => goCall()) instead.
+//
+// Usage:
+//   FromError(conn.Close())                        // Try[Void]
+//   FromError(sb.ListenAndServe(addr))              // Try[Void]
+//   FromError(sb.ListenAndServe(addr)).OnFailure((err) => Println(s"error: $err"))
+func FromError(err error) Try[Void] {
+    if err != nil {
+        return Failure[Void](err)
+    }
+    return Success[Void](Void{})
+}
+


### PR DESCRIPTION
## Summary

- **FIX-075**: Lambda passed to Go function expecting `func()` now correctly generates `func()` instead of `func() <return-type>`. Fixes `Spawn(() => expr)` generating wrong types.
- **FIX-076**: Add `Void` type and `FromError(error) Try[Void]` to std. Void lambdas that silently discard error-only Go returns now produce a compile error.

## Root Cause (FIX-075)

Two gaps in the transpiler:
1. **Analyzer**: `AnalyzeGoFiles()` only ran for pure-Go packages. Mixed GALA+Go packages like `concurrent` (which defines `Spawn` in Go) were skipped, so `concurrent.Spawn`'s type was unknown.
2. **Transformer**: When GALA function metadata was nil (Go-defined functions/vars), no expected parameter type was passed to lambda transformation, so the lambda's return type was inferred from its body instead of being void.

## Changes

- `internal/transpiler/analyzer/analyzer.go` — Run `AnalyzeGoFiles()` for all packages, not just pure-Go
- `internal/transpiler/transformer/calls.go` — Fall back to GoTypeInfo for lambda expected types when GALA metadata unavailable
- `internal/transpiler/transformer/lambdas.go` — Add `goCallReturnsErrorOnly` check; reject void lambdas discarding error returns
- `std/try.gala` — Add `Void` type and `FromError(error) Try[Void]`
- `collection_immutable/BUILD.bazel`, `concurrent/BUILD.bazel` — Fix missing deps
- `examples/` — Three verification examples

## Verification

- `examples/go_func_void_lambda` — FIX-075: Spawn with expression/block lambdas
- `examples/from_error` — FIX-076: FromError converts Go error to Try[Void]
- `examples/lambda_multi_return_type` — BUG-047 investigation (works for same-package)
- `bazel test` passes with no regressions

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)