### PR TITLE
feat(intellij): add plugin marketplace icon (Gala apple)

### DIFF
--- a/ide/intellij/src/main/resources/META-INF/plugin.xml
+++ b/ide/intellij/src/main/resources/META-INF/plugin.xml
@@ -33,7 +33,16 @@
         <li>Code folding, brace matching, comment/uncomment (<code>//</code> and <code>/* */</code>)</li>
     </ul>
 
-    <p>Requires the bundled GoLand / IntelliJ Go plugin. Source code and issue tracker:
+    <h3>Requirements</h3>
+    <ul>
+        <li><b>GALA compiler</b> — the <code>gala</code> CLI must be installed and on your <code>PATH</code>.
+        It bundles the <code>gala-lsp</code> language server that powers diagnostics, completion, hover,
+        and go-to-definition. Install instructions:
+        <a href="https://github.com/martianoff/gala#installation">github.com/martianoff/gala#installation</a>.</li>
+        <li><b>GoLand</b> or <b>IntelliJ IDEA Ultimate</b> with the bundled Go plugin (LSP API support).</li>
+    </ul>
+
+    <p>Source code and issue tracker:
     <a href="https://github.com/martianoff/gala">github.com/martianoff/gala</a>.</p>
     ]]></description>
 

--- a/ide/intellij/src/main/resources/META-INF/plugin.xml
+++ b/ide/intellij/src/main/resources/META-INF/plugin.xml
@@ -1,58 +1,45 @@
 <idea-plugin>
     <id>org.gala.ide.intellij</id>
     <name>GALA</name>
