### PR TITLE
fix: address all reported plugin/LSP issues

### DIFF
--- a/ide/intellij/plugin_test_file.gala
+++ b/ide/intellij/plugin_test_file.gala
@@ -1,0 +1,113 @@
+// Plugin Feature Test File
+// Open this file in GoLand with the GALA plugin to verify all features.
+// Each section tests a specific plugin capability.
+
+package main
+
+import "fmt"
+
+// === 1. Syntax Highlighting ===
+// Keywords should be bold/colored: val, var, func, type, match, case, if, else, for, return
+
+// === 2. Built-in Type Recognition ===
+// These should be highlighted as types:
+// int, string, bool, float64, error, any, byte, rune
+
+// === 3. Struct Declaration + Named Args ===
+type Person struct {
+    val name string
+    val age int
+}
+
+// Hover over Person → should show fields
+// Type "Person(" → should suggest field names: name =, age =
+
+// === 4. Sealed Type + Pattern Matching ===
+sealed type Shape {
+    case Circle(radius float64)
+    case Rectangle(width float64, height float64)
+}
+
+// === 5. Function Declaration ===
+func area(s Shape) float64 {
+    // Hover over Shape → should show sealed cases
+    return s match {
+        // case completion: type "case " → should suggest Circle, Rectangle, _
+        // Type hints: x should show : float64 in pattern bindings
+        case Circle(r) => 3.14159 * r * r
+        case Rectangle(w, h) => w * h
+    }
+}
+
+// === 6. Type Inference + Inlay Hints ===
+func main() {
+    // These should show inferred type hints:
+    val greeting = "Hello"           // : string
+    val count = 42                   // : int
+    val pi = 3.14                    // : float64
+    val yes = true                   // : bool
+
+    // Constructor type inference:
+    val p = Person(name = "Alice", age = 30)  // : Person
+    val c = Circle(radius = 5.0)              // : Shape
+
+    // === 7. Short Variable Declaration (:=) ===
+    x := 100                         // : int
+
+    // === 8. Built-in Functions ===
+    // Println should be highlighted as built-in and offer completion
+    Println(greeting)
+    Println(area(c))
+    Print(count)
+
+    // Go built-ins should also be recognized:
+    val nums = SliceOf(1, 2, 3)
+    val length = len(nums)
+
+    // === 9. Dot Completion (Type-Aware) ===
+    // Type "p." → should suggest: name, age (fields) + methods
+    fmt.Println(p.name)
+
+    // === 10. Option Type + Method Chain ===
+    val opt = Some(42)
+    // Type "opt." → should suggest Option methods: Get, Map, FlatMap, IsDefined, etc.
+    val doubled = opt.Map((x int) => x * 2)
+    // Type "doubled." → should also suggest Option methods (Map returns Option)
+
+    // === 11. String Interpolation ===
+    val msg = s"Hello ${p.name}, age ${p.age}"    // $var and ${expr} should be highlighted
+    val formatted = f"$pi%.2f"
+
+    // === 12. Lambda Expressions ===
+    val double = (x int) => x * 2
+    val add = (a int, b int) => a + b
+    // Lambda params without types: type hints should show inferred types
+    // val mapped = opt.Map((x) => x + 1)
+
+    // === 13. Match as Expression ===
+    val desc = c match {
+        case Circle(r) => s"Circle with radius $r"
+        case Rectangle(w, h) => s"Rect ${w}x${h}"
+    }
+    Println(desc)
+
+    // === 14. If Expression ===
+    val max = if (count > 10) "big" else "small"
+    Println(max)
+
+    // === 15. For Loop ===
+    for i range nums {
+        Println(i)
+    }
+
+    // === 16. Structure View ===
+    // Open Structure view (Alt+7) → should show: Person, Shape, area, main
+
+    // === 17. Go to Definition ===
+    // Ctrl+Click on "Person" → should jump to type declaration
+    // Ctrl+Click on "area" → should jump to function declaration
+    // Ctrl+Click on "greeting" → should jump to val declaration
+
+    // === 18. Find Usages ===
+    // Right-click on "p" → Find Usages → should show all references
+}

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaAnnotator.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaAnnotator.kt
@@ -132,7 +132,12 @@ class GalaAnnotator : Annotator {
         var i = 0
 
         while (i < text.length) {
-            if (text[i] == '$' && i + 1 < text.length && text[i] != '\\') {
+            // Skip escaped dollars ($$)
+            if (text[i] == '$' && i + 1 < text.length && text[i + 1] == '$') {
+                i += 2
+                continue
+            }
+            if (text[i] == '$' && i + 1 < text.length && (i == 0 || text[i - 1] != '\\')) {
                 if (text[i + 1] == '{') {
                     // ${expression} — highlight the ${ and }
                     val braceStart = i

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaInspections.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaInspections.kt
@@ -28,6 +28,10 @@ class GalaDuplicateDeclarationInspection : LocalInspectionTool() {
 
     private fun collectTopLevelNames(element: PsiElement, seen: MutableMap<String, PsiElement>, holder: ProblemsHolder) {
         if (element is PsiNameIdentifierOwner) {
+            // Skip methods (functions with receivers) — same name on different types is valid
+            if (element is FunctionDeclarationNode && isMethodDeclaration(element)) {
+                return
+            }
             val name = element.name
             if (name != null && name.isNotBlank()) {
                 val existing = seen[name]
@@ -55,6 +59,32 @@ class GalaDuplicateDeclarationInspection : LocalInspectionTool() {
                 collectTopLevelNames(child, seen, holder)
             }
         }
+    }
+
+    /** Check if a function declaration has a receiver (making it a method). */
+    private fun isMethodDeclaration(func: FunctionDeclarationNode): Boolean {
+        // A method has a receiver node as a child before the function name
+        // In the PSI tree: func (receiver) name(...) -> has RULE_RECEIVER child
+        for (child in func.children) {
+            if (child.node.elementType == GalaTokenTypes.RULE_RECEIVER) {
+                return true
+            }
+        }
+        // Also check the text — methods start with "func ("
+        val text = func.text.trimStart()
+        if (text.startsWith("func (") || text.startsWith("func(")) {
+            // Could be a function with params, but if there's a second '(' it's a method
+            val firstParen = text.indexOf('(')
+            val closeParen = text.indexOf(')', firstParen + 1)
+            if (closeParen > 0 && closeParen < text.length - 1) {
+                // Check if there's an identifier after the closing paren
+                val afterParen = text.substring(closeParen + 1).trimStart()
+                if (afterParen.isNotEmpty() && (afterParen[0].isLetter() || afterParen[0] == '_')) {
+                    return true
+                }
+            }
+        }
+        return false
     }
 }
 

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -128,10 +128,19 @@ func methodCompletions(richAST *transpiler.RichAST) []lsp.CompletionItem {
 			}
 			seen[name] = true
 			sig := formatMethodSig(m)
+			var insertText string
+			if len(m.ParamNames) == 0 {
+				insertText = name + "()"
+			} else {
+				insertText = name + "("
+			}
 			items = append(items, lsp.CompletionItem{
-				Label:  name,
-				Kind:   kindPtr(lsp.CompletionItemKindMethod),
-				Detail: sig,
+				Label:      name + sig,
+				Kind:       kindPtr(lsp.CompletionItemKindMethod),
+				Detail:     sig,
+				InsertText: insertText,
+				FilterText: name,
+				SortText:   name,
 			})
 		}
 	}
@@ -332,16 +341,26 @@ func typeSpecificCompletions(richAST *transpiler.RichAST, typeName string) []lsp
 		return items
 	}
 
-	// Methods
+	// Methods — auto-insert () and show full signature
 	for name, m := range tm.Methods {
 		if !isExported(name) {
 			continue
 		}
 		sig := formatMethodSig(m)
+		// Auto-insert parentheses
+		var insertText string
+		if len(m.ParamNames) == 0 {
+			insertText = name + "()"
+		} else {
+			insertText = name + "("
+		}
 		items = append(items, lsp.CompletionItem{
-			Label:  name,
-			Kind:   kindPtr(lsp.CompletionItemKindMethod),
-			Detail: sig,
+			Label:      name + sig,
+			Kind:       kindPtr(lsp.CompletionItemKindMethod),
+			Detail:     sig,
+			InsertText: insertText,
+			FilterText: name,
+			SortText:   name,
 		})
 	}
 

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -49,6 +49,20 @@ func (h *GalaHandler) Definition(ctx context.Context, params *lsp.DefinitionPara
 		}
 	}
 
+	// Check import paths — clicking a package name navigates to its directory
+	for path, pkgName := range richAST.Packages {
+		if pkgName == word || word == path {
+			// Try to find the package directory
+			for _, searchPath := range h.getSearchPaths(uriToPath(uri)) {
+				pkgDir := searchPath + "/" + path
+				loc := findFirstGalaFile(pkgDir, word)
+				if loc != nil {
+					return []lsp.Location{*loc}, nil
+				}
+			}
+		}
+	}
+
 	// Local definition search
 	loc := localDefinition(text, word, uri)
 	if loc != nil {
@@ -56,6 +70,23 @@ func (h *GalaHandler) Definition(ctx context.Context, params *lsp.DefinitionPara
 	}
 
 	return nil, nil
+}
+
+func findFirstGalaFile(dir, name string) *lsp.Location {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".gala") {
+			absPath := dir + "/" + e.Name()
+			return &lsp.Location{
+				URI:   lsp.DocumentURI(pathToURI(absPath)),
+				Range: zeroRange(),
+			}
+		}
+	}
+	return nil
 }
 
 func (h *GalaHandler) References(ctx context.Context, params *lsp.ReferenceParams) ([]lsp.Location, error) {

--- a/internal/lsp/inlay_hints.go
+++ b/internal/lsp/inlay_hints.go
@@ -11,7 +11,13 @@ import (
 	"martianoff/gala/internal/transpiler"
 )
 
-var valDeclRegex = regexp.MustCompile(`^\s*(val|var)\s+(\w+)\s*=`)
+var (
+	valDeclRegex     = regexp.MustCompile(`^\s*(val|var)\s+(\w+)\s*=`)
+	shortDeclRegex   = regexp.MustCompile(`^\s*(\w+)\s*:=\s*(.+)$`)
+	lambdaParamRegex = regexp.MustCompile(`\(([^)]*)\)\s*=>`)
+	forRangeRegex    = regexp.MustCompile(`^\s*for\s+(\w+(?:\s*,\s*\w+)?)\s+(?::=\s+)?range\s+(\w+)`)
+	casePatternRegex = regexp.MustCompile(`^\s*case\s+(\w+)\(([^)]*)\)`)
+)
 
 func (h *GalaHandler) InlayHint(ctx context.Context, params *lsp.InlayHintParams) ([]lsp.InlayHint, error) {
 	uri := string(params.TextDocument.URI)
@@ -33,42 +39,239 @@ func (h *GalaHandler) InlayHint(ctx context.Context, params *lsp.InlayHintParams
 			continue
 		}
 
-		matches := valDeclRegex.FindStringSubmatchIndex(line)
-		if matches == nil {
-			continue
-		}
+		// 1. val/var declarations without explicit type
+		hints = append(hints, valDeclHints(line, i, richAST)...)
 
-		eqIdx := strings.Index(line[matches[5]:], "=")
-		if eqIdx < 0 {
-			continue
-		}
-		between := strings.TrimSpace(line[matches[5] : matches[5]+eqIdx])
-		if between != "" {
-			continue
-		}
+		// 1b. Short declarations: name := expr
+		hints = append(hints, shortDeclHints(line, i, richAST)...)
 
-		rhsStart := matches[5] + eqIdx + 1
-		if rhsStart >= len(line) {
-			continue
-		}
-		rhs := strings.TrimSpace(line[rhsStart:])
-		inferredType := inferType(rhs, richAST)
-		if inferredType == "" {
-			continue
-		}
+		// 2. Lambda parameters without types: (x) => or (x, y) =>
+		hints = append(hints, lambdaParamHints(line, i, text, richAST)...)
 
-		kind := lsp.InlayHintKindType
-		label, _ := json.Marshal(": " + inferredType)
-		paddingRight := true
-		hints = append(hints, lsp.InlayHint{
-			Position:     lsp.Position{Line: i, Character: matches[5]},
-			Label:        label,
-			Kind:         &kind,
-			PaddingRight: &paddingRight,
-		})
+		// 3. Pattern match bindings: case Some(x) =>
+		hints = append(hints, casePatternHints(line, i, richAST)...)
 	}
 
 	return hints, nil
+}
+
+func valDeclHints(line string, lineNum int, richAST *transpiler.RichAST) []lsp.InlayHint {
+	matches := valDeclRegex.FindStringSubmatchIndex(line)
+	if matches == nil {
+		return nil
+	}
+
+	eqIdx := strings.Index(line[matches[5]:], "=")
+	if eqIdx < 0 {
+		return nil
+	}
+	between := strings.TrimSpace(line[matches[5] : matches[5]+eqIdx])
+	if between != "" {
+		return nil // Has explicit type
+	}
+
+	rhsStart := matches[5] + eqIdx + 1
+	if rhsStart >= len(line) {
+		return nil
+	}
+	rhs := strings.TrimSpace(line[rhsStart:])
+	inferredType := inferType(rhs, richAST)
+	if inferredType == "" {
+		return nil
+	}
+
+	return []lsp.InlayHint{makeTypeHint(lineNum, matches[5], inferredType)}
+}
+
+func shortDeclHints(line string, lineNum int, richAST *transpiler.RichAST) []lsp.InlayHint {
+	m := shortDeclRegex.FindStringSubmatchIndex(line)
+	if m == nil {
+		return nil
+	}
+	// m[2]:m[3] is the variable name, m[4]:m[5] is the RHS
+	rhs := strings.TrimSpace(line[m[4]:m[5]])
+	inferredType := inferType(rhs, richAST)
+	if inferredType == "" {
+		return nil
+	}
+	return []lsp.InlayHint{makeTypeHint(lineNum, m[3], inferredType)}
+}
+
+func lambdaParamHints(line string, lineNum int, fullText string, richAST *transpiler.RichAST) []lsp.InlayHint {
+	// Find lambda patterns: (x) => or (x, y) =>
+	matches := lambdaParamRegex.FindAllStringSubmatchIndex(line, -1)
+	if matches == nil {
+		return nil
+	}
+
+	var hints []lsp.InlayHint
+	for _, m := range matches {
+		// m[2]:m[3] is the params group
+		paramsStr := line[m[2]:m[3]]
+		params := strings.Split(paramsStr, ",")
+
+		for _, param := range params {
+			param = strings.TrimSpace(param)
+			if param == "" {
+				continue
+			}
+			// Skip if already has a type annotation (contains space after name)
+			parts := strings.Fields(param)
+			if len(parts) > 1 {
+				continue // Has explicit type
+			}
+			paramName := parts[0]
+
+			// Try to infer from context — look for the method being called
+			// e.g., list.Map((x) => ...) — x is the element type of list
+			lambdaType := inferLambdaParamType(line, paramName, fullText, lineNum, richAST)
+			if lambdaType != "" {
+				// Find the param position in the line
+				paramPos := strings.Index(line[m[2]:m[3]], paramName)
+				if paramPos >= 0 {
+					col := m[2] + paramPos + len(paramName)
+					hints = append(hints, makeTypeHint(lineNum, col, lambdaType))
+				}
+			}
+		}
+	}
+	return hints
+}
+
+func casePatternHints(line string, lineNum int, richAST *transpiler.RichAST) []lsp.InlayHint {
+	// Match: case Some(x) => or case Left(val) =>
+	m := casePatternRegex.FindStringSubmatch(line)
+	if m == nil {
+		return nil
+	}
+
+	constructorName := m[1] // e.g., "Some", "Left"
+	bindings := m[2]         // e.g., "x" or "val, key"
+
+	// Find the sealed type and variant
+	var variant *transpiler.SealedVariant
+	for _, tm := range richAST.Types {
+		if !tm.IsSealed {
+			continue
+		}
+		for idx := range tm.SealedVariants {
+			if tm.SealedVariants[idx].Name == constructorName {
+				variant = &tm.SealedVariants[idx]
+				break
+			}
+		}
+		if variant != nil {
+			break
+		}
+	}
+
+	if variant == nil {
+		return nil
+	}
+
+	var hints []lsp.InlayHint
+	bindingParts := strings.Split(bindings, ",")
+	for i, binding := range bindingParts {
+		binding = strings.TrimSpace(binding)
+		if binding == "" || binding == "_" {
+			continue
+		}
+		// Skip if already has type annotation
+		if strings.Contains(binding, " ") {
+			continue
+		}
+		if i < len(variant.FieldTypes) {
+			typeName := variant.FieldTypes[i].String()
+			// Find position in line
+			pos := strings.Index(line, binding)
+			if pos >= 0 {
+				hints = append(hints, makeTypeHint(lineNum, pos+len(binding), typeName))
+			}
+		}
+	}
+	return hints
+}
+
+// inferLambdaParamType tries to infer a lambda parameter's type from the calling context.
+// e.g., in list.Map((x) => ...), if list is Array[Person], x is Person.
+func inferLambdaParamType(line, paramName, fullText string, lineNum int, richAST *transpiler.RichAST) string {
+	// Look for pattern: expr.MethodName((params) => ...)
+	// Find the method name before the lambda
+	lambdaIdx := strings.Index(line, "("+paramName)
+	if lambdaIdx < 0 {
+		lambdaIdx = strings.Index(line, "( "+paramName)
+	}
+	if lambdaIdx <= 0 {
+		return ""
+	}
+
+	// Walk backwards to find .MethodName(
+	i := lambdaIdx - 1
+	if i >= 0 && line[i] == '(' {
+		i--
+	}
+	// Find method name
+	methodEnd := i + 1
+	for i >= 0 && isIdentChar(line[i]) {
+		i--
+	}
+	if i < 0 || line[i] != '.' {
+		return ""
+	}
+	methodName := line[i+1 : methodEnd]
+
+	// Find receiver before the dot
+	dotPos := i
+	i = dotPos - 1
+	for i >= 0 && isIdentChar(line[i]) {
+		i--
+	}
+	receiverName := line[i+1 : dotPos]
+
+	// Resolve the receiver's type
+	receiverType := resolveBaseType(receiverName, fullText, lineNum, richAST)
+	if receiverType == "" {
+		return ""
+	}
+
+	// Find the method's first parameter type
+	tm := findType(richAST, receiverType)
+	if tm == nil {
+		return ""
+	}
+	method, ok := tm.Methods[methodName]
+	if !ok || len(method.ParamTypes) == 0 {
+		return ""
+	}
+
+	// For Map/Filter/ForEach etc., the param type is typically the element type
+	// The method's param is a function type like func(T) U
+	paramType := method.ParamTypes[0]
+	if paramType != nil {
+		typStr := paramType.String()
+		// If it's a func type, extract the param type
+		if strings.HasPrefix(typStr, "func(") {
+			inner := typStr[5:]
+			end := strings.Index(inner, ")")
+			if end > 0 {
+				return inner[:end]
+			}
+		}
+	}
+
+	return ""
+}
+
+func makeTypeHint(line, col int, typeName string) lsp.InlayHint {
+	kind := lsp.InlayHintKindType
+	label, _ := json.Marshal(": " + typeName)
+	paddingRight := true
+	return lsp.InlayHint{
+		Position:     lsp.Position{Line: line, Character: col},
+		Label:        label,
+		Kind:         &kind,
+		PaddingRight: &paddingRight,
+	}
 }
 
 func inferType(expr string, richAST *transpiler.RichAST) string {
@@ -91,29 +294,23 @@ func inferType(expr string, richAST *transpiler.RichAST) string {
 	}
 
 	if idx := strings.IndexAny(expr, "(["); idx > 0 {
-		typeName := expr[:idx]
-		if isExported(typeName) {
-			for key, tm := range richAST.Types {
-				name := tm.Name
-				if name == "" {
-					if i := strings.LastIndex(key, "."); i >= 0 {
-						name = key[i+1:]
-					}
-				}
-				if name == typeName {
-					return typeName
-				}
+		name := expr[:idx]
+		// Handle pkg.TypeName(...)
+		if dotIdx := strings.LastIndex(name, "."); dotIdx > 0 {
+			simpleName := name[dotIdx+1:]
+			if isExported(simpleName) {
+				return resolveConstructorReturnType(simpleName, richAST)
 			}
-			if _, ok := richAST.CompanionObjects[typeName]; ok {
-				return typeName
-			}
+		}
+		if isExported(name) {
+			return resolveConstructorReturnType(name, richAST)
 		}
 	}
 
 	if idx := strings.Index(expr, "("); idx > 0 {
 		funcName := expr[:idx]
 		if fm, ok := richAST.Functions[funcName]; ok && fm.ReturnType != nil && !fm.ReturnType.IsNil() {
-			return fm.ReturnType.String()
+			return fm.ReturnType.BaseName()
 		}
 	}
 

--- a/internal/lsp/typeatpos.go
+++ b/internal/lsp/typeatpos.go
@@ -128,9 +128,10 @@ func splitChain(expr string) []string {
 }
 
 var (
-	valVarDeclRe = regexp.MustCompile(`^\s*(val|var)\s+(\w+)\s+(\w[\w\[\], ]*)?\s*=\s*(.+)$`)
+	valVarDeclRe    = regexp.MustCompile(`^\s*(val|var)\s+(\w+)\s+(\w[\w\[\], ]*)?\s*=\s*(.+)$`)
 	valNotypeDeclRe = regexp.MustCompile(`^\s*(val|var)\s+(\w+)\s*=\s*(.+)$`)
-	paramRe      = regexp.MustCompile(`(\w+)\s+(\w[\w\[\]]*(?:\[[\w, ]+\])?)`)
+	shortDeclRe     = regexp.MustCompile(`^\s*(\w+)\s*:=\s*(.+)$`)
+	paramRe         = regexp.MustCompile(`(\w+)\s+(\w[\w\[\]]*(?:\[[\w, ]+\])?)`)
 )
 
 // resolveBaseType determines the type of the first element in a chain.
@@ -174,6 +175,14 @@ func resolveBaseType(expr, text string, currentLine int, richAST *transpiler.Ric
 				return inferRHSType(rhs, richAST)
 			}
 		}
+
+		// name := Expr (short variable declaration)
+		if m := shortDeclRe.FindStringSubmatch(line); m != nil {
+			if m[1] == name {
+				rhs := strings.TrimSpace(m[2])
+				return inferRHSType(rhs, richAST)
+			}
+		}
 	}
 
 	// 2. Check function parameters
@@ -203,7 +212,34 @@ func resolveBaseType(expr, text string, currentLine int, richAST *transpiler.Ric
 		}
 	}
 
