### PR TITLE
fix(codec): handle Option[T] fields in Codec[T] generator (gap #12)

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1498,6 +1498,19 @@ gala_test(
     ],
 )
 
+# FIX gap #12: Codec[T] must correctly handle Option[T] struct fields.
+# Encode: Some(v) -> value, None -> JSON null.
+# Decode: JSON null or missing field -> None, JSON value -> Some(value).
+gala_test(
+    name = "json_codec_option",
+    src = "json_codec_option.gala",
+    expected = "json_codec_option.out",
+    deps = [
+        "//collection_immutable",
+        "//json",
+    ],
+)
+
 # Regex pattern matching usage
 gala_test(
     name = "regex_usage",

--- a/examples/json_codec_option.gala
+++ b/examples/json_codec_option.gala
@@ -1,0 +1,81 @@
+package main
+
+import (
+    . "martianoff/gala/std"
+    . "martianoff/gala/json"
+)
+
+// Verifies FIX-gap-12: Codec[T] generator correctly handles Option[T] fields.
+// Encode:  Some(v)    -> field has the encoded value.
+//          None[T]()  -> field is JSON null.
+// Decode:  JSON null or missing field -> None[T]().
+//          JSON value                  -> Some[T](value).
+struct User(ID int, Name string, Email Option[string])
+
+// Extra struct to exercise Option over int, float64, bool in one round-trip.
+struct Settings(Age Option[int], Ratio Option[float64], Active Option[bool])
+
+func main() {
+    val codec = Codec[User](SnakeCase())
+
+    // 1. Encode: Some("a@b.com") -> "email":"a@b.com"
+    val withEmail = User(ID = 1, Name = "Alice", Email = Some("a@b.com"))
+    Println(codec.Encode(withEmail).Get())
+
+    // 2. Encode: None -> "email":null
+    val withoutEmail = User(ID = 2, Name = "Bob", Email = None[string]())
+    Println(codec.Encode(withoutEmail).Get())
+
+    // 3. Decode: field present with value -> Some
+    val decodedSome = codec.Decode("{\"id\":1,\"name\":\"Alice\",\"email\":\"a@b.com\"}").Get()
+    decodedSome.Email match {
+        case Some(e) => Println(s"decoded some: $e")
+        case None()  => Println("decoded some: <none>")
+    }
+
+    // 4. Decode: field is JSON null -> None
+    val decodedNull = codec.Decode("{\"id\":2,\"name\":\"Bob\",\"email\":null}").Get()
+    decodedNull.Email match {
+        case Some(e) => Println(s"decoded null: $e")
+        case None()  => Println("decoded null: <none>")
+    }
+
+    // 5. Decode: field missing entirely -> None (same semantics as null)
+    val decodedMissing = codec.Decode("{\"id\":3,\"name\":\"Carol\"}").Get()
+    decodedMissing.Email match {
+        case Some(e) => Println(s"decoded missing: $e")
+        case None()  => Println("decoded missing: <none>")
+    }
+
+    // 6. Encode/decode Option over non-string primitives: int, float64, bool.
+    val settingsCodec = Codec[Settings](CamelCase())
+    val fullSettings = Settings(Age = Some(42), Ratio = Some(0.5), Active = Some(true))
+    val fullJson = settingsCodec.Encode(fullSettings).Get()
+    Println(fullJson)
+
+    val emptySettings = Settings(Age = None[int](), Ratio = None[float64](), Active = None[bool]())
+    Println(settingsCodec.Encode(emptySettings).Get())
+
+    // Round-trip: decode the full encoding and verify each field survived.
+    val roundTripped = settingsCodec.Decode(fullJson).Get()
+    roundTripped.Age match {
+        case Some(a) => Println(s"age: $a")
+        case None()  => Println("age: <none>")
+    }
+    roundTripped.Ratio match {
+        case Some(r) => Println(s"ratio: $r")
+        case None()  => Println("ratio: <none>")
+    }
+    roundTripped.Active match {
+        case Some(b) => Println(s"active: $b")
+        case None()  => Println("active: <none>")
+    }
+
+    // Round-trip the empty settings: every field should be None, regardless of
+    // whether it was serialized as null or (eventually) omitted.
+    val emptyRoundTripped = settingsCodec.Decode(settingsCodec.Encode(emptySettings).Get()).Get()
+    emptyRoundTripped.Age match {
+        case Some(a) => Println(s"empty-age: $a")
+        case None()  => Println("empty-age: <none>")
+    }
+}

--- a/examples/json_codec_option.out
+++ b/examples/json_codec_option.out
@@ -1,0 +1,11 @@
+{"id":1,"name":"Alice","email":"a@b.com"}
+{"id":2,"name":"Bob","email":null}
+decoded some: a@b.com
+decoded null: <none>
+decoded missing: <none>
+{"age":42,"ratio":0.5,"active":true}
+{"age":null,"ratio":null,"active":null}
+age: 42
+ratio: 0.5
+active: true
+empty-age: <none>

--- a/internal/transpiler/transformer/codec.go
+++ b/internal/transpiler/transformer/codec.go
@@ -224,7 +224,7 @@ func (t *galaASTTransformer) genWriteTo(config *structMetaConfig) *ast.FuncDecl 
 			Fun:  &ast.SelectorExpr{X: ast.NewIdent("w"), Sel: ast.NewIdent("WriteKey")},
 			Args: []ast.Expr{keyExpr},
 		}))
