### PR TITLE
fix(build): gala test exits 0 with a notice when no _test.gala files exist

### DIFF
--- a/internal/build/BUILD.bazel
+++ b/internal/build/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
 go_test(
     name = "build_test",
     srcs = [
+        "builder_test.go",
         "deptranspiler_test.go",
         "go_toolchain_test.go",
     ],

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -1145,7 +1145,16 @@ func (b *Builder) Test(verbose bool) error {
 	}
 
 	if len(testFiles) == 0 {
-		return fmt.Errorf("no _test.gala files found in %s", b.workspace.ProjectDir)
+		// Match `go test ./...` behavior: report that no tests were found and
+		// exit successfully. Running `gala test` in a freshly-initialised project
+		// that has source files but no tests yet is a normal state, not a build
+		// failure.
+		label := b.galaMod.Module.Path
+		if label == "" || label == "gala-standalone" {
+			label = b.workspace.ProjectDir
+		}
+		fmt.Printf("?   \t%s\t[no test files]\n", label)
+		return nil
 	}
 
 	// Step 4: Determine package layout

--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -1,0 +1,67 @@
+package build
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTest_NoTestFilesExitsZero verifies that running `gala test` on a project
+// with no _test.gala files exits successfully (with a "no test files" notice)
+// rather than failing. This matches Go's `go test ./...` behavior.
+func TestTest_NoTestFilesExitsZero(t *testing.T) {
+	projectDir := t.TempDir()
+
+	// Minimal gala.mod
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "gala.mod"),
+		[]byte("module example.com/demo\n\ngala 0.0.0\n"), 0644))
+
+	// A single main.gala file with no tests
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "main.gala"),
+		[]byte("package main\n\nfunc main() { Println(\"hi\") }\n"), 0644))
+
+	// Use a builder pointed at an isolated build workspace inside the temp
+	// project dir so we don't touch the user's cache.
+	origHome, hadHome := os.LookupEnv("HOME")
+	origUserProfile, hadProfile := os.LookupEnv("USERPROFILE")
+	isolated := t.TempDir()
+	os.Setenv("HOME", isolated)
+	os.Setenv("USERPROFILE", isolated)
+	t.Cleanup(func() {
+		if hadHome {
+			os.Setenv("HOME", origHome)
+		} else {
+			os.Unsetenv("HOME")
+		}
+		if hadProfile {
+			os.Setenv("USERPROFILE", origUserProfile)
+		} else {
+			os.Unsetenv("USERPROFILE")
+		}
+	})
+
+	b, err := NewBuilder(projectDir, "test", false)
+	require.NoError(t, err)
+
+	// Capture stdout so the test can assert on the friendly notice.
+	origStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	testErr := b.Test(false)
+
+	// Restore stdout and read what was written.
+	_ = w.Close()
+	os.Stdout = origStdout
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	require.NoError(t, testErr, "Test() must not return an error when there are no _test.gala files")
+	require.True(t, strings.Contains(buf.String(), "[no test files]"),
+		"expected '[no test files]' notice in stdout, got: %q", buf.String())
+}


### PR DESCRIPTION
## Summary

Fixes **FIX-001**: `gala test` exits 1 on a project with no `_test.gala` files.

**Category**: USABILITY
**Priority**: P3
**Found in**: gala_tui battle test (BUG-gala_tui-001)

## Root Cause

`Builder.Test` returned an error when it found zero `_test.gala` files, which `cmd/gala/commands/test.go` surfaced as a non-zero exit. A freshly-scaffolded project running `gala test` as a smoke check would see a red CI immediately — the kind of paper cut that frustrates new users.

## Changes

- `internal/build/builder.go` — `Builder.Test` now prints `?   <module>  [no test files]` (matching Go's `go test ./...` notice) and returns `nil` instead of an error when no `_test.gala` files are found.
- `internal/build/builder_test.go` (new) — regression test `TestTest_NoTestFilesExitsZero`.

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (all 265+ tests)

## Repro (before fix)

\`\`\`
gala new demo
cd demo
gala test    # → exit 1, "no _test.gala files found"
\`\`\`

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as BUG-gala_tui-001 in \`C:\Users\maxmr\GolandProjects\gala_battle_tests\gala_tui\REPORT.md\`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)