### PR TITLE
feat(docs): L2 — document mixing guard and Option extractors (audit PR #6)

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -812,6 +812,28 @@ val res = c match {
 
 Extractors can be nested: `case Some(Even(n)) => ...`. You can use the underscore `_` to skip variable bindings in any extractor: `case Some(_) => "Got something"`.
 
+##### Mixing guard and Option extractors in one match
+
+Boolean-returning and `Option`-returning extractors can appear side-by-side in the same `match` expression. The transpiler dispatches on the `Unapply` method's return type: `bool` becomes an `if`-style guard with no binding, `Option[T]` unwraps the inner value via `IsDefined` + `Get` and exposes it to the case body. This lets a single match express "shape" checks (guards) and "shape-plus-destructure" checks (extractors) without having to choose one style upfront.
+
+```gala
+type IsZero struct {}
+func (_ IsZero) Unapply(n int) bool = n == 0
+
+type NonZero struct {}
+func (_ NonZero) Unapply(n int) Option[int] =
+    if (n == 0) None[int]() else Some(n)
+
+func classify(n int) string = n match {
+    case IsZero()              => "zero"                // bool-return guard
+    case NonZero(v) if v < 0   => s"negative($v)"       // Option-return extractor + guard
+    case NonZero(v)            => s"positive($v)"       // Option-return extractor
+    case _                     => "impossible"
+}
+```
+
+See `examples/mixed_guard_extractor.gala` for a runnable version.
+
 ##### Sealed-Variant Pattern Arity
 
 Each variant pattern must bind the exact number of fields the variant

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -340,6 +340,12 @@ gala_test(
 )
 
 gala_test(
+    name = "mixed_guard_extractor",
+    src = "mixed_guard_extractor.gala",
+    expected = "mixed_guard_extractor.out",
+)
+
+gala_test(
     name = "seq_pattern_match",
     src = "seq_pattern_match.gala",
     expected = "seq_pattern_match.out",

--- a/examples/mixed_guard_extractor.gala
+++ b/examples/mixed_guard_extractor.gala
@@ -1,0 +1,35 @@
+package main
+
+// L2 from the transpiler-chief audit: a single match expression can
+// combine bool-returning guards (IsZero) and Option-returning
+// extractors (NonZero) in its case list. The transpiler dispatches
+// each case on the method's return type — bool becomes an if-guard,
+// Option becomes IsDefined + Get — and both flows share the same
+// match body.
+
+type IsZero struct {}
+
+func (_ IsZero) Unapply(n int) bool = n == 0
+
+type NonZero struct {}
+
+func (_ NonZero) Unapply(n int) Option[int] {
+    if n == 0 {
+        return None[int]()
+    }
+    return Some(n)
+}
+
+func classify(n int) string = n match {
+    case IsZero()     => "zero"
+    case NonZero(v) if v < 0 => s"negative($v)"
+    case NonZero(v)   => s"positive($v)"
+    case _            => "impossible"
+}
+
+func main() {
+    Println(classify(0))
+    Println(classify(7))
+    Println(classify(-3))
+    Println(classify(1))
+}

--- a/examples/mixed_guard_extractor.out
+++ b/examples/mixed_guard_extractor.out
@@ -1,0 +1,4 @@
+zero
+positive(7)
+negative(-3)
+positive(1)


### PR DESCRIPTION
## Summary

Audit PR #6 of 6 (final): L2 from the transpiler-chief audit. Stacked on #180.

L2 was framed as "unify guard and extractor patterns under a single abstraction." After verification, the infrastructure is **already in place** — both \`generateDirectUnapplyPattern\` (patterns.go:~1640) and \`generateVariableUnapplyPattern\` (patterns.go:~1892) dispatch on the Unapply return type. What was missing was documentation and a regression-pin example, both of which this PR adds.

### What lands

- \`examples/mixed_guard_extractor.gala\` — runnable example that combines an \`IsZero\` (bool-return) extractor and a \`NonZero\` (Option-return) extractor with a guard and a default in one match.
- \`docs/GALA.MD\` — new "Mixing guard and Option extractors in one match" subsection under Match Expression → Using Extractors, explaining the dispatch rule.

### Retired after verification

L2 was framed as a new language feature. After reading patterns.go the dispatch path already exists. Recording the finding in the commit message so future audits don't re-propose it.

## Test plan

- [x] \`examples:mixed_guard_extractor\` passes
- [x] Core test suite stays green

## Stack (final)

- #175 — PR #1 (error codes)
- #176 — PR #2 (coverage tests)
- #177 — PR #3 (A1 extraction)
- #179 — PR #4 (P1 cache)
- #180 — PR #5 (stdlib hot paths)
- **this PR** — PR #6 (L2 docs + example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)