### PR TITLE
feat: add Option.When/Unless and nil-safe go_interop helpers

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1522,3 +1522,10 @@ gala_go_test(
     name = "type_alias_lambda_inference",
     srcs = ["type_alias_lambda_inference.gala"],
 )
+
+# USR-002: Option.When and Unless factory constructors
+gala_test(
+    name = "option_when",
+    src = "option_when.gala",
+    expected = "option_when.out",
+)

--- a/examples/option_when.gala
+++ b/examples/option_when.gala
@@ -1,0 +1,18 @@
+package main
+
+import . "martianoff/gala/std"
+
+func main() {
+    val name = "Alice"
+    val opt1 = When(name != "", name)
+    val opt2 = When(name == "", name)
+    val opt3 = Unless(name == "", name)
+    val opt4 = Unless(name != "", name)
+
+    Println(s"opt1 defined: ${opt1.IsDefined()}")
+    Println(s"opt1 value: ${opt1.Get()}")
+    Println(s"opt2 defined: ${opt2.IsDefined()}")
+    Println(s"opt3 defined: ${opt3.IsDefined()}")
+    Println(s"opt3 value: ${opt3.Get()}")
+    Println(s"opt4 defined: ${opt4.IsDefined()}")
+}

--- a/examples/option_when.out
+++ b/examples/option_when.out
@@ -1,0 +1,6 @@
+opt1 defined: true
+opt1 value: Alice
+opt2 defined: false
+opt3 defined: true
+opt3 value: Alice
+opt4 defined: false

--- a/go_interop/BUILD.bazel
+++ b/go_interop/BUILD.bazel
@@ -7,4 +7,5 @@ go_library(
     srcs = ["types.go"],
     importpath = "martianoff/gala/go_interop",
     visibility = ["//visibility:public"],
+    deps = ["//std"],
 )

--- a/go_interop/types.go
+++ b/go_interop/types.go
@@ -12,6 +12,8 @@ package go_interop
 import (
 	"sync"
 	"time"
+
+	"martianoff/gala/std"
 )
 
 // === Type Conversion Functions ===
@@ -676,4 +678,28 @@ func (e *SingleThreadExecutionContext) Shutdown() {
 		e.wg.Wait()
 		close(e.tasks)
 	})
+}
+
+// === Nil-Safe Bridge Helpers ===
+
+// OptionFromMap looks up a key in a possibly-nil Go map and returns Option.
+// Returns None if the map is nil or the key is not found.
+func OptionFromMap[K comparable, V any](m map[K]V, key K) std.Option[V] {
+	if m == nil {
+		return std.None[V]{}.Apply()
+	}
+	v, ok := m[key]
+	if !ok {
+		return std.None[V]{}.Apply()
+	}
+	return std.Some[V]{}.Apply(v)
+}
+
+// SliceFromNil converts a possibly-nil Go slice to an empty slice.
+// Useful for range loops that would panic on nil slices.
+func SliceFromNil[T any](slice []T) []T {
+	if slice == nil {
+		return []T{}
+	}
+	return slice
 }

--- a/std/option.gala
+++ b/std/option.gala
@@ -107,3 +107,15 @@ func (o Option[T]) Filter(p func(T) bool) Option[T] {
     }
     return None[T]()
 }
+
+// When returns Some(value) if condition is true, None otherwise.
+func When[T any](condition bool, value T) Option[T] {
+    if condition { return Some(value) }
+    return None[T]()
+}
+
+// Unless returns Some(value) if condition is false, None otherwise.
+func Unless[T any](condition bool, value T) Option[T] {
+    if !condition { return Some(value) }
+    return None[T]()
+}


### PR DESCRIPTION
## Summary

**USR-002**: Add `When[T]` and `Unless[T]` factory functions to std for conditional Option creation.
**USR-005**: Add `OptionFromMap` and `SliceFromNil` to go_interop for safe nil-value conversion.

**Category**: USABILITY
**Priority**: P2
**Found in**: BUGS.MD (USR-002, USR-005)

## Changes

- **`std/option.gala`**: Added `When[T](condition, value)` and `Unless[T](condition, value)` standalone functions
- **`go_interop/types.go`**: Added `OptionFromMap[K,V](m, key)` and `SliceFromNil[T](slice)` 
- **`go_interop/BUILD.bazel`**: Added `//std` dependency
- **`examples/option_when.gala`**: Verification example

**Note**: `ArrayFromSlice` was skipped due to circular dependency (collection_immutable already depends on go_interop). The existing `collection_immutable.ArrayFromSlice` already handles nil slices correctly.

## Verification

- `examples/option_when.gala` — tests When/Unless with true and false conditions
- `bazel build //...` passes
- `bazel test //...` passes (229/229)

## Dependencies

None — this PR can be reviewed and merged independently.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)