-		fieldStmts = append(fieldStmts, genFieldWrite(fieldAccess, fieldType)...)
+		fieldStmts = append(fieldStmts, t.genFieldWrite(fieldAccess, fieldType)...)
 
 		// Wrap in if keys.Get(i) != "" to support Omit (empty key = omitted)
 		stmts = append(stmts, &ast.IfStmt{
@@ -271,6 +271,35 @@ func (t *galaASTTransformer) genReadFrom(config *structMetaConfig) *ast.FuncDecl
 		},
 	}})
 
+	// Default Option[T] fields to None[T]() so a missing JSON field produces
+	// None (not an accidental zero-valued Some). Without this, the zero
+	// _variant tag (Some) leaks through as Some(zero-T) for any field that
+	// wasn't present in the input. This matches Scala circe / serde_json /
+	// encoding/json-with-*T semantics: missing == null == None.
+	for i, fieldName := range meta.FieldNames {
+		fieldType := meta.Fields[fieldName]
+		inner, ok := optionInner(fieldType)
+		if !ok {
+			continue
+		}
+		isImmut := immutFlags != nil && i < len(immutFlags) && immutFlags[i]
+		innerExpr := t.typeToExpr(inner)
+		var defaultValue ast.Expr = &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   &ast.CompositeLit{Type: t.buildNoneType(innerExpr)},
+				Sel: ast.NewIdent("Apply"),
+			},
+		}
+		if isImmut {
+			defaultValue = &ast.CallExpr{Fun: t.stdIdent("NewImmutable"), Args: []ast.Expr{defaultValue}}
+		}
+		stmts = append(stmts, &ast.AssignStmt{
+			Lhs: []ast.Expr{&ast.SelectorExpr{X: ast.NewIdent("result"), Sel: ast.NewIdent(fieldName)}},
+			Tok: token.ASSIGN,
+			Rhs: []ast.Expr{defaultValue},
+		})
+	}
+
 	// r.BeginObject()
 	stmts = append(stmts, exprStmt(methodCall("r", "BeginObject")))
 
@@ -280,8 +309,8 @@ func (t *galaASTTransformer) genReadFrom(config *structMetaConfig) *ast.FuncDecl
 		fieldType := meta.Fields[fieldName]
 		isImmut := immutFlags != nil && i < len(immutFlags) && immutFlags[i]
 
