### PR TITLE
fix: allow match case arms with statement bodies (BUG-054)

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1570,3 +1570,10 @@ gala_test(
         "//time_utils",
     ],
 )
+
+# BUG-054: match as standalone statement (side-effect only, no val assignment)
+gala_test(
+    name = "match_standalone_stmt",
+    src = "match_standalone_stmt.gala",
+    expected = "match_standalone_stmt.out",
+)

--- a/examples/match_standalone_stmt.gala
+++ b/examples/match_standalone_stmt.gala
@@ -1,0 +1,28 @@
+package main
+
+func main() {
+    var sideEffect = 0
+
+    // Test 1: match as standalone statement with assignment body (no block needed)
+    val x = Some(42)
+    x match {
+        case Some(v) => sideEffect = v
+        case _ => sideEffect = -1
+    }
+    Println(s"test1: $sideEffect")
+
+    // Test 2: match as standalone statement with block bodies
+    val y = Some(100)
+    y match {
+        case Some(v) => { sideEffect = v + 1 }
+        case _ => { sideEffect = -1 }
+    }
+    Println(s"test2: $sideEffect")
+
+    // Test 3: match as standalone statement with function call body
+    val z = Some("hello")
+    z match {
+        case Some(v) => Println(s"value: $v")
+        case _ => Println("none")
+    }
+}

--- a/examples/match_standalone_stmt.out
+++ b/examples/match_standalone_stmt.out
@@ -1,0 +1,3 @@
+test1: 42
+test2: 101
+value: hello

--- a/internal/parser/grammar/gala.g4
+++ b/internal/parser/grammar/gala.g4
@@ -177,7 +177,7 @@ keyedElement: (expression ':')? expression;
 
 lambdaExpression: parameters '=>' (expression | block);
 
-caseClause: 'case' pattern (IF guard=expression)? '=>' (body=expression | bodyBlock=block);
+caseClause: 'case' pattern (IF guard=expression)? '=>' (bodyStmt=simpleStatement | bodyBlock=block);
 
 pattern
     : expression ELLIPSIS   # restPattern

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -1144,15 +1144,23 @@ func (t *galaASTTransformer) transformPartialCaseClause(ctx *grammar.CaseClauseC
 				resultType = t.inferResultType(ret.Results[0])
 			}
 		}
-	} else if ctx.GetBody() != nil {
-		expr, err := t.transformExpression(ctx.GetBody())
-		if err != nil {
-			return nil, nil, err
+	} else if ctx.GetBodyStmt() != nil {
+		if exprCtx := ctx.GetBodyStmt().Expression(); exprCtx != nil {
+			expr, err := t.transformExpression(exprCtx)
+			if err != nil {
+				return nil, nil, err
+			}
+			// Wrap in Some(expr)
+			someCall := t.wrapInSome(expr)
+			body = []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{someCall}}}
+			resultType = t.inferResultType(expr)
+		} else {
+			stmt, err := t.transformSimpleStatement(ctx.GetBodyStmt())
+			if err != nil {
+				return nil, nil, err
+			}
+			body = []ast.Stmt{stmt}
 		}
-		// Wrap in Some(expr)
-		someCall := t.wrapInSome(expr)
-		body = []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{someCall}}}
-		resultType = t.inferResultType(expr)
 	}
 
 	bodyBlock := &ast.BlockStmt{List: body}

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -306,13 +306,13 @@ func (t *galaASTTransformer) transformMatchClauses(ctx grammar.IExpressionContex
 						casePatterns = append(casePatterns, "case _")
 					}
 				}
-			} else if ccCtx.GetBody() != nil {
-				bodyExpr, err := t.transformExpression(ccCtx.GetBody())
+			} else if ccCtx.GetBodyStmt() != nil {
+				bodyStmts, bodyType, err := t.transformCaseBodyStmt(ccCtx.GetBodyStmt())
 				if err != nil {
 					return nil, nil, nil, err
 				}
-				defaultBody = append(bindingStmts, &ast.ReturnStmt{Results: []ast.Expr{bodyExpr}})
-				resultTypes = append(resultTypes, t.inferResultType(bodyExpr))
+				defaultBody = append(bindingStmts, bodyStmts...)
+				resultTypes = append(resultTypes, bodyType)
 				casePatterns = append(casePatterns, "case _")
 			}
 			continue
@@ -863,13 +863,13 @@ func (t *galaASTTransformer) transformCaseClauseWithType(ctx *grammar.CaseClause
 		if resultType == nil {
 			resultType = transpiler.VoidType{}
 		}
-	} else if ctx.GetBody() != nil {
-		expr, err := t.transformExpression(ctx.GetBody())
+	} else if ctx.GetBodyStmt() != nil {
+		bodyStmts, bodyType, err := t.transformCaseBodyStmt(ctx.GetBodyStmt())
 		if err != nil {
 			return nil, nil, err
 		}
-		resultType = t.inferResultType(expr)
-		body = []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{expr}}}
+		body = bodyStmts
+		resultType = bodyType
 	}
 
 	// Check for unused pattern variables: user vars that appear in bindings but
