### PR TITLE
fix(lsp,intellij): completion recovery + type highlighting + interpolation color

### DIFF
--- a/ide/intellij/build.gradle.kts
+++ b/ide/intellij/build.gradle.kts
@@ -60,7 +60,7 @@ tasks {
     }
 
     patchPluginXml {
-        sinceBuild.set("251")
+        sinceBuild.set("252")
         untilBuild.set("265.*")
     }
 

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaAnnotator.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaAnnotator.kt
@@ -41,7 +41,7 @@ class GalaAnnotator : Annotator {
             "GALA_TYPE_PARAMETER", DefaultLanguageHighlighterColors.CLASS_NAME
         )
         val INTERPOLATION_VAR = TextAttributesKey.createTextAttributesKey(
-            "GALA_INTERPOLATION_VAR", DefaultLanguageHighlighterColors.VALID_STRING_ESCAPE
+            "GALA_INTERPOLATION_VAR", DefaultLanguageHighlighterColors.TEMPLATE_LANGUAGE_COLOR
         )
 
         private val BUILTIN_TYPE_NAMES = setOf(
@@ -135,6 +135,30 @@ class GalaAnnotator : Annotator {
                 return
             }
         }
+
+        // Any identifier sitting inside a type context (parameter type, return
+        // type, struct field type, generic arg, type alias RHS, etc.) gets the
+        // class-name color. This catches user-defined types like Request or
+        // Handler without requiring them in a hardcoded set.
+        if (isInsideTypeContext(element)) {
+            holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                .textAttributes(BUILTIN_TYPE)
+                .create()
+            return
+        }
+    }
+
+    private fun isInsideTypeContext(element: PsiElement): Boolean {
+        var node = element.parent
+        var depth = 0
+        while (node != null && depth < 8) {
+            if (node.node?.elementType === GalaTokenTypes.RULE_TYPE) {
+                return true
+            }
+            node = node.parent
+            depth++
+        }
+        return false
     }
 
     private fun annotateInterpolatedString(element: PsiElement, holder: AnnotationHolder) {

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/psi/GalaTokenTypes.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/psi/GalaTokenTypes.kt
@@ -77,4 +77,6 @@ object GalaTokenTypes {
     val RULE_PARAMETERS: IElementType get() = ruleIElementTypes[galaParser.RULE_parameters]
     val RULE_SIGNATURE: IElementType get() = ruleIElementTypes[galaParser.RULE_signature]
     val RULE_RECEIVER: IElementType get() = ruleIElementTypes[galaParser.RULE_receiver]
+    val RULE_TYPE: IElementType get() = ruleIElementTypes[galaParser.RULE_type]
+    val RULE_QUALIFIED_IDENTIFIER: IElementType get() = ruleIElementTypes[galaParser.RULE_qualifiedIdentifier]
 }

--- a/internal/lsp/BUILD.bazel
+++ b/internal/lsp/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//internal/transpiler/analyzer",
         "//internal/transpiler/generator",
         "//internal/transpiler/transformer",
+        "@com_github_antlr4_go_antlr_v4//:antlr",
         "@com_github_owenrumney_go_lsp//lsp",
         "@com_github_owenrumney_go_lsp//server",
     ],

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -25,6 +25,20 @@ func (h *GalaHandler) Completion(ctx context.Context, params *lsp.CompletionPara
 
 	isDot := isDotCompletion(text, line, char)
 
+	// If no richAST or no varTypes are cached (file has syntax errors since
+	// it was opened, or only partial analysis ran without the transformer),
+	// use the cursor position to surgically remove the dot trigger, re-parse
+	// the cleaned document, and cache the result. This is the "IntelliJ
+	// trick" used by rust-analyzer — targeted at the known cursor position,
+	// not a file-wide heuristic.
+	if isDot && (richAST == nil || len(varTypeMap) == 0) {
+		h.ensureAnalysis(uri, line, char)
+		h.mu.Lock()
+		richAST = h.richASTs[uri]
+		varTypeMap = h.varTypes[uri]
+		h.mu.Unlock()
+	}
+
 	if isDot && richAST != nil {
 		receiverType := typeAtDot(text, line, char, richAST, varTypeMap)
 		if strings.HasPrefix(receiverType, packagePrefix) {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/antlr4-go/antlr/v4"
 	"github.com/owenrumney/go-lsp/lsp"
 	golsp "github.com/owenrumney/go-lsp/server"
 
@@ -252,6 +253,11 @@ func (h *GalaHandler) analyzeFile(uri, filePath, text string) []lsp.Diagnostic {
 	tree, err := h.parser.Parse(text)
 	if err != nil {
 		diagnostics = append(diagnostics, errorsToDiagnostics(err)...)
+		// Primary parse failed — try ANTLR's error-recovered partial tree.
+		// If the analyzer can extract type metadata from it, cache the
+		// richAST so completion/hover/definition work while mid-edit.
+		partialTree, _ := h.parser.ParseLenient(text)
+		h.tryAnalyzePartial(uri, filePath, partialTree)
 		return diagnostics
 	}
 
@@ -352,6 +358,110 @@ func (h *GalaHandler) resolveProjectDeps(rootPath string) {
 		if info, err := os.Stat(depDir); err == nil && info.IsDir() {
 			h.extraSearchPaths = append(h.extraSearchPaths, depDir)
 		}
+	}
+}
+
+// tryAnalyzePartial attempts to analyze an error-recovered ANTLR tree.
+// The tree may contain nil or error nodes, so this is wrapped in a panic
+// recovery — a crash just means we skip caching rather than losing the
+// LSP connection. When it succeeds, the cached richAST/varTypes keep
+// completion and go-to-def working while the user is mid-edit.
+// tryAnalyzePartial runs the analyzer on ANTLR's error-recovered tree.
+// The tree may have nil/error nodes, so this is wrapped in panic recovery.
+func (h *GalaHandler) tryAnalyzePartial(uri, filePath string, tree antlr.Tree) {
+	if tree == nil {
+		return
+	}
+	defer func() { recover() }()
+
+	searchPaths := h.getSearchPaths(filePath)
+	a := analyzer.NewGalaAnalyzer(h.parser, searchPaths)
+	richAST, err := a.Analyze(tree, filePath)
+	if err != nil || richAST == nil {
+		return
+	}
+
+	h.mu.Lock()
+	h.richASTs[uri] = richAST
+	h.mu.Unlock()
+}
+
+// ensureAnalysis is called by the Completion handler when no cached richAST
+// exists. It uses the "IntelliJ trick" (also used by rust-analyzer): remove
+// the trigger character at the cursor position to produce a syntactically
+// valid document, parse + analyze it, and cache the result. This is surgical
+// — it touches only the character at the known cursor position, not the
+// entire file.
+func (h *GalaHandler) ensureAnalysis(uri string, line, char int) {
+	h.mu.Lock()
+	hasVarTypes := len(h.varTypes[uri]) > 0
+	if h.richASTs[uri] != nil && hasVarTypes {
+		h.mu.Unlock()
+		return
+	}
+	text := h.documents[uri]
+	h.mu.Unlock()
+
+	if text == "" {
+		return
+	}
+
+	lines := strings.Split(text, "\n")
+	if line >= len(lines) {
+		return
+	}
+	l := lines[line]
+
+	// Find the dot at or just before the cursor and remove it.
+	dotPos := -1
+	if char > 0 && char <= len(l) && l[char-1] == '.' {
+		dotPos = char - 1
+	} else {
+		// Walk back past partial identifier to find the dot
+		i := char - 1
+		for i >= 0 && i < len(l) && isIdentChar(l[i]) {
+			i--
+		}
+		if i >= 0 && i < len(l) && l[i] == '.' {
+			dotPos = i
+		}
+	}
+	if dotPos < 0 {
+		return
+	}
+
+	// Remove just the dot, producing e.g. "Text(\"hello\")" from "Text(\"hello\")."
+	lines[line] = l[:dotPos] + l[dotPos+1:]
+	cleanText := strings.Join(lines, "\n")
+
+	tree, err := h.parser.Parse(cleanText)
+	if err != nil {
+		return
+	}
+
+	filePath := uriToPath(uri)
+	searchPaths := h.getSearchPaths(filePath)
+	a := analyzer.NewGalaAnalyzer(h.parser, searchPaths)
+	richAST, aerr := a.Analyze(tree, filePath)
+	if aerr != nil || richAST == nil {
+		return
+	}
+
+	h.mu.Lock()
+	h.richASTs[uri] = richAST
+	h.mu.Unlock()
+
+	xformer := transformer.NewGalaASTTransformer()
+	result, _ := xformer.TransformForLSP(richAST)
+	if result != nil && result.VarTypes != nil {
+		typeMap := make(map[string]string, len(result.VarTypes))
+		for name, typ := range result.VarTypes {
+			typeMap[name] = cleanGoTypeForDisplay(typ.String())
+		}
+		h.mu.Lock()
+		h.varTypes[uri] = typeMap
+		h.lambdaHints[uri] = result.LambdaParamHints
+		h.mu.Unlock()
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -4338,6 +4338,122 @@ func TestDefinition_StructFieldNotInComment(t *testing.T) {
 	}
 }
 
+// TestCompletion_TrailingDotMidFile reproduces a user-reported bug where a
+// trailing `.` on a single-line expression-bodied function (e.g.
+// `func handler() Response = Text("hello").`) breaks the parser for the
+// entire file. The recovery parse must strip only the "bad" dot (whose
+// continuation is a new `func`) while keeping valid chain dots intact
+// in multi-line chains later in the same file.
+func TestCompletion_TrailingDotMidFile(t *testing.T) {
+	harness, _ := newHarnessWithHandler(t)
+	src := "package main\n" +
+		"\n" +
+		"type Resp struct { val body string }\n" +
+		"func (r Resp) WithHeader(k string, v string) Resp = Resp(body = r.body)\n" +
+		"func (r Resp) Done() string = r.body\n" +
+		"func Text(s string) Resp = Resp(body = s)\n" +
+		"\n" +
+		"func textHandler() Resp = Text(\"hello\").\n" +
+		"\n" +
+		"func htmlHandler() Resp = Text(\"<h1>hi</h1>\")\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val x = Text(\"a\").\n" +
+		"        WithHeader(\"k\", \"v\").\n" +
+		"        Done()\n" +
+		"    Println(x)\n" +
+		"}\n"
+	uri := openFileOnDisk(t, harness, src)
+	time.Sleep(200 * time.Millisecond)
+
+	// Cursor after the `.` on textHandler line (line 7)
+	line := "func textHandler() Resp = Text(\"hello\")."
+	list, err := harness.Completion(uri, 7, len(line))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasLabelPrefix(list, "Done") && !hasLabelPrefix(list, "WithHeader") {
+		t.Errorf("expected Resp completions after trailing dot mid-file, got %v", labelSlice(list))
+	}
+}
+
+// TestCompletion_MultiLineChainPartialIdent reproduces a user-reported
+// bug: inside a multi-line fluent chain, typing a prefix right after a dot
+// (`WithHeader(...).D`) produces no completions even though the same chain
+// with just `.` does work. The isDotCompletion walker must look past the
+// partial identifier before the cursor and the flattenLogicalLine helper
+// must then still reach back to the previous line.
+func TestCompletion_MultiLineChainPartialIdent(t *testing.T) {
+	harness, _ := newHarnessWithHandler(t)
+	src := "package main\n" +
+		"\n" +
+		"type Resp struct {\n" +
+		"    val body string\n" +
+		"}\n" +
+		"func (r Resp) WithHeader(k string, v string) Resp = Resp(body = r.body)\n" +
+		"func (r Resp) Done() string = r.body\n" +
+		"func NewResp() Resp = Resp(body = \"\")\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val x = NewResp().\n" +
+		"        WithHeader(\"A\", \"1\").\n" +
+		"        WithHeader(\"B\", \"2\").D\n" +
+		"    Println(x)\n" +
+		"}\n"
+	uri := openFileOnDisk(t, harness, src)
+	time.Sleep(200 * time.Millisecond)
+
+	lineIdx := 12
+	line := "        WithHeader(\"B\", \"2\").D"
+	col := len(line) // cursor right after D
+	list, err := harness.Completion(uri, lineIdx, col)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasLabelPrefix(list, "Done") && !hasLabelPrefix(list, "WithHeader") {
+		t.Errorf("expected Resp method completions after `.D` on multi-line chain, got %v", labelSlice(list))
+	}
+}
+
+// TestCompletion_MultiLineChainInLambdaInIfInFunc mimics the exact nesting
+// from the user's CorsWithConfig bug report: completion after a trailing
+// `.` in a multi-line chain inside a lambda body inside an `if` block
+// inside a function body.
+func TestCompletion_MultiLineChainInLambdaInIfInFunc(t *testing.T) {
+	harness, _ := newHarnessWithHandler(t)
+	// Open the file already in a "partial edit" state — trailing dot at the
+	// end of a multi-line chain — with no prior valid version cached. The
+	// LSP must recover enough tree to still produce method completions;
+	// otherwise the user would see keyword fallback every time they reopen
+	// the IDE with an unsaved chain.
+	broken := "package main\n" +
+		"\n" +
+		"type Req struct { val method string }\n" +
+		"type Resp struct { val body string }\n" +
+		"func (r Req) Method() string = r.method\n" +
+		"func (r Resp) WithHeader(k string, v string) Resp = Resp(body = r.body)\n" +
+		"func (r Resp) Done() string = r.body\n" +
+		"func NewResp() Resp = Resp(body = \"\")\n" +
+		"\n" +
+		"func CorsFilter() Resp = NewResp().\n" +
+		"    WithHeader(\"A\", \"1\").\n" +
+		"    WithHeader(\"B\", \"2\").\n" +
+		"    WithHeader(\"C\", \"3\").\n"
+	uri := openFileOnDisk(t, harness, broken)
+	time.Sleep(200 * time.Millisecond)
+
+	lineIdx := 12 // last chain line with trailing dot
+	line := "    WithHeader(\"C\", \"3\")."
+	col := len(line)
+	list, err := harness.Completion(uri, lineIdx, col)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasLabelPrefix(list, "Done") && !hasLabelPrefix(list, "WithHeader") {
+		t.Errorf("expected Resp method completions after `.` in multi-line chain opened mid-edit, got %v", labelSlice(list))
+	}
+}
+
 // TestDefinition_SealedVariantCrossFile covers go-to-def on a sealed variant
 // used in a different file from where it is declared. Clicking the variant
 // must land on the `case Xxx(...)` line inside the sealed type declaration,

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -17,6 +17,16 @@ func NewAntlrGalaParser() *AntlrGalaParser {
 }
 
 func (p *AntlrGalaParser) Parse(input string) (antlr.Tree, error) {
+	tree, errs := p.ParseLenient(input)
+	if len(errs) > 0 {
+		return nil, &galaerr.MultiError{Errors: errs}
+	}
+	return tree, nil
+}
+
+// ParseLenient always returns ANTLR's error-recovered tree alongside any
+// syntax errors. The tree contains error nodes but is structurally valid.
+func (p *AntlrGalaParser) ParseLenient(input string) (antlr.Tree, []error) {
 	is := antlr.NewInputStream(input)
 	lexer := grammar.NewgalaLexer(is)
 	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
@@ -32,15 +42,13 @@ func (p *AntlrGalaParser) Parse(input string) (antlr.Tree, error) {
 
 	tree := parser.SourceFile()
 
-	if len(errorListener.Errors) > 0 {
-		return nil, &galaerr.MultiError{Errors: errorListener.Errors}
-	}
-
+	var errs []error
+	errs = append(errs, errorListener.Errors...)
 	if err := p.checkEmptyLines(input, tree); err != nil {
-		return nil, &galaerr.MultiError{Errors: []error{err}}
+		errs = append(errs, err)
 	}
 
-	return tree, nil
+	return tree, errs
 }
 
 var emptyLineRegex = regexp.MustCompile(`\r?\n\s*\r?\n`)

--- a/internal/transpiler/parser.go
+++ b/internal/transpiler/parser.go
@@ -22,5 +22,10 @@ func (p *antlrGalaParser) Parse(input string) (antlr.Tree, error) {
 	return p.wrapper.Parse(input)
 }
 
+// ParseLenient implements the GalaParser interface.
+func (p *antlrGalaParser) ParseLenient(input string) (antlr.Tree, []error) {
+	return p.wrapper.ParseLenient(input)
+}
+
 // Ensure antlrGalaParser implements GalaParser interface.
 var _ GalaParser = (*antlrGalaParser)(nil)

--- a/internal/transpiler/transpiler.go
+++ b/internal/transpiler/transpiler.go
@@ -255,6 +255,12 @@ type CompanionObjectMetadata struct {
 // GalaParser defines the interface for parsing Gala source code.
 type GalaParser interface {
 	Parse(input string) (antlr.Tree, error)
+	// ParseLenient always returns ANTLR's error-recovered tree alongside any
+	// syntax errors. The tree may contain error nodes but is structurally
+	// valid enough for the analyzer to extract types, methods, and functions.
+	// Used by the LSP so completion/hover/definition keep working while the
+	// user is mid-edit.
+	ParseLenient(input string) (tree antlr.Tree, errors []error)
 }
 
 // Analyzer analyzes a Gala ANTLR parse tree and produces a RichAST.


### PR DESCRIPTION
## Summary

- LSP dot-completion now works on first open of files with syntax errors (no prior cached state needed)
- IntelliJ plugin highlights user-defined types in type positions and restores string interpolation colors
- Plugin compatibility bumped to IntelliJ 2025.2+

## Bugs fixed

- **Completion dead on fresh open of broken file.** When the user opens a file that already has a trailing `.` (e.g., IDE restart mid-edit), the parser fails and no richAST/varTypes were cached. Dot-completion fell back to keywords. Now: two-tier recovery — `tryAnalyzePartial` caches types from ANTLR's partial tree at DidOpen time, and `ensureAnalysis` surgically removes the dot at the known cursor position at Completion time to get full type inference.
- **String interpolation invisible.** Commit 891ca02 changed `INTERPOLATION_VAR` from `TEMPLATE_LANGUAGE_COLOR` to `VALID_STRING_ESCAPE`, which renders the same shade as `STRING` in most themes. Reverted.
- **User-defined types not highlighted.** `Request`, `Handler`, `Future[Response]` etc. had no type coloring because the annotator only checked hardcoded builtin/std sets. New `isInsideTypeContext` walks the PSI ancestor chain for `type_` rule nodes.

## Approach

### Completion recovery ("IntelliJ trick")

1. **DidOpen/DidChange** — `ParseLenient` returns ANTLR's error-recovered tree. `tryAnalyzePartial` runs the analyzer (not transformer) on it with panic recovery. Caches richAST with types/methods/fields.
2. **Completion** — if `richAST` or `varTypes` are missing, `ensureAnalysis` removes the single `.` at the cursor position, re-parses the cleaned document, runs full analysis + transformer. Surgical: one character at one known position, no file-wide scanning.

### Type highlighting

`isInsideTypeContext` walks up to 8 PSI ancestors looking for `RULE_TYPE`. Any identifier inside a type context gets `CLASS_NAME` color. This catches parameter types, return types, struct field types, generic args, and type alias RHS — all without maintaining a name set.

## Test plan

- [x] `bazel test //internal/lsp:lsp_test`
- [x] `bazel test //internal/transpiler/analyzer:analyzer_test`
- [x] `bazel test //internal/transpiler/transformer:transformer_test`
- [x] `bazel build //ide/intellij:plugin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)