### PR TITLE
feat: add Retry combinator with backoff strategies

### DIFF
--- a/concurrent/BUILD.bazel
+++ b/concurrent/BUILD.bazel
@@ -21,11 +21,18 @@ gala_bootstrap_transpile(
     out = "future.gen.go",
 )
 
+gala_bootstrap_transpile(
+    name = "retry_go",
+    src = "retry.gala",
+    out = "retry.gen.go",
+)
+
 go_library(
     name = "concurrent",
     srcs = [
         "execution_context.go",
         "future.gen.go",
+        "retry.gen.go",
     ],
     importpath = "martianoff/gala/concurrent",
     visibility = ["//visibility:public"],
@@ -33,6 +40,7 @@ go_library(
         "//collection_immutable",
         "//go_interop",
         "//std",
+        "//time_utils",
     ],
 )
 
@@ -43,5 +51,6 @@ gala_go_test(
         ":concurrent",
         "//collection_immutable",
         "//go_interop",
+        "//time_utils",
     ],
 )

--- a/concurrent/future.gala
+++ b/concurrent/future.gala
@@ -1,10 +1,10 @@
 package concurrent
 
 import (
-    "time"
     . "martianoff/gala/std"
     "martianoff/gala/go_interop"
     . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/time_utils"
 )
 
 // FutureState holds the mutable internal state of a Future.
