### PR TITLE
fix: Linux Bazel type-redefined error via symlink-aware file dedup

### DIFF
--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -179,9 +179,8 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 	if len(a.packageFiles) > 0 {
 		// Explicit package files: parse each one, validate package name, add to siblings
 		for _, pf := range a.packageFiles {
-			absPf, _ := filepath.Abs(pf)
-			if absPf == absFilePath {
-				continue // skip self
+			if isSameFile(pf, filePath) {
+				continue // skip self (resolves symlinks for Bazel on Linux)
 			}
 			content, err := ioutil.ReadFile(pf)
 			if err != nil {
@@ -208,15 +207,15 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 		// that happen to share a directory (e.g., examples/). Scanning their imports
 		// would pollute the current file's type resolution with unrelated packages.
 		dirPath := filepath.Dir(filePath)
-		absDirPath, err := filepath.Abs(dirPath)
-		if err == nil && !a.checkedDirs[absDirPath] {
-			a.checkedDirs[absDirPath] = true
+		canonDir := canonicalPath(dirPath)
+		if !a.checkedDirs[canonDir] {
+			a.checkedDirs[canonDir] = true
 			files, err := ioutil.ReadDir(dirPath)
 			if err == nil {
 				for _, f := range files {
 					if !f.IsDir() && filepath.Ext(f.Name()) == ".gala" {
 						otherPath := filepath.Join(dirPath, f.Name())
-						if otherPath == filePath {
+						if isSameFile(otherPath, filePath) {
 							continue
 						}
 						content, err := ioutil.ReadFile(otherPath)
@@ -1782,33 +1781,52 @@ func hasTypeDefinition(meta *transpiler.TypeMetadata) bool {
 	return len(meta.FieldNames) > 0 || (meta.IsSealed && len(meta.SealedVariants) > 0)
 }
 
-// isSameFile checks whether definedIn refers to the same file as absPath.
-// definedIn may be relative or absolute; absPath must be absolute.
-func isSameFile(definedIn, absPath string) bool {
-	if definedIn == "" || absPath == "" {
+// isSameFile checks whether two paths refer to the same file.
+// Handles relative/absolute paths and Bazel symlinks on Linux.
+func isSameFile(pathA, pathB string) bool {
+	if pathA == "" || pathB == "" {
 		return false
 	}
-	absDefinedIn, err := filepath.Abs(definedIn)
+	absA, err := filepath.Abs(pathA)
 	if err != nil {
-		return definedIn == absPath
+		absA = pathA
 	}
-	absOther, err := filepath.Abs(absPath)
+	absB, err := filepath.Abs(pathB)
 	if err != nil {
-		absOther = absPath
+		absB = pathB
 	}
 	// Fast path: string comparison after Abs
-	if absDefinedIn == absOther {
+	if absA == absB {
 		return true
 	}
 	// Resolve symlinks (critical for Bazel local_path_override on Linux where
 	// the same file is reachable via symlinked and real paths)
-	realDefined, err1 := filepath.EvalSymlinks(absDefinedIn)
-	realOther, err2 := filepath.EvalSymlinks(absOther)
-	if err1 == nil && err2 == nil {
-		return realDefined == realOther
+	realA, errA := filepath.EvalSymlinks(absA)
+	realB, errB := filepath.EvalSymlinks(absB)
+	if errA == nil && errB == nil {
+		return realA == realB
 	}
-	// Fallback: compare base filenames as a heuristic
-	return filepath.Base(absDefinedIn) == filepath.Base(absOther)
+	// Fallback: use os.SameFile which compares inodes (works across symlinks)
+	infoA, errA := os.Stat(absA)
+	infoB, errB := os.Stat(absB)
+	if errA == nil && errB == nil {
+		return os.SameFile(infoA, infoB)
+	}
+	return false
+}
+
+// canonicalPath returns a canonical path by resolving symlinks and making absolute.
+// Falls back to filepath.Abs if symlinks can't be resolved.
+func canonicalPath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	real, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return abs
+	}
+	return real
 }
 
 // goExportedFuncRe matches exported (capitalized) standalone function declarations in Go files.


### PR DESCRIPTION
## Summary

Fixes **ISSUE-014** from gala-server: GALA stdlib Bazel build fails on Linux with "type redefined" error.

**Category**: TRANSPILER_BUG
**Priority**: P0 (blocks Bazel CI on Linux)
**Found in**: gala-server

## Root Cause

On Linux with Bazel `local_path_override`, the same `.gala` file is reachable via both symlinked paths (Bazel sandbox) and real paths. The analyzer's self-skip logic used string comparison (`absPf == absFilePath`), which fails when paths differ due to symlinks. The transpiler sees the same file twice and reports "type redefined".

## Changes

- `internal/transpiler/analyzer/analyzer.go`:
  - Package-files self-skip: use `isSameFile()` instead of string `==`
  - Directory-scan self-skip: use `isSameFile()` instead of string `==`
  - Directory dedup cache key: use `canonicalPath()` to resolve symlinks
  - Fixed `isSameFile()`: removed dangerous `filepath.Base()` fallback, added `os.SameFile()` inode comparison
  - Added `canonicalPath()` helper for consistent path normalization

## Verification

- `bazel build //...` passes (227 targets)
- `bazel test //...` passes (227 tests)
- Fix is exercised by all stdlib bootstrap genrules on Linux CI

## Repro (before fix)

```
# On Linux with Bazel and local_path_override to gala:
bazel build //...
ERROR: type "Immutable" in package "std" redefined
```

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: ISSUE-014 in gala-server/TRANSPILER_ISSUES.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)