### PR TITLE
feat: IntelliJ plugin phases 6-8 — inspections, run icons, docs, templates

### DIFF
--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaDocumentationProvider.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaDocumentationProvider.kt
@@ -1,0 +1,110 @@
+package org.gala.ide.intellij
+
+import com.intellij.lang.documentation.AbstractDocumentationProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNameIdentifierOwner
+import org.gala.ide.intellij.psi.*
+
+/**
+ * Quick documentation provider for GALA (Ctrl+Q).
+ * Shows declaration info for functions, types, sealed types, vals, vars.
+ */
+class GalaDocumentationProvider : AbstractDocumentationProvider() {
+
+    override fun generateDoc(element: PsiElement?, originalElement: PsiElement?): String? {
+        if (element == null) return null
+
+        // If the element is an identifier that resolves to a declaration, show the declaration
+        val target = when {
+            element is PsiNameIdentifierOwner -> element
+            element is IdentifierNode -> {
+                val ref = element.reference
+                ref?.resolve() as? PsiNameIdentifierOwner
+            }
+            else -> null
+        } ?: return null
+
+        return buildDoc(target)
+    }
+
+    override fun getQuickNavigateInfo(element: PsiElement?, originalElement: PsiElement?): String? {
+        if (element is PsiNameIdentifierOwner) {
+            return buildQuickInfo(element)
+        }
+        return null
+    }
+
+    private fun buildDoc(element: PsiNameIdentifierOwner): String {
+        val name = element.name ?: "unknown"
+        val kind = getKind(element)
+        val signature = getSignature(element)
+        val file = element.containingFile?.name ?: ""
+
+        return buildString {
+            append("<div class='definition'><pre>")
+            append("<b>$kind</b> $signature")
+            append("</pre></div>")
+            if (file.isNotEmpty()) {
+                append("<div class='content'>")
+                append("<p>Defined in <code>$file</code></p>")
+                append("</div>")
+            }
+        }
+    }
+
+    private fun buildQuickInfo(element: PsiNameIdentifierOwner): String {
+        val kind = getKind(element)
+        val signature = getSignature(element)
+        return "$kind $signature"
+    }
+
+    private fun getKind(element: PsiNameIdentifierOwner): String {
+        return when (element) {
+            is FunctionDeclarationNode -> "func"
+            is TypeDeclarationNode -> "type"
+            is SealedTypeDeclarationNode -> "sealed type"
+            is SealedCaseNode -> "case"
+            is ValDeclarationNode -> "val"
+            is VarDeclarationNode -> "var"
+            is StructShorthandDeclarationNode -> "struct"
+            is MethodSpecNode -> "method"
+            else -> "declaration"
+        }
+    }
+
+    private fun getSignature(element: PsiNameIdentifierOwner): String {
+        return when (element) {
+            is FunctionDeclarationNode -> {
+                val text = element.text
+                text.lines().firstOrNull()?.substringBefore("{")?.trim()
+                    ?.removePrefix("func ")
+                    ?: element.name ?: ""
+            }
+            is SealedTypeDeclarationNode -> {
+                val text = element.text
+                text.lines().firstOrNull()?.substringBefore("{")?.trim()
+                    ?.removePrefix("sealed ")?.removePrefix("type ")
+                    ?: element.name ?: ""
+            }
+            is SealedCaseNode -> {
+                val text = element.text.trim()
+                text.removePrefix("case ")
+            }
+            is TypeDeclarationNode -> {
+                val text = element.text
+                text.lines().firstOrNull()?.substringBefore("{")?.trim()
+                    ?.removePrefix("type ")
+                    ?: element.name ?: ""
+            }
+            is ValDeclarationNode -> {
+                val text = element.text.trim()
+                text.substringBefore("=").trim()
+            }
+            is VarDeclarationNode -> {
+                val text = element.text.trim()
+                text.substringBefore("=").trim()
+            }
+            else -> element.name ?: ""
+        }
+    }
+}

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaInspections.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaInspections.kt
@@ -1,0 +1,145 @@
+package org.gala.ide.intellij
+
+import com.intellij.codeInspection.*
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiNameIdentifierOwner
+import org.gala.ide.intellij.psi.*
+
+/**
+ * Inspection: detects duplicate declarations in the same scope.
+ */
+class GalaDuplicateDeclarationInspection : LocalInspectionTool() {
+    override fun getGroupDisplayName(): String = "GALA"
+    override fun getDisplayName(): String = "Duplicate declaration"
+    override fun getShortName(): String = "GalaDuplicateDeclaration"
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PsiElementVisitor() {
+            override fun visitElement(element: PsiElement) {
+                if (element !is GalaFile) return
+                val seen = mutableMapOf<String, PsiElement>()
+                for (child in element.children) {
+                    collectTopLevelNames(child, seen, holder)
+                }
+            }
+        }
+    }
+
+    private fun collectTopLevelNames(element: PsiElement, seen: MutableMap<String, PsiElement>, holder: ProblemsHolder) {
+        if (element is PsiNameIdentifierOwner) {
+            val name = element.name
+            if (name != null && name.isNotBlank()) {
+                val existing = seen[name]
+                if (existing != null) {
+                    val nameId = element.nameIdentifier
+                    if (nameId != null) {
+                        holder.registerProblem(
+                            nameId,
+                            "'$name' is already declared in this scope",
+                            ProblemHighlightType.GENERIC_ERROR
+                        )
+                    }
+                } else {
+                    seen[name] = element
+                }
+            }
+        }
+        // Recurse into wrapper nodes but not into blocks
+        if (element is GalaPsiNode && element !is BlockNode
+            && element !is FunctionDeclarationNode
+            && element !is TypeDeclarationNode
+            && element !is SealedTypeDeclarationNode
+        ) {
+            for (child in element.children) {
+                collectTopLevelNames(child, seen, holder)
+            }
+        }
+    }
+}
+
+/**
+ * Inspection: detects empty match expressions (match with no case clauses).
+ */
+class GalaEmptyMatchInspection : LocalInspectionTool() {
+    override fun getGroupDisplayName(): String = "GALA"
+    override fun getDisplayName(): String = "Empty match expression"
+    override fun getShortName(): String = "GalaEmptyMatch"
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PsiElementVisitor() {
+            override fun visitElement(element: PsiElement) {
+                if (element is GalaPsiNode && element.node.elementType == GalaTokenTypes.RULE_MATCH_SUFFIX) {
+                    // Check if the match has any case clauses
+                    val hasCases = element.children.any {
+                        it.node.elementType == GalaTokenTypes.RULE_CASE_CLAUSE
+                    }
+                    if (!hasCases) {
+                        holder.registerProblem(
+                            element,
+                            "Empty match expression — add case clauses",
+                            ProblemHighlightType.WARNING
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Inspection: warns about mutable variables (var) that could be val.
+ * Detects var declarations whose value is never reassigned in the same scope.
+ */
+class GalaVarCouldBeValInspection : LocalInspectionTool() {
+    override fun getGroupDisplayName(): String = "GALA"
+    override fun getDisplayName(): String = "'var' could be 'val'"
+    override fun getShortName(): String = "GalaVarCouldBeVal"
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PsiElementVisitor() {
+            override fun visitElement(element: PsiElement) {
+                if (element !is VarDeclarationNode) return
+                val name = element.name ?: return
+                val nameId = element.nameIdentifier ?: return
+
+                // Walk up to find the enclosing scope (function body or file)
+                val scope = findEnclosingScope(element) ?: return
+
+                // Check if the variable is reassigned anywhere in the scope
+                val isReassigned = hasAssignment(scope, name)
+                if (!isReassigned) {
+                    holder.registerProblem(
+                        nameId,
+                        "'var $name' is never reassigned — consider using 'val'",
+                        ProblemHighlightType.WEAK_WARNING
+                    )
+                }
+            }
+        }
+    }
+
+    private fun findEnclosingScope(element: PsiElement): PsiElement? {
+        var current = element.parent
+        while (current != null) {
+            if (current is BlockNode || current is GalaFile) return current
+            current = current.parent
+        }
+        return null
+    }
+
+    private fun hasAssignment(scope: PsiElement, name: String): Boolean {
+        for (child in scope.children) {
+            if (child is GalaPsiNode) {
+                // Check for assignment: name = ... or name += ... etc.
+                val text = child.text
+                if (text.startsWith("$name ") && (text.contains("=") && !text.contains("=="))) {
+                    // Rough heuristic — assignment detected
+                    return true
+                }
+                if (hasAssignment(child, name)) return true
+            }
+        }
+        return false
+    }
+}

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaLineMarkerProvider.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaLineMarkerProvider.kt
@@ -1,0 +1,52 @@
+package org.gala.ide.intellij
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.psi.PsiElement
+import org.antlr.intellij.adaptor.lexer.TokenIElementType
+import org.gala.ide.intellij.parser.galaLexer
+import org.gala.ide.intellij.psi.*
+
+/**
+ * Provides gutter icons for runnable GALA constructs:
+ * - Green play icon on `func main()` declarations
+ * - Test icon on test functions (func TestXxx)
+ */
+class GalaLineMarkerProvider : LineMarkerProvider {
+
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+        // Only mark leaf IDENTIFIER tokens to avoid duplicate markers
+        val elementType = element.node?.elementType
+        if (elementType !is TokenIElementType || elementType.antlrTokenType != galaLexer.IDENTIFIER) {
+            return null
+        }
+
+        val parent = element.parent ?: return null
+        // Check if this is a function name identifier
+        val grandparent = parent.parent
+        if (grandparent !is FunctionDeclarationNode) return null
+        if (grandparent.nameIdentifier !== parent) return null
+
+        val funcName = element.text
+
+        return when {
+            funcName == "main" -> createRunMarker(element, "Run main()", AllIcons.RunConfigurations.TestState.Run)
+            funcName.startsWith("Test") -> createRunMarker(element, "Run $funcName", AllIcons.RunConfigurations.TestState.Run)
+            else -> null
+        }
+    }
+
+    private fun createRunMarker(element: PsiElement, tooltip: String, icon: javax.swing.Icon): LineMarkerInfo<PsiElement> {
+        return LineMarkerInfo(
+            element,
+            element.textRange,
+            icon,
+            { tooltip },
+            null,
+            GutterIconRenderer.Alignment.LEFT,
+            { tooltip }
+        )
+    }
+}

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaLiveTemplateContext.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaLiveTemplateContext.kt
@@ -1,0 +1,14 @@
+package org.gala.ide.intellij
+
+import com.intellij.codeInsight.template.TemplateActionContext
+import com.intellij.codeInsight.template.TemplateContextType
+
+/**
+ * Defines when GALA live templates are available.
+ * Templates are shown in .gala files when the caret is in a code context.
+ */
+class GalaLiveTemplateContext : TemplateContextType("GALA", "GALA") {
+    override fun isInContext(context: TemplateActionContext): Boolean {
+        return context.file.name.endsWith(".gala")
+    }
+}

--- a/ide/intellij/src/main/resources/META-INF/plugin.xml
+++ b/ide/intellij/src/main/resources/META-INF/plugin.xml
@@ -75,6 +75,32 @@
         <gotoSymbolContributor implementationClass="org.gala.ide.intellij.GalaGoToSymbolContributor"/>
         <annotator language="GALA" implementationClass="org.gala.ide.intellij.GalaAnnotator"/>
         <colorSettingsPage implementation="org.gala.ide.intellij.GalaColorSettingsPage"/>
+
+        <!-- Inspections -->
+        <localInspection language="GALA" groupName="GALA" shortName="GalaDuplicateDeclaration"
+                         displayName="Duplicate declaration"
+                         implementationClass="org.gala.ide.intellij.GalaDuplicateDeclarationInspection"
+                         enabledByDefault="true" level="ERROR"/>
+        <localInspection language="GALA" groupName="GALA" shortName="GalaEmptyMatch"
+                         displayName="Empty match expression"
+                         implementationClass="org.gala.ide.intellij.GalaEmptyMatchInspection"
+                         enabledByDefault="true" level="WARNING"/>
+        <localInspection language="GALA" groupName="GALA" shortName="GalaVarCouldBeVal"
+                         displayName="'var' could be 'val'"
+                         implementationClass="org.gala.ide.intellij.GalaVarCouldBeValInspection"
+                         enabledByDefault="true" level="WEAK WARNING"/>
+
+        <!-- Gutter run icons -->
+        <codeInsight.lineMarkerProvider language="GALA"
+                                         implementationClass="org.gala.ide.intellij.GalaLineMarkerProvider"/>
+
+        <!-- Documentation -->
+        <lang.documentationProvider language="GALA"
+                                     implementationClass="org.gala.ide.intellij.GalaDocumentationProvider"/>
+
+        <!-- Live templates -->
+        <defaultLiveTemplates file="/liveTemplates/GALA.xml"/>
+        <liveTemplateContext implementation="org.gala.ide.intellij.GalaLiveTemplateContext"/>
     </extensions>
 
     <actions>

--- a/ide/intellij/src/main/resources/liveTemplates/GALA.xml
+++ b/ide/intellij/src/main/resources/liveTemplates/GALA.xml
@@ -1,0 +1,79 @@
+<templateSet group="GALA">
+    <template name="func" value="func $NAME$($PARAMS$) $RETURN$ {&#10;    $END$&#10;}" description="Function declaration" toReformat="true" toShortenFQNames="true">
+        <variable name="NAME" expression="" defaultValue="name" alwaysStopAt="true" />
+        <variable name="PARAMS" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="RETURN" expression="" defaultValue="" alwaysStopAt="true" />
+        <context><option name="GALA" value="true" /></context>
+    </template>
+
+    <template name="val" value="val $NAME$ = $VALUE$" description="Immutable variable" toReformat="true" toShortenFQNames="true">
+        <variable name="NAME" expression="" defaultValue="name" alwaysStopAt="true" />
+        <variable name="VALUE" expression="" defaultValue="" alwaysStopAt="true" />
+        <context><option name="GALA" value="true" /></context>
+    </template>
+
+    <template name="var" value="var $NAME$ = $VALUE$" description="Mutable variable" toReformat="true" toShortenFQNames="true">
+        <variable name="NAME" expression="" defaultValue="name" alwaysStopAt="true" />
+        <variable name="VALUE" expression="" defaultValue="" alwaysStopAt="true" />
+        <context><option name="GALA" value="true" /></context>
+    </template>
+
+    <template name="match" value="$EXPR$ match {&#10;    case $PATTERN$ =&gt; $BODY$&#10;}" description="Match expression" toReformat="true" toShortenFQNames="true">
+        <variable name="EXPR" expression="" defaultValue="expr" alwaysStopAt="true" />
+        <variable name="PATTERN" expression="" defaultValue="_" alwaysStopAt="true" />
+        <variable name="BODY" expression="" defaultValue="" alwaysStopAt="true" />
+        <context><option name="GALA" value="true" /></context>
+    </template>
+
+    <template name="if" value="if ($COND$) {&#10;    $END$&#10;}" description="If statement" toReformat="true" toShortenFQNames="true">
+        <variable name="COND" expression="" defaultValue="condition" alwaysStopAt="true" />
+        <context><option name="GALA" value="true" /></context>
+    </template>
+
+    <template name="ife" value="if ($COND$) {&#10;    $THEN$&#10;} else {&#10;    $ELSE$&#10;}" description="If-else statement" toReformat="true" toShortenFQNames="true">
+        <variable name="COND" expression="" defaultValue="condition" alwaysStopAt="true" />
+        <variable name="THEN" expression="" defaultValue="" alwaysStopAt="true" />
+        <variable name="ELSE" expression="" defaultValue="" alwaysStopAt="true" />
+        <context><option name="GALA" value="true" /></context>
+    </template>
+
+    <template name="for" value="for $VAR$ range $EXPR$ {&#10;    $END$&#10;}" description="For-range loop" toReformat="true" toShortenFQNames="true">
+        <variable name="VAR" expression="" defaultValue="item" alwaysStopAt="true" />
+        <variable name="EXPR" expression="" defaultValue="collection" alwaysStopAt="true" />
+        <context><option name="GALA" value="true" /></context>
+    </template>
+
+    <template name="sealed" value="sealed type $NAME$ {&#10;    case $CASE$($FIELDS$)&#10;}" description="Sealed type declaration" toReformat="true" toShortenFQNames="true">
+        <variable name="NAME" expression="" defaultValue="MyType" alwaysStopAt="true" />
+        <variable name="CASE" expression="" defaultValue="Variant" alwaysStopAt="true" />
+        <variable name="FIELDS" expression="" defaultValue="value T" alwaysStopAt="true" />
+        <context><option name="GALA" value="true" /></context>
+    </template>
+
+    <template name="struct" value="type $NAME$ struct {&#10;    val $FIELD$ $TYPE$&#10;}" description="Struct type declaration" toReformat="true" toShortenFQNames="true">
+        <variable name="NAME" expression="" defaultValue="MyStruct" alwaysStopAt="true" />
+        <variable name="FIELD" expression="" defaultValue="field" alwaysStopAt="true" />
+        <variable name="TYPE" expression="" defaultValue="string" alwaysStopAt="true" />
+        <context><option name="GALA" value="true" /></context>
+    </template>
+
+    <template name="lambda" value="($PARAMS$) =&gt; $BODY$" description="Lambda expression" toReformat="true" toShortenFQNames="true">
+        <variable name="PARAMS" expression="" defaultValue="x" alwaysStopAt="true" />
+        <variable name="BODY" expression="" defaultValue="" alwaysStopAt="true" />
+        <context><option name="GALA" value="true" /></context>
+    </template>
+
+    <template name="main" value="package main&#10;&#10;func main() {&#10;    $END$&#10;}" description="Main function" toReformat="true" toShortenFQNames="true">
+        <context><option name="GALA" value="true" /></context>
+    </template>
+
+    <template name="println" value="Println($EXPR$)" description="Print line" toReformat="true" toShortenFQNames="true">
+        <variable name="EXPR" expression="" defaultValue="" alwaysStopAt="true" />
+        <context><option name="GALA" value="true" /></context>
+    </template>
+
+    <template name="sinterp" value="s&quot;$TEXT$&quot;" description="String interpolation" toReformat="true" toShortenFQNames="true">
+        <variable name="TEXT" expression="" defaultValue="" alwaysStopAt="true" />
+        <context><option name="GALA" value="true" /></context>
+    </template>
+</templateSet>


### PR DESCRIPTION
## Summary

Completes the remaining IntelliJ plugin phases from the roadmap.

**Phase 6: Inspections**
- Duplicate declaration detection (error level)
- Empty match expression warning
- `var` could be `val` suggestion when variable is never reassigned

**Phase 7: Run Integration**
- Green gutter play icon on `func main()` declarations
- Green gutter icon on `Test*` functions

**Phase 8: Advanced Features**
- Quick documentation (Ctrl+Q) — shows declaration signatures and source file
- 12 live templates: `func`, `val`, `var`, `match`, `if`, `ife`, `for`, `sealed`, `struct`, `lambda`, `main`, `println`, `sinterp`
- Live template context restricted to `.gala` files

## Test plan

- [x] `bazel build //ide/intellij:plugin` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)