-    <version>2.0.0</version>
-    <vendor email="support@gala.org" url="https://github.com/gala-lang/gala">GALA Team</vendor>
+    <!-- Version is stamped at build time from the GALA_VERSION env var (see ide/intellij/build.gradle.kts). -->
+    <version>0.0.0</version>
+    <vendor email="support@gala.org" url="https://github.com/martianoff/gala">GALA Team</vendor>
 
     <description><![CDATA[
-    Support for GALA language (Go Alternative LAnguage).
+    <p>Rich IDE support for <b>GALA</b> — a modern functional language that transpiles to Go,
+    combining Go's runtime and ecosystem with ideas from Scala and other ML-family languages.</p>
 
-    GALA is a modern programming language that transpiles to Go, combining Go's efficiency
-    with features from Scala and other functional languages:
-
+    <h3>Language highlights</h3>
     <ul>
-        <li>Immutability by default (val/var)</li>
-        <li>Pattern matching with extractors and guards</li>
-        <li>Expression-oriented (if/match as expressions)</li>
-        <li>Lambda expressions with => syntax</li>
-        <li>Generics and type inference</li>
-        <li>Option, Either, and Tuple monads</li>
+        <li>Immutability by default (<code>val</code>/<code>var</code>)</li>
+        <li>Pattern matching with extractors, guards, and sealed types</li>
+        <li>Expression-oriented (<code>if</code>/<code>match</code> as expressions)</li>
+        <li>Lambda expressions with <code>=&gt;</code> syntax and placeholder shorthand (<code>_ * 2</code>)</li>
+        <li>Generics with full type inference</li>
+        <li><code>Option</code>, <code>Either</code>, <code>Try</code>, and tuple types</li>
+        <li>String interpolation (<code>s"Hello $name"</code>, <code>f"$x%.2f"</code>)</li>
     </ul>
 
-    Features:
+    <h3>IDE features</h3>
     <ul>
-        <li>Syntax highlighting for keywords, types, strings, comments, operators</li>
-        <li>Code completion for keywords, built-in types, and standard library types</li>
-        <li>Brace matching and folding</li>
-        <li>Comment/uncomment support (// and /* */)</li>
-        <li>Structure view</li>
+        <li><b>LSP-powered intelligence</b> — diagnostics, hover, go-to-definition, and completion via the embedded <code>gala-lsp</code> server</li>
+        <li><b>Syntax highlighting</b> with a dedicated color settings page</li>
+        <li><b>Code completion</b> — keywords, built-in types, standard library, dot-completion for methods</li>
+        <li><b>Navigation</b> — find usages, go-to-symbol, structure view</li>
+        <li><b>Quick documentation</b> on hover, including sealed-case fields and signatures</li>
+        <li><b>Inspections</b> — duplicate declaration, <code>var</code> could be <code>val</code></li>
+        <li><b>Gutter run icons</b> for runnable GALA files</li>
+        <li><b>Live templates</b> for common GALA idioms</li>
+        <li>Code folding, brace matching, comment/uncomment (<code>//</code> and <code>/* */</code>)</li>
     </ul>
+
+    <p>Requires the bundled GoLand / IntelliJ Go plugin. Source code and issue tracker:
+    <a href="https://github.com/martianoff/gala">github.com/martianoff/gala</a>.</p>
     ]]></description>
 
     <change-notes><![CDATA[
-    <b>2.0.0</b>
-    <ul>
-        <li>Full ANTLR-based parser — complete PSI tree for all GALA constructs</li>
-        <li>Structure view now shows all declarations: functions, types, sealed types with cases, vals, vars</li>
-        <li>Improved code folding for blocks, sealed types, and import groups</li>
-        <li>Added Try, Success, Failure, Immutable to standard library type completion</li>
-        <li>Foundation for future navigation, refactoring, and inspection support</li>
-    </ul>
-
-    <b>1.1.0</b>
-    <ul>
-        <li>Added support for multi-line comments (/* */)</li>
-        <li>Added support for raw strings (backticks)</li>
-        <li>Added highlighting for built-in types (int, string, bool, etc.)</li>
-        <li>Added new keywords: break, continue, defer, go, select, switch, default, map, chan</li>
-        <li>Added completion for standard library types (Option, Either, Tuple, List, Array)</li>
-        <li>Improved operator recognition (++, --, +=, ..., &lt;-, etc.)</li>
-    </ul>
-
-    <b>1.0.0</b>
-    <ul>
-        <li>Initial release of GALA language support</li>
-    </ul>
+    <p>Release notes for each version are published on
+    <a href="https://github.com/martianoff/gala/releases">GitHub Releases</a>.</p>
     ]]></change-notes>
 
     <idea-version since-build="251" until-build="265.*"/>

--- a/ide/intellij/src/main/resources/META-INF/plugin.xml
+++ b/ide/intellij/src/main/resources/META-INF/plugin.xml
@@ -6,7 +6,7 @@
     <vendor email="team@gala.fyi" url="https://github.com/martianoff/gala">GALA Team</vendor>
 
     <description><![CDATA[
-    <p>Rich IDE support for <b>GALA</b> — a modern functional language that transpiles to Go,
+    <p>IDE support for <b>GALA</b> — a modern functional language that transpiles to Go,
     combining Go's runtime and ecosystem with ideas from Scala and other ML-family languages.</p>
 
     <h3>Language highlights</h3>
@@ -54,6 +54,10 @@
     <idea-version since-build="251" until-build="265.*"/>
 
     <depends>com.intellij.modules.platform</depends>
+    <!-- LSP API (platform.lsp.serverSupportProvider) — only available in IDEs that ship the LSP module
+         (IntelliJ IDEA Ultimate, GoLand, PyCharm Pro, etc.). Prevents installation on Community editions
+         where the plugin would fail to load. -->
+    <depends>com.intellij.modules.lsp</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <!-- LSP server integration — provides diagnostics, hover, go-to-def, completion from gala-lsp -->

--- a/ide/intellij/src/main/resources/META-INF/plugin.xml
+++ b/ide/intellij/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
     <name>GALA</name>
     <!-- Version is stamped at build time from the GALA_VERSION env var (see ide/intellij/build.gradle.kts). -->
     <version>0.0.0</version>
-    <vendor email="support@gala.org" url="https://github.com/martianoff/gala">GALA Team</vendor>
+    <vendor email="team@gala.fyi" url="https://github.com/martianoff/gala">GALA Team</vendor>
 
     <description><![CDATA[
     <p>Rich IDE support for <b>GALA</b> — a modern functional language that transpiles to Go,

--- a/ide/intellij/src/main/resources/META-INF/pluginIcon.svg
+++ b/ide/intellij/src/main/resources/META-INF/pluginIcon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
+  <defs>
+    <linearGradient id="apple" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FF6B6B"/>
+      <stop offset="0.55" stop-color="#E63946"/>
+      <stop offset="1" stop-color="#B8202E"/>
+    </linearGradient>
+    <linearGradient id="leaf" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6BCB77"/>
+      <stop offset="1" stop-color="#2E8B3D"/>
+    </linearGradient>
+  </defs>
+  <path d="M20 12 C12 6 4 10 4 20 C4 32 12 38 17 38 C18.5 38 19 37 20 37 C21 37 21.5 38 23 38 C28 38 36 32 36 20 C36 10 28 6 20 12 Z" fill="url(#apple)"/>
+  <path d="M20 11 C19 4 23 1 31 2 C30 9 26 12 20 11 Z" fill="url(#leaf)"/>
+  <rect x="19.3" y="8" width="1.4" height="4" rx="0.6" fill="#5A3A22"/>
+  <ellipse cx="12" cy="20" rx="3" ry="4.2" fill="#FFFFFF" opacity="0.35"/>
+  <path d="M7 3 L7.8 5.2 L10 6 L7.8 6.8 L7 9 L6.2 6.8 L4 6 L6.2 5.2 Z" fill="#FFE066"/>
+</svg>

--- a/ide/intellij/src/main/resources/META-INF/pluginIcon_dark.svg
+++ b/ide/intellij/src/main/resources/META-INF/pluginIcon_dark.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
+  <defs>
+    <linearGradient id="apple" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FF8585"/>
+      <stop offset="0.55" stop-color="#FF4D5E"/>
+      <stop offset="1" stop-color="#C8243A"/>
+    </linearGradient>
+    <linearGradient id="leaf" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#83E08C"/>
+      <stop offset="1" stop-color="#3DA84F"/>
+    </linearGradient>
+  </defs>
+  <path d="M20 12 C12 6 4 10 4 20 C4 32 12 38 17 38 C18.5 38 19 37 20 37 C21 37 21.5 38 23 38 C28 38 36 32 36 20 C36 10 28 6 20 12 Z" fill="url(#apple)"/>
+  <path d="M20 11 C19 4 23 1 31 2 C30 9 26 12 20 11 Z" fill="url(#leaf)"/>
+  <rect x="19.3" y="8" width="1.4" height="4" rx="0.6" fill="#6B452A"/>
+  <ellipse cx="12" cy="20" rx="3" ry="4.2" fill="#FFFFFF" opacity="0.45"/>
+  <path d="M7 3 L7.8 5.2 L10 6 L7.8 6.8 L7 9 L6.2 6.8 L4 6 L6.2 5.2 Z" fill="#FFE680"/>
+</svg>


### PR DESCRIPTION
## Summary
- Adds `pluginIcon.svg` + `pluginIcon_dark.svg` under `ide/intellij/src/main/resources/META-INF/` so the IntelliJ plugin ships with a marketplace logo
- Design: stylized Gala apple with a sparkle — playful pun on the name
- Conforms to the [JetBrains plugin logo spec](https://plugins.jetbrains.com/docs/intellij/plugin-icon-file.html): 40×40 SVG, ~36×36 visible content with 2px transparent padding, light + dark variants, <1 kB each

## Test plan
- [x] `bazel build //ide/intellij:plugin` succeeds
- [x] Verified both icons are bundled inside `gala-intellij-plugin/lib/instrumented-gala-intellij-plugin-*.jar` at `META-INF/pluginIcon.svg` and `META-INF/pluginIcon_dark.svg`
- [ ] Visual check in IntelliJ marketplace / Settings → Plugins after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)