### PR TITLE
feat(build): recurse into subpackages of the module on gala build

### DIFF
--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -255,8 +255,12 @@ func (b *Builder) transpile() error {
 		return b.transpileWithSourceDir()
 	}
 
-	// Find all .gala files in the project
-	galaFiles, err := findGalaFiles(b.workspace.ProjectDir)
+	// Find all .gala files in the project, including subpackages. Subdirectories
+	// may host their own GALA packages (e.g. `sub/lib.gala` declaring `package sub`)
+	// that the root package imports; without recursion the root build would fail
+	// with "package <workspace>/gen/sub is not in std" because the subpackage was
+	// never transpiled.
+	galaFiles, err := findGalaFilesRecursive(b.workspace.ProjectDir)
 	if err != nil {
 		return fmt.Errorf("finding gala files: %w", err)
 	}
@@ -301,6 +305,15 @@ func (b *Builder) transpile() error {
 	// This avoids redundant re-analysis of imports (std, collection_immutable, etc.).
 	batchAnalyzer := analyzer.NewBatchAnalyzer(p, searchPaths, b.workspace.ProjectDir)
 
+	// Group files by their parent directory so sibling-based type resolution
+	// only sees files that actually share a Go package. A root-level file is
+	// not a sibling of a file in sub/ even though both belong to the same
+	// GALA module.
+	filesByDir := make(map[string][]string)
+	for _, f := range galaFiles {
+		filesByDir[filepath.Dir(f)] = append(filesByDir[filepath.Dir(f)], f)
+	}
+
 	var allEmbedPatterns []string
 
 	for _, galaFile := range galaFiles {
@@ -310,7 +323,7 @@ func (b *Builder) transpile() error {
 		}
 
 		var siblings []string
-		for _, other := range galaFiles {
+		for _, other := range filesByDir[filepath.Dir(galaFile)] {
 			if other != galaFile {
 				siblings = append(siblings, other)
 			}
@@ -331,10 +344,16 @@ func (b *Builder) transpile() error {
 		if err != nil {
 			relPath = filepath.Base(galaFile)
 		}
+		// Preserve the subdirectory layout in gen/ so each GALA subpackage
+		// lands in its own directory — this is what the Go toolchain needs
+		// to resolve imports like "gala-build-workspace/gen/sub".
 		outName := strings.TrimSuffix(relPath, ".gala") + ".gen.go"
-		outName = strings.ReplaceAll(outName, string(filepath.Separator), "_")
+		outPath := filepath.Join(b.workspace.GenDir, outName)
 
-		if err := b.workspace.WriteGenFile(outName, []byte(goCode)); err != nil {
+		if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+			return fmt.Errorf("creating gen dir for %s: %w", outName, err)
+		}
+		if err := os.WriteFile(outPath, []byte(goCode), 0644); err != nil {
 			return fmt.Errorf("writing %s: %w", outName, err)
 		}
 

--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -138,4 +139,42 @@ func TestTestGenFileName(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// TestFindGalaFilesRecursive_IncludesSubdirs verifies that the recursive
+// file walker used by `gala build` discovers .gala files in subpackages.
+// Before the fix, the project transpilation pipeline called findGalaFiles
+// (non-recursive) and silently dropped any sub/*.gala files, which later
+// tripped up `go build` with "package gala-build-workspace/gen/sub is not
+// in std" since the subpackage had never been transpiled.
+func TestFindGalaFilesRecursive_IncludesSubdirs(t *testing.T) {
+	projectDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "main.gala"),
+		[]byte("package main\nfunc main() {}"), 0644))
+
+	subDir := filepath.Join(projectDir, "sub")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "lib.gala"),
+		[]byte("package sub\nfunc Hello() string = \"hi\""), 0644))
+
+	// _test.gala must NOT be picked up by build-path recursion.
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "extra_test.gala"),
+		[]byte("package sub\nfunc TestX() {}"), 0644))
+
+	// Hidden/build-cache directories must be skipped.
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, ".gala"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, ".gala", "cached.gala"),
+		[]byte("package whatever"), 0644))
+
+	got, err := findGalaFilesRecursive(projectDir)
+	require.NoError(t, err)
+
+	sort.Strings(got)
+	want := []string{
+		filepath.Join(projectDir, "main.gala"),
+		filepath.Join(subDir, "lib.gala"),
+	}
+	sort.Strings(want)
+	require.Equal(t, want, got)
 }


### PR DESCRIPTION
## Summary

Fixes **FIX-007**: \`gala build\` silently skips subpackages of a module.

**Category**: MISSING_FEATURE
**Priority**: P1
**Found in**: gala_tui battle test (BUG-gala_tui-007)

## Root Cause

\`Builder.transpile()\` used \`findGalaFiles\` (non-recursive, explicitly marked "for now" in the source). A multi-package layout like \`main.gala\` + \`sub/lib.gala\` would transpile only the root, then Go's package resolution would fail to find the \`sub\` subpackage. A recursive variant \`findGalaFilesRecursive\` existed but wasn't wired in.

## Changes

- \`internal/build/builder.go\` — \`Builder.transpile()\` now uses \`findGalaFilesRecursive\`, groups files by directory so sibling analysis is per-package, and preserves subdirectory structure in \`gen/\` (\`sub/lib.gala\` → \`gen/sub/lib.gen.go\`).
- \`internal/build/builder_test.go\` — \`TestFindGalaFilesRecursive_IncludesSubdirs\`.

## Verification

- \`bazel build //...\` passes
- \`bazel test //...\` passes (265 tests)
- Manual repro: two-package project builds end-to-end.

## Repro (before fix)

\`\`\`
proj/
  gala.mod       module example.com/proj
  main.gala      package main, imports "example.com/proj/sub"
  sub/
    lib.gala     package sub, func Hello() string = "hi"
\`\`\`
\`gala build\` → \`package gala-build-workspace/gen/sub is not in std\`.

## Dependencies

None.

## Battle Test Report Reference

Originally reported as BUG-gala_tui-007.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)