### PR TITLE
fix: allow lambda arguments before match expression in grammar

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -24,6 +24,8 @@ filegroup(
         "go_type_inference_multifile/helpers.gala",
         "go_type_inference_multifile/main.gala",
         "lib/generic.gala",
+        "match_lambda_arg/main.gala",
+        "match_lambda_arg/types.gala",
         "match_method_chain/main.gala",
         "match_method_chain/types.gala",
         "match_return_iife.gala",
@@ -913,6 +915,17 @@ gala_test(
         "match_method_chain/types.gala",
     ],
     expected = "match_method_chain/match_method_chain.out",
+)
+
+# FIX-050 verification: match on method call chain with lambda argument
+gala_test(
+    name = "match_lambda_arg",
+    srcs = [
+        "match_lambda_arg/main.gala",
+        "match_lambda_arg/types.gala",
+    ],
+    expected = "match_lambda_arg/match_lambda_arg.out",
+    deps = ["//collection_immutable"],
 )
 
 # Struct field auto-unwrapping when passed to functions (FIX-005 verification)

--- a/examples/match_lambda_arg/main.gala
+++ b/examples/match_lambda_arg/main.gala
@@ -1,0 +1,32 @@
+package main
+
+import . "martianoff/gala/collection_immutable"
+
+// FIX-050: match on method call chain with lambda argument
+// This verifies that lambda arguments parse correctly when followed by a match expression.
+
+func findConfig(items Array[Config], key string) string =
+    items.Find((item) => item.key == key) match {
+        case Some(cfg) => cfg.value
+        case None() => "not found"
+    }
+
+func findAndTransform(items Array[Config], key string) string =
+    items.Find((item) => item.key == key) match {
+        case Some(cfg) => s"found: ${cfg.value}"
+        case None() => "missing"
+    }
+
+func main() {
+    val configs = ArrayOf(
+        Config("host", "localhost"),
+        Config("port", "8080"),
+        Config("mode", "debug")
+    )
+
+    Println(findConfig(configs, "host"))
+    Println(findConfig(configs, "port"))
+    Println(findConfig(configs, "unknown"))
+    Println(findAndTransform(configs, "mode"))
+    Println(findAndTransform(configs, "missing"))
+}

--- a/examples/match_lambda_arg/match_lambda_arg.out
+++ b/examples/match_lambda_arg/match_lambda_arg.out
@@ -1,0 +1,5 @@
+localhost
+8080
+not found
+found: debug
+missing

--- a/examples/match_lambda_arg/types.gala
+++ b/examples/match_lambda_arg/types.gala
@@ -1,0 +1,5 @@
+package main
+
+import . "martianoff/gala/collection_immutable"
+
+struct Config(val key string, val value string)

--- a/internal/parser/grammar/gala.g4
+++ b/internal/parser/grammar/gala.g4
@@ -162,7 +162,7 @@ primaryExpr
 
 partialFunctionLiteral: '{' caseClause+ '}';
 argumentList: argument (',' argument)* ','?;  // Allow trailing comma for multiline formatting
-argument: (identifier '=')? pattern;
+argument: (identifier '=')? (lambdaExpression | pattern);
 
 primary
     : identifier

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -278,13 +278,12 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 						break
 					}
 					arg := argCtx.(*grammar.ArgumentContext)
-					pat := arg.Pattern()
-					exprCtx, _, extractErr := extractArgExpression(pat)
+					exprCtx, lambdaCtx, _, extractErr := extractArgContent(arg)
 					if extractErr != nil {
 						continue
 					}
 					// Skip lambda and partial function arguments — can't infer types from them
