### PR TITLE
test: transpiler-chief audit T1-T5 coverage (audit PR #2, re-opened)

### DIFF
--- a/internal/transpiler/analyzer/analyzer_test.go
+++ b/internal/transpiler/analyzer/analyzer_test.go
@@ -472,6 +472,115 @@ func (p Person) Greet() string = fmt.Sprintf("Hello %s", p.Name)
 	})
 }
 
+// TestT4SiblingExtractionSkipsMainAndTest encodes the foot-gun that
+// directory-discovered sibling files must NOT be pulled in when the
+// current file is in a `main` or `test` package. In those packages,
+// sibling `.gala` files are independent programs sharing a directory
+// (the canonical example is `examples/`), so cross-contaminating their
+// metadata would pollute type resolution with unrelated packages.
+//
+// The live skip lives at analyzer.go:~909 in the directory-discovery
+// branch. This test exercises the skip by placing two main-package
+// files in the same directory with conflicting type definitions and
+// asserting that analysis succeeds (the conflict is NOT surfaced
+// because the sibling is not scanned).
+func TestT4SiblingExtractionSkipsMainAndTest(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	searchPaths := getStdSearchPath()
+
+	t.Run("main package does not scan siblings", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Two independent "main" programs sharing a directory — the
+		// canonical examples/ layout. If the analyzer scanned siblings
+		// for main, it would see the duplicate Foo definition and
+		// emit GALA-E0011; the skip should prevent that.
+		file1 := `package main
+
+struct Foo(A int)
+
+func main() {
+    val f = Foo(1)
+    _ = f
+}
+`
+		file2 := `package main
+
+struct Foo(B string)
+
+func main() {
+    val g = Foo("hello")
+    _ = g
+}
+`
+		file1Path := filepath.Join(tmpDir, "prog1.gala")
+		file2Path := filepath.Join(tmpDir, "prog2.gala")
+		require.NoError(t, os.WriteFile(file1Path, []byte(file1), 0644))
+		require.NoError(t, os.WriteFile(file2Path, []byte(file2), 0644))
+
+		a := analyzer.NewGalaAnalyzer(p, searchPaths)
+		tree, err := p.Parse(file1)
+		require.NoError(t, err)
+		_, err = a.Analyze(tree, file1Path)
+		assert.NoError(t, err,
+			"main-package sibling scanning must be skipped; otherwise prog2's Foo would collide with prog1's")
+	})
+
+	t.Run("test package does not scan siblings", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Two test-package programs in the same directory.
+		file1 := `package test
+
+struct Bar(X int)
+`
+		file2 := `package test
+
+struct Bar(Y string)
+`
+		file1Path := filepath.Join(tmpDir, "t1.gala")
+		file2Path := filepath.Join(tmpDir, "t2.gala")
+		require.NoError(t, os.WriteFile(file1Path, []byte(file1), 0644))
+		require.NoError(t, os.WriteFile(file2Path, []byte(file2), 0644))
+
+		a := analyzer.NewGalaAnalyzer(p, searchPaths)
+		tree, err := p.Parse(file1)
+		require.NoError(t, err)
+		_, err = a.Analyze(tree, file1Path)
+		assert.NoError(t, err,
+			"test-package sibling scanning must be skipped")
+	})
+
+	t.Run("library package DOES scan siblings (control)", func(t *testing.T) {
+		// The inverse assertion: for a normal library package, sibling
+		// scanning IS active, so a duplicate type across files DOES
+		// surface as GALA-E0011. This keeps the skip narrow and
+		// guards against an over-broad regression.
+		tmpDir := t.TempDir()
+		file1 := `package mylib
+
+struct Widget(A int)
+`
+		file2 := `package mylib
+
+struct Widget(B string)
+`
+		file1Path := filepath.Join(tmpDir, "f1.gala")
+		file2Path := filepath.Join(tmpDir, "f2.gala")
+		require.NoError(t, os.WriteFile(file1Path, []byte(file1), 0644))
+		require.NoError(t, os.WriteFile(file2Path, []byte(file2), 0644))
+
+		a := analyzer.NewGalaAnalyzer(p, searchPaths)
+		tree, err := p.Parse(file1)
+		require.NoError(t, err)
+		_, err = a.Analyze(tree, file1Path)
+		require.Error(t, err,
+			"library sibling scanning should fire redefinition error")
+		assert.Contains(t, err.Error(), "GALA-E0011")
+		assert.Contains(t, err.Error(), "Widget")
+	})
+}
+
 func keysOf(m map[string]*transpiler.TypeMetadata) []string {
 	var keys []string
 	for k := range m {

--- a/internal/transpiler/transformer/coverage_regression_test.go
+++ b/internal/transpiler/transformer/coverage_regression_test.go
@@ -1,0 +1,189 @@
+package transformer_test
+
+import (
+	"strings"
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTranspiler is a tiny factory used by the coverage regressions below.
+func newTranspiler() *transpiler.GalaToGoTranspiler {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	return transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+}
+
+// TestT1PhantomTypeParamFallback pins the current behaviour of a generic
+// function whose type parameter appears only in the return position.
+//
+// Today this falls back to `any` with a warnInference() message rather
+// than a hard semantic error; see calls.go TODO(B5). The intent is that
+// once every inference path threads the expected type, the fallback is
+// promoted to a coded error. Until then, this test documents the
+// behaviour so a regression into a panic or corrupted type is caught.
+func TestT1PhantomTypeParamFallback(t *testing.T) {
+	trans := newTranspiler()
+	// `magic[T](x int) T` — T is only in the return position. Without
+	// call-site context pinning T, the transpiler falls back to `any`.
+	input := `package main
+
+func magic[T](x int) T
+
+func main() {
+    val r = magic(42)
+    _ = r
+}`
+	out, err := trans.Transpile(input, "")
+	require.NoError(t, err, "phantom type param should transpile (not panic)")
+	assert.NotEmpty(t, out)
+	// Document the current fallback: `any` shows up in the return position.
+	// When B5 lands, replace this with an error-code assertion (the
+	// surrounding commentary explains the promotion contract).
+	assert.Contains(t, out, "any", "expected phantom T to fall back to `any` until B5 lands")
+}
+
+// TestT2UntypedLambdaFallback pins the current behaviour of a lambda
+// whose parameter types cannot be inferred from the surrounding context.
+//
+// Today this falls back to `any` parameters with a warnInference()
+// message; see declarations.go TODO(B11). The test guards against
+// regression into a panic or corrupted Go output; once B11 lands, the
+// assertion flips to an error-code check.
+func TestT2UntypedLambdaFallback(t *testing.T) {
+	trans := newTranspiler()
+	// `val f = (x) => x + 1` — x has no annotation and no expected type.
+	input := `package main
+
+func main() {
+    val f = (x) => x + 1
+    _ = f
+}`
+	out, err := trans.Transpile(input, "")
+	// Today: transpiles with `any` — acceptable until B11.
+	// If this starts erroring, B11 has landed — upgrade the test to
+	// assert the coded error and remove this branch.
+	if err != nil {
+		// B11 has landed; sanity-check that the error carries a code.
+		assert.Contains(t, err.Error(), "GALA-E", "B11 fallback should emit a coded error")
+		return
+	}
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "any", "expected untyped lambda param to fall back to `any` until B11 lands")
+}
+
+// TestT3ExhaustiveSealedNoDefaultEmitsUnreachable asserts that an
+// exhaustive sealed match without an explicit `case _ =>` default
+// compiles and emits a synthesized `panic("unreachable")` tail.
+//
+// This is the Phase 3 round-trip guarantee for sealed matches: if every
+// variant is named, the generated Go still needs a syntactic default so
+// Go's control flow is complete. The transpiler synthesises it; this
+// test pins the generated shape.
+func TestT3ExhaustiveSealedNoDefaultEmitsUnreachable(t *testing.T) {
+	trans := newTranspiler()
+	input := `package main
+
+sealed type Color {
+    case Red()
+    case Green()
+    case Blue()
+}
+
+func describe(c Color) string = c match {
+    case Red()   => "red"
+    case Green() => "green"
+    case Blue()  => "blue"
+}
+
+func main() {
+    val c = Red()
+    _ = describe(c)
+}`
+	out, err := trans.Transpile(input, "")
+	require.NoError(t, err, "exhaustive sealed match should compile without a default")
+	assert.Contains(t, out, `panic("unreachable")`,
+		"expected synthesised panic(\"unreachable\") default for exhaustive sealed match")
+}
+
+// TestT5ImmutableAutoUnwrapInInterpolation asserts that when an
+// Immutable[T]-wrapped value (i.e. a `val`-bound binding) flows into a
+// string interpolation, the transpiler unwraps it with .Get() so the
+// interpolation reads the underlying value rather than the wrapper.
+//
+// Without the auto-unwrap, `s"hello $name"` would call String() on the
+// Immutable wrapper (printing its address/struct form) instead of the
+// intended string. The field-access auto-unwrap is already covered by
+// examples/immutable_slice_field.gala; this test pins the interpolation
+// site too.
+func TestT5ImmutableAutoUnwrapInInterpolation(t *testing.T) {
+	trans := newTranspiler()
+	input := `package main
+
+func main() {
+    val name = "world"
+    val s = s"hello $name"
+    _ = s
+}`
+	out, err := trans.Transpile(input, "")
+	require.NoError(t, err)
+	// The generated Sprintf must read name.Get(), not name itself.
+	assert.Contains(t, out, "name.Get()",
+		"expected interpolation to auto-unwrap the Immutable val binding via .Get()")
+	// And the Sprintf must not see the wrapper type leak as the argument.
+	assert.NotContains(t, firstSprintf(out), "Immutable",
+		"expected the interpolated argument to be unwrapped before Sprintf")
+}
+
+// TestT5ImmutableAutoUnwrapInTupleAccess asserts the same auto-unwrap
+// contract for tuple element access: reading `.V1` / `.V2` on a
+// `val`-bound tuple must unwrap the surrounding Immutable before
+// projecting the field.
+func TestT5ImmutableAutoUnwrapInTupleAccess(t *testing.T) {
+	trans := newTranspiler()
+	input := `package main
+
+func main() {
+    val pair = ("a", 42)
+    val first = pair.V1
+    _ = first
+}`
+	out, err := trans.Transpile(input, "")
+	require.NoError(t, err)
+	// The generated code should read pair.Get().V1, not pair.V1 directly.
+	assert.Contains(t, out, "pair.Get().V1",
+		"expected tuple access to auto-unwrap the Immutable val binding via .Get() before projecting V1")
+}
+
+// firstSprintf returns the first fmt.Sprintf(...) call from generated
+// Go, or the full string if none found. Used by T5 to narrow the
+// assertion window to the interpolation-generated call site.
+func firstSprintf(out string) string {
+	const needle = "fmt.Sprintf("
+	i := strings.Index(out, needle)
+	if i < 0 {
+		return out
+	}
+	// Find the matching close paren naively — good enough for tests.
+	depth := 0
+	for j := i + len(needle) - 1; j < len(out); j++ {
+		switch out[j] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return out[i : j+1]
+			}
+		}
+	}
+	return out[i:]
+}


### PR DESCRIPTION
## Summary

Re-open of #176 against master (original PR auto-closed when its base `fix/audit-pr1-error-codes` was deleted on #175 merge).

Same content as #176:
- T1 phantom type param fallback
- T2 untyped lambda fallback
- T3 exhaustive sealed no-default -> panic("unreachable")
- T4 sibling extraction main/test skip
- T5 Immutable auto-unwrap (interpolation + tuple .V1)

## Test plan

- [x] bazel test //... passes
- [x] All five coverage tests pass

Stacked on merged #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)