### PR TITLE
fix: preserve pointer type in typed pattern matching variables

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -354,6 +354,12 @@ gala_test(
 )
 
 gala_test(
+    name = "bug055_repro",
+    src = "bug055_repro.gala",
+    expected = "bug055_repro.out",
+)
+
+gala_test(
     name = "try_basic",
     src = "try_basic.gala",
     expected = "try_basic.out",

--- a/examples/bug055_repro.gala
+++ b/examples/bug055_repro.gala
@@ -1,0 +1,40 @@
+package main
+
+import (
+    "fmt"
+    . "martianoff/gala/std"
+)
+
+// Simple struct
+type MyData struct {
+    Name string
+    Age  int
+}
+
+type OtherData struct {
+    Value string
+}
+
+// BUG-055: typed pattern matching with pointer type in Option return
+func findData(raw any) Option[*MyData] {
+    return raw match {
+        case sd: *MyData => Some(sd)
+        case _ => None[*MyData]()
+    }
+}
+
+func main() {
+    val d *MyData = &MyData{Name: "Alice", Age: 30}
+    val result = findData(d)
+    result match {
+        case Some(sd) => Println(fmt.Sprintf("found: %s, %d", sd.Name, sd.Age))
+        case _ => Println("not found")
+    }
+
+    val d2 *OtherData = &OtherData{Value: "hello"}
+    val result2 = findData(d2)
+    result2 match {
+        case Some(sd) => Println(fmt.Sprintf("found: %s", sd.Name))
+        case _ => Println("not found (expected)")
+    }
+}

--- a/examples/bug055_repro.out
+++ b/examples/bug055_repro.out
@@ -1,0 +1,2 @@
+found: Alice, 30
+not found (expected)

--- a/internal/transpiler/transformer/patterns.go
+++ b/internal/transpiler/transformer/patterns.go
@@ -243,6 +243,13 @@ func (t *galaASTTransformer) transformTypedPattern(ctx *grammar.TypedPatternCont
 	if qName := t.getType(typeName.String()); !qName.IsNil() {
 		typeName = qName
 	}
+	// FIX-055: If the type expression is a pointer (*T), wrap the resolved type
+	// in PointerType so the pattern variable has the correct pointer type.
+	if _, isPtr := typeExpr.(*ast.StarExpr); isPtr {
+		if _, alreadyPtr := typeName.(transpiler.PointerType); !alreadyPtr {
+			typeName = transpiler.PointerType{Elem: typeName}
+		}
+	}
 	t.addVar(name, typeName)
 
 	okName := t.nextTempVar()


### PR DESCRIPTION
## Summary

- Fixes **BUG-055**: typed pattern matching (`case sd: *T =>`) lost the pointer, storing the variable as `T` instead of `*T`
- Root cause: `getBaseTypeName()` strips `*` from pointer types, so the resolved type was non-pointer
- Adds verification example `examples/bug055_repro.gala`

## Test plan

- [x] `examples/bug055_repro` passes (new)
- [x] All 15 existing match-related examples pass
- [x] No regressions in pattern matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)