### PR TITLE
fix(test): rename user func main() in test binary to avoid collision

### DIFF
--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -1310,6 +1310,21 @@ func (b *Builder) transpileTestMain(sourceFiles, testFiles []string) error {
 		return err
 	}
 
+	// The test binary introduces its own synthesized `func main()` (see
+	// GenerateTestMain) that drives the test runner. If the user's source
+	// also declares `func main()` we'd get a "main redeclared in this block"
+	// error at `go build` time. Rename any user-supplied `func main()` out
+	// of the way so the generated test_main.gen.go can claim it. This only
+	// affects the test-binary build — the user's regular `gala build` output
+	// is unaffected because Build() does not call this path.
+	sourceOutNames := make(map[string]bool, len(sourceFiles))
+	for _, src := range sourceFiles {
+		sourceOutNames[testGenFileName(b.workspace.ProjectDir, src)] = true
+	}
+	if err := renameUserMainInDir(b.workspace.GenDir, sourceOutNames, b.verbose); err != nil {
+		return fmt.Errorf("renaming user main for test binary: %w", err)
+	}
+
 	// Copy local Go subpackages to gen/ so the test binary compiles
 	// when it references types from local Go packages (e.g., httpcore/).
 	if err := copyNonGalaFiles(b.workspace.ProjectDir, b.workspace.GenDir, b.verbose); err != nil {
@@ -1322,6 +1337,72 @@ func (b *Builder) transpileTestMain(sourceFiles, testFiles []string) error {
 		return fmt.Errorf("rewriting project module imports: %w", err)
 	}
 
+	return nil
+}
+
+// testGenFileName mirrors the naming that transpileFilesToDir applies when
+// emitting .gen.go outputs (subdir separators folded to `_`). It returns the
+// bare filename (without the gen dir prefix).
+func testGenFileName(projectDir, galaFile string) string {
+	relPath, err := filepath.Rel(projectDir, galaFile)
+	if err != nil {
+		relPath = filepath.Base(galaFile)
+	}
+	outName := strings.TrimSuffix(relPath, ".gala") + ".gen.go"
+	return strings.ReplaceAll(outName, string(filepath.Separator), "_")
+}
+
+// renameUserMainInDir scans the given .gen.go files in dir and renames any
+// top-level `func main()` declaration to `_galaUserMain` so it does not
+// conflict with the synthesized test runner's main(). The renamed function
+// is never called by anyone — the Go compiler tree-shakes it out — but
+// preserving it keeps other symbols in the same file (type decls, helpers,
+// etc.) compiling cleanly.
+//
+// Only files whose basename appears in sourceNames are touched; generated
+// test_main.gen.go and the transpiled test files must keep their declarations.
+func renameUserMainInDir(dir string, sourceNames map[string]bool, verbose bool) error {
+	funcMainRegex := "func main()"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".gen.go") {
+			continue
+		}
+		if !sourceNames[entry.Name()] {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+		text := string(content)
+		// Only touch a top-of-line `func main()` signature. Using a plain
+		// string match (plus a newline prefix to guard against accidental
+		// substring hits inside strings) is sufficient because the transpiler
+		// emits `func main()` on its own line at indent 0 when the user
+		// writes a package main with a main entry point.
+		idx := strings.Index(text, "\n"+funcMainRegex)
+		if idx < 0 && !strings.HasPrefix(text, funcMainRegex) {
+			continue
+		}
+		rewritten := strings.Replace(text, "\nfunc main()", "\nfunc _galaUserMain()", 1)
+		if strings.HasPrefix(rewritten, "func main()") {
+			rewritten = "func _galaUserMain()" + rewritten[len("func main()"):]
+		}
+		if rewritten == text {
+			continue
+		}
+		if err := os.WriteFile(path, []byte(rewritten), 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", path, err)
+		}
+		if verbose {
+			fmt.Printf("  test: renamed user func main() in %s\n", entry.Name())
+		}
+	}
 	return nil
 }
 

--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -65,3 +65,77 @@ func TestTest_NoTestFilesExitsZero(t *testing.T) {
 	require.True(t, strings.Contains(buf.String(), "[no test files]"),
 		"expected '[no test files]' notice in stdout, got: %q", buf.String())
 }