-		readExpr := genFieldRead(fieldType)
-		if readExpr == nil {
+		caseBody := t.genFieldReadStmts(fieldName, fieldType, isImmut)
+		if caseBody == nil {
 			switchCases = append(switchCases, &ast.CaseClause{
 				List: []ast.Expr{stringLit(fieldName)},
 				Body: []ast.Stmt{exprStmt(methodCall("r", "SkipValue"))},
@@ -289,18 +318,9 @@ func (t *galaASTTransformer) genReadFrom(config *structMetaConfig) *ast.FuncDecl
 			continue
 		}
 
-		assignValue := readExpr
-		if isImmut {
-			assignValue = &ast.CallExpr{Fun: t.stdIdent("NewImmutable"), Args: []ast.Expr{assignValue}}
-		}
-
 		switchCases = append(switchCases, &ast.CaseClause{
 			List: []ast.Expr{stringLit(fieldName)},
-			Body: []ast.Stmt{&ast.AssignStmt{
-				Lhs: []ast.Expr{&ast.SelectorExpr{X: ast.NewIdent("result"), Sel: ast.NewIdent(fieldName)}},
-				Tok: token.ASSIGN,
-				Rhs: []ast.Expr{assignValue},
-			}},
+			Body: caseBody,
 		})
 	}
 
@@ -419,7 +439,50 @@ func (t *galaASTTransformer) genReadFromAny(config *structMetaConfig) *ast.FuncD
 	}
 }
 
