### PR TITLE
feat(lsp): implement textDocument/signatureHelp

### DIFF
--- a/internal/lsp/BUILD.bazel
+++ b/internal/lsp/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "hover.go",
         "inlay_hints.go",
         "server.go",
+        "signature_help.go",
         "symbols.go",
         "typeatpos.go",
     ],
@@ -34,6 +35,7 @@ go_test(
     srcs = [
         "error_lines_test.go",
         "server_test.go",
+        "signature_help_test.go",
         "typeatpos_test.go",
     ],
     data = [

--- a/internal/lsp/BUILD.bazel
+++ b/internal/lsp/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//galaerr",
         "//internal/build",
         "//internal/depman/mod",
+        "//internal/parser/grammar",
         "//internal/transpiler",
         "//internal/transpiler/analyzer",
         "//internal/transpiler/generator",

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -40,13 +40,19 @@ type GalaHandler struct {
 	extraSearchPaths []string          // additional search paths (for testing)
 	client           *golsp.Client     // LSP client for sending notifications
 
-	mu            sync.Mutex
-	documents     map[string]string              // URI -> source text
-	docVersions   map[string]int64               // URI -> monotonic edit version
-	analysisCancels map[string]context.CancelFunc // URI -> cancel func for in-flight analysis
-	richASTs      map[string]*transpiler.RichAST       // URI -> analyzed AST
-	varTypes      map[string]map[string]string         // URI -> (varName -> type) from transpiler
-	lambdaHints   map[string][]transpiler.LambdaParamHint // URI -> lambda param hints from transformer
+	mu              sync.Mutex
+	documents       map[string]string              // URI -> source text
+	docVersions     map[string]int64               // URI -> monotonic edit version
+	analysisCancels map[string]context.CancelFunc  // URI -> cancel func for in-flight analysis
+	richASTs        map[string]*transpiler.RichAST // URI -> analyzed AST
+	// parseTrees caches the raw ANTLR parse tree for the most recent
+	// successful analysis. Features like signatureHelp walk the tree to
+	// locate the call expression at a cursor position rather than doing
+	// byte-level scans.
+	parseTrees  map[string]antlr.Tree
+	parseTexts  map[string]string                       // URI -> the source that produced parseTrees[URI] (may be surgically patched)
+	varTypes    map[string]map[string]string            // URI -> (varName -> type) from transpiler
+	lambdaHints map[string][]transpiler.LambdaParamHint // URI -> lambda param hints from transformer
 }
 
 // SetClient implements server.ClientHandler — receives the LSP client for notifications.
@@ -73,11 +79,22 @@ func (h *GalaHandler) DebugVarTypes(uri string) map[string]string {
 	return h.varTypes[uri]
 }
 
+// DebugParseTree returns the cached parse tree and the source text it was
+// parsed from (may be surgically patched for signatureHelp / completion).
+// For tests.
+func (h *GalaHandler) DebugParseTree(uri string) (antlr.Tree, string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.parseTrees[uri], h.parseTexts[uri]
+}
+
 // NewGalaHandler creates a new GALA LSP handler.
 func NewGalaHandler() *GalaHandler {
 	return &GalaHandler{
 		documents:       make(map[string]string),
 		richASTs:        make(map[string]*transpiler.RichAST),
+		parseTrees:      make(map[string]antlr.Tree),
+		parseTexts:      make(map[string]string),
 		varTypes:        make(map[string]map[string]string),
 		lambdaHints:     make(map[string][]transpiler.LambdaParamHint),
 		docVersions:     make(map[string]int64),
@@ -261,6 +278,12 @@ func (h *GalaHandler) analyzeFile(uri, filePath, text string) []lsp.Diagnostic {
 		// If the analyzer can extract type metadata from it, cache the
 		// richAST so completion/hover/definition work while mid-edit.
 		partialTree, _ := h.parser.ParseLenient(text)
+		if partialTree != nil {
+			h.mu.Lock()
+			h.parseTrees[uri] = partialTree
+			h.parseTexts[uri] = text
+			h.mu.Unlock()
+		}
 		h.tryAnalyzePartial(uri, filePath, partialTree)
 		return diagnostics
 	}
@@ -275,6 +298,8 @@ func (h *GalaHandler) analyzeFile(uri, filePath, text string) []lsp.Diagnostic {
 
 	h.mu.Lock()
 	h.richASTs[uri] = richAST
+	h.parseTrees[uri] = tree
+	h.parseTexts[uri] = text
 	h.mu.Unlock()
 
 	// Use a fresh transformer per analysis to avoid race conditions between
@@ -467,13 +492,14 @@ func (h *GalaHandler) ensureAnalysisForSignature(uri string, line, char int) {
 	if char > len(l) {
 		char = len(l)
 	}
-	// Insert a closing `)` at the cursor to balance the open call.
-	// If the cursor is just after a trailing comma, trim the comma and
-	// then close — "foo(a," → "foo(a)" rather than "foo(a,)" which also
-	// fails to parse.
-	patched := l[:char]
-	patched = strings.TrimRight(patched, " \t,")
-	patched += ")" + l[char:]
+	// Insert a closing `)` at the cursor to balance the open call. We
+	// keep the original text on both sides of the cursor verbatim — no
+	// trimming of trailing whitespace or commas — so cursor byte offsets
+	// survive the patch unchanged and the grammar's trailing-comma
+	// allowance (`argumentList: argument (',' argument)* ','?`) lets
+	// `foo(a, )` parse cleanly while preserving the comma count that
+	// signature help uses for the active-parameter index.
+	patched := l[:char] + ")" + l[char:]
 	lines[line] = patched
 	cleanText := strings.Join(lines, "\n")
 	h.analyzeAndCache(uri, cleanText, "ensureAnalysisForSignature")
@@ -505,6 +531,8 @@ func (h *GalaHandler) analyzeAndCache(uri, cleanText, caller string) {
 
 	h.mu.Lock()
 	h.richASTs[uri] = richAST
+	h.parseTrees[uri] = tree
+	h.parseTexts[uri] = cleanText
 	h.mu.Unlock()
 
 	xformer := transformer.NewGalaASTTransformer()

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -116,6 +116,10 @@ func (h *GalaHandler) Initialize(ctx context.Context, params *lsp.InitializePara
 			CompletionProvider: &lsp.CompletionOptions{
 				TriggerCharacters: []string{".", "("},
 			},
+			SignatureHelpProvider: &lsp.SignatureHelpOptions{
+				TriggerCharacters:   []string{"(", ","},
+				RetriggerCharacters: []string{","},
+			},
 			InlayHintProvider:      &lsp.InlayHintOptions{},
 			ReferencesProvider:     boolPtr(true),
 			DocumentSymbolProvider: boolPtr(true),
@@ -433,6 +437,54 @@ func (h *GalaHandler) ensureAnalysis(uri string, line, char int) {
 	// Remove just the dot, producing e.g. "Text(\"hello\")" from "Text(\"hello\")."
 	lines[line] = l[:dotPos] + l[dotPos+1:]
 	cleanText := strings.Join(lines, "\n")
+	h.analyzeAndCache(uri, cleanText, "ensureAnalysis")
+}
+
+// ensureAnalysisForSignature is the analog of ensureAnalysis for
+// textDocument/signatureHelp. The user's cursor is inside a call that
+// hasn't been closed yet (`foo(` or `foo(a,`), so the raw document
+// usually fails to parse. We close the call by inserting a matching `)`
+// at the cursor — producing a syntactically valid version — then run
+// the normal parse + analyze pipeline and cache the result.
+func (h *GalaHandler) ensureAnalysisForSignature(uri string, line, char int) {
+	h.mu.Lock()
+	hasVarTypes := len(h.varTypes[uri]) > 0
+	if h.richASTs[uri] != nil && hasVarTypes {
+		h.mu.Unlock()
+		return
+	}
+	text := h.documents[uri]
+	h.mu.Unlock()
+
+	if text == "" {
+		return
+	}
+	lines := strings.Split(text, "\n")
+	if line >= len(lines) {
+		return
+	}
+	l := lines[line]
+	if char > len(l) {
+		char = len(l)
+	}
+	// Insert a closing `)` at the cursor to balance the open call.
+	// If the cursor is just after a trailing comma, trim the comma and
+	// then close — "foo(a," → "foo(a)" rather than "foo(a,)" which also
+	// fails to parse.
+	patched := l[:char]
+	patched = strings.TrimRight(patched, " \t,")
+	patched += ")" + l[char:]
+	lines[line] = patched
+	cleanText := strings.Join(lines, "\n")
+	h.analyzeAndCache(uri, cleanText, "ensureAnalysisForSignature")
+}
+
+// analyzeAndCache parses + analyzes + runs the transformer on the given
+// (possibly surgically patched) document text, caching the resulting
+// richAST / varTypes / lambdaHints under the URI. A nil or failing
+// analysis is logged and silently skipped; LSP features then fall back
+// to their normal "no data" behavior.
+func (h *GalaHandler) analyzeAndCache(uri, cleanText, caller string) {
 	tree, err := h.parser.Parse(cleanText)
 	if err != nil {
 		return
@@ -443,11 +495,11 @@ func (h *GalaHandler) ensureAnalysis(uri string, line, char int) {
 	a := analyzer.NewGalaAnalyzer(h.parser, searchPaths)
 	richAST, aerr := a.Analyze(tree, filePath)
 	if aerr != nil {
-		fmt.Fprintf(os.Stderr, "[ensureAnalysis] analyze failed: %v\n", aerr)
+		fmt.Fprintf(os.Stderr, "[%s] analyze failed: %v\n", caller, aerr)
 		return
 	}
 	if richAST == nil {
-		fmt.Fprintf(os.Stderr, "[ensureAnalysis] richAST nil\n")
+		fmt.Fprintf(os.Stderr, "[%s] richAST nil\n", caller)
 		return
 	}
 

--- a/internal/lsp/signature_help.go
+++ b/internal/lsp/signature_help.go
@@ -4,17 +4,21 @@ import (
 	"context"
 	"strings"
 
+	"github.com/antlr4-go/antlr/v4"
 	"github.com/owenrumney/go-lsp/lsp"
 
+	grammar "martianoff/gala/internal/parser/grammar"
 	"martianoff/gala/internal/transpiler"
 )
 
 // SignatureHelp implements textDocument/signatureHelp.
 //
-// Walks backwards from the cursor to find the unbalanced `(` that opens the
-// current call, extracts the method/function name before it, resolves the
-// callee's parameter list (via richAST), and returns a SignatureInformation
-// with ActiveParameter set from the comma count between `(` and the cursor.
+// Locates the call expression at the cursor by walking the ANTLR parse
+// tree — not by byte-level scans — then extracts the callee name,
+// receiver chain, and argument index structurally from the tree. The
+// tree is parsed from a version of the source where the unclosed call
+// has been surgically closed with `)` (see ensureAnalysisForSignature)
+// so ANTLR can actually produce a well-formed postfixExpr.
 func (h *GalaHandler) SignatureHelp(ctx context.Context, params *lsp.SignatureHelpParams) (*lsp.SignatureHelp, error) {
 	uri := string(params.TextDocument.URI)
 	line := int(params.Position.Line)
@@ -30,9 +34,10 @@ func (h *GalaHandler) SignatureHelp(ctx context.Context, params *lsp.SignatureHe
 		return nil, nil
 	}
 
-	// The cursor is inside an unclosed call, so the raw document often
-	// fails to parse. Surgically close the call and re-analyze so we
-	// have richAST + varTypes for type resolution.
+	// Ensure richAST + varTypes are available for signature resolution.
+	// This may short-circuit if the main DidChange pipeline already
+	// produced them (from a lenient/partial parse), or it may parse a
+	// surgically closed variant of the source.
 	if richAST == nil || len(varTypeMap) == 0 {
 		h.ensureAnalysisForSignature(uri, line, char)
 		h.mu.Lock()
@@ -44,7 +49,21 @@ func (h *GalaHandler) SignatureHelp(ctx context.Context, params *lsp.SignatureHe
 		return nil, nil
 	}
 
-	call := findEnclosingCall(text, line, char)
+	// Always parse a freshly-patched version of the source for the tree
+	// walk. Relying on h.parseTrees would risk reading back a tree that
+	// was parsed from a different cursor's patched text (or from a
+	// lenient, error-recovered tree of the raw unclosed source), making
+	// call-site offsets misaligned with the current cursor.
+	treeText, cursorOffset := patchTextForSignature(text, line, char)
+	if cursorOffset < 0 {
+		return nil, nil
+	}
+	tree, _ := h.parser.ParseLenient(treeText)
+	if tree == nil {
+		return nil, nil
+	}
+
+	call := findCallAtOffset(tree, treeText, cursorOffset)
 	if call == nil {
 		return nil, nil
 	}
@@ -74,90 +93,207 @@ func (h *GalaHandler) SignatureHelp(ctx context.Context, params *lsp.SignatureHe
 	}, nil
 }
 
-// callContext captures the information about the enclosing call at a cursor
-// position needed to resolve signature help.
+// callContext captures everything the signature resolver needs about
+// the enclosing call.
 type callContext struct {
-	// name is the callee identifier immediately before the enclosing `(`.
+	// name is the callee identifier: either a trailing `.Method` in a
+	// chain, or the primaryExpr's identifier for a bare call.
 	name string
-	// receiverChain, if non-empty, is the text of the receiver expression
-	// that precedes `name.` — used for resolving method signatures on
-	// chained expressions like `NewServer().WithFilter(` where the chain
-	// before `.WithFilter(` is `NewServer()`.
+	// receiverChain, if non-empty, is the source text of the expression
+	// that precedes `.name` — used for resolving the receiver type on
+	// chained method calls.
 	receiverChain string
-	// argIndex is the zero-based index of the argument the cursor is in,
-	// computed by counting top-level commas between the enclosing `(` and
-	// the cursor.
+	// argIndex is the zero-based index of the argument the cursor sits
+	// in, counted from structural commas in the argumentList.
 	argIndex int
 }
 
-// findEnclosingCall walks backwards from the cursor to find the unbalanced
-// `(` that opens the currently-being-edited call, then extracts the callee
-// name and counts the top-level commas between that `(` and the cursor to
-// determine which argument the cursor is inside.
+// patchTextForSignature inserts a closing `)` at the cursor so the call
+// the user is typing can be parsed to completion. Returns the patched
+// text and the cursor's byte offset inside it (which, by construction,
+// equals the offset of the inserted `)`).
 //
-// Returns nil if there is no enclosing call, if the text before `(` isn't a
-// call-like expression (no identifier), or if the cursor is inside a string
-// literal.
-func findEnclosingCall(text string, line, char int) *callContext {
-	// Compute absolute byte offset of the cursor in text.
+// Everything on either side of the cursor is preserved verbatim — no
+// whitespace or comma trimming — so that (a) the grammar's trailing
+// comma in `argumentList` lets the parser accept `foo(a, )` cleanly
+// and (b) the active-argument index still reflects every comma the
+// user has typed.
+func patchTextForSignature(text string, line, char int) (patched string, cursorOffset int) {
 	lines := strings.Split(text, "\n")
-	if line >= len(lines) {
+	if line < 0 || line >= len(lines) {
+		return "", -1
+	}
+	l := lines[line]
+	if char < 0 {
+		char = 0
+	}
+	if char > len(l) {
+		char = len(l)
+	}
+	lines[line] = l[:char] + ")" + l[char:]
+	patched = strings.Join(lines, "\n")
+	cursorOffset = lineCharToOffset(patched, line, char)
+	return patched, cursorOffset
+}
+
+// lineCharToOffset converts an LSP (0-indexed line, 0-indexed char) to
+// a byte offset into text. Returns -1 if the position is out of range.
+func lineCharToOffset(text string, line, char int) int {
+	offset := 0
+	curLine := 0
+	for i := 0; i < len(text); i++ {
+		if curLine == line {
+			return offset + char // allow char == len(line) (end of line)
+		}
+		if text[i] == '\n' {
+			curLine++
+			offset = i + 1
+		}
+	}
+	if curLine == line {
+		return offset + char
+	}
+	return -1
+}
+
+// findCallAtOffset returns the innermost call-style postfixSuffix (one
+// that has an argumentList) whose argumentList's source range contains
+// the given byte offset. Returns nil if no such call is found.
+func findCallAtOffset(tree antlr.Tree, text string, cursorOffset int) *callContext {
+	f := &callFinder{cursorOffset: cursorOffset, text: text}
+	antlr.ParseTreeWalkerDefault.Walk(f, tree)
+	if f.bestSuffix == nil {
 		return nil
 	}
-	if char > len(lines[line]) {
-		char = len(lines[line])
-	}
-	cursorOffset := 0
-	for i := 0; i < line; i++ {
-		cursorOffset += len(lines[i]) + 1 // +1 for the stripped '\n'
-	}
-	cursorOffset += char
+	return buildCallContext(f.bestSuffix, f.bestParent, text, cursorOffset)
+}
 
-	// Walk backwards from the cursor, tracking nested parens/braces/brackets
-	// and skipping over string literals. We want the first `(` that is not
-	// matched by a `)` to its right (within [0, cursorOffset)).
-	openParenPos := findEnclosingOpenParen(text, cursorOffset)
-	if openParenPos < 0 {
+// callFinder is an ANTLR listener that tracks the innermost postfixSuffix
+// whose argumentList range brackets the cursor.
+type callFinder struct {
+	*grammar.BasegalaListener
+	cursorOffset int
+	text         string
+	bestSuffix   *grammar.PostfixSuffixContext
+	bestParent   *grammar.PostfixExprContext
+	bestDepth    int
+	depth        int
+}
+
+func (f *callFinder) EnterEveryRule(ctx antlr.ParserRuleContext) { f.depth++ }
+func (f *callFinder) ExitEveryRule(ctx antlr.ParserRuleContext)  { f.depth-- }
+
+func (f *callFinder) EnterPostfixSuffix(ctx *grammar.PostfixSuffixContext) {
+	argList := ctx.ArgumentList()
+	// A postfixSuffix that has no argumentList and no '(' terminal is
+	// either a `.id` or `[exprs]` — not a call. Fast-skip it.
+	openParen := findChildTerminal(ctx, "(")
+	if argList == nil && openParen == nil {
+		return
+	}
+	// The argument-list region runs from just after the '(' to the
+	// matching ')'. We consider the cursor "inside" the call when it's
+	// strictly after the '(' and at-or-before the ')'. Using at-or-before
+	// for the close paren means `foo(|)` (cursor right after `(`, at the
+	// position of `)`) counts as inside — which matches user expectation
+	// when they just typed the open paren.
+	start, stop := openParenRange(ctx)
+	if start < 0 {
+		return
+	}
+	if f.cursorOffset <= start || f.cursorOffset > stop {
+		return
+	}
+	if f.depth <= f.bestDepth {
+		return
+	}
+	parent, _ := ctx.GetParent().(*grammar.PostfixExprContext)
+	if parent == nil {
+		return
+	}
+	f.bestSuffix = ctx
+	f.bestParent = parent
+	f.bestDepth = f.depth
+}
+
+// openParenRange returns the byte offsets of the '(' and ')' of a
+// call-style postfixSuffix (or the '(' start and the argument list's
+// stop for a still-unclosed/recovered suffix). Returns (-1, -1) if the
+// suffix has no '('.
+func openParenRange(ctx *grammar.PostfixSuffixContext) (openAfter, closeAt int) {
+	openParen := findChildTerminal(ctx, "(")
+	if openParen == nil {
+		return -1, -1
+	}
+	openAfter = openParen.GetSymbol().GetStart()
+	closeParen := findChildTerminal(ctx, ")")
+	if closeParen != nil {
+		closeAt = closeParen.GetSymbol().GetStart()
+		return openAfter, closeAt
+	}
+	// Recovered tree without a matching ')' — treat end of the suffix as
+	// the close position.
+	if stop := ctx.GetStop(); stop != nil {
+		closeAt = stop.GetStop() + 1
+		return openAfter, closeAt
+	}
+	return openAfter, openAfter + 1
+}
+
+// findChildTerminal returns the first direct terminal-node child whose
+// text equals `literal`, or nil.
+func findChildTerminal(ctx antlr.RuleContext, literal string) antlr.TerminalNode {
+	for _, child := range ctx.GetChildren() {
+		if term, ok := child.(antlr.TerminalNode); ok && term.GetText() == literal {
+			return term
+		}
+	}
+	return nil
+}
+
+// buildCallContext turns a matched call-suffix + its enclosing postfixExpr
+// into the data the signature resolver needs: callee name, receiver text,
+// and argument index.
+func buildCallContext(callSuffix *grammar.PostfixSuffixContext, parent *grammar.PostfixExprContext, text string, cursorOffset int) *callContext {
+	suffixes := parent.AllPostfixSuffix()
+	callIdx := -1
+	for i, s := range suffixes {
+		if s == callSuffix {
+			callIdx = i
+			break
+		}
+	}
+	if callIdx < 0 {
 		return nil
 	}
 
-	// Extract the callee name before the `(`. Skip any whitespace.
-	i := openParenPos - 1
-	for i >= 0 && (text[i] == ' ' || text[i] == '\t') {
-		i--
+	var name, receiverChain string
+	// If the immediately-preceding suffix is `.id`, the callee is that
+	// identifier and the receiver is primaryExpr + suffixes before it.
+	if callIdx > 0 {
+		prev, _ := suffixes[callIdx-1].(*grammar.PostfixSuffixContext)
+		if prev != nil && prev.Identifier() != nil && findChildTerminal(prev, "(") == nil && findChildTerminal(prev, "[") == nil {
+			name = prev.Identifier().GetText()
+			receiverChain = contextText(parent.PrimaryExpr(), text)
+			for i := 0; i < callIdx-1; i++ {
+				receiverChain += contextText(suffixes[i], text)
+			}
+		}
 	}
-	if i < 0 {
-		return nil
-	}
-	nameEnd := i + 1
-	for i >= 0 && isIdentChar(text[i]) {
-		i--
-	}
-	nameStart := i + 1
-	if nameStart >= nameEnd {
-		// No identifier before `(` — e.g. `(expr)` grouping, or lambda
-		// parameter list. Not a call.
-		return nil
-	}
-	name := text[nameStart:nameEnd]
-
-	// Check for a dot before the name — if present, the thing before it is
-	// the receiver expression (needed to look up the method's parameter
-	// list on the receiver's type). Skip whitespace/newlines between the
-	// name and the dot so multi-line chains (`NewServer().\n    .Method(`)
-	// are handled.
-	var receiverChain string
-	j := nameStart - 1
-	for j >= 0 && (text[j] == ' ' || text[j] == '\t' || text[j] == '\n' || text[j] == '\r') {
-		j--
-	}
-	if j >= 0 && text[j] == '.' {
-		receiverChain = text[:j]
+	// No preceding `.id` — this is a bare call on the primary expression.
+	// Use the primary expression's text as the callee name.
+	if name == "" {
+		primaryText := strings.TrimSpace(contextText(parent.PrimaryExpr(), text))
+		// Only treat it as a real call when the primary expression is a
+		// simple identifier. `(x+y)(` and similar grouping-into-call
+		// shapes are not what the user wants signature help for.
+		if primaryText == "" || !isIdentifier(primaryText) {
+			return nil
+		}
+		name = primaryText
 	}
 
-	// Count top-level commas from just after `(` to the cursor.
-	argIndex := countTopLevelCommas(text, openParenPos+1, cursorOffset)
-
+	argIndex := argIndexAt(callSuffix.ArgumentList(), cursorOffset)
 	return &callContext{
 		name:          name,
 		receiverChain: receiverChain,
@@ -165,109 +301,75 @@ func findEnclosingCall(text string, line, char int) *callContext {
 	}
 }
 
-// findEnclosingOpenParen returns the byte offset of the `(` that opens the
-// call containing position `end`, or -1 if no such paren exists. Skips over
-// balanced `()`, `{}`, `[]` pairs and string literals while walking back.
-func findEnclosingOpenParen(text string, end int) int {
-	parenDepth := 0
-	braceDepth := 0
-	bracketDepth := 0
-	i := end - 1
-	for i >= 0 {
-		c := text[i]
-		// Skip over double-quoted strings (walking backwards).
-		if c == '"' && !isEscapedAt(text, i) {
-			j := i - 1
-			for j >= 0 {
-				if text[j] == '"' && !isEscapedAt(text, j) {
-					break
-				}
-				j--
-			}
-			if j < 0 {
-				return -1
-			}
-			i = j - 1
-			continue
-		}
-		switch c {
-		case ')':
-			parenDepth++
-		case '(':
-			if parenDepth == 0 && braceDepth == 0 && bracketDepth == 0 {
-				return i
-			}
-			parenDepth--
-		case '}':
-			braceDepth++
-		case '{':
-			braceDepth--
-		case ']':
-			bracketDepth++
-		case '[':
-			bracketDepth--
-		}
-		i--
+// contextText returns the original source text covered by the given
+// parse-tree context. Uses start/stop character indices from the tokens
+// so whitespace and punctuation are preserved verbatim.
+func contextText(ctx antlr.RuleContext, text string) string {
+	if ctx == nil {
+		return ""
 	}
-	return -1
+	rc, ok := ctx.(interface {
+		GetStart() antlr.Token
+		GetStop() antlr.Token
+	})
+	if !ok {
+		return ""
+	}
+	start, stop := rc.GetStart(), rc.GetStop()
+	if start == nil || stop == nil {
+		return ""
+	}
+	s, e := start.GetStart(), stop.GetStop()
+	if s < 0 || e < 0 || s > e || e >= len(text) {
+		return ""
+	}
+	return text[s : e+1]
 }
 
-// isEscapedAt reports whether the byte at position i is preceded by an odd
-// number of backslashes (i.e. the character is escaped).
-func isEscapedAt(text string, i int) bool {
-	count := 0
-	for j := i - 1; j >= 0 && text[j] == '\\'; j-- {
-		count++
+// argIndexAt counts the commas that are direct children of argumentList
+// (i.e. top-level commas for this call) and end strictly before the
+// cursor. Returns the zero-based active-argument index.
+func argIndexAt(argList grammar.IArgumentListContext, cursorOffset int) int {
+	if argList == nil {
+		return 0
 	}
-	return count%2 == 1
-}
-
-// countTopLevelCommas counts commas in text[start:end] that are not inside
-// nested (), {}, [] pairs and not inside string literals. Returns the
-// argument index for the cursor at `end` — 0 means "first argument".
-func countTopLevelCommas(text string, start, end int) int {
-	if start >= end {
+	rc, ok := argList.(antlr.RuleContext)
+	if !ok {
 		return 0
 	}
 	n := 0
-	parenDepth := 0
-	braceDepth := 0
-	bracketDepth := 0
-	inString := false
-	for i := start; i < end; i++ {
-		c := text[i]
-		if inString {
-			if c == '\\' && i+1 < end {
-				i++
-				continue
-			}
-			if c == '"' {
-				inString = false
-			}
+	for _, child := range rc.GetChildren() {
+		term, ok := child.(antlr.TerminalNode)
+		if !ok {
 			continue
 		}
-		switch c {
-		case '"':
-			inString = true
-		case '(':
-			parenDepth++
-		case ')':
-			parenDepth--
-		case '{':
-			braceDepth++
-		case '}':
-			braceDepth--
-		case '[':
-			bracketDepth++
-		case ']':
-			bracketDepth--
-		case ',':
-			if parenDepth == 0 && braceDepth == 0 && bracketDepth == 0 {
-				n++
-			}
+		if term.GetText() != "," {
+			continue
+		}
+		if term.GetSymbol().GetStart() < cursorOffset {
+			n++
 		}
 	}
 	return n
+}
+
+func isIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if i == 0 {
+			if !(c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+				return false
+			}
+		} else {
+			if !isIdentChar(c) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // resolveCallSignature resolves a callContext to a SignatureInformation by
@@ -360,9 +462,9 @@ func typeConstructorSignature(name string, tm *transpiler.TypeMetadata) *lsp.Sig
 
 // buildParamList returns ParameterInformation entries plus their rendered
 // "name type" labels (used to compose the full signature label). Both
-// slices are returned so the Parameters' Label strings match the
-// corresponding substring inside the signature label, which is what
-// clients use to visually highlight the active parameter.
+// slices are returned so each Parameter's Label matches the corresponding
+// substring inside the signature label — clients use that substring to
+// visually highlight the active parameter.
 func buildParamList(names []string, types []transpiler.Type) ([]lsp.ParameterInformation, []string) {
 	params := make([]lsp.ParameterInformation, 0, len(names))
 	labels := make([]string, 0, len(names))

--- a/internal/lsp/signature_help.go
+++ b/internal/lsp/signature_help.go
@@ -1,0 +1,380 @@
+package lsp
+
+import (
+	"context"
+	"strings"
+
+	"github.com/owenrumney/go-lsp/lsp"
+
+	"martianoff/gala/internal/transpiler"
+)
+
+// SignatureHelp implements textDocument/signatureHelp.
+//
+// Walks backwards from the cursor to find the unbalanced `(` that opens the
+// current call, extracts the method/function name before it, resolves the
+// callee's parameter list (via richAST), and returns a SignatureInformation
+// with ActiveParameter set from the comma count between `(` and the cursor.
+func (h *GalaHandler) SignatureHelp(ctx context.Context, params *lsp.SignatureHelpParams) (*lsp.SignatureHelp, error) {
+	uri := string(params.TextDocument.URI)
+	line := int(params.Position.Line)
+	char := int(params.Position.Character)
+
+	h.mu.Lock()
+	text := h.documents[uri]
+	richAST := h.richASTs[uri]
+	varTypeMap := h.varTypes[uri]
+	h.mu.Unlock()
+
+	if text == "" {
+		return nil, nil
+	}
+
+	// The cursor is inside an unclosed call, so the raw document often
+	// fails to parse. Surgically close the call and re-analyze so we
+	// have richAST + varTypes for type resolution.
+	if richAST == nil || len(varTypeMap) == 0 {
+		h.ensureAnalysisForSignature(uri, line, char)
+		h.mu.Lock()
+		richAST = h.richASTs[uri]
+		varTypeMap = h.varTypes[uri]
+		h.mu.Unlock()
+	}
+	if richAST == nil {
+		return nil, nil
+	}
+
+	call := findEnclosingCall(text, line, char)
+	if call == nil {
+		return nil, nil
+	}
+
+	lines := strings.Split(text, "\n")
+	enclosingFunc := findEnclosingFunc(lines, line)
+
+	sig := resolveCallSignature(call, enclosingFunc, richAST, varTypeMap)
+	if sig == nil {
+		return nil, nil
+	}
+
+	active := call.argIndex
+	if active < 0 {
+		active = 0
+	}
+	if len(sig.Parameters) > 0 && active >= len(sig.Parameters) {
+		active = len(sig.Parameters) - 1
+	}
+	activePtr := active
+	activeSig := 0
+
+	return &lsp.SignatureHelp{
+		Signatures:      []lsp.SignatureInformation{*sig},
+		ActiveSignature: &activeSig,
+		ActiveParameter: &activePtr,
+	}, nil
+}
+
+// callContext captures the information about the enclosing call at a cursor
+// position needed to resolve signature help.
+type callContext struct {
+	// name is the callee identifier immediately before the enclosing `(`.
+	name string
+	// receiverChain, if non-empty, is the text of the receiver expression
+	// that precedes `name.` — used for resolving method signatures on
+	// chained expressions like `NewServer().WithFilter(` where the chain
+	// before `.WithFilter(` is `NewServer()`.
+	receiverChain string
+	// argIndex is the zero-based index of the argument the cursor is in,
+	// computed by counting top-level commas between the enclosing `(` and
+	// the cursor.
+	argIndex int
+}
+
+// findEnclosingCall walks backwards from the cursor to find the unbalanced
+// `(` that opens the currently-being-edited call, then extracts the callee
+// name and counts the top-level commas between that `(` and the cursor to
+// determine which argument the cursor is inside.
+//
+// Returns nil if there is no enclosing call, if the text before `(` isn't a
+// call-like expression (no identifier), or if the cursor is inside a string
+// literal.
+func findEnclosingCall(text string, line, char int) *callContext {
+	// Compute absolute byte offset of the cursor in text.
+	lines := strings.Split(text, "\n")
+	if line >= len(lines) {
+		return nil
+	}
+	if char > len(lines[line]) {
+		char = len(lines[line])
+	}
+	cursorOffset := 0
+	for i := 0; i < line; i++ {
+		cursorOffset += len(lines[i]) + 1 // +1 for the stripped '\n'
+	}
+	cursorOffset += char
+
+	// Walk backwards from the cursor, tracking nested parens/braces/brackets
+	// and skipping over string literals. We want the first `(` that is not
+	// matched by a `)` to its right (within [0, cursorOffset)).
+	openParenPos := findEnclosingOpenParen(text, cursorOffset)
+	if openParenPos < 0 {
+		return nil
+	}
+
+	// Extract the callee name before the `(`. Skip any whitespace.
+	i := openParenPos - 1
+	for i >= 0 && (text[i] == ' ' || text[i] == '\t') {
+		i--
+	}
+	if i < 0 {
+		return nil
+	}
+	nameEnd := i + 1
+	for i >= 0 && isIdentChar(text[i]) {
+		i--
+	}
+	nameStart := i + 1
+	if nameStart >= nameEnd {
+		// No identifier before `(` — e.g. `(expr)` grouping, or lambda
+		// parameter list. Not a call.
+		return nil
+	}
+	name := text[nameStart:nameEnd]
+
+	// Check for a dot before the name — if present, the thing before it is
+	// the receiver expression (needed to look up the method's parameter
+	// list on the receiver's type). Skip whitespace/newlines between the
+	// name and the dot so multi-line chains (`NewServer().\n    .Method(`)
+	// are handled.
+	var receiverChain string
+	j := nameStart - 1
+	for j >= 0 && (text[j] == ' ' || text[j] == '\t' || text[j] == '\n' || text[j] == '\r') {
+		j--
+	}
+	if j >= 0 && text[j] == '.' {
+		receiverChain = text[:j]
+	}
+
+	// Count top-level commas from just after `(` to the cursor.
+	argIndex := countTopLevelCommas(text, openParenPos+1, cursorOffset)
+
+	return &callContext{
+		name:          name,
+		receiverChain: receiverChain,
+		argIndex:      argIndex,
+	}
+}
+
+// findEnclosingOpenParen returns the byte offset of the `(` that opens the
+// call containing position `end`, or -1 if no such paren exists. Skips over
+// balanced `()`, `{}`, `[]` pairs and string literals while walking back.
+func findEnclosingOpenParen(text string, end int) int {
+	parenDepth := 0
+	braceDepth := 0
+	bracketDepth := 0
+	i := end - 1
+	for i >= 0 {
+		c := text[i]
+		// Skip over double-quoted strings (walking backwards).
+		if c == '"' && !isEscapedAt(text, i) {
+			j := i - 1
+			for j >= 0 {
+				if text[j] == '"' && !isEscapedAt(text, j) {
+					break
+				}
+				j--
+			}
+			if j < 0 {
+				return -1
+			}
+			i = j - 1
+			continue
+		}
+		switch c {
+		case ')':
+			parenDepth++
+		case '(':
+			if parenDepth == 0 && braceDepth == 0 && bracketDepth == 0 {
+				return i
+			}
+			parenDepth--
+		case '}':
+			braceDepth++
+		case '{':
+			braceDepth--
+		case ']':
+			bracketDepth++
+		case '[':
+			bracketDepth--
+		}
+		i--
+	}
+	return -1
+}
+
+// isEscapedAt reports whether the byte at position i is preceded by an odd
+// number of backslashes (i.e. the character is escaped).
+func isEscapedAt(text string, i int) bool {
+	count := 0
+	for j := i - 1; j >= 0 && text[j] == '\\'; j-- {
+		count++
+	}
+	return count%2 == 1
+}
+
+// countTopLevelCommas counts commas in text[start:end] that are not inside
+// nested (), {}, [] pairs and not inside string literals. Returns the
+// argument index for the cursor at `end` — 0 means "first argument".
+func countTopLevelCommas(text string, start, end int) int {
+	if start >= end {
+		return 0
+	}
+	n := 0
+	parenDepth := 0
+	braceDepth := 0
+	bracketDepth := 0
+	inString := false
+	for i := start; i < end; i++ {
+		c := text[i]
+		if inString {
+			if c == '\\' && i+1 < end {
+				i++
+				continue
+			}
+			if c == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '(':
+			parenDepth++
+		case ')':
+			parenDepth--
+		case '{':
+			braceDepth++
+		case '}':
+			braceDepth--
+		case '[':
+			bracketDepth++
+		case ']':
+			bracketDepth--
+		case ',':
+			if parenDepth == 0 && braceDepth == 0 && bracketDepth == 0 {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// resolveCallSignature resolves a callContext to a SignatureInformation by
+// looking up the callee in richAST. Supports:
+//   - Bare function calls (`foo(`) → richAST.Functions[name]
+//   - Method calls on a receiver expression (`expr.foo(`) → resolve receiver
+//     type via resolveChainTypeN, then find Methods[name] on that type
+//   - Constructor-like calls on types (`Type(`) → fall back to type fields
+//     treated as a positional parameter list (named args still work via
+//     completion)
+func resolveCallSignature(call *callContext, enclosingFunc string, richAST *transpiler.RichAST, varTypes map[string]string) *lsp.SignatureInformation {
+	// Method call on a receiver expression.
+	if call.receiverChain != "" {
+		receiverType := resolveChainTypeN(call.receiverChain, enclosingFunc, richAST, varTypes, 0)
+		if receiverType != "" {
+			if tm := findType(richAST, receiverType); tm != nil {
+				if m, ok := tm.Methods[call.name]; ok {
+					return methodSignature(call.name, m)
+				}
+			}
+		}
+		// Fall through to bare-name lookup — useful when receiver
+		// resolution fails but the method name uniquely identifies a
+		// function (e.g., dot-imported or free function).
+	}
+
+	// Free function.
+	if fm := findFunction(richAST, call.name); fm != nil {
+		return functionSignature(call.name, fm)
+	}
+
+	// Type constructor: `Person(name = "...", age = 30)` — build a
+	// signature from the type's fields. Named-arg completion is the
+	// primary UX for this, but showing the positional signature gives
+	// useful hint text too.
+	if tm := findType(richAST, call.name); tm != nil && len(tm.FieldNames) > 0 {
+		return typeConstructorSignature(call.name, tm)
+	}
+
+	return nil
+}
+
+func functionSignature(name string, fm *transpiler.FunctionMetadata) *lsp.SignatureInformation {
+	params, labels := buildParamList(fm.ParamNames, fm.ParamTypes)
+	var label strings.Builder
+	label.WriteString("func " + name)
+	if len(fm.TypeParams) > 0 {
+		label.WriteString("[" + strings.Join(fm.TypeParams, ", ") + "]")
+	}
+	label.WriteString("(" + strings.Join(labels, ", ") + ")")
+	if fm.ReturnType != nil && !fm.ReturnType.IsNil() {
+		label.WriteString(" " + fm.ReturnType.String())
+	}
+	return &lsp.SignatureInformation{
+		Label:      label.String(),
+		Parameters: params,
+	}
+}
+
+func methodSignature(name string, m *transpiler.MethodMetadata) *lsp.SignatureInformation {
+	params, labels := buildParamList(m.ParamNames, m.ParamTypes)
+	var label strings.Builder
+	label.WriteString(name)
+	if len(m.TypeParams) > 0 {
+		label.WriteString("[" + strings.Join(m.TypeParams, ", ") + "]")
+	}
+	label.WriteString("(" + strings.Join(labels, ", ") + ")")
+	if m.ReturnType != nil && !m.ReturnType.IsNil() {
+		label.WriteString(" " + m.ReturnType.String())
+	}
+	return &lsp.SignatureInformation{
+		Label:      label.String(),
+		Parameters: params,
+	}
+}
+
+func typeConstructorSignature(name string, tm *transpiler.TypeMetadata) *lsp.SignatureInformation {
+	types := make([]transpiler.Type, 0, len(tm.FieldNames))
+	for _, fn := range tm.FieldNames {
+		types = append(types, tm.Fields[fn])
+	}
+	params, labels := buildParamList(tm.FieldNames, types)
+	var label strings.Builder
+	label.WriteString(name + "(" + strings.Join(labels, ", ") + ")")
+	return &lsp.SignatureInformation{
+		Label:      label.String(),
+		Parameters: params,
+	}
+}
+
+// buildParamList returns ParameterInformation entries plus their rendered
+// "name type" labels (used to compose the full signature label). Both
+// slices are returned so the Parameters' Label strings match the
+// corresponding substring inside the signature label, which is what
+// clients use to visually highlight the active parameter.
+func buildParamList(names []string, types []transpiler.Type) ([]lsp.ParameterInformation, []string) {
+	params := make([]lsp.ParameterInformation, 0, len(names))
+	labels := make([]string, 0, len(names))
+	for i, n := range names {
+		var labelPart string
+		if i < len(types) && types[i] != nil && !types[i].IsNil() {
+			labelPart = n + " " + types[i].String()
+		} else {
+			labelPart = n
+		}
+		labels = append(labels, labelPart)
+		params = append(params, lsp.ParameterInformation{Label: labelPart})
+	}
+	return params, labels
+}

--- a/internal/lsp/signature_help_test.go
+++ b/internal/lsp/signature_help_test.go
@@ -1,0 +1,573 @@
+package lsp_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/owenrumney/go-lsp/lsp"
+	"github.com/owenrumney/go-lsp/servertest"
+)
+
+// requestSignatureHelp invokes textDocument/signatureHelp and decodes the
+// result. Returns nil if the server returned no signature help (null
+// response).
+func requestSignatureHelp(t *testing.T, h *servertest.Harness, uri lsp.DocumentURI, line, char int) *lsp.SignatureHelp {
+	t.Helper()
+	raw, err := h.Call("textDocument/signatureHelp", map[string]interface{}{
+		"textDocument": map[string]string{"uri": string(uri)},
+		"position":     map[string]int{"line": line, "character": char},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw == nil || string(raw) == "null" {
+		return nil
+	}
+	var sh lsp.SignatureHelp
+	if err := json.Unmarshal(raw, &sh); err != nil {
+		t.Fatalf("failed to unmarshal signature help: %v (raw: %s)", err, string(raw))
+	}
+	return &sh
+}
+
+// labelOf pulls the string label from a ParameterInformation. The LSP
+// spec allows either a string or [int, int] range — we emit strings.
+func labelOf(p lsp.ParameterInformation) string {
+	switch v := p.Label.(type) {
+	case string:
+		return v
+	default:
+		return ""
+	}
+}
+
+func activeParam(sh *lsp.SignatureHelp) int {
+	if sh.ActiveParameter == nil {
+		return -1
+	}
+	return *sh.ActiveParameter
+}
+
+// ---- Free function signatures ----
+
+func TestSignatureHelp_FreeFunction_FirstArgument(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func greet(name string, times int) string = name\n" +
+		"\n" +
+		"func main() {\n" +
+		"    greet(\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	// Cursor right after `greet(`
+	sh := requestSignatureHelp(t, h, uri, 5, 10)
+	if sh == nil {
+		t.Fatal("expected signature help, got nil")
+	}
+	if len(sh.Signatures) != 1 {
+		t.Fatalf("expected 1 signature, got %d", len(sh.Signatures))
+	}
+	sig := sh.Signatures[0]
+	if !strings.Contains(sig.Label, "greet") || !strings.Contains(sig.Label, "name string") {
+		t.Errorf("unexpected label: %q", sig.Label)
+	}
+	if got, want := len(sig.Parameters), 2; got != want {
+		t.Errorf("expected %d parameters, got %d", want, got)
+	}
+	if got := labelOf(sig.Parameters[0]); got != "name string" {
+		t.Errorf("param[0] label: got %q want %q", got, "name string")
+	}
+	if got := labelOf(sig.Parameters[1]); got != "times int" {
+		t.Errorf("param[1] label: got %q want %q", got, "times int")
+	}
+	if got, want := activeParam(sh), 0; got != want {
+		t.Errorf("active parameter: got %d want %d", got, want)
+	}
+}
+
+func TestSignatureHelp_FreeFunction_SecondArgument(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func greet(name string, times int) string = name\n" +
+		"\n" +
+		"func main() {\n" +
+		"    greet(\"world\", \n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	sh := requestSignatureHelp(t, h, uri, 5, 19)
+	if sh == nil {
+		t.Fatal("expected signature help, got nil")
+	}
+	if got, want := activeParam(sh), 1; got != want {
+		t.Errorf("active parameter after one comma: got %d want %d", got, want)
+	}
+}
+
+func TestSignatureHelp_FreeFunction_ReturnTypeInLabel(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func add(a int, b int) int = a + b\n" +
+		"\n" +
+		"func main() {\n" +
+		"    add(\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	sh := requestSignatureHelp(t, h, uri, 5, 8)
+	if sh == nil {
+		t.Fatal("expected signature help, got nil")
+	}
+	if !strings.HasSuffix(sh.Signatures[0].Label, " int") {
+		t.Errorf("expected signature label to end with return type ' int', got %q", sh.Signatures[0].Label)
+	}
+}
+
+// ---- Method signatures ----
+
+func TestSignatureHelp_MethodOnLocalVariable(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"type Box struct {\n" +
+		"    val n int\n" +
+		"}\n" +
+		"\n" +
+		"func (b Box) Add(x int, y int) Box = Box(n = b.n + x + y)\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val b = Box(n = 1)\n" +
+		"    b.Add(\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	sh := requestSignatureHelp(t, h, uri, 10, 10)
+	if sh == nil {
+		t.Fatal("expected signature help on method, got nil")
+	}
+	sig := sh.Signatures[0]
+	if !strings.HasPrefix(sig.Label, "Add(") {
+		t.Errorf("expected label starting with Add(, got %q", sig.Label)
+	}
+	if got, want := len(sig.Parameters), 2; got != want {
+		t.Fatalf("expected 2 params, got %d", got)
+	}
+	if got := labelOf(sig.Parameters[0]); got != "x int" {
+		t.Errorf("param[0]: %q", got)
+	}
+	if got := labelOf(sig.Parameters[1]); got != "y int" {
+		t.Errorf("param[1]: %q", got)
+	}
+}
+
+func TestSignatureHelp_MethodInChain(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"type Server struct {\n" +
+		"    val name string\n" +
+		"}\n" +
+		"\n" +
+		"func (s Server) WithName(n string) Server = Server(name = n)\n" +
+		"func (s Server) WithFilter(f string) Server = s\n" +
+		"\n" +
+		"func NewServer() Server = Server(name = \"default\")\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val x = NewServer().WithName(\"demo\").WithFilter(\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	// Cursor just after `WithFilter(`
+	line := "    val x = NewServer().WithName(\"demo\").WithFilter("
+	sh := requestSignatureHelp(t, h, uri, 12, len(line))
+	if sh == nil {
+		t.Fatal("expected signature help on chained method, got nil")
+	}
+	if !strings.HasPrefix(sh.Signatures[0].Label, "WithFilter(") {
+		t.Errorf("expected WithFilter label, got %q", sh.Signatures[0].Label)
+	}
+	if got := labelOf(sh.Signatures[0].Parameters[0]); got != "f string" {
+		t.Errorf("param[0]: %q", got)
+	}
+}
+
+// ---- Nested call argIndex handling ----
+
+func TestSignatureHelp_NestedCall_OuterArgIndex(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func outer(a int, b int) int = a + b\n" +
+		"func inner(x int, y int) int = x + y\n" +
+		"\n" +
+		"func main() {\n" +
+		"    outer(inner(1, 2), \n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	// Cursor on the outer call's 2nd arg, after the inner call + comma
+	sh := requestSignatureHelp(t, h, uri, 6, 23)
+	if sh == nil {
+		t.Fatal("expected signature help, got nil")
+	}
+	if !strings.HasPrefix(sh.Signatures[0].Label, "func outer") {
+		t.Errorf("expected outer func sig, got %q", sh.Signatures[0].Label)
+	}
+	if got, want := activeParam(sh), 1; got != want {
+		t.Errorf("active parameter (skipping comma inside inner(1,2)): got %d want %d", got, want)
+	}
+}
+
+func TestSignatureHelp_NestedCall_InnerCallActive(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func outer(a int, b int) int = a + b\n" +
+		"func inner(x int, y int) int = x + y\n" +
+		"\n" +
+		"func main() {\n" +
+		"    outer(inner(1, \n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	// Cursor inside the inner call's 2nd arg
+	sh := requestSignatureHelp(t, h, uri, 6, 19)
+	if sh == nil {
+		t.Fatal("expected signature help, got nil")
+	}
+	if !strings.HasPrefix(sh.Signatures[0].Label, "func inner") {
+		t.Errorf("expected inner func sig, got %q", sh.Signatures[0].Label)
+	}
+	if got, want := activeParam(sh), 1; got != want {
+		t.Errorf("active parameter: got %d want %d", got, want)
+	}
+}
+
+// ---- String literals must not confuse paren counting ----
+
+func TestSignatureHelp_StringWithParensAndCommas(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func fmt3(a string, b int) string = a\n" +
+		"\n" +
+		"func main() {\n" +
+		"    fmt3(\"a(b,c)d\", \n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	sh := requestSignatureHelp(t, h, uri, 5, 21)
+	if sh == nil {
+		t.Fatal("expected signature help, got nil")
+	}
+	if got, want := activeParam(sh), 1; got != want {
+		t.Errorf("parens/commas inside string literal must not affect count: got %d want %d", got, want)
+	}
+}
+
+func TestSignatureHelp_EscapedQuoteInString(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func fmt3(a string, b int) string = a\n" +
+		"\n" +
+		"func main() {\n" +
+		"    fmt3(\"quote\\\"inside,still\", \n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	// Cursor past the escaped-quote string + comma → arg index 1
+	line := "    fmt3(\"quote\\\"inside,still\", "
+	sh := requestSignatureHelp(t, h, uri, 5, len(line))
+	if sh == nil {
+		t.Fatal("expected signature help, got nil")
+	}
+	if got, want := activeParam(sh), 1; got != want {
+		t.Errorf("escaped quote must not end string: got arg %d want %d", got, want)
+	}
+}
+
+// ---- No call / outside call → nil ----
+
+func TestSignatureHelp_OutsideCall_ReturnsNil(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val x = 1\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	sh := requestSignatureHelp(t, h, uri, 3, 12)
+	if sh != nil {
+		t.Fatalf("expected nil outside a call, got %+v", sh)
+	}
+}
+
+func TestSignatureHelp_ParenGroupingNotCall(t *testing.T) {
+	h := newHarness(t)
+	// `(1 + 2)` is a grouping, not a call — no signature help expected
+	src := "package main\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val x = (1 + \n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	sh := requestSignatureHelp(t, h, uri, 3, 17)
+	if sh != nil {
+		t.Fatalf("expected nil for paren grouping, got %+v", sh)
+	}
+}
+
+// ---- Unknown function → nil ----
+
+func TestSignatureHelp_UnknownFunction_ReturnsNil(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func main() {\n" +
+		"    definitelyNotDefined(\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	sh := requestSignatureHelp(t, h, uri, 3, 25)
+	if sh != nil {
+		t.Fatalf("expected nil for unknown function, got %+v", sh)
+	}
+}
+
+// ---- Type constructor → signature from fields ----
+
+func TestSignatureHelp_TypeConstructor(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"type Person struct {\n" +
+		"    val name string\n" +
+		"    val age int\n" +
+		"}\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val p = Person(\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	sh := requestSignatureHelp(t, h, uri, 8, 19)
+	if sh == nil {
+		t.Fatal("expected signature help for type constructor, got nil")
+	}
+	sig := sh.Signatures[0]
+	if !strings.HasPrefix(sig.Label, "Person(") {
+		t.Errorf("label: got %q", sig.Label)
+	}
+	if got, want := len(sig.Parameters), 2; got != want {
+		t.Fatalf("expected 2 params (fields), got %d", got)
+	}
+	if got := labelOf(sig.Parameters[0]); got != "name string" {
+		t.Errorf("param[0]: %q", got)
+	}
+}
+
+// ---- Multi-line call ----
+
+func TestSignatureHelp_MultiLineCall(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func make4(a int, b int, c int, d int) int = a\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val x = make4(\n" +
+		"        1,\n" +
+		"        2,\n" +
+		"        \n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	// Cursor on the blank line inside the call — third arg
+	sh := requestSignatureHelp(t, h, uri, 8, 8)
+	if sh == nil {
+		t.Fatal("expected signature help inside multi-line call, got nil")
+	}
+	if got, want := activeParam(sh), 2; got != want {
+		t.Errorf("active parameter across lines: got %d want %d", got, want)
+	}
+}
+
+// ---- Active param clamped when beyond parameter count (variadic-style overflow) ----
+
+func TestSignatureHelp_ActiveParamClamped(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func two(a int, b int) int = a + b\n" +
+		"\n" +
+		"func main() {\n" +
+		"    two(1, 2, 3, \n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	// Cursor at "4th" arg — exceeds the 2-param signature; must clamp
+	// to the last param rather than returning out-of-range index.
+	sh := requestSignatureHelp(t, h, uri, 5, 17)
+	if sh == nil {
+		t.Fatal("expected signature help, got nil")
+	}
+	if got, want := activeParam(sh), 1; got != want {
+		t.Errorf("active parameter clamped to last: got %d want %d", got, want)
+	}
+}
+
+// ---- Zero-parameter function ----
+
+func TestSignatureHelp_NoParams(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func nullary() int = 42\n" +
+		"\n" +
+		"func main() {\n" +
+		"    nullary(\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	sh := requestSignatureHelp(t, h, uri, 5, 12)
+	if sh == nil {
+		t.Fatal("expected signature help, got nil")
+	}
+	sig := sh.Signatures[0]
+	if len(sig.Parameters) != 0 {
+		t.Errorf("expected 0 params, got %d", len(sig.Parameters))
+	}
+	if !strings.Contains(sig.Label, "nullary()") {
+		t.Errorf("label: %q", sig.Label)
+	}
+}
+
+// ---- Generic function preserves type params in label ----
+
+func TestSignatureHelp_GenericFunction_LabelShowsTypeParams(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func identity[T](x T) T = x\n" +
+		"\n" +
+		"func main() {\n" +
+		"    identity(\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	sh := requestSignatureHelp(t, h, uri, 5, 13)
+	if sh == nil {
+		t.Fatal("expected signature help for generic fn, got nil")
+	}
+	if !strings.Contains(sh.Signatures[0].Label, "[T]") {
+		t.Errorf("expected [T] in generic signature label, got %q", sh.Signatures[0].Label)
+	}
+}
+
+// ---- Chain completion + signature help integration: the user's
+//      long-builder scenario still resolves the signature properly.
+
+func TestSignatureHelp_LongBuilderChain(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"type Server struct {\n" +
+		"    val name string\n" +
+		"}\n" +
+		"\n" +
+		"func (s Server) WithName(n string) Server = Server(name = n)\n" +
+		"func (s Server) WithPort(p int) Server = s\n" +
+		"func (s Server) WithFilter(f string) Server = s\n" +
+		"\n" +
+		"func NewServer() Server = Server(name = \"d\")\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val x = NewServer().\n" +
+		"        WithName(\"a\").\n" +
+		"        WithPort(1).\n" +
+		"        WithFilter(\"b\").\n" +
+		"        WithFilter(\"c\").\n" +
+		"        WithFilter(\"d\").\n" +
+		"        WithFilter(\"e\").\n" +
+		"        WithFilter(\"f\").\n" +
+		"        WithFilter(\"g\").\n" +
+		"        WithFilter(\"h\").\n" +
+		"        WithFilter(\"i\").\n" +
+		"        WithFilter(\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	// Cursor right after the last `WithFilter(` — long chain.
+	lines := strings.Split(src, "\n")
+	target := -1
+	for i, l := range lines {
+		if strings.HasSuffix(l, "WithFilter(") {
+			target = i
+		}
+	}
+	if target < 0 {
+		t.Fatal("could not locate trailing WithFilter(")
+	}
+	sh := requestSignatureHelp(t, h, uri, target, len(lines[target]))
+	if sh == nil {
+		t.Fatal("expected signature help after deep chain, got nil")
+	}
+	if !strings.HasPrefix(sh.Signatures[0].Label, "WithFilter(") {
+		t.Errorf("expected WithFilter label after deep chain, got %q", sh.Signatures[0].Label)
+	}
+}
+
+// ---- String containing escaped dollar sign and braces (interpolated
+//      string-like content) — parser sees a normal string, paren counter
+//      must treat it as such.
+
+func TestSignatureHelp_InterpolatedStringLiteral(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"func tag(label string, n int) string = label\n" +
+		"\n" +
+		"func main() {\n" +
+		"    tag(s\"hello, ${name}(!)\", \n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(200 * time.Millisecond)
+
+	// Cursor after the interpolated string + comma
+	line := "    tag(s\"hello, ${name}(!)\", "
+	sh := requestSignatureHelp(t, h, uri, 5, len(line))
+	if sh == nil {
+		t.Fatal("expected signature help, got nil")
+	}
+	if got, want := activeParam(sh), 1; got != want {
+		t.Errorf("parens inside interpolation must not leak out: got %d want %d", got, want)
+	}
+}

--- a/internal/lsp/typeatpos.go
+++ b/internal/lsp/typeatpos.go
@@ -290,9 +290,13 @@ func resolveChainTypeN(text string, funcScope string, richAST *transpiler.RichAS
 		}
 		methodName := text[nameStart:nameEnd]
 
-		// Check if there's a dot before the method name (chain)
-		if i >= 0 && text[i] == '.' {
-			receiverType := resolveChainTypeN(text[:i], funcScope, richAST, varTypes, depth+1)
+		// Check if there's a dot before the method name (chain). Skip any
+		// whitespace (including newlines) between the name and the dot so
+		// multi-line chains survive without requiring the caller to flatten
+		// them first.
+		dotIdx := skipTrailingWhitespace(text, i)
+		if dotIdx >= 0 && text[dotIdx] == '.' {
+			receiverType := resolveChainTypeN(text[:dotIdx], funcScope, richAST, varTypes, depth+1)
 			if receiverType != "" {
 				return resolveMethodReturn(richAST, receiverType, methodName)
 			}
@@ -311,9 +315,11 @@ func resolveChainTypeN(text string, funcScope string, richAST *transpiler.RichAS
 		return ""
 	}
 
-	// Check for dot before identifier (pkg.Type or receiver.field)
-	if i >= 0 && text[i] == '.' {
-		receiverType := resolveChainTypeN(text[:i], funcScope, richAST, varTypes, depth+1)
+	// Check for dot before identifier (pkg.Type or receiver.field). Skip
+	// whitespace between the identifier and the dot — same reason as above.
+	dotIdx := skipTrailingWhitespace(text, i)
+	if dotIdx >= 0 && text[dotIdx] == '.' {
+		receiverType := resolveChainTypeN(text[:dotIdx], funcScope, richAST, varTypes, depth+1)
 		if receiverType != "" {
 			// Could be a field access — resolve field type
 			return resolveMethodReturn(richAST, receiverType, name)
@@ -321,6 +327,17 @@ func resolveChainTypeN(text string, funcScope string, richAST *transpiler.RichAS
 	}
 
 	return resolveReceiverType(name, funcScope, richAST, varTypes)
+}
+
+// skipTrailingWhitespace walks backward from `start` over ASCII whitespace
+// (space, tab, newline, carriage return) and returns the index of the first
+// non-whitespace byte, or -1 if it runs off the left.
+func skipTrailingWhitespace(text string, start int) int {
+	j := start
+	for j >= 0 && (text[j] == ' ' || text[j] == '\t' || text[j] == '\n' || text[j] == '\r') {
+		j--
+	}
+	return j
 }
 
 // resolveMethodReturn finds the return type of a method on a given type.

--- a/internal/lsp/typeatpos.go
+++ b/internal/lsp/typeatpos.go
@@ -291,9 +291,11 @@ func resolveChainTypeN(text string, funcScope string, richAST *transpiler.RichAS
 		methodName := text[nameStart:nameEnd]
 
 		// Check if there's a dot before the method name (chain). Skip any
-		// whitespace (including newlines) between the name and the dot so
-		// multi-line chains survive without requiring the caller to flatten
-		// them first.
+		// whitespace (including newlines) — receiver text that's
+		// reconstructed from parse-tree contexts preserves inter-token
+		// whitespace verbatim, so multi-line chains like
+		// `NewServer().\n    WithFilter(...).\n    Method(` arrive here
+		// with newlines between the `)` of one call and the next `.`.
 		dotIdx := skipTrailingWhitespace(text, i)
 		if dotIdx >= 0 && text[dotIdx] == '.' {
 			receiverType := resolveChainTypeN(text[:dotIdx], funcScope, richAST, varTypes, depth+1)


### PR DESCRIPTION
## Summary

Adds parameter-hint popups (`textDocument/signatureHelp`) for GALA function and method calls — the thing the user saw missing when typing `WithFilter(` in their server builder.

## Behavior

- **Free functions** — `greet(|` → `greet(name string, times int) string`, with `ActiveParameter` tracking (each `,` advances).
- **Methods on local vars and chain results** — `x.Add(|`, `NewServer().WithName("a").WithFilter(|`. Receiver type resolved via the existing `resolveChainTypeN`.
- **Type constructors** — `Person(|` shows a positional signature built from the struct's field list.
- **Active parameter is clamped** to the declared arity so `two(1,2,3,|` highlights the last parameter instead of returning an out-of-range index.
- **Returns null** for paren grouping, unknown callees, or cursors outside any call — IDEs hide the popup cleanly.

## Plumbing

- Advertise `SignatureHelpProvider` with trigger `(` + `,` and retrigger `,`.
- Refactor the parse+analyze+cache body out of `ensureAnalysis` into a shared `analyzeAndCache`.
- Add `ensureAnalysisForSignature` which surgically closes the unclosed call with `)` before re-analyzing — the sig-help analog of the IntelliJ-trick used for dot completion.
- Make `resolveChainTypeN` whitespace-tolerant between chain links so multi-line chains resolve without requiring the caller to pre-flatten.

## Test plan

New `signature_help_test.go` — 16 scenarios:

- [x] First/second argument positioning
- [x] Return type in signature label
- [x] Method on local variable (`b.Add(`)
- [x] Method in chain (`NewServer().WithName(\"a\").WithFilter(`)
- [x] Nested calls: outer arg index correct + inner call resolves
- [x] String literal with parens and commas inside it (\"a(b,c)d\")
- [x] Escaped quote inside string
- [x] Outside a call → null
- [x] Plain paren grouping (\`(1 + 2)\`) → null
- [x] Unknown function → null
- [x] Type constructor shows field signature
- [x] Multi-line call with cursor on blank line
- [x] Active param clamped when arg count exceeds arity
- [x] Zero-parameter function (\`nullary(|\`)
- [x] Generic function preserves `[T]` in label
- [x] Long builder chain (13 calls) — exercises deep-chain resolution
- [x] Interpolated-string literal argument doesn't confuse paren counter

All new tests fail before the code change and pass after; full `bazel test //internal/lsp:lsp_test` green; `bazel build //internal/... //cmd/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)