### PR TITLE
fix(build): clear error when Go toolchain is missing from PATH

### DIFF
--- a/internal/build/BUILD.bazel
+++ b/internal/build/BUILD.bazel
@@ -25,7 +25,10 @@ go_library(
 
 go_test(
     name = "build_test",
-    srcs = ["deptranspiler_test.go"],
+    srcs = [
+        "deptranspiler_test.go",
+        "go_toolchain_test.go",
+    ],
     embed = [":build"],
     deps = [
         "@com_github_stretchr_testify//assert",

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -83,6 +83,14 @@ func NewBuilder(projectDir string, stdlibVersion string, verbose bool) (*Builder
 // Otherwise, treats it as relative to the project directory.
 // For library packages (non-main), Build performs a compile check and returns "" with no error.
 func (b *Builder) Build(outputPath string) (string, error) {
+	// Step 0: Verify Go toolchain is on PATH before doing any work.
+	// GALA transpiles to Go, so `go build` is a hard prerequisite. Without
+	// this check users see a cryptic `exec: "go": executable file not found`
+	// error only after transpilation completes.
+	if err := ensureGoToolchain(); err != nil {
+		return "", err
+	}
+
 	// Step 1: Ensure workspace exists
 	if b.verbose {
 		fmt.Printf("Using workspace: %s\n", b.workspace.Dir)
@@ -857,9 +865,25 @@ func (b *Builder) isLibraryPackage() (bool, string) {
 	return false, ""
 }
 
+// ensureGoToolchain verifies that the Go toolchain is available on PATH.
+// Pre-built GALA binaries depend on `go build` to finish the compilation pipeline,
+// so if `go` is not on PATH we surface a clear actionable error before shelling
+// out — the raw exec error ("executable file not found in $PATH") does not
+// explain the prerequisite.
+func ensureGoToolchain() error {
+	if _, err := exec.LookPath("go"); err != nil {
+		return fmt.Errorf("Go 1.25+ is required on your PATH to build GALA programs (GALA transpiles to Go).\nInstall Go from https://go.dev/dl/ and try again")
+	}
+	return nil
+}
+
 // goCompileCheck runs `go build ./...` in the workspace without producing a binary.
 // This verifies that library packages compile correctly.
 func (b *Builder) goCompileCheck() error {
+	if err := ensureGoToolchain(); err != nil {
+		return err
+	}
+
 	if b.verbose {
 		fmt.Println("Running go build (compile check)...")
 	}
@@ -882,6 +906,10 @@ func (b *Builder) goCompileCheck() error {
 
 // goBuild runs `go build` in the workspace and returns the output path.
 func (b *Builder) goBuild(outputPath string) (string, error) {
+	if err := ensureGoToolchain(); err != nil {
+		return "", err
+	}
+
 	if b.verbose {
 		fmt.Println("Running go build...")
 	}

--- a/internal/build/go_toolchain_test.go
+++ b/internal/build/go_toolchain_test.go
@@ -1,0 +1,71 @@
+package build
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestEnsureGoToolchain_Present verifies the happy path: when `go` is on PATH
+// (which it is in CI since we build with Bazel + Go), the check passes with no
+// error.
+func TestEnsureGoToolchain_Present(t *testing.T) {
+	if err := ensureGoToolchain(); err != nil {
+		t.Fatalf("expected Go toolchain to be available, got error: %v", err)
+	}
+}
+
+// TestEnsureGoToolchain_Missing verifies that when `go` is not on PATH the
+// check returns a clear, actionable error message that explains the Go
+// prerequisite. This is gap #3 from the pre-built release user-journey report:
+// previously users saw the raw exec.ErrNotFound message.
+func TestEnsureGoToolchain_Missing(t *testing.T) {
+	// Save and clear PATH so exec.LookPath("go") cannot find the toolchain.
+	origPath, hadPath := os.LookupEnv("PATH")
+	t.Cleanup(func() {
+		if hadPath {
+			os.Setenv("PATH", origPath)
+		} else {
+			os.Unsetenv("PATH")
+		}
+	})
+
+	if err := os.Setenv("PATH", ""); err != nil {
+		t.Fatalf("clearing PATH: %v", err)
+	}
+
+	// On Windows exec.LookPath also consults PATHEXT; clearing PATH alone is
+	// enough since LookPath always resolves relative to PATH, but we clear
+	// PATHEXT too to eliminate any platform-specific edge cases.
+	if runtime.GOOS == "windows" {
+		origPathExt, hadPathExt := os.LookupEnv("PATHEXT")
+		t.Cleanup(func() {
+			if hadPathExt {
+				os.Setenv("PATHEXT", origPathExt)
+			} else {
+				os.Unsetenv("PATHEXT")
+			}
+		})
+		os.Unsetenv("PATHEXT")
+	}
+
+	err := ensureGoToolchain()
+	if err == nil {
+		t.Fatal("expected error when Go toolchain is missing from PATH, got nil")
+	}
+
+	msg := err.Error()
+	// The error must explicitly mention Go and provide an install pointer so
+	// the user knows how to fix the problem without consulting docs.
+	wantSubstrings := []string{
+		"Go",
+		"PATH",
+		"https://go.dev/dl/",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q\nfull message: %s", want, msg)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes pre-built-release gap #3: `gala run main.gala` on a box without Go silently shells out and prints `exec: "go": executable file not found in $PATH`. The error is cryptic and never tells the user that Go is a hard prerequisite.

Detect the missing toolchain via `exec.LookPath("go")` at the top of `Builder.Build` (with a defensive second check inside `goBuild` / `goCompileCheck`) and emit an actionable message **before** any transpilation runs:

```
Go 1.25+ is required on your PATH to build GALA programs (GALA transpiles to Go).
Install Go from https://go.dev/dl/ and try again
```

Companion to PR #190 which added the README prerequisite callout. Docs now explain the requirement; this PR makes the error itself explain it.

## Changes

- `internal/build/builder.go`
  - New unexported helper `ensureGoToolchain()` — single `exec.LookPath("go")` check returning a formatted error.
  - Call it once at the very top of `Builder.Build` so we fail fast before workspace setup or transpilation.
  - Defensive calls at the top of `goBuild` / `goCompileCheck` so direct callers get the same message.
- `internal/build/go_toolchain_test.go` (new) — two table-ish unit tests:
  - `TestEnsureGoToolchain_Present` — happy path (Go is on PATH in CI).
  - `TestEnsureGoToolchain_Missing` — clears `PATH` (and `PATHEXT` on Windows), asserts the returned error contains `Go`, `PATH`, and `https://go.dev/dl/`, restores env via `t.Cleanup`.
- `internal/build/BUILD.bazel` — add the new test file to the `go_test` srcs list.

## Verification

- `bazel build //internal/build:build //internal/build:build_test` passes.
- `bazel test //internal/build:build_test` passes (2/2).
- `bazel test //internal/build:build_test //cmd/...` passes — no regressions in neighboring CLI command tests.

## Test Plan

- [x] Unit test: missing `go` on PATH produces a message mentioning Go, PATH, and the install URL.
- [x] Unit test: present `go` on PATH returns nil.
- [x] Manual reasoning: `Build()` calls `ensureGoToolchain` before `workspace.Ensure`, so the error fires before we touch any filesystem state.

## Scope

Strictly the "go not found" detection — no other build-pipeline changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)