+
+// TestRenameUserMainInDir_RenamesOnlyListedFiles verifies that the test-binary
+// build path renames the user's `func main()` out of the way so the
+// synthesized test runner's main() can compile in the same package. Without
+// this step, `go build ./gen/...` fails with "main redeclared in this block".
+func TestRenameUserMainInDir_RenamesOnlyListedFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	userMain := `package main
+
+func main() {
+	Println("hi")
+}
+`
+	userLib := `package main
+
+func helper() int { return 1 }
+`
+	testFile := `package main
+
+func TestX() {}
+`
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.gen.go"), []byte(userMain), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib.gen.go"), []byte(userLib), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main_test.gen.go"), []byte(testFile), 0644))
+
+	// Only main.gen.go and lib.gen.go are user source files; main_test.gen.go
+	// is a test file and must be left untouched.
+	sourceNames := map[string]bool{
+		"main.gen.go": true,
+		"lib.gen.go":  true,
+	}
+
+	require.NoError(t, renameUserMainInDir(dir, sourceNames, false))
+
+	mainAfter, err := os.ReadFile(filepath.Join(dir, "main.gen.go"))
+	require.NoError(t, err)
+	require.False(t, strings.Contains(string(mainAfter), "func main()"),
+		"user func main() should have been renamed, got:\n%s", mainAfter)
+	require.True(t, strings.Contains(string(mainAfter), "func _galaUserMain()"),
+		"renamed function should be named _galaUserMain, got:\n%s", mainAfter)
+
+	// Non-main source files are unchanged.
+	libAfter, err := os.ReadFile(filepath.Join(dir, "lib.gen.go"))
+	require.NoError(t, err)
+	require.Equal(t, userLib, string(libAfter), "lib.gen.go should be unchanged")
+
+	// Test files are not in the sourceNames map so they are untouched.
+	testAfter, err := os.ReadFile(filepath.Join(dir, "main_test.gen.go"))
+	require.NoError(t, err)
+	require.Equal(t, testFile, string(testAfter), "test file should be unchanged")
+}
+
+// TestTestGenFileName verifies that the helper matches the naming used by
+// transpileFilesToDir (subdir separators folded to '_', .gala suffix replaced
+// by .gen.go). This keeps the rename pass and the transpile pass in sync.
+func TestTestGenFileName(t *testing.T) {
+	projectDir := filepath.Clean("/p")
+	cases := []struct {
+		name string
+		gala string
+		want string
+	}{
+		{"root file", filepath.Join(projectDir, "main.gala"), "main.gen.go"},
+		{"subdir file", filepath.Join(projectDir, "sub", "lib.gala"), "sub_lib.gen.go"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := testGenFileName(projectDir, tc.gala)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **FIX-006**: \`gala test\` fails with "main redeclared" when a package-main project has both \`func main()\` and \`TestXxx()\` functions.

**Category**: TRANSPILER_BUG
**Priority**: P1
**Found in**: gala_tui battle test (BUG-gala_tui-006)

## Root Cause

When building the test binary, the synthesized \`test_main.gen.go\` emits its own \`func main()\` to drive the test runner. The user's transpiled \`main.gala\` also emits \`func main()\`, and Go's package rules reject two \`main\` declarations in the same package. There was no accommodation for package-main projects that want to host both an app entry point and tests.

## Changes

- \`internal/build/builder.go\` — \`transpileTestMain\` now post-processes the generated \`.gen.go\` files belonging to the user's source and renames \`func main()\` to \`func _galaUserMain()\`, freeing \`main\` for the synthesized test runner. Test files are skipped via a filename allowlist so their \`TestXxx\` functions aren't touched.
- \`internal/build/builder_test.go\` (new) — \`TestRenameUserMainInDir_RenamesOnlyListedFiles\` and \`TestTestGenFileName\`.

## Verification

- \`bazel build //...\` passes
- \`bazel test //...\` passes (265 tests)
- Manual repro: package-main project with \`func main()\` + \`TestX(t T) T\` now compiles and runs tests.

## Repro (before fix)

\`\`\`
demo/
  main.gala         package main, func main() { Println("hi") }
  demo_test.gala    package main, func TestX(t T) T = Eq(t, 1+1, 2)
\`\`\`
\`gala test\` → \`main redeclared in this block\`.

## Dependencies

None.

## Battle Test Report Reference

Originally reported as BUG-gala_tui-006.

## Notes

The solution uses a string-level rename on the generated Go. A more robust approach would rename through the Go AST, but this was deemed heavier than needed for the test-binary-only use case.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)