### PR TITLE
fix(intellij): string interpolation ${...} same color as surrounding string

### DIFF
--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaAnnotator.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaAnnotator.kt
@@ -40,8 +40,16 @@ class GalaAnnotator : Annotator {
         val TYPE_PARAMETER = TextAttributesKey.createTextAttributesKey(
             "GALA_TYPE_PARAMETER", DefaultLanguageHighlighterColors.CLASS_NAME
         )
+        // Fallback to INSTANCE_FIELD: its foreground is explicitly set in
+        // the stock Default/Darcula schemes (purple, italic), so it
+        // overrides the lexer's STRING green even when no bundled GALA
+        // color scheme is active. TEMPLATE_LANGUAGE_COLOR only tints the
+        // background — STRING's foreground leaks through, making ${...}
+        // visually indistinguishable from the surrounding string. The
+        // bundled colorSchemes/*.xml set explicit foreground on top of
+        // this fallback.
         val INTERPOLATION_VAR = TextAttributesKey.createTextAttributesKey(
-            "GALA_INTERPOLATION_VAR", DefaultLanguageHighlighterColors.TEMPLATE_LANGUAGE_COLOR
+            "GALA_INTERPOLATION_VAR", DefaultLanguageHighlighterColors.INSTANCE_FIELD
         )
 
         private val BUILTIN_TYPE_NAMES = setOf(

--- a/ide/intellij/src/main/resources/META-INF/plugin.xml
+++ b/ide/intellij/src/main/resources/META-INF/plugin.xml
@@ -84,6 +84,15 @@
         <annotator language="GALA" implementationClass="org.gala.ide.intellij.GalaAnnotator"/>
         <colorSettingsPage implementation="org.gala.ide.intellij.GalaColorSettingsPage"/>
 
+        <!-- Bundled color schemes: guarantee distinct foreground for string
+             interpolation (${...} and $var inside s"..."/f"...") in both
+             light and dark default schemes. Without these, INTERPOLATION_VAR
+             falls back to a base key whose foreground often matches STRING
+             in stock themes, leaving the interpolated expression visually
+             indistinguishable from the surrounding string. -->
+        <bundledColorScheme path="/colorSchemes/GalaDefault"/>
+        <bundledColorScheme path="/colorSchemes/GalaDarcula"/>
+
         <!-- Inspections -->
         <localInspection language="GALA" groupName="GALA" shortName="GalaDuplicateDeclaration"
                          displayName="Duplicate declaration"

--- a/ide/intellij/src/main/resources/colorSchemes/GalaDarcula.xml
+++ b/ide/intellij/src/main/resources/colorSchemes/GalaDarcula.xml
@@ -1,0 +1,10 @@
+<scheme name="Darcula" version="142" parent_scheme="Darcula">
+    <attributes>
+        <option name="GALA_INTERPOLATION_VAR">
+            <value>
+                <option name="FOREGROUND" value="CC7832"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+    </attributes>
+</scheme>

--- a/ide/intellij/src/main/resources/colorSchemes/GalaDefault.xml
+++ b/ide/intellij/src/main/resources/colorSchemes/GalaDefault.xml
@@ -1,0 +1,10 @@
+<scheme name="Default" version="142" parent_scheme="Default">
+    <attributes>
+        <option name="GALA_INTERPOLATION_VAR">
+            <value>
+                <option name="FOREGROUND" value="871094"/>
+                <option name="FONT_TYPE" value="1"/>
+            </value>
+        </option>
+    </attributes>
+</scheme>


### PR DESCRIPTION
## Summary

In `s"..."` and `f"..."` strings, interpolated expressions (`${...}` and `$var`) render the same color as the plain-text parts of the string, making them hard to visually pick out. User-reported with screenshots.

## Root cause

`GalaAnnotator` applies a `GALA_INTERPOLATION_VAR` attribute to the interpolation ranges inside the `INTERPOLATED_STRING`/`FORMAT_STRING` lexer token. Annotator attributes merge with the lexer's `STRING` attributes — the annotator wins only for attributes it actually defines. The fallback key was `TEMPLATE_LANGUAGE_COLOR`, which in stock Default/Darcula schemes only tints the **background**; `STRING`'s green foreground bleeds through, so `${...}` looks the same as the string.

A prior attempt swapped to `VALID_STRING_ESCAPE` and ended up invisible in several themes.

## Fix — two layers

1. **Bundle color schemes** — `colorSchemes/GalaDefault.xml` (purple `#871094` bold) and `colorSchemes/GalaDarcula.xml` (orange `#CC7832` bold) set `GALA_INTERPOLATION_VAR` with an explicit **foreground**. These merge into the user's active stock scheme, so users get distinct colors without touching settings.
2. **Stronger fallback** — change `INTERPOLATION_VAR`'s fallback key to `INSTANCE_FIELD`, whose foreground is always explicitly set in stock schemes (purple italic). Covers custom user schemes that don't define GALA-specific overrides.

Both bundled schemes registered in `plugin.xml` via `<bundledColorScheme>`.

## Test plan

- [x] `bazel build //internal/... //cmd/...` green (non-plugin build).
- [ ] Visual verification in IntelliJ (Default + Darcula themes) — requires installing the plugin build locally; no automated test for scheme rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)