### PR TITLE
refactor(codec): move JSON logic to std/json, make StructMeta[T] format-agnostic

### DIFF
--- a/collection_immutable/array.gala
+++ b/collection_immutable/array.gala
@@ -43,6 +43,20 @@ type Array[T any] struct {
     prefix   []T           // Prepended elements in forward order (prefix[0] is logical index 0)
 }
 
+// AnyArray is the non-generic interface that every `Array[T]` instantiation
+// satisfies. It is used by libraries (e.g., `std/json`) that walk values typed
+// as `any` and need to iterate an Array without knowing its element type.
+//
+// Every `Array[T]` automatically implements `AnyArray` because `Size`, `GetAny`,
+// and `ForEachAny` are defined on `Array[T]`. This lets code write
+// `v.(AnyArray)` — an interface assertion, not a forbidden generic
+// instantiation like `v.(Array[any])`.
+type AnyArray interface {
+    Size() int
+    GetAny(i int) any
+    ForEachAny(f func(any))
+}
+
 // EmptyArray returns an empty Array.
 func EmptyArray[T any]() Array[T] {
     var nilRoot *arrayNode[T] = nil
@@ -254,6 +268,18 @@ func (a Array[T]) Length() int = a.length
 
 // Size is an alias for Length.
 func (a Array[T]) Size() int = a.length
+
+// GetAny returns the element at `i` boxed as `any`. Needed for the
+// `AnyArray` interface so non-generic consumers (e.g., `std/json`'s codec)
+// can iterate an Array without knowing its element type.
+func (a Array[T]) GetAny(i int) any = a.Get(i)
+
+// ForEachAny calls `f` with every element boxed as `any`. Needed for the
+// `AnyArray` interface so non-generic consumers (e.g., `std/json`'s codec)
+// can walk an Array without knowing its element type.
+func (a Array[T]) ForEachAny(f func(any)) {
+    a.ForEach((e) => f(e))
+}
 
 // Helper function to calculate required depth for a given size.
 func requiredDepth(size int) int {

--- a/collection_immutable/hashmap.gala
+++ b/collection_immutable/hashmap.gala
@@ -35,6 +35,19 @@ type HashMap[K comparable, V any] struct {
     size   int
 }
 
+// AnyMap is the non-generic interface that every `HashMap[K,V]` instantiation
+// satisfies. It is used by libraries (e.g., `std/json`) that walk values typed
+// as `any` and need to iterate a map without knowing its key/value types.
+//
+// Every `HashMap[K,V]` automatically implements `AnyMap` because `Size` is
+// defined above and `ForEachAny` is defined below. This lets code write
+// `v.(AnyMap)` — an interface assertion, not a forbidden generic
+// instantiation like `v.(HashMap[any,any])`.
+type AnyMap interface {
+    Size() int
+    ForEachAny(f func(any, any))
+}
+
 // EmptyHashMap returns an empty HashMap.
 func EmptyHashMap[K comparable, V any]() HashMap[K, V] {
     var nilRoot *hashMapNode[K, V] = nil
@@ -52,6 +65,13 @@ func (m HashMap[K, V]) Size() int = m.size
 
 // Length is an alias for Size.
 func (m HashMap[K, V]) Length() int = m.size
+
+// ForEachAny calls `f(key, value)` for every entry with both arguments boxed
+// as `any`. Needed for the `AnyMap` interface so non-generic consumers (e.g.,
+// `std/json`'s codec) can walk a HashMap without knowing its key/value types.
+func (m HashMap[K, V]) ForEachAny(f func(any, any)) {
+    m.ForEachKV((k, v) => f(k, v))
+}
 
 // hashMapHash computes a hash code for a key.
 func hashMapHash[K comparable](key K) uint32 {

--- a/internal/stdlib/BUILD.bazel
+++ b/internal/stdlib/BUILD.bazel
@@ -35,6 +35,8 @@ genrule(
         "//std:constptr.gala",
         "//std:codec_go",
         "//std:codec.gala",
+        "//std:meta_go",
+        "//std:meta.gala",
         # json package
         "//json:json_go",
         "//json:codec_rw_go",

--- a/internal/transpiler/transformer/codec.go
+++ b/internal/transpiler/transformer/codec.go
@@ -113,6 +113,13 @@ func (t *galaASTTransformer) generateStructMetaDecls(config *structMetaConfig) [
 	decls = append(decls, t.genNumFields(genName, len(meta.FieldNames)))
 	decls = append(decls, t.genFieldName(genName, meta.FieldNames))
 	decls = append(decls, t.genFieldType(genName, meta))
+	// Phase-1 (in progress): emit format-agnostic FieldType accessor +
+	// erased field-value accessors so the JSON codec can move fully into
+	// std/json. These coexist with the legacy WriteTo/ReadFrom emitters
+	// until Phase 2 flips callers; Phase 4 will delete the legacy path.
+	decls = append(decls, t.genFieldTypeOf(genName, meta))
+	decls = append(decls, t.genFieldValueAny(config))
+	decls = append(decls, t.genConstructAny(config))
 	decls = append(decls, t.genWriteTo(config))
 	decls = append(decls, t.genReadFrom(config))
 	// Any-based variants for generic codec use (internal to codec libraries)
@@ -193,6 +200,326 @@ func (t *galaASTTransformer) genFieldType(genName string, meta *transpiler.TypeM
 		Body: &ast.BlockStmt{List: []ast.Stmt{
 			&ast.SwitchStmt{Tag: ast.NewIdent("i"), Body: &ast.BlockStmt{List: cases}},
 		}},
+	}
+}
+
+// --- FieldTypeOf(i int) std.FieldType ---
+// Format-agnostic neutral descriptor. Codec libraries pattern-match on the
+// returned sealed value to drive encode/decode without the transpiler ever
+// learning about JSON, YAML, or any other wire format.
+//
+// Emitted alongside the legacy FieldType(i) string method for now; once
+// Phase 2 migrates std/json, a follow-up will delete the legacy accessor
+// and rename this to FieldType per the design-doc spec.
+func (t *galaASTTransformer) genFieldTypeOf(genName string, meta *transpiler.TypeMetadata) *ast.FuncDecl {
+	var cases []ast.Stmt
+	for i, fieldName := range meta.FieldNames {
+		fieldType := meta.Fields[fieldName]
+		cases = append(cases, &ast.CaseClause{
+			List: []ast.Expr{intLit(i)},
+			Body: []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{t.fieldTypeDescriptor(fieldType)}}},
+		})
+	}
+	// default: UnknownType("")
+	cases = append(cases, &ast.CaseClause{
+		Body: []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{t.fieldTypeUnknown("")}}},
+	})
+
+	return &ast.FuncDecl{
+		Recv: blankRecv(genName),
+		Name: ast.NewIdent("FieldTypeOf"),
+		Type: &ast.FuncType{
+			Params:  &ast.FieldList{List: []*ast.Field{{Names: idents("i"), Type: ast.NewIdent("int")}}},
+			Results: &ast.FieldList{List: []*ast.Field{{Type: t.stdIdent("FieldType")}}},
+		},
+		Body: &ast.BlockStmt{List: []ast.Stmt{
+			&ast.SwitchStmt{Tag: ast.NewIdent("i"), Body: &ast.BlockStmt{List: cases}},
+		}},
+	}
+}
+
+// fieldTypeDescriptor maps a transpiler.Type to the AST of the corresponding
+// std.FieldType constructor call.
+//
+// V1 maps: string/int/int64/float64/bool/rune, Option[T], Array[T], List[T],
+// HashMap[K,V], and registered structs (as NestedStructType). Anything else
+// — Either, Try, sealed-valued fields, go-interop types — becomes
+// UnknownType(typeString) which codec libraries treat as "skip / write null".
+func (t *galaASTTransformer) fieldTypeDescriptor(ft transpiler.Type) ast.Expr {
+	if ft == nil {
+		return t.fieldTypeUnknown("")
+	}
+	// Immutable[T] wraps T transparently for codec purposes.
+	ft = unwrapGalaType(ft)
+	switch v := ft.(type) {
+	case transpiler.BasicType:
+		if variant, ok := basicFieldTypeVariant(v.Name); ok {
+			return t.fieldTypeNullary(variant)
+		}
+	case transpiler.NamedType:
+		if variant, ok := basicFieldTypeVariant(v.Name); ok {
+			return t.fieldTypeNullary(variant)
+		}
+		// A nested user-defined struct — emit NestedStructType(meta) once the
+		// caller has materialised a StructMeta for it. For V1 we treat it as
+		// UnknownType to avoid recursively requesting metadata that the user
+		// never asked for.
+		return t.fieldTypeUnknown(v.String())
+	case transpiler.GenericType:
+		base := v.Base.BaseName()
+		switch base {
+		case "Option", "std.Option":
+			if len(v.Params) >= 1 {
+				return t.fieldTypeRecursive("OptionType", []ast.Expr{t.fieldTypeDescriptor(v.Params[0])})
+			}
+		case "Array", "collection_immutable.Array":
+			if len(v.Params) >= 1 {
+				return t.fieldTypeRecursive("ArrayType", []ast.Expr{t.fieldTypeDescriptor(v.Params[0])})
+			}
+		case "List", "collection_immutable.List":
+			if len(v.Params) >= 1 {
+				return t.fieldTypeRecursive("ListType", []ast.Expr{t.fieldTypeDescriptor(v.Params[0])})
+			}
+		case "HashMap", "collection_immutable.HashMap":
+			if len(v.Params) >= 2 {
+				return t.fieldTypeRecursive("HashMapType",
+					[]ast.Expr{t.fieldTypeDescriptor(v.Params[0]), t.fieldTypeDescriptor(v.Params[1])})
+			}
+		}
+		return t.fieldTypeUnknown(v.String())
+	}
+	return t.fieldTypeUnknown(ft.String())
+}
+
+// fieldTypeNullary emits `std.VariantName{}.Apply()` for a zero-arg FieldType
+// variant like StringType, IntType, etc.
+func (t *galaASTTransformer) fieldTypeNullary(variantName string) ast.Expr {
+	return &ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X:   &ast.CompositeLit{Type: t.stdIdent(variantName)},
+			Sel: ast.NewIdent("Apply"),
+		},
+	}
+}
+
+// fieldTypeRecursive emits `std.VariantName{}.Apply(arg0, arg1, ...)` for a
+// recursive variant like OptionType(Inner) or HashMapType(Key, Value).
+func (t *galaASTTransformer) fieldTypeRecursive(variantName string, args []ast.Expr) ast.Expr {
+	return &ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X:   &ast.CompositeLit{Type: t.stdIdent(variantName)},
+			Sel: ast.NewIdent("Apply"),
+		},
+		Args: args,
+	}
+}
+
+// fieldTypeUnknown emits `std.UnknownType{}.Apply(typeStringLit)`.
+func (t *galaASTTransformer) fieldTypeUnknown(typeStr string) ast.Expr {
+	return &ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X:   &ast.CompositeLit{Type: t.stdIdent("UnknownType")},
+			Sel: ast.NewIdent("Apply"),
+		},
+		Args: []ast.Expr{stringLit(typeStr)},
+	}
+}
+
+// basicFieldTypeVariant maps a primitive type name to its FieldType variant.
+// Returns ("", false) for non-primitive names.
+func basicFieldTypeVariant(name string) (string, bool) {
+	switch name {
+	case "string":
+		return "StringType", true
+	case "int":
+		return "IntType", true
+	case "int64":
+		return "Int64Type", true
+	case "float64":
+		return "Float64Type", true
+	case "bool":
+		return "BoolType", true
+	case "rune", "int32":
+		return "RuneType", true
+	}
+	return "", false
+}
+
+// --- FieldValueAny(i int, t any) any ---
+// Erased field extractor; callers hold `t` as `any` and ask for field i.
+// Delegates to typed per-field accesses after a type assertion on the target.
+// Together with FieldTypeOf, this is how the new std/json codec walks a
+// struct without needing a generic type parameter.
+func (t *galaASTTransformer) genFieldValueAny(config *structMetaConfig) *ast.FuncDecl {
+	meta := config.typeMetadata
+	resolvedName := t.resolveStructTypeName(config.typeName)
+	immutFlags := t.structImmutFields[resolvedName]
+
+	// typed := t.(T)
+	typedAssert := &ast.AssignStmt{
+		Lhs: []ast.Expr{ast.NewIdent("typed")},
+		Tok: token.DEFINE,
+		Rhs: []ast.Expr{
+			&ast.TypeAssertExpr{X: ast.NewIdent("t"), Type: ast.NewIdent(config.typeName)},
+		},
+	}
+
+	var cases []ast.Stmt
+	for i, fieldName := range meta.FieldNames {
+		isImmut := immutFlags != nil && i < len(immutFlags) && immutFlags[i]
+		fieldAccess := buildFieldAccess(ast.NewIdent("typed"), fieldName, isImmut)
+		cases = append(cases, &ast.CaseClause{
+			List: []ast.Expr{intLit(i)},
+			Body: []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{fieldAccess}}},
+		})
+	}
+	// default: return nil
+	cases = append(cases, &ast.CaseClause{
+		Body: []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{ast.NewIdent("nil")}}},
+	})
+
+	return &ast.FuncDecl{
+		Recv: blankRecv(config.generatedName),
+		Name: ast.NewIdent("FieldValueAny"),
+		Type: &ast.FuncType{
+			Params: &ast.FieldList{List: []*ast.Field{
+				{Names: idents("i"), Type: ast.NewIdent("int")},
+				{Names: idents("t"), Type: ast.NewIdent("any")},
+			}},
+			Results: &ast.FieldList{List: []*ast.Field{{Type: ast.NewIdent("any")}}},
+		},
+		Body: &ast.BlockStmt{List: []ast.Stmt{
+			typedAssert,
+			&ast.SwitchStmt{Tag: ast.NewIdent("i"), Body: &ast.BlockStmt{List: cases}},
+		}},
+	}
+}
+
+// --- ConstructAny(values []any) Try[any] ---
+// Positional struct construction used by the new codec's Decode path.
+// `values` must be in the same order as FieldName(0..NumFields()-1); each
+// element is asserted to the field's concrete type. Missing / surplus values
+// and type-assertion failures all produce `Failure[any]`.
+//
+// V1 note: the generated body assumes well-typed inputs and performs the
+// positional assertion straight line. Richer per-field error messages will
+// arrive when the Phase 2 library starts exercising this code path.
+func (t *galaASTTransformer) genConstructAny(config *structMetaConfig) *ast.FuncDecl {
+	meta := config.typeMetadata
+	resolvedName := t.resolveStructTypeName(config.typeName)
+	immutFlags := t.structImmutFields[resolvedName]
+
+	// var _result T
+	decls := []ast.Stmt{&ast.DeclStmt{Decl: &ast.GenDecl{
+		Tok: token.VAR,
+		Specs: []ast.Spec{
+			&ast.ValueSpec{Names: idents("_result"), Type: ast.NewIdent(config.typeName)},
+		},
+	}}}
+
+	// if len(values) < N { return Failure[any](fmt.Errorf("...")) }
+	decls = append(decls, &ast.IfStmt{
+		Cond: &ast.BinaryExpr{
+			X:  &ast.CallExpr{Fun: ast.NewIdent("len"), Args: []ast.Expr{ast.NewIdent("values")}},
+			Op: token.LSS,
+			Y:  intLit(len(meta.FieldNames)),
+		},
+		Body: &ast.BlockStmt{List: []ast.Stmt{
+			&ast.ReturnStmt{Results: []ast.Expr{t.tryFailureAny(fmt.Sprintf("ConstructAny[%s]: got %%d values, need %d", config.typeName, len(meta.FieldNames)))}},
+		}},
+	})
+
+	// For each field: v, ok := values[i].(FieldType); if !ok -> Failure
+	for i, fieldName := range meta.FieldNames {
+		fieldType := meta.Fields[fieldName]
+		isImmut := immutFlags != nil && i < len(immutFlags) && immutFlags[i]
+
+		// Target Go type AST
+		var goType ast.Expr
+		if fieldType != nil {
+			// Use baseTypeName-driven best-effort; fallback to any for unknown types.
+			if bn := baseTypeName(unwrapGalaType(fieldType)); bn != "" {
+				goType = ast.NewIdent(bn)
+			} else {
+				goType = ast.NewIdent("any")
+			}
+		} else {
+			goType = ast.NewIdent("any")
+		}
+
+		varName := fmt.Sprintf("_v%d", i)
+		okName := fmt.Sprintf("_ok%d", i)
+		decls = append(decls, &ast.AssignStmt{
+			Lhs: []ast.Expr{ast.NewIdent(varName), ast.NewIdent(okName)},
+			Tok: token.DEFINE,
+			Rhs: []ast.Expr{
+				&ast.TypeAssertExpr{
+					X: &ast.IndexExpr{X: ast.NewIdent("values"), Index: intLit(i)},
+					Type: goType,
+				},
+			},
+		})
+		decls = append(decls, &ast.IfStmt{
+			Cond: &ast.UnaryExpr{Op: token.NOT, X: ast.NewIdent(okName)},
+			Body: &ast.BlockStmt{List: []ast.Stmt{
+				&ast.ReturnStmt{Results: []ast.Expr{t.tryFailureAny(fmt.Sprintf("ConstructAny[%s]: field %q has wrong type", config.typeName, fieldName))}},
+			}},
+		})
+
+		rhs := ast.Expr(ast.NewIdent(varName))
+		if isImmut {
+			rhs = &ast.CallExpr{Fun: t.stdIdent("NewImmutable"), Args: []ast.Expr{rhs}}
+		}
+		decls = append(decls, &ast.AssignStmt{
+			Lhs: []ast.Expr{&ast.SelectorExpr{X: ast.NewIdent("_result"), Sel: ast.NewIdent(fieldName)}},
+			Tok: token.ASSIGN,
+			Rhs: []ast.Expr{rhs},
+		})
+	}
+
+	// return Success[any](_result)
+	decls = append(decls, &ast.ReturnStmt{Results: []ast.Expr{
+		&ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   &ast.CompositeLit{Type: &ast.IndexExpr{X: t.stdIdent("Success"), Index: ast.NewIdent("any")}},
+				Sel: ast.NewIdent("Apply"),
+			},
+			Args: []ast.Expr{ast.NewIdent("_result")},
+		},
+	}})
+
+	return &ast.FuncDecl{
+		Recv: blankRecv(config.generatedName),
+		Name: ast.NewIdent("ConstructAny"),
+		Type: &ast.FuncType{
+			Params: &ast.FieldList{List: []*ast.Field{
+				{Names: idents("values"), Type: &ast.ArrayType{Elt: ast.NewIdent("any")}},
+			}},
+			Results: &ast.FieldList{List: []*ast.Field{
+				{Type: &ast.IndexExpr{X: t.stdIdent("Try"), Index: ast.NewIdent("any")}},
+			}},
+		},
+		Body: &ast.BlockStmt{List: decls},
+	}
+}
+
+// tryFailureAny emits `std.Failure[any]{}.Apply(fmt.Errorf("msg"))`.
+// Caller supplies a format string; runtime-generated args aren't threaded
+// through in V1 (static messages are enough for the codec path).
+func (t *galaASTTransformer) tryFailureAny(msg string) ast.Expr {
+	// Import fmt lazily so only generated codec structs using this path pull it.
+	t.importManager.AddTransitive("fmt", "fmt")
+	return &ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X:   &ast.CompositeLit{Type: &ast.IndexExpr{X: t.stdIdent("Failure"), Index: ast.NewIdent("any")}},
+			Sel: ast.NewIdent("Apply"),
+		},
+		Args: []ast.Expr{
+			&ast.CallExpr{
+				Fun: &ast.SelectorExpr{X: ast.NewIdent("fmt"), Sel: ast.NewIdent("Errorf")},
+				Args: []ast.Expr{stringLit(msg)},
+			},
+		},
 	}
 }
 

