### PR TITLE
fix: remove false-positive empty match inspection

### DIFF
--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaInspections.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaInspections.kt
@@ -59,35 +59,6 @@ class GalaDuplicateDeclarationInspection : LocalInspectionTool() {
 }
 
 /**
- * Inspection: detects empty match expressions (match with no case clauses).
- */
-class GalaEmptyMatchInspection : LocalInspectionTool() {
-    override fun getGroupDisplayName(): String = "GALA"
-    override fun getDisplayName(): String = "Empty match expression"
-    override fun getShortName(): String = "GalaEmptyMatch"
-
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
-        return object : PsiElementVisitor() {
-            override fun visitElement(element: PsiElement) {
-                if (element is GalaPsiNode && element.node.elementType == GalaTokenTypes.RULE_MATCH_SUFFIX) {
-                    // Check if the match has any case clauses
-                    val hasCases = element.children.any {
-                        it.node.elementType == GalaTokenTypes.RULE_CASE_CLAUSE
-                    }
-                    if (!hasCases) {
-                        holder.registerProblem(
-                            element,
-                            "Empty match expression — add case clauses",
-                            ProblemHighlightType.WARNING
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-/**
  * Inspection: warns about mutable variables (var) that could be val.
  * Detects var declarations whose value is never reassigned in the same scope.
  */

--- a/ide/intellij/src/main/resources/META-INF/plugin.xml
+++ b/ide/intellij/src/main/resources/META-INF/plugin.xml
@@ -81,11 +81,7 @@
                          displayName="Duplicate declaration"
                          implementationClass="org.gala.ide.intellij.GalaDuplicateDeclarationInspection"
                          enabledByDefault="true" level="ERROR"/>
-        <localInspection language="GALA" groupName="GALA" shortName="GalaEmptyMatch"
-                         displayName="Empty match expression"
-                         implementationClass="org.gala.ide.intellij.GalaEmptyMatchInspection"
-                         enabledByDefault="true" level="WARNING"/>
-        <localInspection language="GALA" groupName="GALA" shortName="GalaVarCouldBeVal"
+<localInspection language="GALA" groupName="GALA" shortName="GalaVarCouldBeVal"
                          displayName="'var' could be 'val'"
                          implementationClass="org.gala.ide.intellij.GalaVarCouldBeValInspection"
                          enabledByDefault="true" level="WEAK WARNING"/>


### PR DESCRIPTION
## Summary

Removes the empty match inspection that was showing false positives on every expression in the code.

**Root cause:** The `match` keyword is inline in the `postfixExpr` grammar rule — there's no separate PSI node for match expressions. The inspection was checking ALL `postfixExpr` nodes for case clauses, and since most expressions aren't matches, it reported warnings everywhere.

**Fix:** Remove the inspection. Will be reimplemented properly when the LSP server provides real semantic diagnostics.

## Test plan

- [x] `bazel build //ide/intellij:plugin` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)