### PR TITLE
fix(cli): gala run single-file mode with ephemeral gala.mod

### DIFF
--- a/cmd/gala/commands/BUILD.bazel
+++ b/cmd/gala/commands/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
     name = "commands_test",
     srcs = [
         "new_test.go",
+        "project_test.go",
         "run_test.go",
     ],
     embed = [":commands"],

--- a/cmd/gala/commands/project.go
+++ b/cmd/gala/commands/project.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,4 +56,47 @@ type projectNotFoundError struct {
 
 func (e *projectNotFoundError) Error() string {
 	return "gala.mod not found in " + e.startDir + " or any parent directory"
+}
+
+// resolveRunTarget is a variant of findProjectRoot tailored to `gala run`. It
+// matches `go run main.go` semantics: when the user points at a single .gala
+// file and there is no gala.mod anywhere up the tree, fall back to an ephemeral
+// module rooted at the file's containing directory. This removes the first-30-
+// minute "gala.mod not found" wall for toy programs while leaving existing
+// project-resolution behavior untouched for directories and files inside real
+// modules.
+//
+// Returns (projectRoot, ephemeral, error). When ephemeral is true, the caller
+// should expect the Builder to synthesize an in-memory gala.mod for this run.
+func resolveRunTarget(pathArg string) (string, bool, error) {
+	root, err := findProjectRoot(pathArg)
+	if err == nil {
+		return root, false, nil
+	}
+
+	// Only fall back to ephemeral mode when the specific failure is "no
+	// gala.mod found". Any other error (permission, invalid path, etc.)
+	// should propagate unchanged.
+	var notFound *projectNotFoundError
+	if !errors.As(err, &notFound) {
+		return "", false, err
+	}
+
+	// Ephemeral mode is only safe for a single concrete .gala file. For
+	// directory arguments, "no gala.mod" remains a hard error — the user
+	// likely forgot `gala mod init` for a real project, and silently treating
+	// a whole directory as an ephemeral module would hide that.
+	absPath, absErr := filepath.Abs(pathArg)
+	if absErr != nil {
+		return "", false, err
+	}
+	info, statErr := os.Stat(absPath)
+	if statErr != nil || info.IsDir() {
+		return "", false, err
+	}
+	if !strings.HasSuffix(strings.ToLower(absPath), ".gala") {
+		return "", false, err
+	}
+
+	return filepath.Dir(absPath), true, nil
 }

--- a/cmd/gala/commands/project_test.go
+++ b/cmd/gala/commands/project_test.go
@@ -1,0 +1,120 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestResolveRunTarget_FindsExistingGalaMod ensures that `gala run` still
+// resolves to the real project root when a gala.mod is present — the existing
+// behavior is preserved and ephemeral mode is NOT entered.
+func TestResolveRunTarget_FindsExistingGalaMod(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "gala.mod"), []byte("module example.com/test\n"), 0644); err != nil {
+		t.Fatalf("write gala.mod: %v", err)
+	}
+	mainGala := filepath.Join(dir, "main.gala")
+	if err := os.WriteFile(mainGala, []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("write main.gala: %v", err)
+	}
+
+	root, ephemeral, err := resolveRunTarget(mainGala)
+	if err != nil {
+		t.Fatalf("resolveRunTarget returned error: %v", err)
+	}
+	if ephemeral {
+		t.Fatalf("expected ephemeral=false when gala.mod is present, got true")
+	}
+	// Resolve symlinks / evaluate for platform-consistent comparison on macOS/Windows.
+	if !samePath(root, dir) {
+		t.Fatalf("expected project root %q, got %q", dir, root)
+	}
+}
+
+// TestResolveRunTarget_EphemeralSingleFile exercises the gap #2 fix: a fresh
+// user writes main.gala in an empty directory with no gala.mod and runs
+// `gala run main.gala`. We must return the file's directory as the project
+// root and signal ephemeral mode.
+func TestResolveRunTarget_EphemeralSingleFile(t *testing.T) {
+	dir := t.TempDir()
+	mainGala := filepath.Join(dir, "main.gala")
+	if err := os.WriteFile(mainGala, []byte("package main\n\nfunc main() = Println(\"hi\")\n"), 0644); err != nil {
+		t.Fatalf("write main.gala: %v", err)
+	}
+
+	root, ephemeral, err := resolveRunTarget(mainGala)
+	if err != nil {
+		t.Fatalf("resolveRunTarget returned error: %v", err)
+	}
+	if !ephemeral {
+		t.Fatalf("expected ephemeral=true when no gala.mod and single .gala file, got false")
+	}
+	if !samePath(root, dir) {
+		t.Fatalf("expected project root %q, got %q", dir, root)
+	}
+}
+
+// TestResolveRunTarget_DirectoryStillErrors guards the scope of the fix: a
+// directory argument with no gala.mod must still fail. Treating a whole
+// directory as an ephemeral module would hide a forgotten `gala mod init`
+// on a real project.
+func TestResolveRunTarget_DirectoryStillErrors(t *testing.T) {
+	// Use a tempdir that we know has no gala.mod in any ancestor. Skip if the
+	// OS tempdir root happens to sit inside some parent module (unlikely on
+	// CI but possible on developer machines).
+	dir := t.TempDir()
+	if _, err := findProjectRoot(dir); err == nil {
+		t.Skipf("temp dir %s has a gala.mod ancestor; skipping negative test", dir)
+	}
+
+	_, ephemeral, err := resolveRunTarget(dir)
+	if err == nil {
+		t.Fatalf("expected error for directory without gala.mod, got success")
+	}
+	if ephemeral {
+		t.Fatalf("expected ephemeral=false for directory arg, got true")
+	}
+}
+
+// TestResolveRunTarget_NonGalaFileErrors ensures that a non-.gala file
+// argument does not silently trigger ephemeral mode.
+func TestResolveRunTarget_NonGalaFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := findProjectRoot(dir); err == nil {
+		t.Skipf("temp dir %s has a gala.mod ancestor; skipping negative test", dir)
+	}
+	other := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(other, []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("write main.go: %v", err)
+	}
+
+	_, ephemeral, err := resolveRunTarget(other)
+	if err == nil {
+		t.Fatalf("expected error for non-.gala file without gala.mod, got success")
+	}
+	if ephemeral {
+		t.Fatalf("expected ephemeral=false for .go file, got true")
+	}
+}
+
+// samePath compares two filesystem paths in a platform-tolerant way. On
+// Windows the comparison is case-insensitive because Go's t.TempDir() can
+// round-trip paths through different case conventions (e.g. C:\Users vs
+// c:\users).
+func samePath(a, b string) bool {
+	aa, _ := filepath.EvalSymlinks(a)
+	bb, _ := filepath.EvalSymlinks(b)
+	if aa == "" {
+		aa = a
+	}
+	if bb == "" {
+		bb = b
+	}
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(aa, bb)
+	}
+	return aa == bb
+}

