### PR TITLE
fix(onboarding): remove first-30-minute friction walls

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -159,16 +159,35 @@ val dateRegex = regex.MustCompile("(\\d{4})-(\\d{2})-(\\d{2})")
 
 ## Quick Start
 
+**New to GALA?** Try it instantly in the [browser playground](https://gala-playground.fly.dev) — no install. Or follow the full [Getting Started guide](https://martianoff.github.io/gala/getting-started/).
+
 ### 1. Install
 
-Download a pre-built binary from [Releases](https://github.com/martianoff/gala/releases), or build from source:
+Download a pre-built binary from [Releases](https://github.com/martianoff/gala/releases), rename it to `gala` (or `gala.exe` on Windows), and add it to your `PATH`.
+
+GALA transpiles to Go, so it needs [Go 1.25+](https://go.dev/dl/) on your `PATH` to compile programs. Install Go first if you don't have it.
+
+Or build from source:
 
 ```bash
 git clone https://github.com/martianoff/gala.git && cd gala
 bazel build //cmd/gala:gala
 ```
 
-### 2. Write
+Verify the install:
+
+```bash
+gala version
+```
+
+### 2. Create a project
+
+```bash
+mkdir hello && cd hello
+gala mod init example.com/hello
+```
+
+Write `main.gala`:
 
 ```gala
 package main
@@ -188,14 +207,15 @@ func main() {
 ### 3. Run
 
 ```bash
-gala run main.gala                        # Transpile + compile + run
-gala build                                # Build project to binary
-gala test                                 # Run tests
-gala run examples/hello/main.gala         # Run subdirectory executable
+gala run main.gala     # Transpile + compile + run
+gala build             # Build project to a binary
+gala test              # Run tests
 
-# Or with Bazel (recommended for larger projects)
+# Or with Bazel (for larger projects)
 bazel build //... && bazel test //...
 ```
+
+**Need help?** Ask in [GitHub Discussions](https://github.com/martianoff/gala/discussions).
 
 ---
 
@@ -506,6 +526,10 @@ Download from [Releases](https://github.com/martianoff/gala/releases):
 | macOS (x64) | `gala-darwin-amd64` |
 | macOS (Apple Silicon) | `gala-darwin-arm64` |
 | Windows (x64) | `gala-windows-amd64.exe` |
+
+After downloading, rename the binary to `gala` (or `gala.exe` on Windows) and add it to your `PATH`.
+
+**Prerequisite:** GALA needs [Go 1.25+](https://go.dev/dl/) on your `PATH` to compile programs. Install Go before running `gala build` or `gala run`.
 
 ### Build from Source
 

--- a/cmd/gala/commands/build.go
+++ b/cmd/gala/commands/build.go
@@ -54,7 +54,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 	absProjectDir, err := findProjectRoot(projectDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		fmt.Fprintln(os.Stderr, "Run 'gala mod init' to create one.")
+		fmt.Fprintln(os.Stderr, "Run 'gala mod init <module-path>' to create one. Example: gala mod init example.com/myapp")
 		os.Exit(1)
 	}
 

--- a/cmd/gala/commands/run.go
+++ b/cmd/gala/commands/run.go
@@ -65,7 +65,7 @@ func runRun(cmd *cobra.Command, args []string) {
 	absProjectDir, err := findProjectRoot(projectDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		fmt.Fprintln(os.Stderr, "Run 'gala mod init' to create one.")
+		fmt.Fprintln(os.Stderr, "Run 'gala mod init <module-path>' to create one. Example: gala mod init example.com/myapp")
 		os.Exit(1)
 	}
 

--- a/ide/intellij/README.MD
+++ b/ide/intellij/README.MD
@@ -49,13 +49,13 @@ The plugin uses the [antlr4-intellij-adaptor](https://github.com/antlr/antlr4-in
 
 ### Install the LSP Server
 
-The plugin connects to `gala-lsp` for advanced features (diagnostics, hover, cross-file navigation, inlay hints).
+The plugin connects to the `gala` CLI for advanced features (diagnostics, hover, cross-file navigation, inlay hints). The LSP is now a subcommand of the main CLI — `gala lsp` — so there's no separate binary to install.
 
-1. Build: `bazel build //cmd/gala-lsp:gala-lsp`
-2. Copy to PATH: `cp bazel-bin/cmd/gala-lsp/gala-lsp_/gala-lsp ~/.local/bin/` (or set `GALA_LSP_PATH`)
-3. Restart GoLand — the LSP server starts automatically when a `.gala` file is opened
+1. Install the `gala` CLI: download from [Releases](https://github.com/martianoff/gala/releases) or build via `bazel build //cmd/gala:gala` and place the binary on your `PATH`.
+2. Override with the `GALA_PATH` environment variable if the CLI lives outside `PATH`.
+3. Restart GoLand — the LSP server starts automatically when a `.gala` file is opened.
 
-### LSP Server Features (via `gala-lsp`)
+### LSP Server Features (via `gala lsp`)
 
 | Feature | Description |
 |---------|-------------|

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaLspServerProvider.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaLspServerProvider.kt
@@ -11,7 +11,7 @@ import java.io.File
  * LSP server provider for GALA.
  * Starts `gala lsp` when a .gala file is opened.
  *
- * The gala CLI is expected to be on PATH (installed via `gala install`).
+ * The gala CLI is expected to be on PATH (see project README for install instructions).
  * Override with GALA_PATH environment variable.
  */
 class GalaLspServerSupportProvider : LspServerSupportProvider {

--- a/website/getting-started.md
+++ b/website/getting-started.md
@@ -48,7 +48,16 @@ The compiled binary will be at `bazel-bin/cmd/gala/gala_/gala`.
 
 ## Hello World
 
-### 1. Write
+### 1. Create a project
+
+```bash
+mkdir hello && cd hello
+gala mod init example.com/hello
+```
+
+`gala mod init` creates a `gala.mod` file; the module path is any unique identifier you choose.
+
+### 2. Write
 
 Create a file called `main.gala`:
 
@@ -62,7 +71,7 @@ func main() {
 
 `Println` is a built-in function -- no imports needed.
 
-### 2. Run
+### 3. Run
 
 ```bash
 gala run main.gala
@@ -74,7 +83,7 @@ Output:
 Hello, GALA!
 ```
 
-That is it. GALA transpiles your code to Go, compiles it, and runs the binary.
+That is it. GALA transpiles your code to Go, compiles it, and runs the binary. (Make sure [Go 1.25+](https://go.dev/dl/) is on your `PATH` — GALA shells out to `go build` under the hood.)
 
 ---
 


### PR DESCRIPTION
## Summary

A fresh user following the README Quick Start can't reach hello world today — `gala run` requires an undocumented `gala.mod`, and the pre-built binary silently shells out to `go build`. This PR closes those two gaps by documenting the hidden prerequisites and fixes several stale references across README, IntelliJ docs, and the website.

## What changed

**Quick Start rewrite (`README.MD`)**
- Playground + Getting Started link at top
- Go 1.25+ prerequisite disclosed (previously only mentioned under "Build from Source")
- `gala mod init` added as an explicit step
- `gala version` added as a verify-install step
- Broken `gala run examples/hello/main.gala` line removed (path never existed; actual file is `examples/hello.gala`, and `gala run` wouldn't have worked there without a `gala.mod` anyway)
- GitHub Discussions link added as help path
- Second Installation section also gains the Go prerequisite callout and binary-rename instruction

**Error messages (`cmd/gala/commands/{run,build}.go`)**
- `gala.mod not found` now shows a concrete example:
  `Run 'gala mod init <module-path>' to create one. Example: gala mod init example.com/myapp`

**IntelliJ plugin (`ide/intellij/README.MD` + `GalaLspServerProvider.kt`)**
- Drops dead `//cmd/gala-lsp:gala-lsp` target reference — LSP is now the `gala lsp` subcommand
- Removes stale `gala install` reference from Kotlin docstring

**Website (`website/getting-started.md`)**
- Moves `gala mod init` before the first `gala run` so the walkthrough works end-to-end
- Notes Go toolchain prerequisite inline

## Why

Without these fixes, the README Quick Start produces this happy path for a new user:

1. Install binary → add to PATH (✓)
2. Write `main.gala` as shown
3. Run `gala run main.gala` → error: `gala.mod not found`
4. Run `gala mod init` as suggested → works
5. Run `gala run main.gala` → error: `go build: exec: "go": executable file not found`
6. Install Go, retry → finally works at ~20 minutes in

Post-PR the same user gets a runnable hello world in 3-5 minutes with every prerequisite disclosed upfront.

## Not in scope (tracked separately)

- Making `gala run main.gala` work without `gala.mod` (code change, auto-create ephemeral module)
- `gala new <name>` scaffolder
- Homebrew / Scoop / `curl | sh` installers
- VS Code extension + JetBrains Marketplace submission
- Detecting absent `go` binary and printing a clear error

## Test plan

- [x] `bazel build //cmd/gala:gala` passes with modified error-message strings
- [ ] Manual: fresh-user walkthrough following the new Quick Start verbatim on macOS / Linux / Windows
- [ ] Confirm IntelliJ plugin README's new LSP install steps work against a released binary
- [ ] Verify `website/getting-started.md` renders correctly on the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)