### PR TITLE
fix: val Go interface method calls get spurious .Get() unwrap

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1041,6 +1041,13 @@ gala_test(
     expected = "tuple_return_widen.out",
 )
 
+# Val Go interface method calls should not get spurious .Get() unwrapping
+gala_test(
+    name = "val_go_interface_method",
+    src = "val_go_interface_method.gala",
+    expected = "val_go_interface_method.out",
+)
+
 # FIX-041 verification: ToBytes/ToString/ToRunes byte conversion helpers
 gala_test(
     name = "byte_conversion",

--- a/examples/val_go_interface_method.gala
+++ b/examples/val_go_interface_method.gala
@@ -1,0 +1,19 @@
+package main
+
+import (
+    "context"
+)
+
+// Verify that val variables holding Go interface types can call methods
+// without spurious .Get() unwrapping on the return value.
+// Bug: ctx.Err() was generated as ctx.Get().Err.Get()() because the
+// fallback heuristic in isImmutableField matched "Err" from std.Try.Failure.
+func main() {
+    val ctx = context.Background()
+
+    // Method call on Go interface should not have .Get() on return
+    val err = ctx.Err()
+    if err == nil {
+        Println("context ok")
+    }
+}

--- a/examples/val_go_interface_method.out
+++ b/examples/val_go_interface_method.out
@@ -1,0 +1,1 @@
+context ok

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -148,47 +148,48 @@ func (t *galaASTTransformer) isImmutableField(xType transpiler.Type, selExpr *as
 	}
 
 	// Fallback: when receiver type is unknown AND the base expression is a
-	// {val}.Get() call (indicating an Immutable-wrapped struct whose type
-	// inference didn't propagate), scan all known struct types for the field.
-	// Only unwrap if every struct that has this field agrees it's immutable.
+	// {val}.Get() call, try to resolve the val's stored type from scope and
+	// check if the field is immutable on that specific type.
+	// We do NOT scan all known types — that's too broad and causes false
+	// positives (e.g., "Err" matching std.Try.Err on a context.Context val).
 	if xTypeName == "" || xType.IsNil() {
-		isValGetCall := false
 		if ce, ok := selExpr.X.(*ast.CallExpr); ok && len(ce.Args) == 0 {
 			if se, ok := ce.Fun.(*ast.SelectorExpr); ok && se.Sel.Name == "Get" {
 				if id, ok := se.X.(*ast.Ident); ok && t.isVal(id.Name) {
-					isValGetCall = true
-				}
-			}
-		}
-		if isValGetCall {
-			foundField := false
-			allImmutable := true
-			// Check structImmutFields (current file types)
-			for tName, fields := range t.structFields {
-				for i, f := range fields {
-					if f == selName {
-						foundField = true
-						if i >= len(t.structImmutFields[tName]) || !t.structImmutFields[tName][i] {
-							allImmutable = false
+					// Resolve the val's actual type from scope
+					valType := t.getValType(id.Name)
+					if !valType.IsNil() {
+						innerType := valType
+						// Unwrap Immutable[T] → T
+						if gen, ok := valType.(transpiler.GenericType); ok && len(gen.Params) > 0 {
+							baseName := gen.Base.String()
+							if baseName == transpiler.TypeImmutable || baseName == "std."+transpiler.TypeImmutable {
+								innerType = gen.Params[0]
+							}
 						}
-						break
+						// Check if the resolved inner type has this field as immutable
+						innerName := innerType.String()
+						if idx := strings.Index(innerName, "["); idx != -1 {
+							innerName = innerName[:idx]
+						}
+						innerName = strings.TrimPrefix(innerName, "*")
+						resolvedInner := t.resolveStructTypeName(innerName)
+						if fields, ok := t.structFields[resolvedInner]; ok {
+							for i, f := range fields {
+								if f == selName {
+									return t.structImmutFields[resolvedInner][i]
+								}
+							}
+						}
+						if typeMeta := t.getTypeMeta(innerName); typeMeta != nil {
+							for i, f := range typeMeta.FieldNames {
+								if f == selName {
+									return i < len(typeMeta.ImmutFlags) && typeMeta.ImmutFlags[i]
+								}
+							}
+						}
 					}
 				}
-			}
-			// Check typeMetas (cross-package types)
-			for _, meta := range t.typeMetas {
-				for i, f := range meta.FieldNames {
-					if f == selName {
-						foundField = true
-						if i >= len(meta.ImmutFlags) || !meta.ImmutFlags[i] {
-							allImmutable = false
-						}
-						break
-					}
-				}
-			}
-			if foundField && allImmutable {
-				return true
 			}
 		}
 	}

--- a/internal/transpiler/transformer/scope.go
+++ b/internal/transpiler/transformer/scope.go
@@ -79,6 +79,17 @@ func (t *galaASTTransformer) getType(name string) transpiler.Type {
 	return transpiler.NilType{}
 }
 
+func (t *galaASTTransformer) getValType(name string) transpiler.Type {
+	s := t.currentScope
+	for s != nil {
+		if typeName, ok := s.valTypes[name]; ok {
+			return typeName
+		}
+		s = s.parent
+	}
+	return transpiler.NilType{}
+}
+
 func (t *galaASTTransformer) isVal(name string) bool {
 	s := t.currentScope
 	for s != nil {


### PR DESCRIPTION
## Summary

Fixes the bug reported in `BUG_REPORT_CTX_ERR.md`: `val` variables holding Go interface types (e.g., `context.Context`) generate incorrect code with spurious `.Get()` on method return values.

**Before:** `ctx.Get().Err.Get()()` (wrong — treats `Err` as field, adds `.Get()`)
**After:** `ctx.Get().Err()` (correct — method call, no unwrap)

## Root Cause

The `isImmutableField` fallback heuristic scanned ALL known struct types when the receiver type was unknown. The field name `Err` matched `std.Try.Failure.Err` (a sealed type variant field), causing a spurious `.Get()` insertion even though the receiver was `context.Context` (a Go interface with no GALA fields).

## Changes

- `internal/transpiler/transformer/postfix.go`: Replace wildcard struct scan with targeted type resolution — resolve the val's stored type from scope and only check that specific type's fields
- `internal/transpiler/transformer/scope.go`: Add `getValType()` helper
- `examples/val_go_interface_method.gala`: Verification example

## Test plan

- [x] `bazel build //...` passes
- [x] `bazel test //...` passes (227 tests)
- [x] `examples/val_go_interface_method` passes
- [x] Verified `ctx.Get().Err()` generated correctly (no `.Get()` on return)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)