--- a/cmd/gala/commands/run.go
+++ b/cmd/gala/commands/run.go
@@ -71,11 +71,18 @@ func runRun(cmd *cobra.Command, args []string) {
 	// Resolve project root and optional source directory.
 	// If the argument is a .gala file or subdirectory, find gala.mod for deps
 	// but compile from the file's directory (multi-package build).
-	absProjectDir, err := findProjectRoot(projectDir)
+	// Matching `go run main.go` semantics: if no gala.mod exists and the
+	// argument is a single .gala file, fall back to an ephemeral module
+	// rooted at the file's directory. The Builder already synthesizes an
+	// in-memory gala.mod when none is on disk.
+	absProjectDir, ephemeral, err := resolveRunTarget(projectDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		fmt.Fprintln(os.Stderr, "Run 'gala mod init <module-path>' to create one. Example: gala mod init example.com/myapp")
 		os.Exit(1)
+	}
+	if ephemeral && runVerbose {
+		fmt.Fprintf(os.Stderr, "No gala.mod found; running %s in ephemeral module at %s\n", projectDir, absProjectDir)
 	}
 
 	// Create builder


### PR DESCRIPTION
## Summary

Closes adoption **gap #2**: `gala run main.gala` in an empty directory now works without `gala.mod`, matching `go run main.go` semantics.

Previously, a fresh user writing `main.gala` with `package main` and no `gala.mod` hit `Error: gala.mod not found in ... or any parent directory` — a first-30-minute adoption wall. PR #190 landed a docs-only mitigation (clearer error suggesting `gala mod init <path>`); this PR is the real code fix.

## Root cause

`cmd/gala/commands/run.go:runRun` called `findProjectRoot`, which aborts on missing `gala.mod`. The downstream `build.NewBuilder` already had an in-memory `gala.mod` fallback (`Module.Path = "gala-standalone"`), but the CLI step never got far enough to use it.

## Changes

- **`cmd/gala/commands/project.go`**: new `resolveRunTarget(pathArg) (root, ephemeral, err)`. Delegates to `findProjectRoot`; on `projectNotFoundError`, falls back to ephemeral mode **only** when the argument is a single concrete `.gala` file. Directory arguments, non-`.gala` files, or any other error still propagate unchanged.
- **`cmd/gala/commands/run.go`**: `runRun` now uses `resolveRunTarget`. Adds a verbose-only stderr notice when ephemeral mode kicks in.
- **`cmd/gala/commands/project_test.go`** (new): four unit tests covering the contract — gala.mod present, ephemeral single-file, directory-still-errors, non-gala-file-still-errors.
- **`cmd/gala/commands/BUILD.bazel`**: adds `go_test` target.

## Scope discipline

- `findProjectRoot` itself is untouched, so `gala build` and `gala test` semantics are unchanged.
- Ephemeral mode only applies to single `.gala` file arguments; `gala run .` in an empty dir still errors with the `gala mod init` hint (a forgotten init on a real project shouldn't be silently masked).
- The existing `isLibraryPackage` check already rejects non-main packages with a clean error, so no new code was needed for that case.

## Verification

**Unit tests** — `bazel test //cmd/gala/commands:commands_test` PASSED

**End-to-end smoke tests** with a freshly built `gala.exe`:

| Scenario | Result |
|---|---|
| Temp dir, only `main.gala`, no `gala.mod` | `hello from ephemeral mode` ✅ |
| Temp dir, `mylib.gala` with `package mylib`, no `gala.mod` | `Error: cannot run a library package.` ✅ |
| Temp dir with no `.gala` files, `gala run .` | `Error: gala.mod not found... Run 'gala mod init...'` ✅ (unchanged) |
| Temp dir with `gala.mod` + `main.gala`, `gala run .` | `hello from regular mode` ✅ (unchanged) |

## Repro (before fix)

```console
$ mkdir /tmp/fresh && cd /tmp/fresh
$ cat > main.gala <<EOF
package main
func main() { Println("hello") }
EOF
$ gala run main.gala
Error: gala.mod not found in /tmp/fresh or any parent directory
Run 'gala mod init <module-path>' to create one. Example: gala mod init example.com/myapp
```

After this PR: prints `hello`, no setup needed.

---
Generated with [Claude Code](https://claude.com/claude-code)
