### PR TITLE
fix: void match expressions and Println returns void

### DIFF
--- a/docs/DEPENDENCY_MANAGEMENT.MD
+++ b/docs/DEPENDENCY_MANAGEMENT.MD
@@ -81,7 +81,7 @@ myproject/
 
 ### Bazel Projects
 
-For Bazel projects, `gala mod tidy` generates the necessary `go.mod` and `go.sum` files:
+For Bazel projects, `gala mod tidy` generates a portable `go.mod` (and `go.sum` when Go dependencies are present):
 
 ```bash
 # Initialize
@@ -91,7 +91,7 @@ gala mod init github.com/user/myproject
 gala mod add github.com/example/gala-utils@v1.2.3
 gala mod add github.com/google/uuid@v1.6.0 --go
 
-# Sync dependencies (generates go.mod and go.sum for Bazel)
+# Sync dependencies (generates portable go.mod for Bazel)
 gala mod tidy
 
 # Build with Bazel
@@ -290,7 +290,7 @@ This command:
 - Adds missing dependencies found in imports
 - Removes unused dependencies
 - Marks indirect dependencies appropriately
-- **For Bazel projects**: Generates a portable `go.mod` with Go dependencies only (GALA stdlib deps are stripped — they're resolved by `gala build` or Bazel's bzlmod extension)
+- **For Bazel projects**: Generates a portable `go.mod` with Go dependencies only (GALA stdlib deps are stripped). Generates `go.sum` only when Go dependencies are present
 
 `gala mod tidy` handles both single-line and multi-line import blocks, and recognizes known GALA dependencies (like `std`, `collection_immutable`, etc.) automatically.
 
@@ -346,7 +346,7 @@ When you run `gala build`, GALA:
 
 For Bazel projects:
 
-1. Run `gala mod tidy` to generate `go.mod` and `go.sum` (Go dependencies only)
+1. Run `gala mod tidy` to generate `go.mod` (and `go.sum` if Go dependencies are present)
 2. GALA dependencies are handled by the bzlmod extension
 3. Build with `bazel build //:target`
 
@@ -507,13 +507,15 @@ go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 use_repo(go_deps, "com_github_google_uuid")
 
-# GALA dependencies
+# GALA dependencies (only needed if gala.mod has external GALA deps)
 gala = use_extension("@gala//:extensions.bzl", "gala")
 gala.from_file(gala_mod = "//:gala.mod")
 use_repo(gala, "com_github_example_utils")
 ```
 
-**Important:** Run `gala mod tidy` to generate `go.mod` and `go.sum` files that Bazel needs for Go dependencies.
+The `gala.from_file()` extension is only needed when your project has external GALA module dependencies listed in `gala.mod`. If your project only uses the GALA stdlib (`std`, `collection_immutable`, etc.) and Go packages, you can omit the `gala` extension block entirely — stdlib packages are provided by the `@gala` module itself.
+
+**Important:** Run `gala mod tidy` to keep `go.mod` in sync. For Bazel projects, `go.mod` only contains Go dependencies — GALA stdlib deps are resolved by Bazel automatically.
 
 ### BUILD Files
 

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -858,9 +858,9 @@ func (t *galaASTTransformer) transformCaseClauseWithType(ctx *grammar.CaseClause
 				}
 			}
 		}
-		// If resultType is still nil but body is non-empty, this is a void (side-effect) branch
-		// (e.g., last statement is an assignment like `items = items.Append(v)`)
-		if resultType == nil && len(body) > 0 {
+		// If resultType is still nil, this is a void (side-effect) branch:
+		// either empty block `{}` or last statement is an assignment/loop
+		if resultType == nil {
 			resultType = transpiler.VoidType{}
 		}
 	} else if ctx.GetBody() != nil {

--- a/internal/transpiler/transformer/type_inference_calls.go
+++ b/internal/transpiler/transformer/type_inference_calls.go
@@ -149,6 +149,15 @@ func (t *galaASTTransformer) inferCallExprType(e *ast.CallExpr) transpiler.Type 
 
 // inferCallSelectorType handles type inference for call expressions with selector function (e.g., x.Method()).
 func (t *galaASTTransformer) inferCallSelectorType(e *ast.CallExpr, sel *ast.SelectorExpr, typeArgs []transpiler.Type) transpiler.Type {
+	// GALA's Println/Print are rewritten to fmt.Println/fmt.Print.
+	// Treat them as void — the Go (int, error) return is an implementation detail.
+	if pkgId, ok := sel.X.(*ast.Ident); ok && pkgId.Name == "fmt" {
+		switch sel.Sel.Name {
+		case "Println", "Print":
+			return transpiler.VoidType{}
+		}
+	}
+
 	// Handle Apply method on composite literal: Some[int]{}.Apply(value) -> Option[int]
 	if sel.Sel.Name == "Apply" {
 		if compLit, ok := sel.X.(*ast.CompositeLit); ok {

--- a/internal/transpiler/transformer/type_inference_calls.go
+++ b/internal/transpiler/transformer/type_inference_calls.go
@@ -413,8 +413,12 @@ func (t *galaASTTransformer) inferCallIdentType(e *ast.CallExpr, id *ast.Ident, 
 	// Handle calling a variable of function type (e.g., thunk() where thunk is func() Stream[T])
 	varType := t.getType(id.Name)
 	if !varType.IsNil() {
-		if funcType, ok := varType.(transpiler.FuncType); ok && len(funcType.Results) > 0 {
-			return funcType.Results[0]
+		if funcType, ok := varType.(transpiler.FuncType); ok {
+			if len(funcType.Results) > 0 {
+				return funcType.Results[0]
+			}
+			// Void function (no return type) — e.g., func()
+			return transpiler.VoidType{}
 		}
 		// If the variable has a named type (e.g., Handler), check if it's a type alias
 		// for a function type and use the underlying function type's return type.
@@ -429,9 +433,13 @@ func (t *galaASTTransformer) inferCallIdentType(e *ast.CallExpr, id *ast.Ident, 
 			}
 		}
 		if underlyingType, ok := t.typeAliases[aliasKey]; ok {
-			if funcType, ok := underlyingType.(transpiler.FuncType); ok && len(funcType.Results) > 0 {
-				t.traceType(e, funcType.Results[0], "type-alias-call")
-				return funcType.Results[0]
+			if funcType, ok := underlyingType.(transpiler.FuncType); ok {
+				if len(funcType.Results) > 0 {
+					t.traceType(e, funcType.Results[0], "type-alias-call")
+					return funcType.Results[0]
+				}
+				// Void function alias (no return type) — e.g., type Callback func()
+				return transpiler.VoidType{}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- **ISSUE-003**: Match used for side-effect dispatch now works — void function calls (`func()`, type aliases like `type Callback func()`) return `VoidType` instead of `NilType`, and empty block bodies `{}` are treated as void
- **Println/Print**: Type inference now returns void instead of Go's `(int, error)`, so `() => Println("hello")` correctly generates `func() { ... }` instead of `func() int { ... }`
- **DOC-001**: Clarified `gala.from_file()` in MODULE.bazel is only needed for external GALA deps
- **DOC-002**: Updated docs — `go.sum` only generated when Go dependencies are present

## Test plan

- [x] `bazel build //...` — 852 targets pass
- [x] `bazel test //...` — 227 tests pass
- [x] Void match on `Option[func()]` transpiles correctly
- [x] `() => Println("hello")` generates `func() { ... }` (not `func() int`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)