@@ -908,6 +908,27 @@ func (t *galaASTTransformer) transformCaseClauseWithType(ctx *grammar.CaseClause
 	}
 
 	return ifStmt, resultType, nil
+}
+
+// transformCaseBodyStmt transforms a simpleStatement case body.
+// Returns (stmts, resultType, error) where stmts are the Go statements for the body,
+// and resultType is the type (VoidType for assignments/incDec, or the expression type).
+func (t *galaASTTransformer) transformCaseBodyStmt(ctx grammar.ISimpleStatementContext) ([]ast.Stmt, transpiler.Type, error) {
+	// If the body is an expression, wrap it in a return (value-returning case)
+	if exprCtx := ctx.Expression(); exprCtx != nil {
+		expr, err := t.transformExpression(exprCtx)
+		if err != nil {
+			return nil, nil, err
+		}
+		resultType := t.inferResultType(expr)
+		return []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{expr}}}, resultType, nil
+	}
+	// Otherwise it's a side-effect statement (assignment, incDec, shortVarDecl)
+	stmt, err := t.transformSimpleStatement(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return []ast.Stmt{stmt}, transpiler.VoidType{}, nil
 }
 
 // Pattern transformation functions moved to patterns.go

--- a/internal/transpiler/transformer/patterns.go
+++ b/internal/transpiler/transformer/patterns.go
@@ -377,7 +377,7 @@ func (t *galaASTTransformer) transformCaseClause(ctx *grammar.CaseClauseContext,
 
 	var body []ast.Stmt
 	bodyBlockCtx := ctx.GetBodyBlock()
-	bodyCtx := ctx.GetBody()
+	bodyStmtCtx := ctx.GetBodyStmt()
 	if bodyBlockCtx != nil {
 		b, err := t.transformBlock(bodyBlockCtx.(*grammar.BlockContext))
 		if err != nil {
@@ -394,12 +394,12 @@ func (t *galaASTTransformer) transformCaseClause(ctx *grammar.CaseClauseContext,
 				}
 			}
 		}
-	} else if bodyCtx != nil {
-		expr, err := t.transformExpression(ctx.GetBody())
+	} else if bodyStmtCtx != nil {
+		bodyStmts, _, err := t.transformCaseBodyStmt(bodyStmtCtx)
 		if err != nil {
 			return nil, err
 		}
-		body = []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{expr}}}
+		body = bodyStmts
 	}
 
 	bodyBlock := &ast.BlockStmt{List: body}

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -362,13 +362,13 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 						casePatterns = append(casePatterns, "case _")
 					}
 				}
-			} else if ccCtx.GetBody() != nil {
-				bodyExpr, err := t.transformExpression(ccCtx.GetBody())
+			} else if ccCtx.GetBodyStmt() != nil {
+				bodyStmts, bodyType, err := t.transformCaseBodyStmt(ccCtx.GetBodyStmt())
 				if err != nil {
 					return nil, err
 				}
-				defaultBody = append(bindingStmts, &ast.ReturnStmt{Results: []ast.Expr{bodyExpr}})
-				resultTypes = append(resultTypes, t.inferResultType(bodyExpr))
+				defaultBody = append(bindingStmts, bodyStmts...)
+				resultTypes = append(resultTypes, bodyType)
 				casePatterns = append(casePatterns, "case _")
 			}
 			continue


### PR DESCRIPTION
## Summary

- **BUG-054**: `match` case arms now accept assignments and other statements as bodies, not just expressions or blocks
- Changed `caseClause` grammar rule from `body=expression` to `bodyStmt=simpleStatement`, enabling `case X => sideEffect = v` without block syntax
- Updated all transformer call sites (`match.go`, `postfix.go`, `patterns.go`, `lambdas.go`) with new `transformCaseBodyStmt` helper

## Root Cause

The ANTLR grammar's `caseClause` rule only accepted `expression | block` after `=>`. An assignment like `sideEffect = v` is a `simpleStatement`, not an expression, so the parser rejected it with `no viable alternative at input`.

## Repro (before fix)

```gala
val x = Some(42)
x match {
    case Some(v) => sideEffect = v   // SyntaxError!
    case _ => sideEffect = -1
}
```

## Test plan

- [x] New `examples/match_standalone_stmt` test — assignments, block bodies, and function calls in case arms
- [x] `bazel build //...` passes
- [x] `bazel test //...` — all 233 tests pass, zero regressions

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)