@@ -175,8 +175,8 @@ func (f Future[T]) Await() Try[T] {
 
 // AwaitFor blocks until the Future is completed or the timeout expires.
 // Returns None if the timeout expires before the Future completes.
-func (f Future[T]) AwaitFor(timeout time.Duration) Option[Try[T]] {
-    val received = go_interop.WaitSignalTimeout(f.state.done, timeout)
+func (f Future[T]) AwaitFor(timeout Duration) Option[Try[T]] {
+    val received = go_interop.WaitSignalTimeout(f.state.done, timeout.ToGoDuration())
     if received {
         f.state.mu.RLock()
         val r = f.state.result

--- a/concurrent/future_test.gala
+++ b/concurrent/future_test.gala
@@ -1,11 +1,11 @@
 package main
 
 import (
-    "time"
     . "martianoff/gala/test"
     . "martianoff/gala/std"
     . "martianoff/gala/concurrent"
     . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/time_utils"
 )
 
 func TestFutureOf(t T) T {
@@ -187,7 +187,7 @@ func TestPromiseSuccess(t T) T {
     val f = p.Future()
 
     Spawn(() => {
-        time.Sleep(10 * time.Millisecond)
+        Sleep(Milliseconds(10))
         p.Success(42)
     })
 
@@ -201,7 +201,7 @@ func TestPromiseFailure(t T) T {
     val f = p.Future()
 
     Spawn(() => {
-        time.Sleep(10 * time.Millisecond)
+        Sleep(Milliseconds(10))
         p.Failure(FutureError(Message = "async error"))
     })
 
@@ -221,7 +221,7 @@ func TestPromiseCompleteOnce(t T) T {
 
 func TestAwaitFor(t T) T {
     val f = FutureOf[int](42)
-    val result = f.AwaitFor(100 * time.Millisecond)
+    val result = f.AwaitFor(Milliseconds(100))
     var t1 = IsSome(t, result)
     return Eq[int](t1, result.Get().Get(), 42)
 }
@@ -286,7 +286,7 @@ func TestAndThen(t T) T {
     val result = f.Await()
     var t1 = IsSuccess(t, result)
     var t2 = Eq[int](t1, result.Get(), 10)
-    time.Sleep(10 * time.Millisecond)
+    Sleep(Milliseconds(10))
     return Eq[int](t2, sideEffect, 10)
 }
 

--- a/concurrent/retry.gala
+++ b/concurrent/retry.gala
@@ -1,0 +1,46 @@
+package concurrent
+
+import (
+    "fmt"
+    . "martianoff/gala/std"
+    . "martianoff/gala/time_utils"
+)
+
+// Retry executes action up to maxAttempts times.
+// Returns the first Success, or the last Failure after all attempts are exhausted.
+// The backoff function receives the attempt number (0-based) and returns the delay
+// before the next attempt.
+func Retry[T any](maxAttempts int, backoff func(int) Duration, action func(int) Try[T]) Try[T] {
+    var lastResult = Failure[T](fmt.Errorf("no attempts made"))
+    for i := 0; i < maxAttempts; i++ {
+        val result = action(i)
+        lastResult = result
+        if result.IsSuccess() {
+            return result
+        }
+        if i < maxAttempts - 1 {
+            Sleep(backoff(i))
+        }
+    }
+    return lastResult
+}
+
+// ConstantBackoff returns a backoff function that always waits the same duration.
+func ConstantBackoff(d Duration) func(int) Duration =
+    (_ int) => d
+
+// ExponentialBackoff returns a backoff function with exponential growth capped at max.
+func ExponentialBackoff(initial Duration, max Duration) func(int) Duration {
+    return (attempt int) => {
+        var d = initial
+        for i := 0; i < attempt; i++ {
+            d = d.Multiply(2)
+            if d.Compare(max) > 0 { return max }
+        }
+        return d
+    }
+}
+
+// NoBackoff returns a backoff function with zero delay.
+func NoBackoff() func(int) Duration =
+    (_ int) => ZeroDuration()

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1559,3 +1559,14 @@ gala_test(
         "//examples/go_struct_bridge",
     ],
 )
+
+# USR-006: Retry combinator with backoff strategies
+gala_test(
+    name = "retry_backoff",
+    src = "retry_backoff.gala",
+    expected = "retry_backoff.out",
+    deps = [
+        "//concurrent",
+        "//time_utils",
+    ],
+)

--- a/examples/retry_backoff.gala
+++ b/examples/retry_backoff.gala
@@ -1,0 +1,44 @@
+package main
+
+import (
+    "fmt"
+    . "martianoff/gala/std"
+    . "martianoff/gala/concurrent"
+    . "martianoff/gala/time_utils"
+)
+
+func main() {
+    // 1. Retry succeeds on third attempt
+    var count1 = 0
+    val result1 = Retry(5, ConstantBackoff(Milliseconds(1)), (attempt int) => {
+        count1 = count1 + 1
+        if count1 <= 2 {
+            return Failure[string](fmt.Errorf("attempt %d failed", attempt))
+        }
+        return Success("hello")
+    })
+    Println(result1)
+
+    // 2. All attempts fail
+    val result2 = Retry(3, NoBackoff(), (_ int) => {
+        return Failure[int](fmt.Errorf("always fails"))
+    })
+    Println(result2)
+
+    // 3. Succeeds immediately
+    val result3 = Retry(3, NoBackoff(), (_ int) => {
+        return Success(42)
+    })
+    Println(result3)
+
+    // 4. Exponential backoff (succeeds on attempt 2)
+    var count4 = 0
+    val result4 = Retry(5, ExponentialBackoff(Milliseconds(1), Milliseconds(100)), (attempt int) => {
+        count4 = count4 + 1
+        if count4 <= 1 {
+            return Failure[string](fmt.Errorf("attempt %d failed", attempt))
+        }
+        return Success("recovered")
+    })
+    Println(result4)
+}

--- a/examples/retry_backoff.out
+++ b/examples/retry_backoff.out
@@ -1,0 +1,4 @@
+Success(hello)
+Failure(always fails)
+Success(42)
+Success(recovered)


### PR DESCRIPTION
## Summary

**USR-006**: Add `Retry[T](maxAttempts, backoff, action)` combinator to `concurrent/` with backoff strategy helpers. Also migrates `Future.AwaitFor()` API from Go `time.Duration` to GALA `time_utils.Duration`.

## Changes

- **`concurrent/retry.gala`** (NEW): `Retry[T]`, `ConstantBackoff`, `ExponentialBackoff`, `NoBackoff` — all using GALA `time_utils.Duration`
- **`concurrent/future.gala`**: `AwaitFor(timeout Duration)` now uses `time_utils.Duration` instead of `time.Duration`
- **`concurrent/future_test.gala`**: Updated to use `Sleep(Milliseconds(N))` instead of `time.Sleep(N * time.Millisecond)`
- **`concurrent/BUILD.bazel`**: Added `retry_go` transpile target, `//time_utils` dep
- **`examples/retry_backoff.gala`**: Verification example with all backoff strategies

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (233/233)
- Example covers: succeed after retries, all-fail, immediate success, exponential backoff

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)