### PR TITLE
fix(transpiler): method-return type inference for pointer receivers on non-generic types

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1826,6 +1826,7 @@ gala_library(
     srcs = [
         "multifile_lib_regress/go_interop.gala",
         "multifile_lib_regress/logic.gala",
+        "multifile_lib_regress/pointer_method_field.gala",
         "multifile_lib_regress/types.gala",
     ],
     importpath = "martianoff/gala/examples/multifile_lib_regress",

--- a/examples/multifile_lib_regress/pointer_method_field.gala
+++ b/examples/multifile_lib_regress/pointer_method_field.gala
@@ -1,0 +1,26 @@
+package multifile_lib_regress
+
+// --- Regression: cross-file pointer-receiver method return field access ---
+// When a method is defined with a pointer receiver in a sibling file and its
+// return type has an immutable field, chained field access must auto-unwrap
+// the inner Immutable[T] wrapper. Previously the method-return type
+// inference bailed out for *Buffer (PointerType over non-generic named type)
+// because the fallback only retried for generic receivers, leaving xType
+// NilType at the .Bold access site and defeating isImmutableField.
+
+type StyleInfo struct {
+    Bold   bool
+    Italic bool
+}
+
+type Canvas struct {
+    Width  int
+    Height int
+}
+
+func (c *Canvas) StyleAt(x int, y int) StyleInfo = StyleInfo(Bold = true, Italic = false)
+
+func NewCanvas(w int, h int) *Canvas = &Canvas(Width = w, Height = h)
+
+// Exposes the chained access for the regression test to call from main.
+func BoldAt(c *Canvas, x int, y int) bool = c.StyleAt(x, y).Bold

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -60,4 +60,12 @@ func main() {
 
     // GALA struct named-arg — should wrap in Immutable (correct)
     Println(multifile_lib_regress.GalaCookieName("session", "abc123"))
+
+    // Cross-file pointer-receiver method return field access: the call site
+    // `canvas.StyleAt(0, 0).Bold` must auto-unwrap the Immutable[bool] wrapper
+    // around .Bold. Before the fix, method-return type inference for *Canvas
+    // returned NilType (non-generic PointerType fallback missing), so
+    // isImmutableField on .Bold saw an unknown xType and emitted plain .Bold.
+    val canvas = multifile_lib_regress.NewCanvas(80, 24)
+    Println(multifile_lib_regress.BoldAt(canvas, 0, 0))
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -7,3 +7,4 @@ key not found (expected)
 value-for-test-key
 Cookie(session=abc123, path=/)
 session
+true

--- a/internal/transpiler/transformer/type_inference_calls.go
+++ b/internal/transpiler/transformer/type_inference_calls.go
@@ -313,14 +313,24 @@ func (t *galaASTTransformer) inferCallSelectorType(e *ast.CallExpr, sel *ast.Sel
 		// Unwrap pointer types to get to the underlying type for method lookup
 		// e.g., for *Array[int].Find(), unwrap to Array[int]
 		underlyingType := xType
+		wasPointer := false
 		if ptr, ok := xType.(transpiler.PointerType); ok {
 			underlyingType = ptr.Elem
+			wasPointer = true
 		}
 		// Fallback: try base type name for generic types
 		// e.g., for Pair[int, string].Swap(), try looking up Pair
 		if genType, ok := underlyingType.(transpiler.GenericType); ok {
 			baseTypeName := genType.Base.String()
 			if result := t.resolveMethodCallTypeWithParams(baseTypeName, sel.Sel.Name, typeArgs, e.Args, -1, genType.Params); !result.IsNil() {
+				return result
+			}
+		} else if wasPointer {
+			// Fallback: for pointer to non-generic type, retry method lookup
+			// against the unwrapped type name. Methods defined with pointer
+			// receivers are registered under the base type name, not the
+			// pointer type, so *Buffer.StyleAt → Buffer.StyleAt lookup.
+			if result := t.resolveMethodCallType(underlyingType.String(), sel.Sel.Name, typeArgs, e.Args, -1); !result.IsNil() {
 				return result
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes **FIX-009**: chained field access on a method return of a pointer receiver on a non-generic type doesn't auto-unwrap \`Immutable[T]\`, causing type-mismatch errors at call-site argument positions.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P2
**Found in**: gala_tui battle test (BUG-gala_tui-009)

## Note on FIX-008

The task bundled FIX-008 and FIX-009 under a shared cross-file-analyzer hypothesis. **That hypothesis was wrong** — the two bugs have different root causes. FIX-009 is a receiver-type-resolution bug that manifests same-file too for non-generic pointer receivers. FIX-008 is a separate sibling-extraction gap for top-level \`val\` declarations that requires a new \`RichAST.Vals map[string]Type\` field — a core-data-structure change that was held pending explicit sign-off per the fix team's ground rules. **This PR fixes FIX-009 only.**

## Root Cause

\`inferCallSelectorType\` in \`internal/transpiler/transformer/type_inference_calls.go\` only retried the method-metadata lookup with the pointer stripped when the underlying type was generic. For a non-generic \`*Buffer\`, \`resolveMethodCallType("*Buffer", "StyleAt")\` always returned \`NilType\`, so the \`.Bold\` access on the return value saw an unknown xType, and \`isImmutableField\` bailed out — emitting plain \`.Bold\` on an \`Immutable[bool]\` and producing the type mismatch.

## Changes

- \`internal/transpiler/transformer/type_inference_calls.go\` — adds the pointer-stripped fallback for the non-generic branch (14-line delta at lines 313–333).
- \`examples/multifile_lib_regress/pointer_method_field.gala\` (new) — regression fixture with \`*Canvas.StyleAt(...) → StyleInfo\` chain.
- \`examples/multifile_lib_regress_test.gala\` — driver calls \`BoldAt(canvas, 0, 0)\` to exercise cross-file chained field access.
- \`examples/multifile_lib_regress_test.out\` — updated expected output.
- \`examples/BUILD.bazel\` — added the new source.

## Verification

- \`bazel build //...\` passes
- \`bazel test //...\` passes (265 tests including \`//examples:multifile_lib_regress_test\`)
- The \`gala_tui\` battle test passes with all six \`.Get()\` workarounds removed (99/99 tests pass).

## Repro (before fix)

\`\`\`gala
type Buffer struct { ... }
func (b *Buffer) StyleAt(x int, y int) Style { ... }

// in a different file, same package:
IsTrue(t, b.StyleAt(2, 1).Bold)
// → cannot use b.StyleAt(2, 1).Bold (value of type std.Immutable[bool])
//   as bool value in argument to IsTrue
\`\`\`

## Dependencies

None.

## Battle Test Report Reference

Originally reported as BUG-gala_tui-009. The bundled BUG-gala_tui-008 remains OPEN pending sign-off on the RichAST change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)