### PR TITLE
fix: gala test internal package support + BUG-047 lambda inference

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -2590,22 +2590,45 @@ Test files use the `_test.gala` suffix and are placed alongside source files:
 ```
 mypackage/
   mycode.gala
-  mycode_test.gala    # Test file with package main
+  mycode_test.gala    # Test file (same package as source)
 ```
 
 ### Writing Tests
 
 Test functions must:
-- Use `package main` and import the modules being tested
+- Use the **same package** as the code being tested (for internal tests) or `package main` (for standalone tests)
 - Start with `Test` prefix (e.g., `TestAddition`)
 - Take a single parameter of type `T` and return `T`
 - Return the modified test context after assertions
+
+#### Internal Tests (Library Packages)
+
+Internal tests use the same package as the library, allowing access to unexported identifiers:
+
+```gala
+package mypackage
+
+import (
+    . "martianoff/gala/test"
+)
+
+func TestInternalLogic(t T) T {
+    // Can access unexported fields, functions, and types
+    val result = internalHelper(42)
+    return Eq(t, result, 84)
+}
+```
+
+#### External Tests (Standalone)
+
+External tests use `package main` and import the modules being tested:
 
 ```gala
 package main
 
 import (
     . "martianoff/gala/test"
+    . "mymodule/mypackage"
 )
 
 func TestAddition(t T) T {
@@ -2818,19 +2841,41 @@ The `T` test context provides methods:
 
 ### BUILD.bazel Configuration
 
-Use the `gala_go_test` macro to define tests:
+#### External Tests (package main)
+
+Use `gala_go_test` for tests that import the library as a dependency:
 
 ```python
 load("//:gala.bzl", "gala_go_test")
 
 gala_go_test(
     name = "mycode_test",
-    srcs = ["main.gala"],
+    srcs = ["main_test.gala"],
     deps = [":mypackage"],
 )
 ```
 
-### Output Comparison Tests
+#### Internal Tests (same package)
+
+For internal tests that need access to unexported identifiers, use `pkg` to match the library package name and `lib_srcs` to include the library source files:
+
+```python
+load("//:gala.bzl", "gala_go_test")
+
+_SRCS = glob(["*.gala"], exclude = ["*_test.gala"])
+
+gala_go_test(
+    name = "mypackage_test",
+    srcs = glob(["*_test.gala"]),
+    pkg = "mypackage",
+    lib_srcs = _SRCS,
+    deps = ["@gala//collection_immutable", "@gala//concurrent"],
+)
+```
+
+The macro uses `go_test` with `embed` for internal tests, properly handling the package compilation that `go_binary` cannot support. Add any GALA stdlib packages your library imports to `deps` — the macro auto-adds `@gala//test` and `@gala//std`.
+
+#### Output Comparison Tests
 
 For tests that compare program output against expected files, use `gala_test`:
 
