### PR TITLE
feat: support GALA named-arg syntax for Go struct construction

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1549,3 +1549,13 @@ gala_test(
     src = "option_when.gala",
     expected = "option_when.out",
 )
+
+# USR-004: Go struct construction with GALA named-arg syntax
+gala_test(
+    name = "go_struct_named_args",
+    src = "go_struct_named_args.gala",
+    expected = "go_struct_named_args.out",
+    deps = [
+        "//examples/go_struct_bridge",
+    ],
+)

--- a/examples/go_struct_bridge/BUILD.bazel
+++ b/examples/go_struct_bridge/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_struct_bridge",
+    srcs = ["bridge.go"],
+    importpath = "martianoff/gala/examples/go_struct_bridge",
+    visibility = ["//visibility:public"],
+)

--- a/examples/go_struct_bridge/bridge.go
+++ b/examples/go_struct_bridge/bridge.go
@@ -1,0 +1,16 @@
+// Package go_struct_bridge provides a simple Go struct for testing GALA named-arg construction.
+package go_struct_bridge
+
+import "fmt"
+
+// Cookie represents a simple HTTP cookie for testing.
+type Cookie struct {
+	Name  string
+	Value string
+	Path  string
+}
+
+// String returns a readable representation of the cookie.
+func (c Cookie) String() string {
+	return fmt.Sprintf("Cookie(%s=%s, path=%s)", c.Name, c.Value, c.Path)
+}

--- a/examples/go_struct_named_args.gala
+++ b/examples/go_struct_named_args.gala
@@ -1,0 +1,13 @@
+package main
+
+import "martianoff/gala/examples/go_struct_bridge"
+
+func main() {
+    // USR-004: Go struct construction with GALA named-arg syntax
+    val c = go_struct_bridge.Cookie(Name = "session", Value = "abc123", Path = "/")
+    Println(c.String())
+
+    // Multiple Go structs
+    val c2 = go_struct_bridge.Cookie(Name = "theme", Value = "dark", Path = "/settings")
+    Println(c2.String())
+}

--- a/examples/go_struct_named_args.out
+++ b/examples/go_struct_named_args.out
@@ -1,0 +1,2 @@
+Cookie(session=abc123, path=/)
+Cookie(theme=dark, path=/settings)

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -1167,7 +1167,56 @@ func (t *galaASTTransformer) handleNamedArgsCall(fun ast.Expr, args []ast.Expr, 
 		return &ast.CompositeLit{Type: typeExpr, Elts: elts}, nil
 	}
 
+	// Fallback: if the type is not a known GALA struct, check if it's a Go-imported type.
+	// Go structs from bridge/external packages can use GALA named-arg syntax: Type(Field = value)
+	// which generates a plain Go composite literal: Type{Field: value}.
+	if t.isGoImportedType(fun) {
+		var elts []ast.Expr
+		for fieldName, val := range namedArgs {
+			elts = append(elts, &ast.KeyValueExpr{
+				Key:   ast.NewIdent(fieldName),
+				Value: val,
+			})
+		}
+		// Sort fields alphabetically for deterministic output
+		t.sortKeyValueExprs(elts)
+		return &ast.CompositeLit{Type: fun, Elts: elts}, nil
+	}
+
 	return nil, galaerr.NewSemanticError(fmt.Sprintf("named arguments only supported for Copy method or struct construction (type: %s)", typeName))
+}
+
+// isGoImportedType checks if an expression refers to a Go-imported type (not a GALA struct).
+// This is used to determine if named-arg syntax should generate a plain Go composite literal.
+func (t *galaASTTransformer) isGoImportedType(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.SelectorExpr:
+		// pkg.Type — check if 'pkg' is an imported package
+		if id, ok := e.X.(*ast.Ident); ok {
+			return t.importManager.IsPackage(id.Name)
+		}
+	case *ast.IndexExpr:
+		// Type[T] or pkg.Type[T] — recurse into the base
+		return t.isGoImportedType(e.X)
+	case *ast.IndexListExpr:
+		// Type[T1, T2] or pkg.Type[T1, T2] — recurse into the base
+		return t.isGoImportedType(e.X)
+	}
+	return false
+}
+
+// sortKeyValueExprs sorts a slice of ast.Expr (expected to be *ast.KeyValueExpr) by key name
+// for deterministic output ordering.
+func (t *galaASTTransformer) sortKeyValueExprs(elts []ast.Expr) {
+	for i := 1; i < len(elts); i++ {
+		for j := i; j > 0; j-- {
+			a := elts[j-1].(*ast.KeyValueExpr).Key.(*ast.Ident).Name
+			b := elts[j].(*ast.KeyValueExpr).Key.(*ast.Ident).Name
+			if a > b {
+				elts[j-1], elts[j] = elts[j], elts[j-1]
+			}
+		}
+	}
 }
 
 // findSealedVariantFields looks up the field names for a sealed variant by searching


### PR DESCRIPTION
## Summary

Fixes **USR-004**: Go struct types from bridge packages can now use `Type(Field = value)` syntax.

**Category**: USABILITY
**Priority**: P2
**Found in**: BUGS.MD (USR-004)

## Root Cause

`handleNamedArgsCall()` only looked up types in `structFields` (GALA-defined structs). Go-imported struct types were rejected with "named arguments only supported for struct construction".

## Changes

- **`calls.go`**: Added fallback in `handleNamedArgsCall()` — when type not in `structFields`, checks if it's a Go-imported type via `isGoImportedType()` and generates a plain Go composite literal (`Type{Field: value}`) without `NewImmutable()` wrapping
- **`examples/go_struct_bridge/`**: Go bridge package with test struct
- **`examples/go_struct_named_args.gala`**: Verification example

## Verification

- `examples/go_struct_named_args.gala` — tests `bridge.Cookie(Name = "session", Value = "abc123")`
- `bazel build //...` passes
- `bazel test //...` passes (229/229)

## Repro (before fix)

```gala
// Had to use Go colon syntax:
br.AddCookie(httpcore.BridgeCookie{Name: "session", Value: "abc"})

// Now can use GALA named-arg syntax:
br.AddCookie(httpcore.BridgeCookie(Name = "session", Value = "abc"))
```

## Dependencies

None — this PR can be reviewed and merged independently.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)