### PR TITLE
fix(match): reject bare return inside value-producing match (gap #4)

### DIFF
--- a/docs/errors/GALA-E0015.md
+++ b/docs/errors/GALA-E0015.md
@@ -1,0 +1,88 @@
+# GALA-E0015 — Bare `return` inside a match branch used as a value
+
+**When it fires.** A `match` expression is used as a value (its result is
+assigned to a variable, returned from a function as an expression, or passed
+as an argument) and one of its branches ends with a bare `return` — a
+`return` statement with no value.
+
+**Minimal repro.**
+
+```gala
+package main
+
+import "os"
+
+func run(path string) {
+    val data = Try(() => os.ReadFile(path)) match {
+        case Success(b)   => string(b)
+        case Failure(err) => {
+            Println(s"error: ${err.Error()}")
+            return                     // <- bare return in a value-match branch
+        }
+    }
+    Println(data)
+}
+```
+
+**Error output.**
+
+```
+[SemanticError GALA-E0015] main.gala:10:31 bare `return` inside a match branch whose result is used as a value
+```
+
+**Why it is an error.** GALA transpiles a match-as-value into a Go
+immediately-invoked function expression (IIFE):
+
+```go
+data := func(obj ...) string {
+    switch ... {
+    case Success:  return string(b)
+    case Failure:  fmt.Println(...); return   // <- invalid: IIFE must return string
+    }
+}(...)
+```
+
+A bare `return` inside that IIFE does not exit the enclosing function — it
+exits the IIFE — and because the IIFE has a non-void return type, the Go
+compiler rejects it with *"not enough return values"*.
+
+**Fix.** Pick whichever restructuring best matches the intent.
+
+1.  **Early-exit before the match** — test the failure case first and
+    `return` from the outer function, then destructure the success case:
+
+    ```gala
+    func run(path string) {
+        val result = Try(() => os.ReadFile(path))
+        if (result.IsFailure()) {
+            Println(s"error: ${result.GetError().Error()}")
+            return
+        }
+        Println(string(result.Get()))
+    }
+    ```
+
+2.  **Use combinators** — `Recover`, `Map`, `GetOrElse`, etc. avoid the IIFE
+    entirely and compose cleanly:
+
+    ```gala
+    func run(path string) {
+        val data = Try(() => os.ReadFile(path))
+            .Map((b) => string(b))
+            .GetOrElse("")
+        if (data == "") { return }
+        Println(data)
+    }
+    ```
+
+3.  **Return from a `match` used as the function body** — if the match
+    itself is the function's last expression, each branch can legitimately
+    `return` a value (including `return` on its own when the function is
+    `Unit`/void).
+
+**Rationale.** GALA's match-as-value form has expression semantics: every
+branch must contribute a value of the match's result type. A bare `return`
+is a *statement-level* control-flow operation whose scope (outer function
+vs. enclosing IIFE) is ambiguous without extra machinery. Rather than pick
+one interpretation silently and generate surprising Go, the transpiler
+rejects the construct and points to the explicit rewrites above.

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -615,6 +615,15 @@ gala_test(
     expected = "match_return_iife.out",
 )
 
+# Gap #4 (GALA-E0015): a value-producing match with a bare `return` inside a
+# branch is rejected at transpile time. This example shows the positive form
+# (destructure with .IsFailure() and return before the match).
+gala_test(
+    name = "gap04_repro",
+    src = "gap04_repro.gala",
+    expected = "gap04_repro.out",
+)
+
 # FIX-053: NewImmutable[T](nil) explicit type param
 gala_test(
     name = "newimmutable_nil",

--- a/examples/gap04_repro.gala
+++ b/examples/gap04_repro.gala
@@ -1,0 +1,26 @@
+package main
+
+import "os"
+
+// Positive form of gap #4 (GALA-E0015): a match-as-value that needs to early-
+// exit from the outer function cannot use a bare `return` inside a branch,
+// because the generated IIFE has a non-void return type. Instead, destructure
+// the Try first and early-return before the match.
+//
+// The negative form — a bare `return` inside a value-producing match — is
+// exercised as a transpile-error test in
+// internal/transpiler/transformer/error_codes_test.go (GALA-E0015).
+
+func run(path string) {
+    val result = Try(() => os.ReadFile(path))
+    if (result.IsFailure()) {
+        Println("error: file not found")
+        return
+    }
+    val data = string(result.Get())
+    Println(data)
+}
+
+func main() {
+    run("nonexistent-file.txt")
+}

--- a/examples/gap04_repro.out
+++ b/examples/gap04_repro.out
@@ -1,0 +1,1 @@
+error: file not found

--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -126,6 +126,13 @@ const (
 
 	// E0014: default value expression type does not match the parameter type.
 	CodeParamDefaultTypeMismatch ErrorCode = "GALA-E0014"
+
+	// E0015: bare `return` inside a match branch that is used as a value.
+	// The match is wrapped in an IIFE whose return type is non-void, so a
+	// bare `return` would produce invalid Go. Users intending to early-exit
+	// the enclosing function must restructure the code (e.g., `.Recover`, or
+	// pattern-match on the value first and then return outside the match).
+	CodeBareReturnInValueMatch ErrorCode = "GALA-E0015"
 )
 
 // MultiError collects multiple GALA errors.

--- a/internal/transpiler/transformer/error_codes_test.go
+++ b/internal/transpiler/transformer/error_codes_test.go
@@ -165,6 +165,50 @@ func main() {
 			expectCode:     galaerr.CodeParamDefaultTypeMismatch,
 			expectContains: "default for parameter",
 		},
+		{
+			// Repro of fix/gap-04: a match used as a value (assigned to `val`)
+			// whose Failure branch ends with a bare `return` would previously
+			// emit invalid Go (the IIFE has return type string but returns no
+			// value). We now reject this at transpile time with GALA-E0015.
+			name: "GALA-E0015 bare return inside value-producing match (Try)",
+			input: `package main
+
+import "os"
+
+func run(path string) {
+    val data = Try(() => os.ReadFile(path)) match {
+        case Success(b)   => string(b)
+        case Failure(err) => {
+            Println(s"error: ${err.Error()}")
+            return
+        }
+    }
+    Println(data)
+}
+
+func main() { run("missing.txt") }`,
+			expectCode:     galaerr.CodeBareReturnInValueMatch,
+			expectContains: "bare `return`",
+		},
+		{
+			// Same shape with Option. The Some branch yields a value, the None
+			// branch bare-returns. Result type of the match is `int`, so the
+			// bare return is ambiguous and must be rejected.
+			name: "GALA-E0015 bare return inside value-producing match (Option)",
+			input: `package main
+
+func lookup(opt Option[int]) int {
+    val n = opt match {
+        case Some(v) => v
+        case None()  => { return }
+    }
+    return n * 2
+}
+
+func main() { lookup(None[int]()) }`,
+			expectCode:     galaerr.CodeBareReturnInValueMatch,
+			expectContains: "bare `return`",
+		},
 	}
 
 	for _, tc := range cases {
@@ -209,6 +253,63 @@ func main() {
 	out, err := trans.Transpile(input, "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, out)
+}
+
+// TestGap04BareReturnRefactoredCompiles is the positive companion to the
+// GALA-E0015 cases above. The same intent (early-exit on Failure) expressed
+// via an early `if` before the match — rather than a bare `return` inside a
+// match branch — must compile cleanly.
+func TestGap04BareReturnRefactoredCompiles(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	// Refactored form: destructure with .IsFailure() / .Get() outside the
+	// match so the `return` is a top-level statement of `run`, not nested
+	// inside an IIFE.
+	input := `package main
+
+import "os"
+
+func run(path string) {
+    val result = Try(() => os.ReadFile(path))
+    if (result.IsFailure()) {
+        Println("error reading file")
+        return
+    }
+    Println(string(result.Get()))
+}
+
+func main() { run("missing.txt") }`
+	_, err := trans.Transpile(input, "")
+	require.NoError(t, err, "refactored form (early return before match) must compile")
+}
+
+// TestGap04BareReturnAllowedInVoidMatch guards against false positives:
+// GALA-E0015 must only fire when the match's result is a value. A match whose
+// every branch is side-effectful (VoidType) may contain bare returns because
+// the generated IIFE has no return type.
+func TestGap04BareReturnAllowedInVoidMatch(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	input := `package main
+
+func run(opt Option[int]) {
+    opt match {
+        case Some(n) => Println(n)
+        case None()  => { Println("nothing"); return }
+    }
+}
+
+func main() { run(Some(1)) }`
+	_, err := trans.Transpile(input, "")
+	require.NoError(t, err, "bare return is allowed inside void (side-effect) match branches")
 }
 
 // TestT10TypeVarSubstitutionDepthCap exercises the B8 guard. Build a

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -147,6 +147,90 @@ func (t *galaASTTransformer) isSealedExhaustive(matchedType transpiler.Type, pat
 	return true, len(missing) == 0, missing
 }
 
+// containsBareReturn reports whether any statement in stmts (recursively) is a
+// `return` with no results. It is used to detect "bare return" inside a branch
+// of a match-as-value expression, which would generate invalid Go because the
+// generated IIFE has a non-void return type.
+//
+// Only structural containers are traversed (blocks, if/else, the top-level
+// case body). Constructs that establish their own return scope (func literals,
+// nested IIFEs) are NOT traversed, since a bare return inside a nested lambda
+// exits that lambda, not the enclosing match IIFE.
+func containsBareReturn(stmts []ast.Stmt) bool {
+	for _, s := range stmts {
+		if stmtContainsBareReturn(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func stmtContainsBareReturn(stmt ast.Stmt) bool {
+	switch s := stmt.(type) {
+	case *ast.ReturnStmt:
+		return len(s.Results) == 0
+	case *ast.BlockStmt:
+		return containsBareReturn(s.List)
+	case *ast.IfStmt:
+		if s.Body != nil && containsBareReturn(s.Body.List) {
+			return true
+		}
+		if s.Else != nil && stmtContainsBareReturn(s.Else) {
+			return true
+		}
+		return false
+	case *ast.LabeledStmt:
+		return stmtContainsBareReturn(s.Stmt)
+	}
+	return false
+}
+
+// validateNoBareReturnsInValueMatch rejects a match expression whose result is
+// used as a value (non-void) but whose case bodies contain a bare `return`.
+// Such a construct would emit Go like:
+//
+//	func(obj T) string { ...; return /* no value */ }(subject)
+//
+// which fails to compile with "not enough return values". The user intent is
+// ambiguous between "exit the outer function" and "exit the match IIFE", so we
+// reject it and point at explicit rewrites in docs/errors/GALA-E0015.md.
+//
+// Called after case bodies have been transformed and the common result type
+// has been inferred; no-ops when resultType is void/nil.
+func (t *galaASTTransformer) validateNoBareReturnsInValueMatch(
+	clauses []ast.Stmt,
+	defaultBody []ast.Stmt,
+	resultType transpiler.Type,
+	startLine, startCol int,
+) error {
+	if resultType == nil || resultType.IsNil() {
+		return nil
+	}
+	if _, isVoid := resultType.(transpiler.VoidType); isVoid {
+		return nil
+	}
+	offender := false
+	for _, c := range clauses {
+		if stmtContainsBareReturn(c) {
+			offender = true
+			break
+		}
+	}
+	if !offender && containsBareReturn(defaultBody) {
+		offender = true
+	}
+	if !offender {
+		return nil
+	}
+	return galaerr.NewCodedSemanticError(
+		galaerr.CodeBareReturnInValueMatch,
+		startLine, startCol,
+		"bare `return` inside a match branch whose result is used as a value",
+		"the match is wrapped in a function that must return "+resultType.String()+
+			"; restructure to early-exit before the match, or use combinators like .Recover / .GetOrElse. See docs/errors/GALA-E0015.md",
+	)
+}
+
 // validateSealedVariantArity checks that each sealed-variant extractor pattern
 // binds the same number of fields as the variant declares. Wildcards and
 // binding names each count as one field. Patterns that do not target a known
@@ -495,6 +579,13 @@ func (t *galaASTTransformer) transformMatchClauses(ctx grammar.IExpressionContex
 	}
 	resultType, err := t.inferCommonResultType(resultTypes, casePatterns, matchCtx)
 	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Reject bare `return` inside a value-producing match (the IIFE would need
+	// to return a concrete type, but a bare return produces none). See GALA-E0015.
+	startLine, startCol := ctx.GetStart().GetLine(), ctx.GetStart().GetColumn()
+	if err := t.validateNoBareReturnsInValueMatch(clauses, defaultBody, resultType, startLine, startCol); err != nil {
 		return nil, nil, nil, err
 	}
 

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -404,6 +404,15 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 		return nil, err
 	}
 
+	// Reject bare `return` inside a value-producing match (the IIFE would need
+	// to return a concrete type, but a bare return produces none). See GALA-E0015.
+	{
+		startLine, startCol := ctx.GetStart().GetLine(), ctx.GetStart().GetColumn()
+		if err := t.validateNoBareReturnsInValueMatch(clauses, defaultBody, resultType, startLine, startCol); err != nil {
+			return nil, err
+		}
+	}
+
 	// Note: We keep result types with unresolved type parameters because they are valid Go
 	// when inside a generic function where the type parameters are in scope.
 


### PR DESCRIPTION
## Summary

Fixes product gap **#4**: `Try match { case Failure => { ...; return } }` currently generates invalid Go.

Given

```gala
func run(path string) {
    val data = Try(() => os.ReadFile(path)) match {
        case Success(b)   => string(b)
        case Failure(err) => { Println(s"error: $err"); return }
    }
    Println(data)
}
```

the transpiler previously emitted

```go
var data = std.NewImmutable(func(obj std.Try[[]byte]) string {
    // ... Success: return string(b)
    // ... Failure:
    fmt.Println(...)
    return  // ← invalid: IIFE return type is string
})
```

which Go rejects with *"not enough return values (have (), want (string))"*.

This PR picks **option (b)** from the gap brief: emit a clear transpile-time error (`GALA-E0015`) and point users at two idiomatic rewrites.

## Why option (b), not option (a)

Option (a) — hoist the branch's `return` out of the IIFE to the outer function — would require a new statement-level lowering of match-as-value (the current form is an expression-producing IIFE), context-aware decisions at every caller of `transformExpression` / `transformShortVarDecl` / function-body-return, and would still not help when the match is nested deep in a larger expression with no enclosing statement context. See `docs/private/fix-attempts/gap-04.md` (gitignored) for the full rationale. Option (b) is additive — it only rejects code that today silently produces uncompilable Go — and can be tightened later once a real statement-level lowering exists.

## Changes

- `galaerr/errors.go` — new stable code `CodeBareReturnInValueMatch = "GALA-E0015"`.
- `docs/errors/GALA-E0015.md` — diagnostic reference with repro, rationale, and two canonical rewrites.
- `internal/transpiler/transformer/match.go`:
  - `containsBareReturn` / `stmtContainsBareReturn` — AST walkers that find a bare `return` reachable through blocks / if-else / labeled statements, **without** descending into nested `FuncLit` (a bare return inside a nested lambda targets that lambda, not this match).
  - `validateNoBareReturnsInValueMatch` — runs after `inferCommonResultType`; no-ops when the result type is void, otherwise emits `GALA-E0015`.
  - Wired into `transformMatchClauses` (old match path).
- `internal/transpiler/transformer/postfix.go` — same check wired into `buildMatchExpressionFromClauses` (postfix match path).
- `internal/transpiler/transformer/error_codes_test.go` — two negative cases (`Try`, `Option`), one positive refactored-form test, and one false-positive guard (bare return is **allowed** in a void-match because the IIFE has no return type).
- `examples/gap04_repro.gala` + `gap04_repro.out` + BUILD — positive example using the recommended rewrite (`.IsFailure()` + early return before the match).

## Verification

- `bazel test //...` — 254 tests pass, none failed.
- New tests cover both directions: reject the bad form, accept the refactored form, accept bare returns inside void matches.
- Existing match / Try examples still transpile: `try_go_interop.gala`, `try_basic.gala`, `match_return_iife.gala`, `match_block_branch.gala`.

## Error message

```
[SemanticError GALA-E0015] main.gala:7:15 bare \`return\` inside a match branch whose result is used as a value (hint: the match is wrapped in a function that must return string; restructure to early-exit before the match, or use combinators like .Recover / .GetOrElse. See docs/errors/GALA-E0015.md)
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)