@@ -2857,8 +2902,8 @@ gala test -v                  # Verbose output
 ```
 
 `gala test` handles both project types:
-- **`package main` projects**: source and test files are compiled together
-- **Library packages**: test files are compiled as `package main` and import the library under test
+- **`package main` projects**: source and test files are compiled together as `package main`
+- **Library packages**: source and test files are compiled together in the **same package**, enabling internal tests that can access unexported identifiers. Under the hood, `gala test` generates a `_test.go` harness with `TestMain` and runs tests via `go test`.
 
 #### Using Bazel
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//:gala.bzl", "gala_binary", "gala_library", "gala_test")
+load("//:gala.bzl", "gala_binary", "gala_go_test", "gala_library", "gala_test")
 
 filegroup(
     name = "gala_sources",
@@ -1502,4 +1502,10 @@ gala_test(
         "//concurrent",
         "//go_interop",
     ],
+)
+
+# FIX-080 (BUG-047): Lambda return type inference via type alias resolution
+gala_go_test(
+    name = "type_alias_lambda_inference",
+    srcs = ["type_alias_lambda_inference.gala"],
 )

--- a/examples/type_alias_lambda_inference.gala
+++ b/examples/type_alias_lambda_inference.gala
@@ -1,0 +1,54 @@
+package main
+
+import (
+    . "martianoff/gala/test"
+)
+
+// Type aliases for function types — used by the lambda inference fix (BUG-047).
+// The transpiler must resolve these to their underlying func types and propagate
+// expected param/return types to lambdas in expression functions.
+
+type Transformer func(int) string
+
+type Processor func(string, Transformer) string
+
+// Expression function returning a type-alias function type.
+// The lambda should infer param types from the Transformer alias.
+func DoubleToString() Transformer = (x) => {
+    if x > 100 {
+        return "big"
+    }
+    return "small"
+}
+
+// Multi-return-path lambda — the type should be inferred as string (from Transformer).
+func ClassifySign() Transformer = (x) => {
+    if x > 0 {
+        return "positive"
+    }
+    if x < 0 {
+        return "negative"
+    }
+    return "zero"
+}
+
+// Nested type alias — Processor takes a Transformer.
+func ApplyAndWrap(prefix string) Processor = (s, tf) => {
+    val result = tf(42)
+    return prefix + ": " + result
+}
+
+func TestTypeAliasLambda(t T) T {
+    val tf = DoubleToString()
+    var t1 = Eq(t, tf(50), "small")
+    var t2 = Eq(t1, tf(200), "big")
+
+    val sign = ClassifySign()
+    var t3 = Eq(t2, sign(5), "positive")
+    var t4 = Eq(t3, sign(-3), "negative")
+    var t5 = Eq(t4, sign(0), "zero")
+
+    val proc = ApplyAndWrap("Result")
+    return Eq(t5, proc("test", sign), "Result: positive")
+}
+

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -944,8 +944,6 @@ func (b *Builder) Test(verbose bool) error {
 	if err := b.workspace.CleanGen(); err != nil {
 		return fmt.Errorf("cleaning gen dir: %w", err)
 	}
-	// Also clean testgen/ for library test runs
-	os.RemoveAll(filepath.Join(b.workspace.Dir, "testgen"))
 
 	// Step 5: Transpile files
 	if isLib {
@@ -981,66 +979,96 @@ func (b *Builder) Test(verbose bool) error {
 		fmt.Printf("Found %d test function(s): %s\n", len(allTestFuncs), strings.Join(allTestFuncs, ", "))
 	}
 
-	// Step 8: Generate test_main.go
-	// For library packages, test files are in testgen/ (separate from gen/).
-	// For main packages, everything is in gen/.
-	testMainDir := b.workspace.GenDir
-	buildTarget := "./gen/..."
+	// Step 8: Generate test harness
 	if isLib {
-		testMainDir = filepath.Join(b.workspace.Dir, "testgen")
-		buildTarget = "./testgen/..."
-	}
+		// For library packages: generate a _test.go harness that uses Go's testing
+		// framework with TestMain. This enables internal tests (same package) that
+		// can access unexported identifiers. Tests run via `go test`.
+		pkgName := detectPackageName(sourceFiles[0])
+		harnessCode := GenerateGoTestHarness(pkgName, allTestFuncs)
+		harnessPath := filepath.Join(b.workspace.GenDir, "gala_test_harness_test.go")
+		if err := os.WriteFile(harnessPath, []byte(harnessCode), 0644); err != nil {
+			return fmt.Errorf("writing gala_test_harness_test.go: %w", err)
+		}
+		if b.verbose {
+			fmt.Println("Generated gala_test_harness_test.go")
+		}
 
-	testMainCode := GenerateTestMain(allTestFuncs)
-	testMainPath := filepath.Join(testMainDir, "test_main.gen.go")
-	if err := os.WriteFile(testMainPath, []byte(testMainCode), 0644); err != nil {
-		return fmt.Errorf("writing test_main.gen.go: %w", err)
-	}
-
-	if b.verbose {
-		fmt.Println("Generated test_main.gen.go")
-	}
-
-	// Step 9: Build the test binary
-	testBinary := filepath.Join(b.workspace.Dir, "test-binary")
-	if isWindows() {
-		testBinary += ".exe"
-	}
-
-	args := []string{"build", "-o", testBinary, buildTarget}
-	cmd := exec.Command("go", args...)
-	cmd.Dir = b.workspace.Dir
-	cmd.Env = append(os.Environ(), "GOMODCACHE="+b.config.GoPkgDir)
-
-	if b.verbose {
+		// Step 9: Run tests via `go test`
+		args := []string{"test", "-count=1"}
+		if verbose {
+			args = append(args, "-v")
+		}
+		args = append(args, "./gen/...")
+		cmd := exec.Command("go", args...)
+		cmd.Dir = b.workspace.Dir
+		cmd.Env = append(os.Environ(), "GOMODCACHE="+b.config.GoPkgDir)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
-		fmt.Printf("Running: go %s\n", strings.Join(args, " "))
-	} else {
-		cmd.Stderr = os.Stderr
-	}
 
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("go build (test): %w", err)
-	}
-
-	// Step 10: Execute the test binary
-	if b.verbose {
-		fmt.Println("Running tests...")
-		fmt.Println()
-	}
-
-	execCmd := exec.Command(testBinary)
-	execCmd.Stdin = os.Stdin
-	execCmd.Stdout = os.Stdout
-	execCmd.Stderr = os.Stderr
-	execCmd.Dir = b.workspace.ProjectDir
-
-	if err := execCmd.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return fmt.Errorf("tests failed (exit code %d)", exitErr.ExitCode())
+		if b.verbose {
+			fmt.Printf("Running: go %s\n", strings.Join(args, " "))
 		}
-		return fmt.Errorf("running test binary: %w", err)
+
+		if err := cmd.Run(); err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				return fmt.Errorf("tests failed (exit code %d)", exitErr.ExitCode())
+			}
+			return fmt.Errorf("go test: %w", err)
+		}
+	} else {
+		// For main packages: generate test_main.gen.go with func main() and
+		// build a test binary.
+		testMainCode := GenerateTestMain(allTestFuncs)
+		testMainPath := filepath.Join(b.workspace.GenDir, "test_main.gen.go")
+		if err := os.WriteFile(testMainPath, []byte(testMainCode), 0644); err != nil {
+			return fmt.Errorf("writing test_main.gen.go: %w", err)
+		}
+		if b.verbose {
+			fmt.Println("Generated test_main.gen.go")
+		}
+
+		// Step 9: Build the test binary
+		testBinary := filepath.Join(b.workspace.Dir, "test-binary")
+		if isWindows() {
+			testBinary += ".exe"
+		}
+
+		args := []string{"build", "-o", testBinary, "./gen/..."}
+		cmd := exec.Command("go", args...)
+		cmd.Dir = b.workspace.Dir
+		cmd.Env = append(os.Environ(), "GOMODCACHE="+b.config.GoPkgDir)
+
+		if b.verbose {
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			fmt.Printf("Running: go %s\n", strings.Join(args, " "))
+		} else {
+			cmd.Stderr = os.Stderr
+		}
+
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("go build (test): %w", err)
+		}
+
+		// Step 10: Execute the test binary
+		if b.verbose {
+			fmt.Println("Running tests...")
+			fmt.Println()
+		}
+
+		execCmd := exec.Command(testBinary)
+		execCmd.Stdin = os.Stdin
+		execCmd.Stdout = os.Stdout
+		execCmd.Stderr = os.Stderr
+		execCmd.Dir = b.workspace.ProjectDir
+
+		if err := execCmd.Run(); err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				return fmt.Errorf("tests failed (exit code %d)", exitErr.ExitCode())
+			}
+			return fmt.Errorf("running test binary: %w", err)
+		}
 	}
 
 	return nil
@@ -1053,10 +1081,9 @@ func (b *Builder) transpileTestMain(sourceFiles, testFiles []string) error {
 	return b.transpileFiles(allFiles, allFiles)
 }
 
-// transpileTestLibrary transpiles source files as a library and test files as package main.
-// Source files go into gen/ as their original library package.
-// Test files go into testgen/ and are rewritten to package main with a dot-import
-// of the library package, avoiding Go's "multiple packages in directory" conflict.
+// transpileTestLibrary transpiles source files and test files into gen/ as the
+// same package. This enables internal tests that can access unexported identifiers.
+// Test files are transpiled alongside source files in the same directory.
 func (b *Builder) transpileTestLibrary(sourceFiles, testFiles []string) error {
 	// Transpile source files into gen/ as the library package
 	if err := b.transpileFilesToDir(sourceFiles, sourceFiles, b.workspace.GenDir); err != nil {
@@ -1068,34 +1095,17 @@ func (b *Builder) transpileTestLibrary(sourceFiles, testFiles []string) error {
 		return fmt.Errorf("copying local Go subpackages: %w", err)
 	}
 
-	// Rewrite imports that reference the project's Go module path
-	if err := b.rewriteProjectModuleImports(b.workspace.GenDir); err != nil {
-		return fmt.Errorf("rewriting project module imports: %w", err)
-	}
-
-	// Create testgen/ directory for test files (separate from library in gen/)
-	testGenDir := filepath.Join(b.workspace.Dir, "testgen")
-	if err := os.MkdirAll(testGenDir, 0755); err != nil {
-		return fmt.Errorf("creating testgen dir: %w", err)
-	}
-
-	// Transpile test files into testgen/
-	// Test files see source files as siblings for type resolution
+	// Transpile test files into gen/ (same directory, same package as library).
+	// Test files see source files as siblings for type resolution.
 	allFiles := append(sourceFiles, testFiles...)
-	if err := b.transpileFilesToDir(testFiles, allFiles, testGenDir); err != nil {
+	if err := b.transpileFilesToDir(testFiles, allFiles, b.workspace.GenDir); err != nil {
 		return fmt.Errorf("transpiling test files: %w", err)
 	}
 
-	// Rewrite generated test files: change package to "main" and add dot-import
-	// of the library package from gen/
-	if err := rewriteTestFilesAsMain(testGenDir); err != nil {
-		return fmt.Errorf("rewriting test files as package main: %w", err)
-	}
-
-	// Rewrite project module imports in testgen/ too, so go mod tidy doesn't
-	// try to fetch stale remote modules that have been replaced locally.
-	if err := b.rewriteProjectModuleImports(testGenDir); err != nil {
-		return fmt.Errorf("rewriting test project module imports: %w", err)
+	// Rewrite imports that reference the project's Go module path.
+	// This covers both source and test files in gen/ uniformly.
+	if err := b.rewriteProjectModuleImports(b.workspace.GenDir); err != nil {
+		return fmt.Errorf("rewriting project module imports: %w", err)
 	}
 
 	return nil

--- a/internal/build/testgen.go
+++ b/internal/build/testgen.go
@@ -72,3 +72,43 @@ func GenerateTestMain(testFuncs []string) string {
 
 	return sb.String()
 }
+
+// GenerateGoTestHarness generates a _test.go file that bridges GALA tests
+// with Go's testing framework. This enables internal tests (same package)
+// for library packages, allowing access to unexported identifiers.
+//
+// The generated file uses TestMain(m *testing.M) as the entry point,
+// which calls the GALA test framework's RunTests(). This is a _test.go
+// file so it's only compiled by `go test`, not `go build`.
+func GenerateGoTestHarness(pkgName string, testFuncs []string) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("package %s\n\n", pkgName))
+
+	sb.WriteString("import (\n")
+	sb.WriteString("\t\"testing\"\n")
+	sb.WriteString("\t\"martianoff/gala/std\"\n")
+	sb.WriteString("\t. \"martianoff/gala/test\"\n")
+	sb.WriteString(")\n\n")
+
+	// Sort for deterministic output
+	sorted := make([]string, len(testFuncs))
+	copy(sorted, testFuncs)
+	sort.Strings(sorted)
+
+	// Generate TestMain that delegates to GALA's RunTests
+	sb.WriteString("func TestMain(m *testing.M) {\n")
+	sb.WriteString("\tRunTests(")
+
+	for i, funcName := range sorted {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(fmt.Sprintf("TestFunc{Name: std.NewImmutable(\"%s\"), F: std.NewImmutable(%s)}", funcName, funcName))
+	}
+
+	sb.WriteString(")\n")
+	sb.WriteString("}\n")
+
+	return sb.String()
+}

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -710,9 +710,35 @@ func (t *galaASTTransformer) transformFunctionDeclaration(ctx *grammar.FunctionD
 		}
 		body = b
 	} else if ctx.Expression() != nil {
-		expr, err := t.transformExpression(ctx.Expression())
-		if err != nil {
-			return nil, err
+		var expr ast.Expr
+		var err error
+
+		// If the expression is a lambda and the return type resolves to a function type,
+		// pass expected types to the lambda for better type inference (BUG-047 fix).
+		// This enables lambdas in expression functions like `func Foo() Filter = (req, next) => { ... }`
+		// to receive expected param/return types from the type alias (e.g., Filter = func(Request, Handler) Future[Response]).
+		lambdaCtx := t.findLambdaInExpression(ctx.Expression())
+		if lambdaCtx != nil && funcType.Results != nil && len(funcType.Results.List) > 0 {
+			if expectedFuncType := t.resolveReturnTypeAsFuncType(funcType.Results.List[0].Type); expectedFuncType != nil {
+				var expectedRetType ast.Expr
+				var expectedParamTypes []transpiler.Type
+				if len(expectedFuncType.Results) > 0 {
+					expectedRetType = t.typeToExpr(expectedFuncType.Results[0])
+				} else {
+					expectedRetType = ExpectedVoid
+				}
+				expectedParamTypes = expectedFuncType.Params
+				expr, err = t.transformLambdaWithExpectedType(lambdaCtx, expectedRetType, expectedParamTypes)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+		if expr == nil {
+			expr, err = t.transformExpression(ctx.Expression())
+			if err != nil {
+				return nil, err
+			}
 		}
 		if funcType.Results != nil && len(funcType.Results.List) > 0 {
 			expr = t.wrapWithAssertion(expr, funcType.Results.List[0].Type)
@@ -730,6 +756,33 @@ func (t *galaASTTransformer) transformFunctionDeclaration(ctx *grammar.FunctionD
 		Type: funcType,
 		Body: body,
 	}, nil
+}
+
+// resolveReturnTypeAsFuncType resolves an AST type expression to a transpiler.FuncType,
+// following type aliases. For example, if the type is "Filter" and Filter is aliased to
+// func(Request, Handler) Future[Response], this returns the FuncType with the resolved
+// param and return types. Returns nil if the type is not a function type.
+func (t *galaASTTransformer) resolveReturnTypeAsFuncType(typeExpr ast.Expr) *transpiler.FuncType {
+	// Convert AST type to transpiler type
+	tp := t.astTypeToTranspilerType(typeExpr)
+	if tp == nil || tp.IsNil() {
+		return nil
+	}
+
+	// Check if it's already a FuncType
+	if ft, ok := tp.(transpiler.FuncType); ok {
+		return &ft
+	}
+
+	// Try resolving via type alias
+	typeName := tp.BaseName()
+	if underlyingType, ok := t.typeAliases[typeName]; ok {
+		if ft, ok := underlyingType.(transpiler.FuncType); ok {
+			return &ft
+		}
+	}
+
+	return nil
 }
 
 func (t *galaASTTransformer) transformStructShorthandDeclaration(ctx *grammar.StructShorthandDeclarationContext) ([]ast.Decl, error) {


### PR DESCRIPTION
## Summary

- **FIX-077 (USABILITY-001)**: `gala test` now supports internal package tests — test files compile in the same package as the library, enabling access to unexported identifiers
- **FIX-078 (USABILITY-009)**: Stale remote module downloads eliminated — unified import rewriting in gen/ removes need for separate testgen/ directory
- **FIX-080 (BUG-047)**: Lambda return type inference via type alias resolution — expression functions returning type aliases (e.g., `Filter = func(Request, Handler) Future[Response]`) now propagate expected types to lambdas

## Changes

### FIX-077: Internal package test support
- `internal/build/builder.go`: `transpileTestLibrary()` puts test files in `gen/` (same dir, same package) instead of separate `testgen/`
- `internal/build/testgen.go`: New `GenerateGoTestHarness()` generates `_test.go` with `TestMain` for `go test` integration
- `internal/build/builder.go`: Library tests use `go test -v ./gen/...` instead of `go build -o test-binary ./testgen/...`

### FIX-080: Lambda type inference
- `internal/transpiler/transformer/declarations.go`: Expression function body detects lambdas and resolves return type aliases to `FuncType`, passing expected types to `transformLambdaWithExpectedType`
- New `resolveReturnTypeAsFuncType` helper for type alias → FuncType resolution

### Documentation
- `docs/GALA.MD`: Updated testing section with internal test documentation, Bazel `gala_go_test` with `lib_srcs` example

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (227 tests)
- gala-server: `gala test` runs 222/235 tests (previously 0 — was fully blocked)
- gala-server: `gala build` compiles without explicit `[Response]` type params on `FutureOf`/`FutureApply`

## Test plan

- [x] All 227 bazel tests pass
- [x] `gala test` on gala-server: 222/235 pass (13 integration test failures are pre-existing)
- [x] `gala build` on gala-server: compiles without `[Response]` workarounds
- [x] New `type_alias_lambda_inference.gala` example verifies BUG-047 fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)