### PR TITLE
fix(errors): coded errors GALA-E0007..E0014 + hint backfill (audit PR #1)

### DIFF
--- a/docs/errors/GALA-E0007.md
+++ b/docs/errors/GALA-E0007.md
@@ -1,0 +1,37 @@
+# GALA-E0007 — Slice literal not supported
+
+**When it fires.** A GALA source file uses a Go-style slice literal
+(`[]T{...}`) as an expression. Slices are not a first-class GALA construct.
+
+**Minimal repro.**
+
+```gala
+package main
+
+func main() {
+    val xs = []int{1, 2, 3}
+}
+```
+
+**Error output.**
+
+```
+[SemanticError GALA-E0007] main.gala:4:14 slice literals are not a first-class GALA construct (hint: use collection_immutable.Array or collection_mutable.Array for type-safe collections, or go_interop.SliceOf()/SliceEmpty() for Go interop)
+```
+
+**Fix.** Use a GALA collection or a Go-interop helper depending on intent:
+
+```gala
+import "collection_immutable"
+import "go_interop"
+
+val a = collection_immutable.ArrayOf(1, 2, 3)   // immutable, type-safe
+val s = go_interop.SliceOf(1, 2, 3)             // raw Go []int for interop
+```
+
+**Rationale.** GALA's type system reasons about immutable collections and
+explicit Go-interop shapes. A bare `[]int{...}` literal would sit outside
+that model and silently escape to Go, eliminating the compile-time
+guarantees that make GALA collections predictable (e.g. defensive copies,
+structural sharing). The error points the author at the two canonical
+replacements so the choice is explicit.

--- a/docs/errors/GALA-E0008.md
+++ b/docs/errors/GALA-E0008.md
@@ -1,0 +1,36 @@
+# GALA-E0008 — Map literal not supported
+
+**When it fires.** A GALA source file uses a Go-style map literal
+(`map[K]V{...}`) as an expression. Maps are not a first-class GALA construct.
+
+**Minimal repro.**
+
+```gala
+package main
+
+func main() {
+    val m = map[string]int{"a": 1, "b": 2}
+}
+```
+
+**Error output.**
+
+```
+[SemanticError GALA-E0008] main.gala:4:13 map literals are not a first-class GALA construct (hint: use collection_immutable.HashMap or collection_mutable.HashMap for type-safe maps, or go_interop.MapEmpty()/MapPut() for Go interop)
+```
+
+**Fix.** Use a GALA `HashMap` or Go-interop helpers:
+
+```gala
+import "collection_immutable"
+import "go_interop"
+
+val m  = collection_immutable.HashMapOf(("a", 1), ("b", 2))
+val g  = go_interop.MapPut(go_interop.MapEmpty[string, int](), "a", 1)
+```
+
+**Rationale.** Same as GALA-E0007: GALA reasons about its own immutable map
+types. Allowing raw Go map literals would erase the GALA-side invariants
+(unordered iteration semantics aside, immutable maps can safely be shared
+without defensive copies). Forcing the caller to name one of the two
+supported paths keeps that distinction visible at the call site.

--- a/docs/errors/GALA-E0009.md
+++ b/docs/errors/GALA-E0009.md
@@ -1,0 +1,28 @@
+# GALA-E0009 — Unknown pattern type
+
+**When it fires.** The transformer reached a pattern AST node it does not
+recognize. This is defensive — the ANTLR grammar is supposed to prevent any
+pattern shape that the transformer cannot handle from being parsed in the
+first place.
+
+**Minimal repro.** None — reaching this error means either
+
+1. a new grammar rule for patterns was added but no transformer case was
+   written for it, or
+2. the grammar accepts a shape that the transformer has never supported.
+
+**Error output.**
+
+```
+[SemanticError GALA-E0009] main.gala:L:C unrecognized pattern syntax (internal type *grammar.FooPatternContext) (hint: this usually means a new grammar rule is missing transformer support; please report at github.com/martianoff/gala/issues)
+```
+
+**Fix.** Report the issue with the offending source file and the exact
+context type shown in the error. The transpiler needs a new case in
+`transformPatternWithType` (`internal/transpiler/transformer/patterns.go`).
+
+**Rationale.** Before this code existed the site used a raw
+`fmt.Errorf("unknown pattern type: %T", patCtx)` which produced an
+untracked error without a source span. Users who hit it had no way to
+distinguish "transpiler bug" from "my syntax is wrong". The coded error
+makes the bug class explicit so issues can be filed with a queryable tag.

--- a/docs/errors/GALA-E0010.md
+++ b/docs/errors/GALA-E0010.md
@@ -1,0 +1,28 @@
+# GALA-E0010 — Duplicate package name in directory
+
+**When it fires.** Two or more `.gala` files in the same directory declare
+different `package` names, and the current file is not a `_test.gala` file.
+Test files may diverge by one character (like Go's `pkg_test` convention);
+regular sources cannot.
+
+**Minimal repro.**
+
+```
+lib/a.gala  // package mylib
+lib/b.gala  // package other   <-- triggers the error
+```
+
+**Error output.**
+
+```
+[SemanticError GALA-E0010] b.gala:1:0 directory lib has files with different package names: "mylib" and "other" (hint: use the same package name across all sibling .gala files, or move the file to a different directory)
+```
+
+**Fix.** Either rename one of the packages so both files agree, or move the
+outlier file into its own directory.
+
+**Rationale.** GALA's sibling-file resolution treats every `.gala` file in a
+directory as part of the same compilation unit, so conflicting package
+names break cross-file type resolution. Catching the mismatch at the
+analyzer layer is much cheaper than letting it surface as a series of
+"unresolved identifier" errors during transform.

--- a/docs/errors/GALA-E0011.md
+++ b/docs/errors/GALA-E0011.md
@@ -1,0 +1,32 @@
+# GALA-E0011 — Type redefined
+
+**When it fires.** A `type` / `struct-shorthand` / `sealed type` with the
+same name is declared more than once in the same package (across any
+combination of files).
+
+**Minimal repro.**
+
+```gala
+// a.gala
+package main
+type User struct { Name string }
+
+// b.gala
+package main
+type User struct { Email string }   // redefines User
+```
+
+**Error output.**
+
+```
+[SemanticError GALA-E0011] b.gala:2:5 type "User" in package "main" redefined (first defined in a.gala) (hint: remove the duplicate declaration or rename one of the types)
+```
+
+**Fix.** Delete one of the declarations, merge their fields, or rename one
+of the types so both can coexist.
+
+**Rationale.** The transpiler builds a single canonical metadata entry per
+type; a second declaration would silently overwrite the first, producing
+surprising method-dispatch behavior and generated Go that references fields
+that no longer exist. Catching the duplicate at the analyzer layer makes
+the collision obvious.

--- a/docs/errors/GALA-E0012.md
+++ b/docs/errors/GALA-E0012.md
@@ -1,0 +1,30 @@
+# GALA-E0012 — Method redefined
+
+**When it fires.** A method with the same name is declared twice on the same
+type (across any combination of files).
+
+**Minimal repro.**
+
+```gala
+// a.gala
+package main
+type User struct { Name string }
+func (u User) Greet() string = "hello"
+
+// b.gala
+package main
+func (u User) Greet() string = "hola"   // duplicate
+```
+
+**Error output.**
+
+```
+[SemanticError GALA-E0012] b.gala:2:5 method "Greet" on type "User" in package "main" redefined (first defined in a.gala) (hint: remove the duplicate method or rename it)
+```
+
+**Fix.** Delete one of the definitions or rename the second method.
+
+**Rationale.** Method resolution uses a single map keyed by method name; a
+second declaration would silently replace the first, making the behavior
+order-of-loading dependent and hard to debug. This also mirrors Go's own
+rule — Go forbids duplicate methods on the same receiver.

--- a/docs/errors/GALA-E0013.md
+++ b/docs/errors/GALA-E0013.md
@@ -1,0 +1,34 @@
+# GALA-E0013 — Non-defaulted parameter after defaulted parameter
+
+**When it fires.** A function signature declares a parameter without a
+default after a parameter that has one. Defaults must be contiguous and at
+the tail of the parameter list.
+
+**Minimal repro.**
+
+```gala
+package main
+
+func create(a int = 5, b int) int = a + b
+//                     ^^^^^^ no default, but follows a default
+```
+
+**Error output.**
+
+```
+[SemanticError GALA-E0013] main.gala:3:5 parameter "b" in create has no default but follows a parameter with a default (hint: move parameters with defaults to the end of the parameter list)
+```
+
+**Fix.** Reorder the parameters so all defaults come last, or give the
+follower a default too:
+
+```gala
+func create(b int, a int = 5) int = a + b
+// or
+func create(a int = 5, b int = 0) int = a + b
+```
+
+**Rationale.** With mixed defaults the call-site rules become ambiguous:
+what does `create(7)` mean — `a = 7, b = default?` or `a = default, b = 7`?
+Requiring contiguous trailing defaults makes positional calls unambiguous
+while still allowing named-argument calls to pick any subset.

--- a/docs/errors/GALA-E0014.md
+++ b/docs/errors/GALA-E0014.md
@@ -1,0 +1,38 @@
+# GALA-E0014 — Default expression type mismatch
+
+**When it fires.** A parameter's default-value literal is statically
+incompatible with the parameter's declared type.
+
+**Minimal repro.**
+
+```gala
+package main
+
+func create(a int = "not-an-int") int = a
+//                  ^^^^^^^^^^^^ string literal does not match int
+```
+
+**Error output.**
+
+```
+[SemanticError GALA-E0014] main.gala:3:5 default for parameter "a" has type string, expected int (hint: fix the default expression or change the parameter type)
+```
+
+**Fix.** Either adjust the default expression to match the parameter type
+or change the parameter type to match the intended default:
+
+```gala
+func create(a int    = 0)            int    = a
+func create(a string = "not-an-int") string = a
+```
+
+**Rationale.** Default-argument injection happens at the call site, so a
+mismatched default would either fail to compile in Go with a less
+actionable error, or (worse) silently round-trip through an implicit
+conversion. Catching the mismatch at analyzer time keeps the error near
+the declaration where the fix is obvious.
+
+Currently the check runs only for literal defaults — non-literal
+expressions (like `f()` or `x + 1`) skip the check because their types
+depend on resolution context. The literal subset catches the cases most
+likely to be typos.

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -21,6 +21,14 @@ Each code has a dedicated documentation page in this directory explaining:
 | `GALA-E0004` | Sealed variant arity mismatch | [GALA-E0004.md](GALA-E0004.md) |
 | `GALA-E0005` | Missing `Unapply` on extractor | [GALA-E0005.md](GALA-E0005.md) |
 | `GALA-E0006` | Multiple default cases | [GALA-E0006.md](GALA-E0006.md) |
+| `GALA-E0007` | Slice literal not supported | [GALA-E0007.md](GALA-E0007.md) |
+| `GALA-E0008` | Map literal not supported | [GALA-E0008.md](GALA-E0008.md) |
+| `GALA-E0009` | Unknown pattern type | [GALA-E0009.md](GALA-E0009.md) |
+| `GALA-E0010` | Duplicate package name in directory | [GALA-E0010.md](GALA-E0010.md) |
+| `GALA-E0011` | Type redefined | [GALA-E0011.md](GALA-E0011.md) |
+| `GALA-E0012` | Method redefined | [GALA-E0012.md](GALA-E0012.md) |
+| `GALA-E0013` | Non-defaulted parameter after defaulted parameter | [GALA-E0013.md](GALA-E0013.md) |
+| `GALA-E0014` | Default expression type mismatch | [GALA-E0014.md](GALA-E0014.md) |
 
 ## Adding a new code
 

--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -102,6 +102,30 @@ const (
 
 	// E0006: multiple default cases in a single match expression.
 	CodeMultipleDefaults ErrorCode = "GALA-E0006"
+
+	// E0007: slice literal in GALA source; slices are not a first-class literal.
+	CodeSliceLiteralNotSupported ErrorCode = "GALA-E0007"
+
+	// E0008: map literal in GALA source; maps are not a first-class literal.
+	CodeMapLiteralNotSupported ErrorCode = "GALA-E0008"
+
+	// E0009: pattern AST node the transformer does not recognize (defensive).
+	CodeUnknownPatternType ErrorCode = "GALA-E0009"
+
+	// E0010: sibling .gala files in the same directory declare different packages.
+	CodeDuplicatePackageName ErrorCode = "GALA-E0010"
+
+	// E0011: type with the same name declared more than once in a package.
+	CodeTypeRedefinition ErrorCode = "GALA-E0011"
+
+	// E0012: method with the same name declared more than once on a type.
+	CodeMethodRedefinition ErrorCode = "GALA-E0012"
+
+	// E0013: non-defaulted parameter follows a parameter with a default value.
+	CodeParamMissingDefaultAfterDefault ErrorCode = "GALA-E0013"
+
+	// E0014: default value expression type does not match the parameter type.
+	CodeParamDefaultTypeMismatch ErrorCode = "GALA-E0014"
 )
 
 // MultiError collects multiple GALA errors.

--- a/internal/transpiler/analyzer/BUILD.bazel
+++ b/internal/transpiler/analyzer/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "martianoff/gala/internal/transpiler/analyzer",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//galaerr",
         "//internal/parser/grammar",
         "//internal/transpiler",
         "//internal/transpiler/generator",

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 
+	"martianoff/gala/galaerr"
 	"martianoff/gala/internal/parser/grammar"
 	"martianoff/gala/internal/transpiler"
 	"martianoff/gala/internal/transpiler/generator"
@@ -224,9 +225,15 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 			if !ok {
 				continue
 			}
-			otherPkgName := otherSF.PackageClause().(*grammar.PackageClauseContext).Identifier().GetText()
+			pkgClause := otherSF.PackageClause().(*grammar.PackageClauseContext)
+			otherPkgName := pkgClause.Identifier().GetText()
 			if otherPkgName != pkgName {
-				return nil, fmt.Errorf("package file %s has package %s, expected %s", pf, otherPkgName, pkgName)
+				return nil, galaerr.NewCodedSemanticError(
+					galaerr.CodeDuplicatePackageName,
+					pkgClause.GetStart().GetLine(), pkgClause.GetStart().GetColumn(),
+					fmt.Sprintf("package file %s declares package %q but sibling files declare %q", pf, otherPkgName, pkgName),
+					"use the same package name across all sibling .gala files, or move the file to a different directory",
+				)
 			}
 			siblingTrees = append(siblingTrees, otherSF)
 			siblingPaths = append(siblingPaths, pf)
@@ -260,12 +267,18 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 						if !ok {
 							continue
 						}
-						otherPkgName := otherSF.PackageClause().(*grammar.PackageClauseContext).Identifier().GetText()
+						pkgClause := otherSF.PackageClause().(*grammar.PackageClauseContext)
+						otherPkgName := pkgClause.Identifier().GetText()
 						siblingIsTest := strings.HasSuffix(f.Name(), "_test.gala")
 						currentIsTest := strings.HasSuffix(filePath, "_test.gala")
 						// Allow _test.gala files to have different package names (like Go's _test.go convention)
 						if otherPkgName != pkgName && !(siblingIsTest || currentIsTest) {
-							return nil, fmt.Errorf("multiple package names in directory %s: %s and %s", dirPath, pkgName, otherPkgName)
+							return nil, galaerr.NewCodedSemanticError(
+								galaerr.CodeDuplicatePackageName,
+								pkgClause.GetStart().GetLine(), pkgClause.GetStart().GetColumn(),
+								fmt.Sprintf("directory %s has files with different package names: %q and %q", dirPath, pkgName, otherPkgName),
+								"use the same package name across all sibling .gala files, or move the file to a different directory",
+							)
 						}
 						// Include sibling if packages match AND (sibling is not test OR current is test)
 						// This follows Go semantics: test files see all package siblings during testing
@@ -518,9 +531,12 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 				// Error if type is being redefined from a DIFFERENT file.
 				// Skip if DefinedIn is empty (cache) or same file (re-analysis from analyzePackage).
 				if existing.DefinedIn != "" && hasTypeDefinition(existing) && !(existing.DefinedIn != filePath && isSameFile(existing.DefinedIn, absFilePath)) {
-					line := ctx.GetStart().GetLine()
-					return nil, fmt.Errorf("%s:%d: type %q in package %q redefined (first defined in %s)",
-						filePath, line, typeName, pkgName, existing.DefinedIn)
+					return nil, galaerr.NewCodedSemanticError(
+						galaerr.CodeTypeRedefinition,
+						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+						fmt.Sprintf("type %q in package %q redefined (first defined in %s)", typeName, pkgName, existing.DefinedIn),
+						"remove the duplicate declaration or rename one of the types",
+					)
 				}
 				meta = existing
 				// Clear fields to avoid duplicates if re-analyzing
@@ -637,9 +653,12 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 			pos := transpiler.PosFromToken(ctx.Identifier().GetStart())
 			if existing, ok := richAST.Types[fullTypeName]; ok && existing.Package == pkgName {
 				if existing.DefinedIn != "" && hasTypeDefinition(existing) && !(existing.DefinedIn != filePath && isSameFile(existing.DefinedIn, absFilePath)) {
-					line := ctx.GetStart().GetLine()
-					return nil, fmt.Errorf("%s:%d: type %q in package %q redefined (first defined in %s)",
-						filePath, line, typeName, pkgName, existing.DefinedIn)
+					return nil, galaerr.NewCodedSemanticError(
+						galaerr.CodeTypeRedefinition,
+						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+						fmt.Sprintf("type %q in package %q redefined (first defined in %s)", typeName, pkgName, existing.DefinedIn),
+						"remove the duplicate declaration or rename one of the types",
+					)
 				}
 				meta = existing
 				meta.Fields = make(map[string]transpiler.Type)
@@ -696,9 +715,12 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 			}
 			// Check for redefinition (skip if DefinedIn is empty — type came from cache)
 			if existing, ok := richAST.Types[fullSealedName]; ok && existing.DefinedIn != "" && hasTypeDefinition(existing) && !(existing.DefinedIn != filePath && isSameFile(existing.DefinedIn, absFilePath)) {
-				line := ctx.GetStart().GetLine()
-				return nil, fmt.Errorf("%s:%d: type %q in package %q redefined (first defined in %s)",
-					filePath, line, sealedName, pkgName, existing.DefinedIn)
+				return nil, galaerr.NewCodedSemanticError(
+					galaerr.CodeTypeRedefinition,
+					ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+					fmt.Sprintf("type %q in package %q redefined (first defined in %s)", sealedName, pkgName, existing.DefinedIn),
+					"remove the duplicate declaration or rename one of the types",
+				)
 			}
 			a.analyzeSealedType(ctx, pkgName, richAST)
 			if meta, ok := richAST.Types[fullSealedName]; ok {
@@ -798,9 +820,12 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 						if existing, exists := typeMeta.Methods[methodName]; exists {
 							// Error if method already has a user-defined implementation
 							if existing.DefinedIn != "" && !(existing.DefinedIn != filePath && isSameFile(existing.DefinedIn, absFilePath)) {
-								line := ctx.GetStart().GetLine()
-								return nil, fmt.Errorf("%s:%d: method %q on type %q in package %q redefined (first defined in %s)",
-									filePath, line, methodName, baseType, pkgName, existing.DefinedIn)
+								return nil, galaerr.NewCodedSemanticError(
+									galaerr.CodeMethodRedefinition,
+									ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+									fmt.Sprintf("method %q on type %q in package %q redefined (first defined in %s)", methodName, baseType, pkgName, existing.DefinedIn),
+									"remove the duplicate method or rename it",
+								)
 							}
 							// Preserve IsGeneric if it was pre-populated
 							methodMeta.IsGeneric = existing.IsGeneric
@@ -879,7 +904,7 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 					}
 				}
 				// Validate default parameter rules
-				if err := validateDefaultParams(funcMeta, ctx.GetStart().GetLine(), filePath); err != nil {
+				if err := validateDefaultParams(funcMeta, ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(), filePath); err != nil {
 					return nil, err
 				}
 				richAST.Functions[fullFuncName] = funcMeta
@@ -1830,8 +1855,12 @@ func (a *galaAnalyzer) analyzePackage(relPath string) (*transpiler.RichAST, erro
 					}
 					if existingMeta, ok := pkgAST.Types[typeName]; ok {
 						if hasTypeDefinition(existingMeta) && existingMeta.DefinedIn != "" && !sameAsFilePath(existingMeta.DefinedIn) {
-							return nil, fmt.Errorf("type %q in package %q redefined (first defined in %s)",
-								newMeta.Name, res.PackageName, existingMeta.DefinedIn)
+							return nil, galaerr.NewCodedSemanticError(
+								galaerr.CodeTypeRedefinition,
+								newMeta.Pos.Line, newMeta.Pos.Column,
+								fmt.Sprintf("type %q in package %q redefined (first defined in %s)", newMeta.Name, res.PackageName, existingMeta.DefinedIn),
+								"remove the duplicate declaration or rename one of the types",
+							)
 						}
 					}
 				}
@@ -2119,7 +2148,12 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 			// Skip if DefinedIn is empty — the type came from cache and should be overwritable.
 			if existing, ok := richAST.Types[fullTypeName]; ok && len(existing.FieldNames) > 0 {
 				if existing.DefinedIn != "" && !isSameFile(existing.DefinedIn, absSibPath) {
-					return fmt.Errorf("type %q in package %q redefined (first defined in %s)", typeName, pkgName, existing.DefinedIn)
+					return galaerr.NewCodedSemanticError(
+						galaerr.CodeTypeRedefinition,
+						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+						fmt.Sprintf("type %q in package %q redefined (first defined in %s)", typeName, pkgName, existing.DefinedIn),
+						"remove the duplicate declaration or rename one of the types",
+					)
 				}
 				if existing.DefinedIn != "" {
 					continue
@@ -2245,7 +2279,12 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 			}
 			if existing, ok := richAST.Types[fullTypeName]; ok && len(existing.FieldNames) > 0 {
 				if existing.DefinedIn != "" && !isSameFile(existing.DefinedIn, absSibPath) {
-					return fmt.Errorf("type %q in package %q redefined (first defined in %s)", typeName, pkgName, existing.DefinedIn)
+					return galaerr.NewCodedSemanticError(
+						galaerr.CodeTypeRedefinition,
+						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+						fmt.Sprintf("type %q in package %q redefined (first defined in %s)", typeName, pkgName, existing.DefinedIn),
+						"remove the duplicate declaration or rename one of the types",
+					)
 				}
 				if existing.DefinedIn != "" {
 					continue
@@ -2309,7 +2348,12 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 			// Skip if DefinedIn is empty — the type came from cache.
 			if existing, ok := richAST.Types[fullTypeName]; ok && existing.IsSealed {
 				if existing.DefinedIn != "" && !isSameFile(existing.DefinedIn, absSibPath) {
-					return fmt.Errorf("type %q in package %q redefined (first defined in %s)", typeName, pkgName, existing.DefinedIn)
+					return galaerr.NewCodedSemanticError(
+						galaerr.CodeTypeRedefinition,
+						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+						fmt.Sprintf("type %q in package %q redefined (first defined in %s)", typeName, pkgName, existing.DefinedIn),
+						"remove the duplicate declaration or rename one of the types",
+					)
 				}
 				if existing.DefinedIn != "" {
 					continue
@@ -2478,7 +2522,8 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 // 1. Parameters with defaults must come after all required parameters
 // 2. Variadic parameters cannot have defaults
 // 3. Default expression types must be compatible with parameter types (for literals)
-func validateDefaultParams(funcMeta *transpiler.FunctionMetadata, line int, filePath string) error {
+func validateDefaultParams(funcMeta *transpiler.FunctionMetadata, line, column int, filePath string) error {
+	_ = filePath // filePath is retained for future use; position info now travels via the coded error
 	if len(funcMeta.DefaultExprs) == 0 {
 		return nil
 	}
@@ -2494,8 +2539,12 @@ func validateDefaultParams(funcMeta *transpiler.FunctionMetadata, line int, file
 			if i < len(funcMeta.ParamNames) {
 				paramName = funcMeta.ParamNames[i]
 			}
-			return fmt.Errorf("%s:%d: parameter %q has no default value but follows parameter with default in function %s (parameters with defaults must be contiguous at end of parameter list)",
-				filePath, line, paramName, funcMeta.Name)
+			return galaerr.NewCodedSemanticError(
+				galaerr.CodeParamMissingDefaultAfterDefault,
+				line, column,
+				fmt.Sprintf("parameter %q in %s has no default but follows a parameter with a default", paramName, funcMeta.Name),
+				"move parameters with defaults to the end of the parameter list",
+			)
 		}
 	}
 
@@ -2517,8 +2566,12 @@ func validateDefaultParams(funcMeta *transpiler.FunctionMetadata, line int, file
 			if i < len(funcMeta.ParamNames) {
 				paramName = funcMeta.ParamNames[i]
 			}
-			return fmt.Errorf("%s:%d: default value for parameter %q has type %s, but parameter type is %s",
-				filePath, line, paramName, literalType, paramType)
+			return galaerr.NewCodedSemanticError(
+				galaerr.CodeParamDefaultTypeMismatch,
+				line, column,
+				fmt.Sprintf("default for parameter %q has type %s, expected %s", paramName, literalType, paramType),
+				"fix the default expression or change the parameter type",
+			)
 		}
 	}
 

--- a/internal/transpiler/transformer/constructors.go
+++ b/internal/transpiler/transformer/constructors.go
@@ -80,12 +80,22 @@ func (t *galaASTTransformer) transformCompositeLiteral(ctx *grammar.CompositeLit
 
 	// Reject slice literals - users should use collection_immutable.Array, collection_mutable.Array, or go_interop.SliceOf() or go_interop.SliceEmpty() for Go interop
 	if _, isArray := typeExpr.(*ast.ArrayType); isArray {
-		return nil, fmt.Errorf("slice literals are not supported in GALA; use collection_immutable.Array or collection_mutable.Array for type-safe collections, or go_interop.SliceOf() or go_interop.SliceEmpty() for Go interoperability")
+		return nil, galaerr.NewCodedSemanticError(
+			galaerr.CodeSliceLiteralNotSupported,
+			ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+			"slice literals are not a first-class GALA construct",
+			"use collection_immutable.Array or collection_mutable.Array for type-safe collections, or go_interop.SliceOf()/SliceEmpty() for Go interop",
+		)
 	}
 
 	// Reject map literals - users should use collection_immutable.HashMap, collection_mutable.HashMap or go_interop.MapEmpty() for Go interop
 	if _, isMap := typeExpr.(*ast.MapType); isMap {
-		return nil, fmt.Errorf("map literals are not supported in GALA; use collection_immutable.HashMap or collection_mutable.HashMap for type-safe maps, or go_interop.MapEmpty()/go_interop.MapPut() for Go interoperability")
+		return nil, galaerr.NewCodedSemanticError(
+			galaerr.CodeMapLiteralNotSupported,
+			ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+			"map literals are not a first-class GALA construct",
+			"use collection_immutable.HashMap or collection_mutable.HashMap for type-safe maps, or go_interop.MapEmpty()/MapPut() for Go interop",
+		)
 	}
 
 	// Look up struct field immutability flags so we can wrap immutable field values

--- a/internal/transpiler/transformer/error_codes_test.go
+++ b/internal/transpiler/transformer/error_codes_test.go
@@ -121,6 +121,50 @@ func main() {
 			expectCode:     galaerr.CodeMultipleDefaults,
 			expectContains: "multiple default",
 		},
+		{
+			name: "GALA-E0007 slice literal rejected",
+			input: `package main
+
+func main() {
+    val xs = []int{1, 2, 3}
+}`,
+			expectCode:     galaerr.CodeSliceLiteralNotSupported,
+			expectContains: "slice literals",
+		},
+		{
+			name: "GALA-E0008 map literal rejected",
+			input: `package main
+
+func main() {
+    val m = map[string]int{"a": 1}
+}`,
+			expectCode:     galaerr.CodeMapLiteralNotSupported,
+			expectContains: "map literals",
+		},
+		{
+			name: "GALA-E0013 non-defaulted param follows defaulted param",
+			input: `package main
+
+func create(a int = 5, b int) int = a + b
+
+func main() {
+    create(1, 2)
+}`,
+			expectCode:     galaerr.CodeParamMissingDefaultAfterDefault,
+			expectContains: "has no default",
+		},
+		{
+			name: "GALA-E0014 default expression type mismatch",
+			input: `package main
+
+func create(a int = "not-an-int") int = a
+
+func main() {
+    create()
+}`,
+			expectCode:     galaerr.CodeParamDefaultTypeMismatch,
+			expectContains: "default for parameter",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/transpiler/transformer/literals_test.go
+++ b/internal/transpiler/transformer/literals_test.go
@@ -32,7 +32,7 @@ func main() {
     val x = []int{1, 2, 3}
 }`,
 			expectError:  true,
-			errorContain: "slice literals are not supported",
+			errorContain: "GALA-E0007",
 		},
 		{
 			name: "map literal should fail",
@@ -42,7 +42,7 @@ func main() {
     val x = map[string]int{"a": 1, "b": 2}
 }`,
 			expectError:  true,
-			errorContain: "map literals are not supported",
+			errorContain: "GALA-E0008",
 		},
 		{
 			name: "empty map literal should fail",
@@ -52,7 +52,7 @@ func main() {
     val x = map[string]int{}
 }`,
 			expectError:  true,
-			errorContain: "map literals are not supported",
+			errorContain: "GALA-E0008",
 		},
 		{
 			name: "map type in function signature is allowed",

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -371,7 +371,7 @@ func (t *galaASTTransformer) transformMatchClauses(ctx grammar.IExpressionContex
 					galaerr.CodeMultipleDefaults,
 					ccCtx.GetStart().GetLine(), ccCtx.GetStart().GetColumn(),
 					"multiple default cases in match expression",
-					"")
+					"keep one default case; combine logic with guards or nested matches if you need sub-cases")
 			}
 			foundDefault = true
 
@@ -470,7 +470,7 @@ func (t *galaASTTransformer) transformMatchClauses(ctx grammar.IExpressionContex
 				galaerr.CodeNonExhaustiveMatch,
 				ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
 				fmt.Sprintf("non-exhaustive match: missing cases: %s", strings.Join(missing, ", ")),
-				"")
+				"add the missing variant cases, or add a `case _ => ...` default to cover them")
 		} else if isSealed && isExhaustive {
 			// Exhaustive sealed match — generate synthetic panic("unreachable") default
 			defaultBody = []ast.Stmt{

--- a/internal/transpiler/transformer/patterns.go
+++ b/internal/transpiler/transformer/patterns.go
@@ -43,7 +43,12 @@ func (t *galaASTTransformer) transformPatternWithType(patCtx grammar.IPatternCon
 		// If we get here, it's an error (rest patterns must be part of a sequence pattern)
 		return nil, nil, galaerr.NewSemanticErrorAt(ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(), "rest pattern (...) can only be used as the last argument in a sequence pattern like Array(first, second, rest...)")
 	default:
-		return nil, nil, fmt.Errorf("unknown pattern type: %T", patCtx)
+		return nil, nil, galaerr.NewCodedSemanticError(
+			galaerr.CodeUnknownPatternType,
+			patCtx.GetStart().GetLine(), patCtx.GetStart().GetColumn(),
+			fmt.Sprintf("unrecognized pattern syntax (internal type %T)", patCtx),
+			"this usually means a new grammar rule is missing transformer support; please report at github.com/martianoff/gala/issues",
+		)
 	}
 }
 


### PR DESCRIPTION
## Summary

Audit PR #1 of 6: R1–R9 error-code migration from the transpiler-chief audit.

- Adds eight new stable codes `GALA-E0007..E0014` (append-only, never renumbered).
- Migrates nine unstructured `fmt.Errorf` / `errors.New` sites to `galaerr.NewCodedSemanticError` with source span + actionable hint.
- Backfills the empty hints on `E0002` (non-exhaustive match) and `E0006` (multiple defaults).
- Adds `docs/errors/GALA-E0007.md..E0014.md` with the standard page shape (when-it-fires / minimal repro / error output / fix / rationale).
- Adds four new negative cases to `error_codes_test.go`; `E0011`/`E0012` are exercised through pre-existing `analyzer_test.go` `"redefined"` assertions.

## Coded sites

| Code | Site | Kind |
|---|---|---|
| `GALA-E0007` | `constructors.go` slice literal | feature unavailability |
| `GALA-E0008` | `constructors.go` map literal | feature unavailability |
| `GALA-E0009` | `patterns.go` default case | defensive (transpiler-bug signal) |
| `GALA-E0010` | `analyzer.go` two sites | duplicate package name |
| `GALA-E0011` | `analyzer.go` six sites | type redefined |
| `GALA-E0012` | `analyzer.go` one site | method redefined |
| `GALA-E0013` | `analyzer.go` validateDefaultParams | non-defaulted follows defaulted |
| `GALA-E0014` | `analyzer.go` validateDefaultParams | default literal type mismatch |

## Test plan

- [x] `bazel build //...` passes
- [x] `bazel test //...` passes (251/251)
- [x] Every new check has a `docs/errors/GALA-Exxxx.md` page
- [x] `docs/errors/README.md` index updated

## Next in stack

- PR #2 — coverage tests (T1–T5)
- PR #3 — `handleNamedArgsCall` extraction (A1)
- PR #4 — analyzer caches (P1/P2)
- PR #5 — stdlib hot-path fixes (S1/S2/S3)
- PR #6 — unified guard/extractor patterns (L2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)