### PR TITLE
feat(cli): add `gala new <name>` project scaffolder (gap #5)

### DIFF
--- a/cmd/gala/commands/BUILD.bazel
+++ b/cmd/gala/commands/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "commands",
@@ -15,6 +15,7 @@ go_library(
         "mod_tidy.go",
         "mod_update.go",
         "mod_verify.go",
+        "new.go",
         "project.go",
         "root.go",
         "run.go",
@@ -42,4 +43,10 @@ go_library(
         "@com_github_owenrumney_go_lsp//server",
         "@com_github_spf13_cobra//:cobra",
     ],
+)
+
+go_test(
+    name = "commands_test",
+    srcs = ["new_test.go"],
+    embed = [":commands"],
 )

--- a/cmd/gala/commands/new.go
+++ b/cmd/gala/commands/new.go
@@ -1,0 +1,138 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"martianoff/gala/internal/depman/mod"
+)
+
+// newModulePath optionally overrides the auto-generated module path.
+var newModulePath string
+
+var newCmd = &cobra.Command{
+	Use:   "new <name>",
+	Short: "Scaffold a new GALA project",
+	Long: `Create a new directory <name> pre-populated with a minimal
+runnable GALA project:
+
+  <name>/
+    gala.mod      module example.com/<name>  (override with --module)
+    main.gala     "Hello, GALA!" program
+    .gitignore    standard GALA build-output excludes
+
+Examples:
+  gala new myapp                                   # module example.com/myapp
+  gala new myapp --module github.com/you/myapp     # explicit module path`,
+	Args: cobra.ExactArgs(1),
+	Run:  runNew,
+}
+
+func init() {
+	newCmd.Flags().StringVar(&newModulePath, "module", "", "Module path (default: example.com/<name>)")
+}
+
+func runNew(cmd *cobra.Command, args []string) {
+	name := args[0]
+
+	if err := validateProjectName(name); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Fail if the target directory already exists.
+	if _, err := os.Stat(name); err == nil {
+		fmt.Fprintf(os.Stderr, "Error: %q already exists\n", name)
+		os.Exit(1)
+	} else if !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Error: failed to stat %q: %v\n", name, err)
+		os.Exit(1)
+	}
+
+	modulePath := newModulePath
+	if modulePath == "" {
+		modulePath = "example.com/" + filepath.Base(name)
+	}
+
+	if err := scaffoldProject(name, modulePath); err != nil {
+		// Best-effort cleanup on failure so the user can re-run.
+		_ = os.RemoveAll(name)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Created new GALA project %q (module %s)\n", name, modulePath)
+	fmt.Println()
+	fmt.Printf("  cd %s\n", name)
+	fmt.Println("  gala run main.gala")
+}
+
+// validateProjectName rejects empty names, absolute paths, parent traversal,
+// and path separators. The name must be usable as a plain directory name.
+func validateProjectName(name string) error {
+	if name == "" {
+		return fmt.Errorf("project name cannot be empty")
+	}
+	if filepath.IsAbs(name) {
+		return fmt.Errorf("project name must be a relative directory name, not an absolute path")
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("invalid project name %q", name)
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("project name %q must not contain path separators", name)
+	}
+	return nil
+}
+
+// scaffoldProject creates <dir>/ with gala.mod, main.gala, and .gitignore.
+func scaffoldProject(dir, modulePath string) error {
+	if err := os.Mkdir(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %q: %w", dir, err)
+	}
+
+	// gala.mod — reuse the same writer used by `gala mod init` for consistency.
+	galaMod := mod.NewFile(modulePath)
+	galaMod.Gala = Version
+	if err := mod.WriteFile(galaMod, filepath.Join(dir, "gala.mod")); err != nil {
+		return fmt.Errorf("failed to write gala.mod: %w", err)
+	}
+
+	// main.gala — minimal runnable program.
+	mainContent := `package main
+
+func main() {
+    Println("Hello, GALA!")
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "main.gala"), []byte(mainContent), 0644); err != nil {
+		return fmt.Errorf("failed to write main.gala: %w", err)
+	}
+
+	// .gitignore — GALA build-output and cache excludes.
+	// Mirrors the top-level repo .gitignore entries relevant to a user project.
+	gitignoreContent := `# GALA build workspaces and cache
+.gala/
+
+# Bazel output (if the user adopts Bazel)
+/bazel-*
+
+# Editor / IDE
+.idea/
+.vscode/
+*.iml
+
+# OS cruft
+.DS_Store
+Thumbs.db
+`
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(gitignoreContent), 0644); err != nil {
+		return fmt.Errorf("failed to write .gitignore: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/gala/commands/new_test.go
+++ b/cmd/gala/commands/new_test.go
@@ -1,0 +1,110 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateProjectName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"simple name", "myapp", false},
+		{"with digits", "app123", false},
+		{"with hyphen", "my-app", false},
+		{"with underscore", "my_app", false},
+		{"empty", "", true},
+		{"dot", ".", true},
+		{"parent", "..", true},
+		{"forward slash", "foo/bar", true},
+		{"backslash", `foo\bar`, true},
+		{"absolute unix", "/tmp/foo", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateProjectName(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateProjectName(%q) error = %v, wantErr = %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestScaffoldProject(t *testing.T) {
+	tmp := t.TempDir()
+	projectDir := filepath.Join(tmp, "hello")
+	modulePath := "example.com/hello"
+
+	if err := scaffoldProject(projectDir, modulePath); err != nil {
+		t.Fatalf("scaffoldProject: %v", err)
+	}
+
+	// Verify the three expected files exist.
+	expectedFiles := []string{"gala.mod", "main.gala", ".gitignore"}
+	for _, f := range expectedFiles {
+		path := filepath.Join(projectDir, f)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("missing file %s: %v", f, err)
+		}
+		if info.IsDir() {
+			t.Fatalf("%s: expected file, got directory", f)
+		}
+	}
+
+	// Verify gala.mod has the correct module line.
+	modContent, err := os.ReadFile(filepath.Join(projectDir, "gala.mod"))
+	if err != nil {
+		t.Fatalf("read gala.mod: %v", err)
+	}
+	if !strings.Contains(string(modContent), "module "+modulePath) {
+		t.Fatalf("gala.mod missing module line for %q, got:\n%s", modulePath, string(modContent))
+	}
+
+	// Verify main.gala has package main and a main func that prints the greeting.
+	mainContent, err := os.ReadFile(filepath.Join(projectDir, "main.gala"))
+	if err != nil {
+		t.Fatalf("read main.gala: %v", err)
+	}
+	mainStr := string(mainContent)
+	if !strings.Contains(mainStr, "package main") {
+		t.Fatalf("main.gala missing 'package main':\n%s", mainStr)
+	}
+	if !strings.Contains(mainStr, "func main()") {
+		t.Fatalf("main.gala missing 'func main()':\n%s", mainStr)
+	}
+	if !strings.Contains(mainStr, `Println("Hello, GALA!")`) {
+		t.Fatalf("main.gala missing expected Println call:\n%s", mainStr)
+	}
+
+	// Verify .gitignore excludes the GALA build/cache directory.
+	giContent, err := os.ReadFile(filepath.Join(projectDir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(giContent), ".gala/") {
+		t.Fatalf(".gitignore missing '.gala/' exclude:\n%s", string(giContent))
+	}
+}
+
+func TestScaffoldProjectCustomModule(t *testing.T) {
+	tmp := t.TempDir()
+	projectDir := filepath.Join(tmp, "proj")
+	modulePath := "github.com/someone/proj"
+
+	if err := scaffoldProject(projectDir, modulePath); err != nil {
+		t.Fatalf("scaffoldProject: %v", err)
+	}
+
+	modContent, err := os.ReadFile(filepath.Join(projectDir, "gala.mod"))
+	if err != nil {
+		t.Fatalf("read gala.mod: %v", err)
+	}
+	if !strings.Contains(string(modContent), "module "+modulePath) {
+		t.Fatalf("gala.mod missing custom module path %q, got:\n%s", modulePath, string(modContent))
+	}
+}

--- a/cmd/gala/commands/root.go
+++ b/cmd/gala/commands/root.go
@@ -20,6 +20,7 @@ This tool provides:
   - Dependency management (gala mod)
 
 Usage:
+  gala new <name>               Scaffold a new GALA project
   gala build                    Build project to binary
   gala run                      Build and run project
   gala test                     Run tests in project
@@ -83,6 +84,7 @@ func init() {
 	rootCmd.AddCommand(cleanCmd)
 	rootCmd.AddCommand(testCmd)
 	rootCmd.AddCommand(cacheCmd)
+	rootCmd.AddCommand(newCmd)
 
 	// Add global flags that mirror transpile flags for backward compatibility
 	rootCmd.Flags().StringVarP(&transpileInput, "input", "i", "", "Path to the input .gala file")


### PR DESCRIPTION
## Summary

Closes product **gap #5**: new users had no way to get a runnable GALA project on disk in one step. Every other subcommand (`build`, `run`, `test`, `mod …`) assumes `gala.mod` + source already exist.

`gala new <name>` fixes that:

```
gala new myproject
cd myproject && gala run main.gala
# => Hello, GALA!
```

Creates `<name>/` with three files:

- `gala.mod` — `module example.com/<name>` (override with `--module <path>`), written via the same `internal/depman/mod` path used by `gala mod init` so output stays consistent.
- `main.gala` — `package main` + `func main() { Println("Hello, GALA!") }`.
- `.gitignore` — `.gala/`, `/bazel-*`, editor/OS cruft.

## Scope discipline (deliberate non-goals)

- Only `gala new <name>`. No `--cli` / `--http` / `--lib` template flags — follow-ups.
- No `git init` side-effect.
- Fails fast with exit 1 if `<name>` already exists.
- Rejects empty / absolute / path-separator / `.` / `..` names.

## Changes

- `cmd/gala/commands/new.go` (new) — `newCmd` cobra command + `validateProjectName` + `scaffoldProject`.
- `cmd/gala/commands/new_test.go` (new) — table tests for name validation, happy-path scaffold check on all three generated files, custom `--module` flag path.
- `cmd/gala/commands/root.go` — register `newCmd`, mention it in the root `Long` help.
- `cmd/gala/commands/BUILD.bazel` — add `new.go` to `go_library` srcs, add `go_test` target.

## Verification

- `bazel build //cmd/gala:gala` — passes.
- `bazel test //cmd/gala/commands:commands_test` — passes (1/1, 4 subtests).
- `bazel test //...` — 253/254 pass. The one failure (`//internal/lsp:lsp_test`) is in unrelated LSP `TestCompletion_*` / `TestDefinition_*` / `TestMultiPackage_*` cases that don't touch anything in this PR. Flagging for awareness but leaving it to the LSP owners.
- End-to-end smoke test (manual):
  - `gala new myproject` → three files on disk, exits 0.
  - `cd myproject && gala run main.gala` → prints `Hello, GALA!`.
  - `gala new myproject` (second run) → `Error: "myproject" already exists`, exit 1.
  - `gala new custom --module github.com/me/custom` → `gala.mod` carries the explicit module line.

## Test plan

- [ ] Reviewer: `bazel test //cmd/gala/commands:commands_test` locally.
- [ ] Reviewer: `bazel build //cmd/gala:gala` then run `gala new demo && cd demo && gala run main.gala` — expect `Hello, GALA!`.
- [ ] Reviewer: confirm `.gitignore` excludes match the project's conventions.

## Follow-ups (not in this PR)

- `--cli` / `--http` / `--lib` starter templates.
- Optional `--git` flag for `git init`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)