### PR TITLE
fix(cli): honor subdir source path in `gala build`

### DIFF
--- a/cmd/gala/commands/build.go
+++ b/cmd/gala/commands/build.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -63,6 +64,16 @@ func runBuild(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
+	}
+
+	// If the argument points to a subdirectory or file inside the project,
+	// set it as source dir for multi-package builds (e.g., `gala build examples/hello`).
+	absArg, _ := filepath.Abs(projectDir)
+	if info, err := os.Stat(absArg); err == nil && !info.IsDir() {
+		absArg = filepath.Dir(absArg)
+	}
+	if absArg != absProjectDir {
+		builder.SetSourceDir(absArg)
 	}
 
 	// Run build


### PR DESCRIPTION
## Summary

- `gala build` walked up to find `gala.mod` but never tracked the original argument, so running it from a subdirectory (e.g. `examples/hello`) silently compile-checked the library root instead of building the subdir's `package main`.
- `gala run` already solved this by calling `builder.SetSourceDir(absArg)` when the given path resolves to a directory different from the walked-up project root (`cmd/gala/commands/run.go:79-87`).
- This PR ports the same block into `runBuild` so both commands behave identically.

## Test plan

- [x] `bazel build //cmd/gala:gala` passes
- [x] In `gala-server/examples/hello/`, `gala build` now transpiles `main.gala` as `package main` with the root as a lib dep (previously printed `ok (library compiled successfully)`)
- [x] `gala build` and `gala run` produce matching behavior in the same dir
- [ ] `bazel test //...` (local run recommended before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)