### PR TITLE
refactor: simplify LSP code after review

### DIFF
--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -97,16 +97,6 @@ func NewSyntaxError(line, column int, msg string) *SyntaxError {
 	}
 }
 
-// NewSemanticError creates a new SemanticError.
-func NewSemanticError(msg string) *SemanticError {
-	return &SemanticError{
-		BaseError: BaseError{
-			Msg:     msg,
-			ErrType: TypeSemantic,
-		},
-	}
-}
-
 // NewSemanticErrorAt creates a SemanticError with line and column position.
 func NewSemanticErrorAt(line, column int, msg string) *SemanticError {
 	return &SemanticError{

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -27,9 +27,8 @@ func (h *GalaHandler) Completion(ctx context.Context, params *lsp.CompletionPara
 
 	if isDot && richAST != nil {
 		receiverType := typeAtDot(text, line, char, richAST, varTypeMap)
-		if strings.HasPrefix(receiverType, "__package__:") {
-			// Package dot completion — show types and functions from that package
-			pkgName := receiverType[len("__package__:"):]
+		if strings.HasPrefix(receiverType, packagePrefix) {
+			pkgName := strings.TrimPrefix(receiverType, packagePrefix)
 			items = append(items, packageCompletions(richAST, pkgName)...)
 		} else if receiverType != "" {
 			items = append(items, typeSpecificCompletions(richAST, receiverType)...)

--- a/internal/lsp/gotype.go
+++ b/internal/lsp/gotype.go
@@ -2,6 +2,14 @@ package lsp
 
 import "strings"
 
+// stripTypeParams removes generic type parameters: "Option[int]" → "Option".
+func stripTypeParams(s string) string {
+	if idx := strings.Index(s, "["); idx > 0 {
+		return s[:idx]
+	}
+	return s
+}
+
 // cleanGoTypeForDisplay converts GALA transpiler Type.String() to a display name.
 // Removes package prefixes and unwraps Immutable[T] → T.
 func cleanGoTypeForDisplay(typeStr string) string {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -151,7 +151,6 @@ func (h *GalaHandler) DidChange(ctx context.Context, params *lsp.DidChangeTextDo
 	// Start analysis after a short debounce to batch rapid keystrokes.
 	// Use a goroutine with sleep instead of AfterFunc for cleaner cancellation.
 	go func() {
-		// Short debounce — batches rapid keystrokes
 		select {
 		case <-time.After(300 * time.Millisecond):
 		case <-analysisCtx.Done():
@@ -197,7 +196,12 @@ func (h *GalaHandler) DidChange(ctx context.Context, params *lsp.DidChangeTextDo
 func (h *GalaHandler) DidClose(ctx context.Context, params *lsp.DidCloseTextDocumentParams) error {
 	uri := string(params.TextDocument.URI)
 	h.mu.Lock()
+	if cancel, ok := h.analysisCancels[uri]; ok {
+		cancel()
+		delete(h.analysisCancels, uri)
+	}
 	delete(h.documents, uri)
+	delete(h.docVersions, uri)
 	delete(h.richASTs, uri)
 	delete(h.varTypes, uri)
 	h.mu.Unlock()
@@ -393,20 +397,6 @@ func errorToDiagnostic(err error) lsp.Diagnostic {
 			line = l - 1
 			if n >= 2 {
 				char = c
-			}
-		}
-	}
-
-	// Also handle MultiError (multiple errors from parser/analyzer)
-	// by extracting the first line number from any sub-error
-	var multiErr *galaerr.MultiError
-	if errors.As(err, &multiErr) {
-		for _, subErr := range multiErr.Errors {
-			d := errorToDiagnostic(subErr)
-			if d.Range.Start.Line > 0 {
-				line = d.Range.Start.Line
-				char = d.Range.Start.Character
-				break
 			}
 		}
 	}

--- a/internal/lsp/typeatpos.go
+++ b/internal/lsp/typeatpos.go
@@ -9,6 +9,8 @@ import (
 
 var funcDeclPattern = regexp.MustCompile(`^\s*func\s+(?:\([^)]*\)\s+)?(\w+)`)
 
+const packagePrefix = "__package__:"
+
 // findEnclosingFunc scans lines backwards from the given line to find the enclosing function name.
 func findEnclosingFunc(lines []string, targetLine int) string {
 	for i := targetLine; i >= 0; i-- {
@@ -110,11 +112,7 @@ func typeAtDot(text string, line, char int, richAST *transpiler.RichAST, varType
 func resolveReceiverType(name, funcScope string, richAST *transpiler.RichAST, varTypes map[string]string) string {
 	// 1. Check transpiler's resolved var types (function-scoped)
 	if typStr := lookupVarType(varTypes, funcScope, name); typStr != "" {
-		base := typStr
-		if idx := strings.Index(base, "["); idx > 0 {
-			base = base[:idx]
-		}
-		return base
+		return stripTypeParams(typStr)
 	}
 
 	if richAST == nil {
@@ -124,11 +122,7 @@ func resolveReceiverType(name, funcScope string, richAST *transpiler.RichAST, va
 	// 2. Check if it's a function call return type
 	if fm, ok := richAST.Functions[name]; ok {
 		if fm.ReturnType != nil && !fm.ReturnType.IsNil() {
-			base := cleanGoTypeForDisplay(fm.ReturnType.String())
-			if idx := strings.Index(base, "["); idx > 0 {
-				base = base[:idx]
-			}
-			return base
+			return stripTypeParams(cleanGoTypeForDisplay(fm.ReturnType.String()))
 		}
 	}
 
@@ -147,14 +141,14 @@ func resolveReceiverType(name, funcScope string, richAST *transpiler.RichAST, va
 	// 4. Check if it's a package name → return package marker for package completion
 	for _, pkgName := range richAST.Packages {
 		if pkgName == name {
-			return "__package__:" + name
+			return packagePrefix + name
 		}
 	}
 
 	// 4b. Check if it's an import alias → resolve to actual package name
 	if richAST.ImportAliases != nil {
 		if pkgName, ok := richAST.ImportAliases[name]; ok {
-			return "__package__:" + pkgName
+			return packagePrefix + pkgName
 		}
 	}
 
@@ -168,9 +162,18 @@ func resolveReceiverType(name, funcScope string, richAST *transpiler.RichAST, va
 	return ""
 }
 
+const maxChainDepth = 10
+
 // resolveChainType resolves the type of a chain expression like "order.Validate()" or "x"
 // by recursively processing the text before the final dot.
 func resolveChainType(text string, funcScope string, richAST *transpiler.RichAST, varTypes map[string]string) string {
+	return resolveChainTypeN(text, funcScope, richAST, varTypes, 0)
+}
+
+func resolveChainTypeN(text string, funcScope string, richAST *transpiler.RichAST, varTypes map[string]string, depth int) string {
+	if depth > maxChainDepth {
+		return ""
+	}
 	text = strings.TrimSpace(text)
 	if text == "" {
 		return ""
@@ -178,13 +181,13 @@ func resolveChainType(text string, funcScope string, richAST *transpiler.RichAST
 
 	// If ends with ')' — method/function call, resolve its return type
 	if text[len(text)-1] == ')' {
-		depth := 1
+		parenDepth := 1
 		i := len(text) - 2
-		for i >= 0 && depth > 0 {
+		for i >= 0 && parenDepth > 0 {
 			if text[i] == ')' {
-				depth++
+				parenDepth++
 			} else if text[i] == '(' {
-				depth--
+				parenDepth--
 			}
 			i--
 		}
@@ -201,7 +204,7 @@ func resolveChainType(text string, funcScope string, richAST *transpiler.RichAST
 
 		// Check if there's a dot before the method name (chain)
 		if i >= 0 && text[i] == '.' {
-			receiverType := resolveChainType(text[:i], funcScope, richAST, varTypes)
+			receiverType := resolveChainTypeN(text[:i], funcScope, richAST, varTypes, depth+1)
 			if receiverType != "" {
 				return resolveMethodReturn(richAST, receiverType, methodName)
 			}
@@ -222,7 +225,7 @@ func resolveChainType(text string, funcScope string, richAST *transpiler.RichAST
 
 	// Check for dot before identifier (pkg.Type or receiver.field)
 	if i >= 0 && text[i] == '.' {
-		receiverType := resolveChainType(text[:i], funcScope, richAST, varTypes)
+		receiverType := resolveChainTypeN(text[:i], funcScope, richAST, varTypes, depth+1)
 		if receiverType != "" {
 			// Could be a field access — resolve field type
 			return resolveMethodReturn(richAST, receiverType, name)
@@ -240,20 +243,11 @@ func resolveMethodReturn(richAST *transpiler.RichAST, typeName, methodName strin
 	}
 	if m, ok := tm.Methods[methodName]; ok {
 		if m.ReturnType != nil && !m.ReturnType.IsNil() {
-			base := cleanGoTypeForDisplay(m.ReturnType.String())
-			if idx := strings.Index(base, "["); idx > 0 {
-				base = base[:idx]
-			}
-			return base
+			return stripTypeParams(cleanGoTypeForDisplay(m.ReturnType.String()))
 		}
 	}
-	// Check fields
 	if ft, ok := tm.Fields[methodName]; ok {
-		base := cleanGoTypeForDisplay(ft.String())
-		if idx := strings.Index(base, "["); idx > 0 {
-			base = base[:idx]
-		}
-		return base
+		return stripTypeParams(cleanGoTypeForDisplay(ft.String()))
 	}
 	return ""
 }

--- a/internal/transpiler/transformer/scope.go
+++ b/internal/transpiler/transformer/scope.go
@@ -30,14 +30,7 @@ func (t *galaASTTransformer) addVal(name string, typeName transpiler.Type) {
 		t.currentScope.vals[name] = true
 		t.currentScope.valTypes[name] = typeName
 	}
-	// Collect for LSP — scope by current function to prevent cross-function collisions
-	if t.lspVarTypes != nil && typeName != nil && !typeName.IsNil() {
-		key := name
-		if t.lspCurrentFunc != "" {
-			key = t.lspCurrentFunc + "." + name
-		}
-		t.lspVarTypes[key] = typeName
-	}
+	t.recordLSPVarType(name, typeName)
 }
 
 func (t *galaASTTransformer) addVar(name string, typeName transpiler.Type) {
@@ -45,30 +38,20 @@ func (t *galaASTTransformer) addVar(name string, typeName transpiler.Type) {
 		t.currentScope.vals[name] = false
 		t.currentScope.valTypes[name] = typeName
 	}
-	// Collect for LSP — scope by current function to prevent cross-function collisions
-	if t.lspVarTypes != nil && typeName != nil && !typeName.IsNil() {
-		key := name
-		if t.lspCurrentFunc != "" {
-			key = t.lspCurrentFunc + "." + name
-		}
-		t.lspVarTypes[key] = typeName
-	}
+	t.recordLSPVarType(name, typeName)
 }
 
-// collectAllVarTypes returns all variable types from the current scope stack.
-// Used by LSP to expose the transformer's resolved types.
-func (t *galaASTTransformer) collectAllVarTypes() map[string]transpiler.Type {
-	result := make(map[string]transpiler.Type)
-	s := t.currentScope
-	for s != nil {
-		for name, typ := range s.valTypes {
-			if _, exists := result[name]; !exists {
-				result[name] = typ
-			}
-		}
-		s = s.parent
+// recordLSPVarType stores a variable's type for LSP features (inlay hints, completion).
+// Keys are scoped by current function name to prevent cross-function collisions.
+func (t *galaASTTransformer) recordLSPVarType(name string, typeName transpiler.Type) {
+	if t.lspVarTypes == nil || typeName == nil || typeName.IsNil() {
+		return
 	}
-	return result
+	key := name
+	if t.lspCurrentFunc != "" {
+		key = t.lspCurrentFunc + "." + name
+	}
+	t.lspVarTypes[key] = typeName
 }
 
 func (t *galaASTTransformer) getType(name string) transpiler.Type {


### PR DESCRIPTION
## Summary

Code cleanup from `/simplify` review by 3 parallel agents (reuse, quality, efficiency).

### Code Reuse
- **`stripTypeParams()`** — new helper replacing 4 inline `strings.Index(base, "[")` patterns
- **`recordLSPVarType()`** — extracted from duplicate blocks in `addVal`/`addVar`
- **`packagePrefix` constant** — replaces stringly-typed `"__package__:"` across 3 files

### Dead Code Removal
- **`collectAllVarTypes()`** — unused since lspVarTypes scoping was introduced
- **Unreachable `MultiError` branch** in `errorToDiagnostic` — caller already unwraps
- **`NewSemanticError()` function** — all 34 callers now use `NewSemanticErrorAt`

### Correctness
- **`DidClose` cleanup** — cancels in-flight analysis goroutine, deletes `analysisCancels` and `docVersions` maps (previously leaked)
- **`resolveChainType` depth limit** — capped at 10 to prevent stack overflow on pathological chains

### Not Fixed (false positives / acceptable)
- `findEnclosingFunc` O(n) scan — acceptable for typical file sizes, caching adds complexity
- `lookupVarType` double map lookup — O(1), needed for scoped fallback
- `DidOpen`/`DidSave` synchronous analysis — LSP ordering guarantees prevent interleaving

🤖 Generated with [Claude Code](https://claude.com/claude-code)