-	// 3. Check for-range loop variables
+	// 3. Check if it's a known function call (not exported but in current package)
+	if fm, ok := richAST.Functions[name]; ok {
+		if fm.ReturnType != nil && !fm.ReturnType.IsNil() {
+			return fm.ReturnType.BaseName()
+		}
+	}
+
+	// 4. Check package-qualified access: pkg.Function(...)
+	if strings.Contains(expr, ".") {
+		parts := strings.SplitN(expr, ".", 2)
+		if len(parts) == 2 {
+			methodPart := parts[1]
+			methodName := methodPart
+			if idx := strings.Index(methodName, "("); idx > 0 {
+				methodName = methodName[:idx]
+			}
+			// Check if it's a package function
+			for _, tm := range richAST.Types {
+				if method, ok := tm.Methods[methodName]; ok {
+					if method.ReturnType != nil && !method.ReturnType.IsNil() {
+						return method.ReturnType.BaseName()
+					}
+				}
+			}
+		}
+	}
+
+	// 5. Check for-range loop variables
 	for i := currentLine; i >= 0; i-- {
 		line := strings.TrimSpace(lines[i])
 		if strings.HasPrefix(line, "for ") && strings.Contains(line, "range") {
@@ -219,11 +255,13 @@ func resolveBaseType(expr, text string, currentLine int, richAST *transpiler.Ric
 	return ""
 }
 
-// findType looks up a type in the RichAST by simple name.
+// findType looks up a type in the RichAST by simple name, handling aliases.
 func findType(richAST *transpiler.RichAST, name string) *transpiler.TypeMetadata {
+	// Direct lookup
 	if tm, ok := richAST.Types[name]; ok {
 		return tm
 	}
+	// Suffix match (package-qualified keys)
 	for key, tm := range richAST.Types {
 		typeName := tm.Name
 		if typeName == "" {
@@ -233,6 +271,15 @@ func findType(richAST *transpiler.RichAST, name string) *transpiler.TypeMetadata
 		}
 		if typeName == name {
 			return tm
+		}
+	}
+	// Check type aliases — resolve alias to underlying type and look up
+	if richAST.TypeAliases != nil {
+		if aliasType, ok := richAST.TypeAliases[name]; ok {
+			underlying := aliasType.BaseName()
+			if underlying != name {
+				return findType(richAST, underlying)
+			}
 		}
 	}
 	return nil
@@ -299,11 +346,34 @@ func inferRHSType(rhs string, richAST *transpiler.RichAST) string {
 		return "int"
 	}
 
-	// Constructor: Name(...) or Name[T](...)
+	// Constructor: Name(...) or Name[T](...) or pkg.Name(...) or alias.Name(...)
 	if idx := strings.IndexAny(rhs, "(["); idx > 0 {
 		name := rhs[:idx]
+		// Handle package-qualified: pkg.TypeName(...) or alias.TypeName(...)
+		if dotIdx := strings.LastIndex(name, "."); dotIdx > 0 {
+			simpleName := name[dotIdx+1:]
+			if isExported(simpleName) {
+				return resolveConstructorReturnType(simpleName, richAST)
+			}
+		}
 		if isExported(name) {
 			return resolveConstructorReturnType(name, richAST)
+		}
+	}
+
+	// Package-qualified method call: pkg.FuncName(...) or alias.FuncName(...)
+	if dotIdx := strings.Index(rhs, "."); dotIdx > 0 {
+		afterDot := rhs[dotIdx+1:]
+		if parenIdx := strings.Index(afterDot, "("); parenIdx > 0 {
+			funcName := afterDot[:parenIdx]
+			if isExported(funcName) {
+				// Check functions in all analyzed packages
+				if fm, ok := richAST.Functions[funcName]; ok {
+					if fm.ReturnType != nil && !fm.ReturnType.IsNil() {
+						return fm.ReturnType.BaseName()
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes all reported issues with the IntelliJ plugin and LSP server:

1. **False duplicate on methods with receivers** — skip methods in duplicate declaration inspection
2. **Package names clickable** — definition handler resolves import paths to package directories
3. **Method suggestions show full signatures** — `ToOption() Option[T]` with auto-inserted `()`
4. **Lambda type hints** — infer param types from calling context (`list.Map((x) => ...)`)
5. **Pattern match type hints** — show field types on case bindings (`case Some(x) =>` shows `: T`)
6. **Short declarations** — `:=` now gets type inference and inlay hints
7. **Package-qualified constructors** — `alias.TypeName(...)` and `pkg.TypeName(...)` resolved
8. **Type aliases** — resolved through `richAST.TypeAliases`
9. **String interpolation escape fix** — `$$` and `\$` handled correctly
10. **Plugin test file** — `ide/intellij/plugin_test_file.gala` with 18 test sections

## Test plan

- [x] `bazel build //cmd/gala:gala //ide/intellij:plugin` — both build
- [x] `bazel test //internal/lsp:lsp_test` — all tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)