### PR TITLE
feat(sealed): allow bare identifier for zero-field sealed cases

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -487,6 +487,29 @@ sealed type Shape {
 }
 ```
 
+Parentheses are optional on zero-field variants. The declaration above can also be written as:
+
+```gala
+sealed type Shape {
+    case Circle(Radius float64)
+    case Rectangle(Width float64, Height float64)
+    case Point                   // bare identifier is equivalent to `case Point()`
+}
+```
+
+The same applies in match patterns — `case Point` and `case Point()` are interchangeable:
+
+```gala
+val desc = s match {
+    case Circle(r) => ...
+    case Rectangle(w, h) => ...
+    case Point => "a point"       // bare form
+    // case Point() => "a point"  // equivalent
+}
+```
+
+Variants with one or more fields always require parentheses (`case Rectangle(w, h)`, not `case Rectangle`).
+
 This generates:
 - Parent struct `Shape` with all variant fields merged + `_variant` discriminator
 - Empty companion structs `Circle{}`, `Rectangle{}`, `Point{}`

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -750,6 +750,12 @@ gala_test(
 )
 
 gala_test(
+    name = "sealed_bare_variants",
+    src = "sealed_bare_variants.gala",
+    expected = "sealed_bare_variants.out",
+)
+
+gala_test(
     name = "composite_lit_if_cond",
     src = "composite_lit_if_cond.gala",
     expected = "composite_lit_if_cond.out",

--- a/examples/sealed_bare_variants.gala
+++ b/examples/sealed_bare_variants.gala
@@ -1,0 +1,45 @@
+package main
+
+import "fmt"
+
+// Zero-field sealed variants may be declared with or without parentheses.
+// This mirrors Scala/Kotlin conventions and removes a small paper cut for users.
+sealed type LogLevel {
+    case Debug                  // bare identifier — no parens
+    case Info()                 // explicit empty parens
+    case Warn                   // bare identifier
+    case Error()                // explicit empty parens
+    case Custom(Name string)    // one-field variant still requires parens
+}
+
+// match patterns accept both bare-identifier and paren forms for zero-field cases.
+func describe(l LogLevel) string = l match {
+    case Debug         => "debug"
+    case Info()        => "info"
+    case Warn          => "warn"
+    case Error()       => "error"
+    case Custom(name)  => "custom: " + name
+}
+
+// Exhaustive match: mix and match forms to prove both work in the same match.
+func level(l LogLevel) int = l match {
+    case Debug        => 0
+    case Info         => 1
+    case Warn()       => 2
+    case Error        => 3
+    case Custom(_)    => 4
+}
+
+func main() {
+    fmt.Println(describe(Debug()))
+    fmt.Println(describe(Info()))
+    fmt.Println(describe(Warn()))
+    fmt.Println(describe(Error()))
+    fmt.Println(describe(Custom("alert")))
+
+    fmt.Println(level(Debug()))
+    fmt.Println(level(Info()))
+    fmt.Println(level(Warn()))
+    fmt.Println(level(Error()))
+    fmt.Println(level(Custom("x")))
+}

--- a/examples/sealed_bare_variants.out
+++ b/examples/sealed_bare_variants.out
@@ -1,0 +1,10 @@
+debug
+info
+warn
+error
+custom: alert
+0
+1
+2
+3
+4

--- a/internal/parser/grammar/gala.g4
+++ b/internal/parser/grammar/gala.g4
@@ -21,7 +21,9 @@ embedPatterns: STRING (',' STRING)*;
 structShorthandDeclaration: 'struct' identifier parameters;
 
 sealedTypeDeclaration: SEALED 'type' identifier (typeParameters)? '{' sealedCase+ '}';
-sealedCase: CASE identifier '(' sealedCaseFieldList? ')';
+// Parentheses are optional for zero-field variants: `case Debug` and `case Debug()` are both valid.
+// Variants with fields still require parentheses: `case Add(l Expr, r Expr)`.
+sealedCase: CASE identifier ('(' sealedCaseFieldList? ')')?;
 sealedCaseFieldList: sealedCaseField (',' sealedCaseField)* ','?;
 sealedCaseField: identifier type;
 

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -78,15 +78,28 @@ func (t *galaASTTransformer) parseMatchSubject(ctx grammar.IExpressionContext) (
 }
 
 // extractVariantName extracts the variant/constructor name from a case pattern text.
-// E.g. "Circle(r)" → "Circle", "Point()" → "Point"
+// E.g. "Circle(r)" → "Circle", "Point()" → "Point", "Debug" → "Debug"
+// Bare uppercase identifiers (e.g., `case Debug =>`) name zero-field sealed variants;
+// they are recognised as variant patterns rather than simple bindings.
 func extractVariantName(patternText string) string {
 	idx := strings.Index(patternText, "(")
-	if idx <= 0 {
+	var name string
+	if idx < 0 {
+		// No call suffix — bare identifier form like `Debug`.
+		name = patternText
+	} else if idx == 0 {
 		return ""
+	} else {
+		name = patternText[:idx]
 	}
-	name := patternText[:idx]
 	if len(name) == 0 || name[0] < 'A' || name[0] > 'Z' {
 		return ""
+	}
+	// Reject identifiers containing non-identifier characters (e.g., dots, operators).
+	for _, ch := range name {
+		if !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_') {
+			return ""
+		}
 	}
 	return name
 }

--- a/internal/transpiler/transformer/patterns.go
+++ b/internal/transpiler/transformer/patterns.go
@@ -206,6 +206,24 @@ func (t *galaASTTransformer) transformExpressionPatternWithType(patExprCtx gramm
 	// with an identifier, but they're not simple bindings.
 	if p := t.getPrimaryFromExpression(patExprCtx); p != nil && p.Identifier() != nil {
 		name := p.Identifier().GetText()
+
+		// Before treating as a simple binding, check if the identifier refers to a
+		// zero-field extractor (e.g., sealed variant `case Debug`). Writing `case Debug =>`
+		// in a match should be equivalent to `case Debug() =>` when Debug is a sealed
+		// case companion whose Unapply returns bool.
+		if meta := t.getTypeMeta(name); meta != nil {
+			if unapplyMeta, hasUnapply := meta.Methods["Unapply"]; hasUnapply {
+				// Only route through the extractor path for zero-arg extractors — i.e.,
+				// Unapply returns bool (guard extractor) and the type takes no type
+				// parameters. That is precisely the shape generated for zero-field
+				// sealed variants. For 1+-field sealed variants (Option-returning),
+				// a bare identifier legitimately remains a simple binding.
+				if basic, ok := unapplyMeta.ReturnType.(transpiler.BasicType); ok && basic.Name == "bool" && len(meta.TypeParams) == 0 {
+					return t.generateDirectUnapplyPattern(name, meta, nil, unapplyMeta, objExpr, nil, matchedType)
+				}
+			}
+		}
+
 		t.currentScope.vals[name] = false // Treat as var to avoid .Get() wrapping
 		// Set the type of the bound variable to the matched type
 		if matchedType != nil && !matchedType.IsNil() {


### PR DESCRIPTION
## Summary

Fixes **gap #7**: bare identifier `case Debug` was rejected at both the sealed type declaration site and inside match patterns. Scala / Kotlin users expected it to just work. After this PR, `case Debug` and `case Debug()` are interchangeable for zero-field variants in both positions.

## Root cause

1. **Grammar** — `sealedCase: CASE identifier '(' sealedCaseFieldList? ')';` required parens.
2. **Match transformer** — even with a grammar fix, `patterns.go` would route a bare identifier into the "Simple Binding" branch (treating `Debug` as a pattern variable). The exhaustiveness check then complained about a missing variant, and the binding failed "unused variable in match branch".
3. **Exhaustiveness** — `extractVariantName` in `match.go` only recognised `Name(…)` forms; bare `Name` silently returned `""`.

## Changes

- `internal/parser/grammar/gala.g4` — `sealedCase: CASE identifier ('(' sealedCaseFieldList? ')')?;` (parens now optional). ANTLR regenerates the Go parser automatically.
- `internal/transpiler/transformer/patterns.go` — in `transformExpressionPatternWithType`, before the simple-binding branch, check whether the bare identifier resolves to a type whose `Unapply` returns `bool` and has no type parameters (the exact shape of a zero-field sealed variant). If so, route through `generateDirectUnapplyPattern` with `nil` argList. Generated output is byte-identical to the paren form: `Debug{}.Unapply(obj)`.
- `internal/transpiler/transformer/match.go` — `extractVariantName` now recognises bare uppercase identifiers so the exhaustiveness checker sees them.
- `examples/sealed_bare_variants.gala` (+ `.out` + BUILD.bazel entry) — verification example covering declaration both ways, match both ways, mixing inside a single match, and preserving the field-required rule for `case Custom(Name string)`.
- `docs/GALA.MD` — documents the optional-parens rule for zero-field variants. Variants with fields still require parens.

The fix is deliberately narrow — only zero-arg extractors (`len(TypeParams) == 0`) with a `bool`-returning Unapply take the new path. Option-returning sealed variants with one or more fields still require parens at the match site, because a bare identifier there is still a valid simple binding.

## Verification

- `bazel build //...` passes
- `bazel test //...` passes — **254 tests, 0 failures**
- New test `examples/sealed_bare_variants` passes
- Existing `sealed_types`, `sealed_recursive`, `sealed_wildcard`, `sealed_field_clash`, `sealed_shared_fields`, `match_sealed_branch_infer` all still pass

## Repro (before fix)

```gala
sealed type LogLevel {
    case Debug      // parser error: expected '('
    case Info()
}

level match {
    case Debug => "d"  // "unused variable 'Debug' in match branch"
    case Info() => "i"
}
```

After this PR, both forms parse and transpile correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)