-					if t.findLambdaInExpression(exprCtx) != nil || t.findPartialFunctionInExpression(exprCtx) != nil {
+					if lambdaCtx != nil || t.findLambdaInExpression(exprCtx) != nil || t.findPartialFunctionInExpression(exprCtx) != nil {
 						continue
 					}
 					expr, err := t.transformExpression(exprCtx)
@@ -319,8 +318,7 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 			hasSpread := false
 			for i, argCtx := range argListCtx.AllArgument() {
 				arg := argCtx.(*grammar.ArgumentContext)
-				pat := arg.Pattern()
-				exprCtx, isSpread, extractErr := extractArgExpression(pat)
+				exprCtx, lambdaCtx, isSpread, extractErr := extractArgContent(arg)
 				if extractErr != nil {
 					return nil, extractErr
 				}
@@ -338,11 +336,20 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 				genMethodCtx := t.buildMethodCallContext(methodMeta, typeSubst, false)
 				expectedType := t.resolveExpectedArgType(genMethodCtx, i)
 
-				expr, err := t.transformArgumentWithExpectedType(exprCtx, expectedType)
-				if err != nil {
-					return nil, err
+				if lambdaCtx != nil {
+					// Direct lambda argument (FIX-050)
+					expr, err := t.transformLambdaArgWithExpectedType(lambdaCtx, expectedType)
+					if err != nil {
+						return nil, err
+					}
+					mArgs = append(mArgs, expr)
+				} else {
+					expr, err := t.transformArgumentWithExpectedType(exprCtx, expectedType)
+					if err != nil {
+						return nil, err
+					}
+					mArgs = append(mArgs, expr)
 				}
-				mArgs = append(mArgs, expr)
 			}
 
 			var funExpr ast.Expr
@@ -431,8 +438,7 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 				hasSpread := false
 				for i, argCtx := range argListCtx.AllArgument() {
 					arg := argCtx.(*grammar.ArgumentContext)
-					pat := arg.Pattern()
-					exprCtx, isSpread, extractErr := extractArgExpression(pat)
+					exprCtx, lambdaCtx, isSpread, extractErr := extractArgContent(arg)
 					if extractErr != nil {
 						return nil, extractErr
 					}
@@ -442,7 +448,13 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 					// Only pass void function types (avoids unresolved type params in return types)
 					unresolvedCtx := t.buildMethodCallContext(methodMeta, typeSubst, true)
 					expectedType := t.resolveExpectedArgType(unresolvedCtx, i)
-					expr, err := t.transformArgumentWithExpectedType(exprCtx, expectedType)
+					var expr ast.Expr
+					var err error
+					if lambdaCtx != nil {
+						expr, err = t.transformLambdaArgWithExpectedType(lambdaCtx, expectedType)
+					} else {
+						expr, err = t.transformArgumentWithExpectedType(exprCtx, expectedType)
+					}
 					if err != nil {
 						return nil, err
 					}
@@ -462,34 +474,38 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 			argIdx := 0
 			for _, argCtx := range argListCtx.AllArgument() {
 				arg := argCtx.(*grammar.ArgumentContext)
-				pat := arg.Pattern()
+				exprCtx, lambdaCtx, isSpreadAll, extractErr := extractArgContent(arg)
+				if extractErr != nil {
+					return nil, extractErr
+				}
+				if isSpreadAll {
+					hasSpread = true
+				}
 				if arg.Identifier() != nil {
 					argName := arg.Identifier().GetText()
-					exprCtx, isSpread, extractErr := extractArgExpression(pat)
-					if extractErr != nil {
-						return nil, extractErr
-					}
-					if isSpread {
-						hasSpread = true
-					}
 					resolvedMethodCtx := t.buildMethodCallContext(methodMeta, typeSubst, false)
 					expectedType := t.resolveNamedArgExpectedType(resolvedMethodCtx, argName)
-					expr, err := t.transformArgumentWithExpectedType(exprCtx, expectedType)
+					var expr ast.Expr
+					var err error
+					if lambdaCtx != nil {
+						expr, err = t.transformLambdaArgWithExpectedType(lambdaCtx, expectedType)
+					} else {
+						expr, err = t.transformArgumentWithExpectedType(exprCtx, expectedType)
+					}
 					if err != nil {
 						return nil, err
 					}
 					mNamedArgs[argName] = expr
 				} else {
-					exprCtx, isSpread, extractErr := extractArgExpression(pat)
-					if extractErr != nil {
-						return nil, extractErr
-					}
-					if isSpread {
-						hasSpread = true
-					}
 					resolvedMethodCtx := t.buildMethodCallContext(methodMeta, typeSubst, false)
 					expectedType := t.resolveExpectedArgType(resolvedMethodCtx, argIdx)
-					expr, err := t.transformArgumentWithExpectedType(exprCtx, expectedType)
+					var expr ast.Expr
+					var err error
+					if lambdaCtx != nil {
+						expr, err = t.transformLambdaArgWithExpectedType(lambdaCtx, expectedType)
+					} else {
+						expr, err = t.transformArgumentWithExpectedType(exprCtx, expectedType)
+					}
 					if err != nil {
 						return nil, err
 					}
@@ -519,15 +535,20 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 		hasSpread := false
 		for _, argCtx := range argListCtx.AllArgument() {
 			arg := argCtx.(*grammar.ArgumentContext)
-			pat := arg.Pattern()
-			exprCtx, isSpread, extractErr := extractArgExpression(pat)
+			exprCtx, lambdaCtx, isSpread, extractErr := extractArgContent(arg)
 			if extractErr != nil {
 				return nil, extractErr
 			}
 			if isSpread {
 				hasSpread = true
 			}
-			expr, err := t.transformArgumentWithExpectedType(exprCtx, transpiler.NilType{})
+			var expr ast.Expr
+			var err error
+			if lambdaCtx != nil {
+				expr, err = t.transformLambdaArgWithExpectedType(lambdaCtx, transpiler.NilType{})
+			} else {
+				expr, err = t.transformArgumentWithExpectedType(exprCtx, transpiler.NilType{})
+			}
 			if err != nil {
 				return nil, err
 			}
@@ -604,19 +625,18 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 	argIdx := 0
 	for _, argCtx := range argListCtx.AllArgument() {
 		arg := argCtx.(*grammar.ArgumentContext)
-		pat := arg.Pattern()
+		exprCtx, lambdaCtx, isSpreadAll, extractErr := extractArgContent(arg)
+		if extractErr != nil {
+			return nil, extractErr
+		}
+		if isSpreadAll {
+			hasSpread = true
+		}
 
 		// Check for named argument
 		if arg.Identifier() != nil {
 			// This is a named argument
 			argName := arg.Identifier().GetText()
-			exprCtx, isSpread, extractErr := extractArgExpression(pat)
-			if extractErr != nil {
-				return nil, extractErr
-			}
-			if isSpread {
-				hasSpread = true
-			}
 			// Look up expected type from struct field types for lambda inference
 			var namedExpectedType transpiler.Type = transpiler.NilType{}
 			if structFieldExpectedTypes != nil {
@@ -657,24 +677,29 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 					}
 				}
 			}
-			expr, err := t.transformArgumentWithExpectedType(exprCtx, namedExpectedType)
+			var expr ast.Expr
+			var err error
+			if lambdaCtx != nil {
+				expr, err = t.transformLambdaArgWithExpectedType(lambdaCtx, namedExpectedType)
+			} else {
+				expr, err = t.transformArgumentWithExpectedType(exprCtx, namedExpectedType)
+			}
 			if err != nil {
 				return nil, err
 			}
 			namedArgs[argName] = expr
 		} else {
 			// Positional argument - use expected type if available
-			exprCtx, isSpread, extractErr := extractArgExpression(pat)
-			if extractErr != nil {
-				return nil, extractErr
-			}
-			if isSpread {
-				hasSpread = true
-			}
 			// Resolve expected type using unified function call context
 			funcCallCtx := t.buildFuncCallContext(funcMeta, inferredTypeSubst, goFuncParamTypes, structFieldExpectedTypes)
 			expectedType := t.resolveExpectedArgType(funcCallCtx, argIdx)
-			expr, err := t.transformArgumentWithExpectedType(exprCtx, expectedType)
+			var expr ast.Expr
+			var err error
+			if lambdaCtx != nil {
+				expr, err = t.transformLambdaArgWithExpectedType(lambdaCtx, expectedType)
+			} else {
+				expr, err = t.transformArgumentWithExpectedType(exprCtx, expectedType)
+			}
 			if err != nil {
 				return nil, err
 			}
@@ -1464,6 +1489,23 @@ func (t *galaASTTransformer) transformArgumentWithExpectedType(exprCtx grammar.I
 	return t.transformExpression(exprCtx)
 }
 
+// transformLambdaArgWithExpectedType transforms a direct lambda argument (FIX-050).
+// When the grammar's argument rule matches lambdaExpression directly instead of going through
+// pattern -> expression -> primaryExpr -> lambdaExpression, we get the lambda context directly.
+func (t *galaASTTransformer) transformLambdaArgWithExpectedType(lambdaCtx *grammar.LambdaExpressionContext, expectedType transpiler.Type) (ast.Expr, error) {
+	var expectedRetType ast.Expr
+	var expectedParamTypes []transpiler.Type
+	if funcType, ok := expectedType.(transpiler.FuncType); ok {
+		if len(funcType.Results) > 0 {
+			expectedRetType = t.typeToExpr(funcType.Results[0])
+		} else {
+			expectedRetType = ExpectedVoid
+		}
+		expectedParamTypes = funcType.Params
+	}
+	return t.transformLambdaWithExpectedType(lambdaCtx, expectedRetType, expectedParamTypes)
+}
+
 func (t *galaASTTransformer) inferTypeArgsFromApply(
 	typeMeta *transpiler.TypeMetadata,
 	methodMeta *transpiler.MethodMetadata,
@@ -1688,15 +1730,14 @@ func (t *galaASTTransformer) inferFuncTypeSubstFromArgs(funcMeta *transpiler.Fun
 		if arg.Identifier() != nil {
 			continue // skip named args
 		}
-		pat := arg.Pattern()
-		exprCtx, _, extractErr := extractArgExpression(pat)
+		exprCtx, lambdaCtx, _, extractErr := extractArgContent(arg)
 		if extractErr != nil {
 			argIdx++
 			continue
 		}
 
 		// Skip lambda arguments — we're inferring type params FOR them
-		if t.findLambdaInExpression(exprCtx) != nil {
+		if lambdaCtx != nil || t.findLambdaInExpression(exprCtx) != nil {
 			argIdx++
 			continue
 		}

--- a/internal/transpiler/transformer/methods.go
+++ b/internal/transpiler/transformer/methods.go
@@ -80,6 +80,9 @@ func (t *galaASTTransformer) transformCopyCall(receiver ast.Expr, argListCtx *gr
 			return nil, galaerr.NewSemanticError(fmt.Sprintf("struct %s has no field %s", typeName, fieldName))
 		}
 		pat := arg.Pattern()
+		if pat == nil {
+			return nil, galaerr.NewSemanticError("Copy overrides must be expressions")
+		}
 		ep, ok := pat.(*grammar.ExpressionPatternContext)
 		if !ok {
 			return nil, galaerr.NewSemanticError("Copy overrides must be expressions")

--- a/internal/transpiler/transformer/patterns.go
+++ b/internal/transpiler/transformer/patterns.go
@@ -579,6 +579,9 @@ func (t *galaASTTransformer) generateDirectTupleStructMatch(objExpr ast.Expr, ar
 	// Generate bindings for each pattern argument using direct field access
 	for i, argCtx := range args {
 		arg := argCtx.(*grammar.ArgumentContext)
+		if arg.Pattern() == nil {
+			continue
+		}
 		patternText := arg.Pattern().GetText()
 
 		if isWildcard(patternText) {
@@ -679,6 +682,9 @@ func (t *galaASTTransformer) generateDirectStructFieldMatch(objExpr ast.Expr, ar
 	// Generate bindings for each pattern argument using direct field access
 	for i, argCtx := range args {
 		arg := argCtx.(*grammar.ArgumentContext)
+		if arg.Pattern() == nil {
+			continue
+		}
 		patternText := arg.Pattern().GetText()
 
 		if isWildcard(patternText) {
@@ -792,8 +798,10 @@ func (t *galaASTTransformer) hasRestPattern(argList *grammar.ArgumentListContext
 	}
 	for _, argCtx := range argList.AllArgument() {
 		arg := argCtx.(*grammar.ArgumentContext)
-		if _, ok := arg.Pattern().(*grammar.RestPatternContext); ok {
-			return true
+		if pat := arg.Pattern(); pat != nil {
+			if _, ok := pat.(*grammar.RestPatternContext); ok {
+				return true
+			}
 		}
 	}
 	return false
@@ -886,7 +894,9 @@ func (t *galaASTTransformer) generateSeqPatternMatch(objExpr ast.Expr, argList *
 
 	for i, argCtx := range args {
 		arg := argCtx.(*grammar.ArgumentContext)
-		if restPat, ok := arg.Pattern().(*grammar.RestPatternContext); ok {
+		if pat := arg.Pattern(); pat == nil {
+			nonRestCount++
+		} else if restPat, ok := pat.(*grammar.RestPatternContext); ok {
 			restPatternIndex = i
 			// Get the identifier before ...
 			exprText := restPat.Expression().GetText()
@@ -941,6 +951,10 @@ func (t *galaASTTransformer) generateSeqPatternMatch(objExpr ast.Expr, argList *
 	for _, argCtx := range args {
 		arg := argCtx.(*grammar.ArgumentContext)
 		patCtx := arg.Pattern()
+		if patCtx == nil {
+			argIndex++
+			continue
+		}
 
 		// Skip rest pattern for now
 		if _, ok := patCtx.(*grammar.RestPatternContext); ok {
@@ -1711,6 +1725,9 @@ func (t *galaASTTransformer) generateDirectUnapplyPattern(
 		// For each argument pattern, generate direct field access
 		for i, argCtx := range argList.AllArgument() {
 			arg := argCtx.(*grammar.ArgumentContext)
+			if arg.Pattern() == nil {
+				continue
+			}
 			patternText := arg.Pattern().GetText()
 
 			if isWildcard(patternText) {
@@ -1963,6 +1980,9 @@ func (t *galaASTTransformer) generateVariableUnapplyPattern(
 
 		for i, argCtx := range argList.AllArgument() {
 			arg := argCtx.(*grammar.ArgumentContext)
+			if arg.Pattern() == nil {
+				continue
+			}
 			patternText := arg.Pattern().GetText()
 
 			if isWildcard(patternText) {

--- a/internal/transpiler/transformer/spread.go
+++ b/internal/transpiler/transformer/spread.go
@@ -10,7 +10,12 @@ import (
 // extractArgExpression extracts the expression from a pattern in a function argument.
 // It handles both ExpressionPatternContext (regular args) and RestPatternContext (spread args like x...).
 // Returns the expression context, whether it's a spread argument, and an error if the pattern type is unsupported.
+// NOTE: After FIX-050, an argument may be a direct lambdaExpression instead of a pattern.
+// In that case pat is nil — callers should check arg.LambdaExpression() first.
 func extractArgExpression(pat grammar.IPatternContext) (grammar.IExpressionContext, bool, error) {
+	if pat == nil {
+		return nil, false, galaerr.NewSemanticError("only expressions allowed as function arguments")
+	}
 	if ep, ok := pat.(*grammar.ExpressionPatternContext); ok {
 		return ep.Expression(), false, nil
 	}
@@ -18,6 +23,19 @@ func extractArgExpression(pat grammar.IPatternContext) (grammar.IExpressionConte
 		return rp.Expression(), true, nil
 	}
 	return nil, false, galaerr.NewSemanticError("only expressions allowed as function arguments")
+}
+
+// extractArgContent extracts the expression or lambda from an ArgumentContext.
+// After FIX-050, an argument may contain either a pattern (with an expression) or a direct lambdaExpression.
+// Returns: exprCtx (may be nil for direct lambda), lambdaCtx (non-nil for direct lambda), isSpread, error.
+func extractArgContent(arg *grammar.ArgumentContext) (grammar.IExpressionContext, *grammar.LambdaExpressionContext, bool, error) {
+	// Check for direct lambda first (FIX-050: lambdaExpression alternative in argument rule)
+	if lambdaCtx := arg.LambdaExpression(); lambdaCtx != nil {
+		return nil, lambdaCtx.(*grammar.LambdaExpressionContext), false, nil
+	}
+	pat := arg.Pattern()
+	exprCtx, isSpread, err := extractArgExpression(pat)
+	return exprCtx, nil, isSpread, err
 }
 
 // ellipsisPos returns a non-zero token.Pos if hasSpread is true, indicating variadic expansion.


### PR DESCRIPTION
## Summary

Fixes **FIX-050**: `match` on method call chain with lambda argument fails to parse.

**Category**: TRANSPILER_BUG
**Priority**: P1
**Found in**: BUGS.MD (BUG-050)

## Root Cause

ANTLR's LL(*) lookahead was exhausted when parsing lambda expressions inside method call arguments followed by `match`. The `argument` rule delegated to `pattern → expression`, forcing deep traversal before reaching `primaryExpr` where lambda/parenthesized-expression disambiguation occurs.

## Changes

- **`gala.g4`**: Changed `argument` rule to `(identifier '=')? (lambdaExpression | pattern)` — gives lambdas a direct branch at the argument level
- **`calls.go`**: Updated 7 call sites to handle direct lambda arguments via `transformLambdaArgWithExpectedType()`
- **`spread.go`**: Added `extractArgContent()` helper for both lambda and pattern paths
- **`methods.go`**, **`patterns.go`**: Added nil guards for `arg.Pattern()` safety

## Verification

- `examples/match_lambda_arg/` — tests `items.Find((item) => ...) match { ... }` pattern
- `bazel build //...` passes
- `bazel test //...` passes (229/229)

## Repro (before fix)

```gala
func findAndApply(items Array[Tuple[string, string]], path string) Option[string] =
    items.Find((item) => item.V1 == path) match {
        case Some(item) => Some(item.V2)
        case None() => None[string]()
    }
```

## Dependencies

None — this PR can be reviewed and merged independently.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)