-func genFieldWrite(fieldAccess ast.Expr, fieldType transpiler.Type) []ast.Stmt {
+// genFieldWrite generates the Go statements that serialize a single struct field
+// to the FieldWriter `w`.
+//
+// For plain types: `w.WriteString(v.Field)` (or WriteInt, WriteBool, …).
+//
+// For Option[T] fields: branches on the Option's state so `WriteNull()` is
+// called with no arguments (matching the FieldWriter interface) when the
+// field is None, and the inner T is written via the appropriate WriteXxx
+// when the field is Some:
+//
+//	if fieldAccess.IsDefined() {
+//	    w.WriteString(fieldAccess.Get())
+//	} else {
+//	    w.WriteNull()
+//	}
+func (t *galaASTTransformer) genFieldWrite(fieldAccess ast.Expr, fieldType transpiler.Type) []ast.Stmt {
+	if inner, ok := optionInner(fieldType); ok {
+		// Option[T] field: branch on IsDefined / IsEmpty.
+		innerMethod := writeMethodForBasicType(baseTypeName(unwrapGalaType(inner)))
+		if innerMethod == "WriteNull" {
+			// Unsupported inner type (nested Option, custom struct, etc.).
+			// Emit a single WriteNull so the output is at least valid JSON and
+			// the Go code still compiles. Proper support for these inner types
+			// is tracked separately.
+			return []ast.Stmt{exprStmt(methodCall("w", "WriteNull"))}
+		}
+
+		// if fieldAccess.IsDefined() { w.WriteXxx(fieldAccess.Get()) } else { w.WriteNull() }
+		someBody := &ast.BlockStmt{List: []ast.Stmt{exprStmt(&ast.CallExpr{
+			Fun: &ast.SelectorExpr{X: ast.NewIdent("w"), Sel: ast.NewIdent(innerMethod)},
+			Args: []ast.Expr{&ast.CallExpr{
+				Fun: &ast.SelectorExpr{X: fieldAccess, Sel: ast.NewIdent("Get")},
+			}},
+		})}}
+		noneBody := &ast.BlockStmt{List: []ast.Stmt{exprStmt(methodCall("w", "WriteNull"))}}
+		return []ast.Stmt{&ast.IfStmt{
+			Cond: &ast.CallExpr{
+				Fun: &ast.SelectorExpr{X: fieldAccess, Sel: ast.NewIdent("IsDefined")},
+			},
+			Body: someBody,
+			Else: noneBody,
+		}}
+	}
+
 	baseType := unwrapGalaType(fieldType)
 	method := writeMethodForBasicType(baseTypeName(baseType))
 	return []ast.Stmt{exprStmt(&ast.CallExpr{
@@ -428,19 +491,115 @@ func genFieldWrite(fieldAccess ast.Expr, fieldType transpiler.Type) []ast.Stmt {
 	})}
 }
 
-func genFieldRead(fieldType transpiler.Type) ast.Expr {
+// genFieldReadStmts generates the Go statements that populate
+// `result.<fieldName>` from the FieldReader `r` for a single field.
+//
+// For plain types it emits a single assignment:
+//
+//	result.Name = r.ReadString().Get()
+//
+// For Option[T] it branches on r.IsNull() so JSON `null` decodes to
+// None[T]() and any other JSON value decodes to Some[T](read value). A
+// missing field never reaches this code path — the switch in ReadFrom
+// simply skips fields that are absent, leaving the zero Option value
+// (None) in `result`. So JSON `null` and missing-field have the same
+// observable result: `None[T]()`. This matches Scala's circe, Go's
+// encoding/json (with *T), and most mainstream JSON libraries.
+//
+// Returns nil if the field type cannot be read (e.g. composite kinds),
+// signalling the caller to emit a SkipValue fallback.
+func (t *galaASTTransformer) genFieldReadStmts(fieldName string, fieldType transpiler.Type, isImmut bool) []ast.Stmt {
+	lhs := &ast.SelectorExpr{X: ast.NewIdent("result"), Sel: ast.NewIdent(fieldName)}
+
+	if inner, ok := optionInner(fieldType); ok {
+		innerMethod := readMethodForBasicType(baseTypeName(unwrapGalaType(inner)))
+		if innerMethod == "" {
+			// Can't decode this inner type — skip the value.
+			return nil
+		}
+		innerExpr := t.typeToExpr(inner)
+
+		// Some[T]{}.Apply(r.ReadXxx().Get())
+		someValue := &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   &ast.CompositeLit{Type: t.buildSomeType(innerExpr)},
+				Sel: ast.NewIdent("Apply"),
+			},
+			Args: []ast.Expr{&ast.CallExpr{
+				Fun: &ast.SelectorExpr{
+					X:   methodCall("r", innerMethod),
+					Sel: ast.NewIdent("Get"),
+				},
+			}},
+		}
+
+		// None[T]{}.Apply()
+		noneValue := &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   &ast.CompositeLit{Type: t.buildNoneType(innerExpr)},
+				Sel: ast.NewIdent("Apply"),
+			},
+		}
+
+		someAssignValue := ast.Expr(someValue)
+		noneAssignValue := ast.Expr(noneValue)
+		if isImmut {
+			someAssignValue = &ast.CallExpr{Fun: t.stdIdent("NewImmutable"), Args: []ast.Expr{someAssignValue}}
+			noneAssignValue = &ast.CallExpr{Fun: t.stdIdent("NewImmutable"), Args: []ast.Expr{noneAssignValue}}
+		}
+
+		// if r.IsNull() { r.ReadNull(); result.F = None[T]{}.Apply() } else { result.F = Some[T]{}.Apply(r.ReadX().Get()) }
+		thenBody := &ast.BlockStmt{List: []ast.Stmt{
+			exprStmt(methodCall("r", "ReadNull")),
+			&ast.AssignStmt{Lhs: []ast.Expr{lhs}, Tok: token.ASSIGN, Rhs: []ast.Expr{noneAssignValue}},
+		}}
+		elseBody := &ast.BlockStmt{List: []ast.Stmt{
+			&ast.AssignStmt{Lhs: []ast.Expr{lhs}, Tok: token.ASSIGN, Rhs: []ast.Expr{someAssignValue}},
+		}}
+		return []ast.Stmt{&ast.IfStmt{
+			Cond: methodCall("r", "IsNull"),
+			Body: thenBody,
+			Else: elseBody,
+		}}
+	}
+
 	baseType := unwrapGalaType(fieldType)
 	method := readMethodForBasicType(baseTypeName(baseType))
 	if method == "" {
 		return nil
 	}
 	// r.ReadXxx().Get()
