### PR TITLE
fix(stdlib): List.GroupBy panics in AppendAll on empty bucket

### DIFF
--- a/collection_immutable/list.gala
+++ b/collection_immutable/list.gala
@@ -559,20 +559,30 @@ func (l List[T]) PartitionMap[A any, B any](f func(T) Either[A, B]) Tuple[List[A
 }
 
 // GroupBy partitions this list into a map of lists according to a discriminator function.
+//
+// A zero-valued List[T] returned by a missing-key map lookup has isEmpty=false
+// and tail=nil (Go zero values), so calling Append on it would dereference
+// a nil tail. Branch on MapContains and start a fresh emptyList for new keys.
 func (l List[T]) GroupBy[K comparable](f func(T) K) map[K]List[T] {
     var result = go_interop.MapEmpty[K, List[T]]()
     var current = l
     for !current.isEmpty {
         val elem = current.head
         val key = f(elem)
-        val existing = result[key]
-        result[key] = existing.Append(elem)
+        if go_interop.MapContains(result, key) {
+            result[key] = result[key].Append(elem)
+        } else {
+            result[key] = consList[T](elem, emptyList[T]())
+        }
         current = *current.tail
     }
     return result
 }
 
 // GroupMap partitions elements and maps values according to discriminator and value functions.
+//
+// See GroupBy for why we must branch on MapContains instead of reading the
+// zero-valued List[V] back from the map.
 func (l List[T]) GroupMap[K comparable, V any](key func(T) K, value func(T) V) map[K]List[V] {
     var result = go_interop.MapEmpty[K, List[V]]()
     var current = l
@@ -580,8 +590,11 @@ func (l List[T]) GroupMap[K comparable, V any](key func(T) K, value func(T) V) m
         val elem = current.head
         val k = key(elem)
         val v = value(elem)
-        val existing = result[k]
-        result[k] = existing.Append(v)
+        if go_interop.MapContains(result, k) {
+            result[k] = result[k].Append(v)
+        } else {
+            result[k] = consList[V](v, emptyList[V]())
+        }
         current = *current.tail
     }
     return result

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -340,6 +340,13 @@ gala_test(
 )
 
 gala_test(
+    name = "list_groupby_string_keys",
+    src = "list_groupby_string_keys.gala",
+    expected = "list_groupby_string_keys.out",
+    deps = ["//collection_immutable"],
+)
+
+gala_test(
     name = "mixed_guard_extractor",
     src = "mixed_guard_extractor.gala",
     expected = "mixed_guard_extractor.out",

--- a/examples/list_groupby_string_keys.gala
+++ b/examples/list_groupby_string_keys.gala
@@ -1,0 +1,40 @@
+package main
+
+import (
+    . "martianoff/gala/collection_immutable"
+)
+
+// Regression test for gap #6: List.GroupBy with string keys panics in
+// AppendAll. A zero-valued List[T] returned by map[K]List[T] lookups has
+// isEmpty = false (Go bool zero value), which makes Append iterate over a
+// nil tail pointer. GroupBy must treat missing keys as empty lists.
+//
+// We stringify each bucket via FoldLeft (returns a concrete type, dodges
+// a separate lambda-inference quirk on map-indexed List values) so this
+// test pins the GroupBy fix on its own.
+func describeString(prefix string, l List[string]) string {
+    return prefix + ":" + l.FoldLeft("", (acc, w) => acc + " " + w) + " len=" + s"${l.Size()}"
+}
+
+func describeInt(prefix string, l List[int]) string {
+    return prefix + ":" + l.FoldLeft("", (acc, x) => acc + " " + s"$x")
+}
+
+func main() {
+    // String keys — the original panic case.
+    val words = ListOf("a", "b", "a", "c", "b", "a")
+    val grouped = words.GroupBy((w) => w)
+
+    val bucketA = grouped["a"]
+    val bucketB = grouped["b"]
+    val bucketC = grouped["c"]
+    Println(describeString("a", bucketA))
+    Println(describeString("b", bucketB))
+    Println(describeString("c", bucketC))
+
+    // Int keys — baseline that must keep working.
+    val nums = ListOf(1, 2, 3, 4, 5, 6)
+    val byParity = nums.GroupBy((n) => n % 2)
+    Println(describeInt("evens", byParity[0]))
+    Println(describeInt("odds", byParity[1]))
+}

--- a/examples/list_groupby_string_keys.out
+++ b/examples/list_groupby_string_keys.out
@@ -1,0 +1,5 @@
+a: a a a len=3
+b: b b len=2
+c: c len=1
+evens: 2 4 6
+odds: 1 3 5


### PR DESCRIPTION
## Summary

Fixes **gap #6**: `List.GroupBy` (and `List.GroupMap`) panic inside `AppendAll`
the first time any key is seen.

Reported symptom:
```gala
ListOf(\"a\", \"b\", \"a\").GroupBy((w) => w)
// runtime panic in List_GroupBy -> Append -> AppendAll
```

The panic was described as string-key specific, but the underlying defect
is key-type independent.

## Root cause

`collection_immutable/list.gala` — pre-fix `GroupBy`:

```gala
val existing = result[key]            // zero List[T] when key absent
result[key] = existing.Append(elem)   // AppendAll dereferences nil tail
```

`result` is a raw `map[K]List[T]`. A missing-key lookup returns the zero
`List[T]`. In the generated Go, `List` has an `isEmpty Immutable[bool]`
field whose Go zero value wraps `false`, so the zero list *looks* non-empty
to every method — but its `tail Immutable[*List[T]]` is a nil pointer
wrapper. `AppendAll` therefore skips its `isEmpty` fast path and
dereferences `*nil` on the first loop iteration.

`Array.GroupBy` is unaffected because `Array`'s zero value
(`root=nil, length=0, prefix=nil`) is a valid empty representation and its
`Append` path handles it correctly.

`List.GroupMap` is identical in shape and has the same bug.
`List.GroupMapReduce` already guards with a parallel `seen` map and is fine.

## Fix

Branch on `go_interop.MapContains` before reading the bucket back out;
construct a fresh one-element list with `consList[T](elem, emptyList[T]())`
on first hit so only valid (non-zero) lists ever live in the accumulator.

Same fix applied to `GroupMap`.

## Changes

- `collection_immutable/list.gala` — `GroupBy`, `GroupMap` now branch on
  `go_interop.MapContains`.
- `examples/list_groupby_string_keys.gala` + `.out` — new regression test
  covering the string-key panic case plus an int-key baseline.
- `examples/BUILD.bazel` — register the new `gala_test`.

## Verification

- `bazel test //examples:list_groupby_string_keys` — pass
- `bazel test //...` — 254/254 pass

## Dependencies

None — independent fix, ready to review and merge against `master`.