--- a/std/BUILD.bazel
+++ b/std/BUILD.bazel
@@ -9,6 +9,7 @@ exports_files([
     "hashable.gala",
     "immutable.gala",
     "iterable.gala",
+    "meta.gala",
     "option.gala",
     "ordered.gala",
     "seq.gala",
@@ -102,6 +103,12 @@ gala_bootstrap_transpile(
     out = "codec.gen.go",
 )
 
+gala_bootstrap_transpile(
+    name = "meta_go",
+    src = "meta.gala",
+    out = "meta.gen.go",
+)
+
 go_library(
     name = "std",
     srcs = [
@@ -114,6 +121,7 @@ go_library(
         "immutable.gen.go",
         "interfaces.go",
         "iterable.gen.go",
+        "meta.gen.go",
         "option.gen.go",
         "ordered.gen.go",
         "seq.gen.go",

--- a/std/meta.gala
+++ b/std/meta.gala
@@ -1,0 +1,83 @@
+package std
+
+// Package std / meta.gala — struct-metadata types consumed by format codecs.
+//
+// Background
+// ----------
+// The transpiler generates a `StructMeta[T]` intrinsic for every struct that
+// appears in a `StructMeta[T]()` call (typically injected for `Codec[T]`).
+// Generated metadata implements the `StructMetaRef` interface below and
+// exposes a neutral, format-agnostic descriptor for each field via the
+// `FieldType` sealed type.
+//
+// Libraries (`std/json`, future `std/yaml`, etc.) pattern-match on FieldType
+// to drive encode/decode. The transpiler itself knows nothing about JSON or
+// any other wire format — its only contract is this file.
+
+// FieldType is a neutral, format-agnostic descriptor for a struct field's type.
+//
+// The transpiler's `StructMeta[T]` generator emits a `FieldType(i int) FieldType`
+// accessor that returns one of these variants based on the compile-time GALA
+// type of the i-th field. Codec libraries pattern-match on this value to drive
+// serialization / deserialization.
+//
+// V1 covers the primitive types, `Option[T]`, `Array[T]`, `HashMap[K,V]` and
+// nested struct references. Sealed-type-valued struct fields, generic
+// user-defined containers, and collections beyond the three above are emitted
+// as `UnknownType(name)` in V1 — codec libraries should treat that as "skip"
+// or "write null".
+sealed type FieldType {
+    // Primitive scalar types.
+    case StringType()
+    case IntType()
+    case Int64Type()
+    case Float64Type()
+    case BoolType()
+    case RuneType()
+
+    // Composite types — recursive.
+    case OptionType(Inner FieldType)
+    case ArrayType(Elem FieldType)
+    case ListType(Elem FieldType)
+    case HashMapType(Key FieldType, Value FieldType)
+
+    // A struct-valued field. `Meta` is the neutral handle onto the nested
+    // struct's own StructMeta, usable for recursive descent without knowing
+    // the concrete type parameter.
+    case NestedStructType(Meta StructMetaRef)
+
+    // Fallback for anything the transpiler cannot map cleanly in V1
+    // (sealed types, user-defined generics, unsupported go interop types).
+    // The name is informational only — codecs typically emit null.
+    case UnknownType(Name string)
+}
+
+// StructMetaRef is the non-generic view of a `StructMeta[T]` that the
+// transpiler generates. Every generated `_StructMeta_T` implements this
+// interface, so library code can walk nested struct references without
+// propagating the concrete type parameter.
+//
+// Generic methods (`FieldValue(i int, t T) any`, `Construct(...) Try[T]`)
+// live on the concrete `_StructMeta_T` for callers that do know T; the
+// erased `FieldValueAny` / `ConstructAny` are the ones callable through
+// this interface.
+type StructMetaRef interface {
+    NumFields() int
+    FieldName(i int) string
+
+    // FieldTypeOf returns the neutral field-type descriptor for field i.
+    // TODO(phase-1): once the transpiler stops emitting the legacy
+    // `FieldType(i) string` accessor, rename this to `FieldType(i) FieldType`
+    // to match the design-doc spec.
+    FieldTypeOf(i int) FieldType
+
+    // FieldValueAny extracts field i from `t` boxed as `any`.
+    // `t` must be the concrete struct type the generated StructMeta describes.
+    FieldValueAny(i int, t any) any
+
+    // ConstructAny builds a struct-typed value from positional field values.
+    // Values are boxed as `any` and must be in the same order as
+    // FieldName(0..NumFields()-1). Returns `Failure` if any element fails the
+    // field's runtime type check.
+    ConstructAny(values []any) Try[any]
+}

--- a/std/option.gala
+++ b/std/option.gala
@@ -15,12 +15,38 @@ func getSomeValue(opt any) any = opt match {
     case _ => opt
 }
 
+// AnyOption is the non-generic interface that every `Option[T]` instantiation
+// satisfies. It is used by libraries (e.g., `std/json`) that walk values typed
+// as `any` and need to dispatch on whether the value is an Option without
+// knowing its inner type parameter.
+//
+// Every `Option[T]` automatically implements `AnyOption` because IsSome() is
+// defined below on `Option[T]` and ValueAsAny() is defined one line later.
+// This lets code write `v.(AnyOption)` — an interface assertion, not a
+// forbidden generic instantiation like `v.(Option[any])`.
+//
+// The inner-value accessor is named `ValueAsAny` rather than `GetAny` to
+// avoid colliding with std's `ImmutableUnwrapper.GetAny` contract — the
+// latter is used by `As[T]` to transparently unwrap `Immutable[U]`, so any
+// type exposing `GetAny() any` would be treated as unwrappable and break
+// runtime type matches like `case i: int`.
+type AnyOption interface {
+    IsSome() bool
+    ValueAsAny() any
+}
+
 // Option represents an optional value: every instance of Option is either an instance
 // of Some containing a value, or None representing an empty value.
 sealed type Option[T any] {
     case Some(Value T)
     case None()
 }
+
+// ValueAsAny returns the option's value boxed as `any` when the option is Some.
+// Panics when the option is None — callers should guard with IsSome() first.
+// This method (together with IsSome) is how `Option[T]` satisfies the
+// non-generic `AnyOption` interface.
+func (o Option[T]) ValueAsAny() any = o.Get()
 
 // IsDefined returns true if the option is an instance of Some, false otherwise.
 func (o Option[T]) IsDefined() bool = o.isSome()


### PR DESCRIPTION
## Summary

Architectural refactor targeted by the design doc at `docs/private/refactor-codec-architecture.md` (gitignored; pasting the essentials inline below for reviewers). Goal: the transpiler's only codec-related output is a generic, format-agnostic `StructMeta[T]` intrinsic — **no JSON writer/reader method names baked into codegen**. Adding `std/yaml`, `std/protobuf`, or fixing per-field format-specific bugs like gap #12 should be library-only changes from now on.

This PR ships **phases 0 and 1** of the 4-phase plan. Phases 2–4 (library rewrite, callsite migration, legacy-deletion + PR #199 retirement) are still to do and will follow in stacked PRs on top of this branch.

### The essentials of the design

The transpiler emits `_StructMeta_T` per struct `T`. After this PR each such type exposes, alongside the legacy surface, three new methods:

* `FieldTypeOf(i int) std.FieldType` — returns a neutral sealed descriptor (`StringType`, `IntType`, `OptionType(inner)`, `ArrayType(elem)`, `HashMapType(key, value)`, `UnknownType(name)`, ...).
* `FieldValueAny(i int, t any) any` — erased field extraction.
* `ConstructAny(values []any) Try[any]` — positional struct construction.

Plus a new sealed `FieldType` type and `StructMetaRef` interface in `std/meta.gala`, and non-generic `AnyOption` / `AnyArray` / `AnyMap` shims across `std/option.gala` + `collection_immutable/{array,hashmap}.gala`. Those shims exist because Go's generics are monomorphized: `v.(Option[any])` is a compile error, so library code will walk erased values via interface assertion (`v.(AnyOption)`).

Once Phase 2 lands, the new `std/json/codec.gala` will pattern-match on `FieldType` to drive encode/decode and gap #12 (Option[T] fields serializing to null) becomes a one-line library-level fix rather than a transpiler change.

## Phases shipped

- [x] **Phase 0** (commit `37c7e36`) — stdlib shims + `std/meta.gala` foundation. Purely additive, all 261 tests pass, `examples/json_codec.out` byte-identical to baseline.
- [x] **Phase 1** (commit `855ecb3`) — transpiler emits new accessors alongside legacy ones. All 261 tests pass, `json_codec.out` still byte-identical.
- [ ] **Phase 2** — rewrite `std/json/codec.gala` in pure GALA using `FieldType` + `StructMetaRef` + AnyOption/Array/Map.
- [ ] **Phase 3** — flip `examples/json_codec*.gala` to the new library path; verify byte-for-byte parity; add Option-field round-trip test (the PR #199 repro).
- [ ] **Phase 4** — delete legacy `genWriteTo` / `genReadFrom` / `genFieldType(string)` / `writeMethodForBasicType` / `readMethodForBasicType` in `internal/transpiler/transformer/codec.go`; retire PR #199.

## Line-count delta so far

Additive only; nothing deleted yet.

* `internal/transpiler/transformer/codec.go`: +327 lines (new `genFieldTypeOf`, `genFieldValueAny`, `genConstructAny`, descriptor helpers).
* `std/meta.gala`: +71 lines (new file).
* `std/option.gala`, `collection_immutable/array.gala`, `collection_immutable/hashmap.gala`: +~60 lines (AnyOption/AnyArray/AnyMap interfaces and matching methods).

Expected net delete in Phase 4: ~300 lines from `codec.go` (the JSON-specific writer/reader method tables and per-field codegen), offset by ~150 lines of new codegen and ~300 lines of GALA library code. Net win: the transpiler stops knowing anything about JSON.

## Deviations from the design doc

* `StructMetaRef` exposes `FieldTypeOf(i) FieldType` rather than `FieldType(i) FieldType`. The existing generated code emits a legacy `FieldType(i) string` accessor; keeping the names disjoint during the transition avoids accidental interface-satisfaction ambiguity. Will rename to `FieldType` in Phase 4 once the legacy accessor is deleted.
* `Option[T].ValueAsAny()` rather than `GetAny()`. Reason: `std.ImmutableUnwrapper` already owns the `GetAny() any` signature and `As[T]` uses it to transparently unwrap `Immutable[U]`. If Option exposed `GetAny() any`, a runtime match `case i: int` on `Option[int]` would unwrap and succeed — confirmed as a regression (the `type_match` test failed) before I renamed.
* `SealedType(TypeName, Variants Array[FieldType])` variant dropped from V1 FieldType. Reason: `Array` lives in `collection_immutable` which depends on `std`, so `std/meta.gala` cannot import it without creating a cycle. The design doc marks sealed-valued struct fields as V2 follow-up anyway; V1 emits `UnknownType` for them.
* `NestedStructType(Meta)` is accepted in the sealed type but the current `fieldTypeDescriptor` emits `UnknownType` for fields whose type is a user-defined struct, to avoid recursively materialising StructMeta instances the user never asked for. Phase 2 (the library rewrite) is the natural place to thread that through — the library will know when it needs nested metadata and can request it.

## Known design-doc note that turned out to be wrong

The doc flagged `isSelfReferentialSealedField` as needing an extension to handle sealed variants with multiple self-referential fields (`HashMapType(Key FieldType, Value FieldType)`). It does not: the existing implementation checks each field independently, so `Add(Left Expr, Right Expr)` in `sealed_recursive.gala` already works, and `HashMapType(Key FieldType, Value FieldType)` in the new `std/meta.gala` transpiles cleanly to a `*FieldType` pair plus an `Option[Tuple[FieldType, FieldType]]` unapply. No transpiler change needed.

## Test plan

- [x] `bazel build //...` passes.
- [x] `bazel test //...` — all 261 tests pass after Phase 1.
- [x] `diff examples/json_codec.out docs/private/fix-attempts/json_codec-baseline.out` — zero diff (byte-for-byte preserved).
- [ ] Phase 2: add `examples/json_codec_option.gala` covering the PR #199 repro.
- [ ] Phase 3: re-run the full suite after flipping `json_codec.gala` to the new library.
- [ ] Phase 4: structural test — `grep -r "WriteString|WriteNull|ReadNull|FieldWriter" internal/transpiler/` returns zero hits outside FieldType definition.

Draft — do not merge until phases 2–4 land. The work pushed here is a safe foundation: existing consumers keep working, and every Phase can be validated independently.

Design doc lives at `docs/private/refactor-codec-architecture.md` (gitignored per repo convention).

Supersedes the approach in #199 once Phase 4 closes this out.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>