-	return &ast.CallExpr{
+	var readExpr ast.Expr = &ast.CallExpr{
 		Fun: &ast.SelectorExpr{
 			X:   &ast.CallExpr{Fun: &ast.SelectorExpr{X: ast.NewIdent("r"), Sel: ast.NewIdent(method)}},
 			Sel: ast.NewIdent("Get"),
 		},
 	}
+	if isImmut {
+		readExpr = &ast.CallExpr{Fun: t.stdIdent("NewImmutable"), Args: []ast.Expr{readExpr}}
+	}
+	return []ast.Stmt{&ast.AssignStmt{
+		Lhs: []ast.Expr{lhs},
+		Tok: token.ASSIGN,
+		Rhs: []ast.Expr{readExpr},
+	}}
+}
+
+// optionInner detects Option[T] field types and returns the inner T.
+// Recognises both the bare name `Option` (when std is dot-imported, the
+// common case) and the fully-qualified `std.Option`.
+func optionInner(typ transpiler.Type) (transpiler.Type, bool) {
+	// Peel Immutable[Option[T]] -> Option[T] first (val-field).
+	t := unwrapGalaType(typ)
+	gt, ok := t.(transpiler.GenericType)
+	if !ok || len(gt.Params) != 1 {
+		return nil, false
+	}
+	base := gt.Base.BaseName()
+	if base == "Option" || base == "std.Option" {
+		return gt.Params[0], true
+	}
+	return nil, false
 }
 
 func baseTypeName(t transpiler.Type) string {


### PR DESCRIPTION
## Summary

Fixes **gap #12**: `Codec[T]` codegen breaks when a struct has an `Option[T]` field.

```gala
struct User(ID int, Name string, Email Option[string])
val codec = Codec[User](SnakeCase())
codec.Encode(User(ID = 1, Name = "Alice", Email = Some("a@b.com"))).Get()
```

Transpile used to succeed and `go build` then failed with:

```
gen/main.gen.go:81:15: too many arguments in call to w.WriteNull
  have (std.Option[string])
  want ()
```

## Root cause

`internal/transpiler/transformer/codec.go` derives the FieldWriter method from the field's *base type name*. For `Option[string]` the base name is `"Option"`, which isn't in the primitives switch, so the generator fell through to `WriteNull` and emitted `w.WriteNull(field)` — but `FieldWriter.WriteNull()` takes no arguments. Cryptic Go-level compile error at the user's first try.

## Fix — all local to `codec.go`

1. **`optionInner(t)` helper** — detects `Option[T]` (bare name or `std.Option`) and peels `Immutable[Option[T]]`.
2. **`genFieldWrite`** emits `if v.F.IsDefined() { w.WriteX(v.F.Get()) } else { w.WriteNull() }` for Option fields.
3. **`genFieldRead` → `genFieldReadStmts`** now returns statements so it can emit:
   ```go
   if r.IsNull() {
       r.ReadNull()
       result.F = std.None[T]{}.Apply()
   } else {
       result.F = std.Some[T]{}.Apply(r.ReadX().Get())
   }
   ```
4. **Default-populate Option fields to `None[T]()`** before the read loop, so missing JSON fields decode to `None` (zero-value `_variant` would otherwise surface as `Some(zero-T)` because `Some` is listed first in the sealed definition so `_Option_Some == 0`).

## Semantic decision — JSON null vs missing field

**Both `null` and missing field decode to `None[T]()`.**

This matches circe, serde_json, and `encoding/json` with `*T`. Trade-off: `{}` → decode → encode will emit `{"email":null}` (one-way loss of presence). A future `OmitEmpty("Email")` builder on `JsonEncoder[T]` can suppress the null for opt-in callers. Documented in `docs/private/fix-attempts/gap-12.md` (gitignored).

## Verification

- New `examples/json_codec_option.gala` covers:
  - Encode `Some(string)` → value; `None[string]()` → JSON null
  - Decode JSON value → `Some`; JSON null → `None`; missing field → `None`
  - `Option[int]`, `Option[float64]`, `Option[bool]` round-trip
- `bazel test //...` passes — 254 tests, zero regressions.
- Existing `examples/json_codec` (no Option fields) passes unchanged — generated output is byte-identical for structs without Option.

## Repro (before fix)

```gala
import . "martianoff/gala/json"
struct User(ID int, Name string, Email Option[string])
val codec = Codec[User](SnakeCase())
codec.Encode(User(ID = 1, Name = "Alice", Email = Some("a@b.com"))).Get()
// -> go build: too many arguments in call to w.WriteNull
```

## Dependencies

None — independent fix against `master`.

---
Generated with [Claude Code](https://claude.com/claude-code)