### PR TITLE
feat(docs): L2 — document mixing guard and Option extractors (audit PR #6, re-opened)

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -812,6 +812,28 @@ val res = c match {
 
 Extractors can be nested: `case Some(Even(n)) => ...`. You can use the underscore `_` to skip variable bindings in any extractor: `case Some(_) => "Got something"`.
 
+##### Mixing guard and Option extractors in one match
+
+Boolean-returning and `Option`-returning extractors can appear side-by-side in the same `match` expression. The transpiler dispatches on the `Unapply` method's return type: `bool` becomes an `if`-style guard with no binding, `Option[T]` unwraps the inner value via `IsDefined` + `Get` and exposes it to the case body. This lets a single match express "shape" checks (guards) and "shape-plus-destructure" checks (extractors) without having to choose one style upfront.
+
+```gala
+type IsZero struct {}
+func (_ IsZero) Unapply(n int) bool = n == 0
+
+type NonZero struct {}
+func (_ NonZero) Unapply(n int) Option[int] =
+    if (n == 0) None[int]() else Some(n)
+
+func classify(n int) string = n match {
+    case IsZero()              => "zero"                // bool-return guard
+    case NonZero(v) if v < 0   => s"negative($v)"       // Option-return extractor + guard
+    case NonZero(v)            => s"positive($v)"       // Option-return extractor
+    case _                     => "impossible"
+}
+```
+
+See `examples/mixed_guard_extractor.gala` for a runnable version.
+
 ##### Sealed-Variant Pattern Arity
 
 Each variant pattern must bind the exact number of fields the variant

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -340,6 +340,12 @@ gala_test(
 )
 
 gala_test(
+    name = "mixed_guard_extractor",
+    src = "mixed_guard_extractor.gala",
+    expected = "mixed_guard_extractor.out",
+)
+
+gala_test(
     name = "seq_pattern_match",
     src = "seq_pattern_match.gala",
     expected = "seq_pattern_match.out",

--- a/examples/mixed_guard_extractor.gala
+++ b/examples/mixed_guard_extractor.gala
@@ -1,0 +1,35 @@
+package main
+
+// L2 from the transpiler-chief audit: a single match expression can
+// combine bool-returning guards (IsZero) and Option-returning
+// extractors (NonZero) in its case list. The transpiler dispatches
+// each case on the method's return type — bool becomes an if-guard,
+// Option becomes IsDefined + Get — and both flows share the same
+// match body.
+
+type IsZero struct {}
+
+func (_ IsZero) Unapply(n int) bool = n == 0
+
+type NonZero struct {}
+
+func (_ NonZero) Unapply(n int) Option[int] {
+    if n == 0 {
+        return None[int]()
+    }
+    return Some(n)
+}
+
+func classify(n int) string = n match {
+    case IsZero()     => "zero"
+    case NonZero(v) if v < 0 => s"negative($v)"
+    case NonZero(v)   => s"positive($v)"
+    case _            => "impossible"
+}
+
+func main() {
+    Println(classify(0))
+    Println(classify(7))
+    Println(classify(-3))
+    Println(classify(1))
+}

--- a/examples/mixed_guard_extractor.out
+++ b/examples/mixed_guard_extractor.out
@@ -1,0 +1,4 @@
+zero
+positive(7)
+negative(-3)
+positive(1)


### PR DESCRIPTION
## Summary

Re-open of #181 against master after its base branch was deleted on #188 merge.

Final PR in the audit stack: L2 documentation + \`examples/mixed_guard_extractor.gala\` regression pin. Dispatch infrastructure is already in \`patterns.go\`; this PR adds the docs section and runnable example.

Stacked on merged #175, #182, #185, #186, #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)