### PR TITLE
fix(build): honor replace directive in gala.mod before fetching deps

### DIFF
--- a/internal/build/BUILD.bazel
+++ b/internal/build/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     ],
     embed = [":build"],
     deps = [
+        "//internal/depman/mod",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -167,6 +167,10 @@ func (b *Builder) Build(outputPath string) (string, error) {
 }
 
 // ensureDeps fetches any GALA dependencies that are not yet cached locally.
+// Requirements covered by a `replace` directive pointing to a local path are
+// served from that directory instead of being fetched, mirroring Go's
+// `go mod` replace semantics. Non-local replaces (module => module@ver) still
+// fetch, but using the replacement coordinates.
 func (b *Builder) ensureDeps() error {
 	galaReqs := b.galaMod.GalaRequires()
 	if len(galaReqs) == 0 {
@@ -178,18 +182,92 @@ func (b *Builder) ensureDeps() error {
 	fetcher := fetch.NewGitFetcher(cache)
 
 	for _, req := range galaReqs {
-		modDir := b.config.GalaModulePath(req.Path, req.Version)
+		if _, isLocal, ok := b.resolveReplace(req); ok {
+			// Local replaces need no fetch — the source is already on disk.
+			if isLocal {
+				if b.verbose {
+					fmt.Printf("Replace: %s@%s => local path (fetch skipped)\n",
+						req.Path, req.Version)
+				}
+				continue
+			}
+			// Module replace: fetch the replacement coordinates if not cached.
+			// fall through with the effective path below
+		}
+
+		modDir := b.effectiveDepDir(req)
 		if _, err := os.Stat(modDir); err == nil {
-			continue // Already cached
+			continue // Already cached or local replacement present
 		}
+
+		fetchPath, fetchVersion := req.Path, req.Version
+		if newPath, newVersion, isModuleReplace := b.resolveModuleReplace(req); isModuleReplace {
+			fetchPath, fetchVersion = newPath, newVersion
+		}
+
 		if b.verbose {
-			fmt.Printf("Fetching %s@%s...\n", req.Path, req.Version)
+			fmt.Printf("Fetching %s@%s...\n", fetchPath, fetchVersion)
 		}
-		if _, _, err := fetcher.Fetch(req.Path, req.Version); err != nil {
-			return fmt.Errorf("fetching %s@%s: %w", req.Path, req.Version, err)
+		if _, _, err := fetcher.Fetch(fetchPath, fetchVersion); err != nil {
+			return fmt.Errorf("fetching %s@%s: %w", fetchPath, fetchVersion, err)
 		}
 	}
 	return nil
+}
+
+// resolveReplace reports whether `req` has a matching replace directive in
+// the active gala.mod, and (if so) returns the resolved source path, an
+// isLocal flag, and ok=true. A replace matches when Old.Path equals req.Path
+// and Old.Version is either empty (wildcard) or equals req.Version.
+func (b *Builder) resolveReplace(req mod.Require) (path string, isLocal bool, ok bool) {
+	if b.galaMod == nil {
+		return "", false, false
+	}
+	for _, rep := range b.galaMod.Replace {
+		if rep.Old.Path != req.Path {
+			continue
+		}
+		if rep.Old.Version != "" && rep.Old.Version != req.Version {
+			continue
+		}
+		if rep.New.IsLocal() {
+			resolved := rep.New.Path
+			if !filepath.IsAbs(resolved) {
+				resolved = filepath.Join(b.workspace.ProjectDir, resolved)
+			}
+			return filepath.Clean(resolved), true, true
+		}
+		return b.config.GalaModulePath(rep.New.Path, rep.New.Version), false, true
+	}
+	return "", false, false
+}
+
+// resolveModuleReplace returns the replacement module coordinates (path,
+// version) for a non-local replace directive, or ok=false if none applies.
+func (b *Builder) resolveModuleReplace(req mod.Require) (path, version string, ok bool) {
+	if b.galaMod == nil {
+		return "", "", false
+	}
+	for _, rep := range b.galaMod.Replace {
+		if rep.Old.Path != req.Path {
+			continue
+		}
+		if rep.Old.Version != "" && rep.Old.Version != req.Version {
+			continue
+		}
+		if rep.New.IsLocal() {
+			return "", "", false
+		}
+		return rep.New.Path, rep.New.Version, true
+	}
+	return "", "", false
+}
+
+// effectiveDepDir returns the on-disk directory where a dependency's source
+// files can be read from — the local replacement path if one is configured,
+// otherwise the standard module cache location.
+func (b *Builder) effectiveDepDir(req mod.Require) string {
+	return resolveEffectiveDepDir(b.config, b.galaMod, b.workspace.ProjectDir, req)
 }
 
 // ensureStdlib extracts the stdlib to the versioned cache if not present.
@@ -295,7 +373,7 @@ func (b *Builder) transpile() error {
 	searchPaths := []string{b.workspace.ProjectDir, stdlibDir}
 
 	for _, req := range b.galaMod.GalaRequires() {
-		searchPaths = append(searchPaths, b.config.GalaModulePath(req.Path, req.Version))
+		searchPaths = append(searchPaths, b.effectiveDepDir(req))
 	}
 	p := transpiler.NewAntlrGalaParser()
 	tr := transformer.NewGalaASTTransformer()
@@ -420,7 +498,7 @@ func (b *Builder) transpileWithSourceDir() error {
 	stdlibDir := b.config.StdlibVersionDir(b.stdlibVersion)
 	searchPaths := []string{b.workspace.ProjectDir, stdlibDir}
 	for _, req := range b.galaMod.GalaRequires() {
-		searchPaths = append(searchPaths, b.config.GalaModulePath(req.Path, req.Version))
+		searchPaths = append(searchPaths, b.effectiveDepDir(req))
 	}
 	p := transpiler.NewAntlrGalaParser()
 	tr := transformer.NewGalaASTTransformer()
@@ -810,6 +888,9 @@ func (b *Builder) generateGoMod() error {
 	}
 
 	gen := NewGoModGenerator(b.config)
+	// Propagate the project directory so local replace directives (paths
+	// relative to the user's gala.mod) resolve against the correct root.
+	gen.SetProjectDir(b.workspace.ProjectDir)
 	newContent := gen.GenerateGoMod(b.galaMod, b.stdlibVersion, b.transpiledDeps)
 
 	// Check if go.mod content has changed
@@ -997,11 +1078,17 @@ func (b *Builder) transpileDeps() error {
 		return nil
 	}
 
-	// Check if deps have changed by hashing gala.mod requirements
+	// Check if deps have changed by hashing gala.mod requirements and any
+	// replace directives. Including replaces ensures that retargeting a dep
+	// (e.g. toggling `replace X => ../localX`) invalidates the cache.
 	depsHashFile := filepath.Join(b.workspace.Dir, ".gala-deps-hash")
 	h := sha256.New()
 	for _, req := range galaReqs {
 		h.Write([]byte(req.Path + "@" + req.Version + "\n"))
+	}
+	for _, rep := range b.galaMod.Replace {
+		h.Write([]byte("replace " + rep.Old.Path + "@" + rep.Old.Version +
+			"=>" + rep.New.Path + "@" + rep.New.Version + "\n"))
 	}
 	currentHash := hex.EncodeToString(h.Sum(nil))
 
@@ -1014,8 +1101,9 @@ func (b *Builder) transpileDeps() error {
 				allExist = false
 				break
 			}
-			// Key by internal module path (from dep's gala.mod), matching TranspileDeps() behavior
-			modPath := resolveDepInternalModulePath(b.config, req)
+			// Key by internal module path (from dep's gala.mod), matching TranspileDeps() behavior.
+			// Use the replace-aware source dir so local replaces are honored.
+			modPath := resolveDepInternalModulePathAt(b.effectiveDepDir(req), req)
 			b.transpiledDeps[modPath] = dir
 		}
 		if allExist {
@@ -1047,8 +1135,14 @@ func (b *Builder) transpileDeps() error {
 // resolveDepInternalModulePath reads a dependency's gala.mod to get its declared
 // module path. Falls back to dep.Path if not found.
 func resolveDepInternalModulePath(config *Config, dep mod.Require) string {
-	cachedDir := config.GalaModulePath(dep.Path, dep.Version)
-	galaModPath := filepath.Join(cachedDir, "gala.mod")
+	return resolveDepInternalModulePathAt(config.GalaModulePath(dep.Path, dep.Version), dep)
+}
+
+// resolveDepInternalModulePathAt is like resolveDepInternalModulePath but uses
+// an explicit source directory, making it safe to use with replace directives
+// that point outside the module cache.
+func resolveDepInternalModulePathAt(srcDir string, dep mod.Require) string {
+	galaModPath := filepath.Join(srcDir, "gala.mod")
 	if depMod, err := mod.ParseFile(galaModPath); err == nil {
 		if depMod.Module.Path != "" {
 			return depMod.Module.Path
@@ -1566,7 +1660,7 @@ func (b *Builder) transpileFilesToDir(files []string, allSiblings []string, outD
 	searchPaths := []string{b.workspace.ProjectDir, stdlibDir}
 
 	for _, req := range b.galaMod.GalaRequires() {
-		searchPaths = append(searchPaths, b.config.GalaModulePath(req.Path, req.Version))
+		searchPaths = append(searchPaths, b.effectiveDepDir(req))
 	}
 
 	p := transpiler.NewAntlrGalaParser()

--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"martianoff/gala/internal/depman/mod"
 )
 
 // TestTest_NoTestFilesExitsZero verifies that running `gala test` on a project
@@ -26,8 +28,6 @@ func TestTest_NoTestFilesExitsZero(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "main.gala"),
 		[]byte("package main\n\nfunc main() { Println(\"hi\") }\n"), 0644))
 
-	// Use a builder pointed at an isolated build workspace inside the temp
-	// project dir so we don't touch the user's cache.
 	origHome, hadHome := os.LookupEnv("HOME")
 	origUserProfile, hadProfile := os.LookupEnv("USERPROFILE")
 	isolated := t.TempDir()
@@ -69,8 +69,7 @@ func TestTest_NoTestFilesExitsZero(t *testing.T) {
 
 // TestRenameUserMainInDir_RenamesOnlyListedFiles verifies that the test-binary
 // build path renames the user's `func main()` out of the way so the
-// synthesized test runner's main() can compile in the same package. Without
-// this step, `go build ./gen/...` fails with "main redeclared in this block".
+// synthesized test runner's main() can compile in the same package.
 func TestRenameUserMainInDir_RenamesOnlyListedFiles(t *testing.T) {
 	dir := t.TempDir()
 
@@ -93,8 +92,6 @@ func TestX() {}
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib.gen.go"), []byte(userLib), 0644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "main_test.gen.go"), []byte(testFile), 0644))
 
-	// Only main.gen.go and lib.gen.go are user source files; main_test.gen.go
-	// is a test file and must be left untouched.
 	sourceNames := map[string]bool{
 		"main.gen.go": true,
 		"lib.gen.go":  true,
@@ -109,12 +106,10 @@ func TestX() {}
 	require.True(t, strings.Contains(string(mainAfter), "func _galaUserMain()"),
 		"renamed function should be named _galaUserMain, got:\n%s", mainAfter)
 
-	// Non-main source files are unchanged.
 	libAfter, err := os.ReadFile(filepath.Join(dir, "lib.gen.go"))
 	require.NoError(t, err)
 	require.Equal(t, userLib, string(libAfter), "lib.gen.go should be unchanged")
 
-	// Test files are not in the sourceNames map so they are untouched.
 	testAfter, err := os.ReadFile(filepath.Join(dir, "main_test.gen.go"))
 	require.NoError(t, err)
 	require.Equal(t, testFile, string(testAfter), "test file should be unchanged")
@@ -122,7 +117,7 @@ func TestX() {}
 
 // TestTestGenFileName verifies that the helper matches the naming used by
 // transpileFilesToDir (subdir separators folded to '_', .gala suffix replaced
-// by .gen.go). This keeps the rename pass and the transpile pass in sync.
+// by .gen.go).
 func TestTestGenFileName(t *testing.T) {
 	projectDir := filepath.Clean("/p")
 	cases := []struct {
@@ -143,10 +138,6 @@ func TestTestGenFileName(t *testing.T) {
 
 // TestFindGalaFilesRecursive_IncludesSubdirs verifies that the recursive
 // file walker used by `gala build` discovers .gala files in subpackages.
-// Before the fix, the project transpilation pipeline called findGalaFiles
-// (non-recursive) and silently dropped any sub/*.gala files, which later
-// tripped up `go build` with "package gala-build-workspace/gen/sub is not
-// in std" since the subpackage had never been transpiled.
 func TestFindGalaFilesRecursive_IncludesSubdirs(t *testing.T) {
 	projectDir := t.TempDir()
 
@@ -177,4 +168,117 @@ func TestFindGalaFilesRecursive_IncludesSubdirs(t *testing.T) {
 	}
 	sort.Strings(want)
 	require.Equal(t, want, got)
+}
+
+// TestResolveEffectiveDepDir_LocalReplace verifies that a `replace` directive
+// pointing to a local path short-circuits the module cache lookup.
+func TestResolveEffectiveDepDir_LocalReplace(t *testing.T) {
+	projectDir := t.TempDir()
+	localDep := filepath.Join(projectDir, "..", "parent")
+
+	galaMod := &mod.File{
+		Module: mod.Module{Path: "example.com/sub"},
+		Require: []mod.Require{
+			{Path: "example.com/parent", Version: "v0.0.0"},
+		},
+		Replace: []mod.Replace{
+			{
+				Old: mod.ModuleVersion{Path: "example.com/parent"},
+				New: mod.ModuleVersion{Path: "../parent"},
+			},
+		},
+	}
+
+	config := DefaultConfig()
+	got := resolveEffectiveDepDir(config, galaMod, projectDir,
+		mod.Require{Path: "example.com/parent", Version: "v0.0.0"})
+
+	want := filepath.Clean(localDep)
+	require.Equal(t, want, got, "local replace must resolve to the replacement path")
+}
+
+// TestResolveEffectiveDepDir_NoMatch falls back to the module cache when no
+// replace entry applies.
+func TestResolveEffectiveDepDir_NoMatch(t *testing.T) {
+	projectDir := t.TempDir()
+	galaMod := &mod.File{
+		Require: []mod.Require{
+			{Path: "example.com/other", Version: "v1.0.0"},
+		},
+	}
+	config := DefaultConfig()
+	got := resolveEffectiveDepDir(config, galaMod, projectDir,
+		mod.Require{Path: "example.com/other", Version: "v1.0.0"})
+
+	require.Equal(t, config.GalaModulePath("example.com/other", "v1.0.0"), got)
+}
+
+// TestResolveEffectiveDepDir_ModuleReplace verifies that replace directives
+// retargeting one module version to another (non-local form) redirect the
+// lookup to the replacement's cache entry rather than the original.
+func TestResolveEffectiveDepDir_ModuleReplace(t *testing.T) {
+	galaMod := &mod.File{
+		Require: []mod.Require{
+			{Path: "example.com/foo", Version: "v1.0.0"},
+		},
+		Replace: []mod.Replace{
+			{
+				Old: mod.ModuleVersion{Path: "example.com/foo"},
+				New: mod.ModuleVersion{Path: "example.com/fork", Version: "v1.2.3"},
+			},
+		},
+	}
+	config := DefaultConfig()
+	got := resolveEffectiveDepDir(config, galaMod, "",
+		mod.Require{Path: "example.com/foo", Version: "v1.0.0"})
+
+	require.Equal(t, config.GalaModulePath("example.com/fork", "v1.2.3"), got)
+}
+
+// TestEnsureDeps_LocalReplaceSkipsFetch verifies the end-to-end behavior of
+// the builder's ensureDeps: a local replacement must not trigger a fetch.
+func TestEnsureDeps_LocalReplaceSkipsFetch(t *testing.T) {
+	tmp := t.TempDir()
+	parent := filepath.Join(tmp, "parent")
+	require.NoError(t, os.MkdirAll(parent, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(parent, "gala.mod"),
+		[]byte("module example.com/parent\n\ngala 0.0.0\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(parent, "lib.gala"),
+		[]byte("package parent\nfunc Greeting() string = \"hi\"\n"), 0644))
+
+	sub := filepath.Join(tmp, "sub")
+	require.NoError(t, os.MkdirAll(sub, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "gala.mod"),
+		[]byte("module example.com/sub\n\ngala 0.0.0\n\nrequire example.com/parent v0.0.0\n\nreplace example.com/parent => ../parent\n"),
+		0644))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, "main.gala"),
+		[]byte("package main\nimport \"example.com/parent\"\nfunc main() { Println(parent.Greeting()) }\n"),
+		0644))
+
+	origHome, hadHome := os.LookupEnv("HOME")
+	origUserProfile, hadProfile := os.LookupEnv("USERPROFILE")
+	isolated := t.TempDir()
+	os.Setenv("HOME", isolated)
+	os.Setenv("USERPROFILE", isolated)
+	t.Cleanup(func() {
+		if hadHome {
+			os.Setenv("HOME", origHome)
+		} else {
+			os.Unsetenv("HOME")
+		}
+		if hadProfile {
+			os.Setenv("USERPROFILE", origUserProfile)
+		} else {
+			os.Unsetenv("USERPROFILE")
+		}
+	})
+
+	b, err := NewBuilder(sub, "test", false)
+	require.NoError(t, err)
+	require.NoError(t, b.workspace.Ensure())
+
+	require.NoError(t, b.ensureDeps(), "local replace must short-circuit the fetch")
+
+	got := b.effectiveDepDir(mod.Require{Path: "example.com/parent", Version: "v0.0.0"})
+	require.Equal(t, filepath.Clean(parent), got)
 }

--- a/internal/build/deptranspiler.go
+++ b/internal/build/deptranspiler.go
@@ -72,14 +72,14 @@ func (dt *DepTranspiler) TranspileDeps() (map[string]string, error) {
 // resolveInternalModulePath reads a dependency's gala.mod to get its declared
 // module path. Falls back to dep.Path if not found.
 func (dt *DepTranspiler) resolveInternalModulePath(dep mod.Require) string {
-	cachedDir := dt.config.GalaModulePath(dep.Path, dep.Version)
-	galaModPath := filepath.Join(cachedDir, "gala.mod")
-	if depMod, err := mod.ParseFile(galaModPath); err == nil {
-		if depMod.Module.Path != "" {
-			return depMod.Module.Path
-		}
-	}
-	return dep.Path
+	return resolveDepInternalModulePathAt(dt.effectiveDepDir(dep), dep)
+}
+
+// effectiveDepDir returns the source directory for a dependency, honoring
+// local replace directives in the active gala.mod. Replace entries that
+// point to another module version still fall back to the cache.
+func (dt *DepTranspiler) effectiveDepDir(dep mod.Require) string {
+	return resolveEffectiveDepDir(dt.config, dt.galaMod, dt.workspace.ProjectDir, dep)
 }
 
 // collectGalaDeps recursively collects all GALA dependencies.
@@ -100,8 +100,8 @@ func (dt *DepTranspiler) collectGalaDeps(f *mod.File, allDeps map[string]mod.Req
 		}
 		visited[key] = true
 
-		// Check if cached dir has .gala files
-		cachedDir := dt.config.GalaModulePath(req.Path, req.Version)
+		// Check if cached dir (or local replacement) has .gala files
+		cachedDir := dt.effectiveDepDir(req)
 		galaFiles, err := findGalaFiles(cachedDir)
 		if err != nil || len(galaFiles) == 0 {
 			// No .gala files — pure Go package, skip transpilation
@@ -120,7 +120,7 @@ func (dt *DepTranspiler) collectGalaDeps(f *mod.File, allDeps map[string]mod.Req
 
 // transpileSingleDep transpiles a single GALA dependency and returns the output directory.
 func (dt *DepTranspiler) transpileSingleDep(dep mod.Require, transpiledDirs map[string]string) (string, error) {
-	srcDir := dt.config.GalaModulePath(dep.Path, dep.Version)
+	srcDir := dt.effectiveDepDir(dep)
 
 	galaFiles, err := findGalaFiles(srcDir)
 	if err != nil {
@@ -148,7 +148,7 @@ func (dt *DepTranspiler) transpileSingleDep(dep mod.Require, transpiledDirs map[
 	depGalaModPath := filepath.Join(srcDir, "gala.mod")
 	if depMod, err := mod.ParseFile(depGalaModPath); err == nil {
 		for _, depReq := range depMod.GalaRequires() {
-			depSrcDir := dt.config.GalaModulePath(depReq.Path, depReq.Version)
+			depSrcDir := dt.effectiveDepDir(depReq)
 			searchPaths = append(searchPaths, depSrcDir)
 		}
 	}
@@ -226,7 +226,7 @@ func (dt *DepTranspiler) generateDepGoMod(dep mod.Require, outDir string, transp
 	}
 
 	// Build a mapping from require path -> internal module path for this dep's own GALA deps
-	srcDir := dt.config.GalaModulePath(dep.Path, dep.Version)
+	srcDir := dt.effectiveDepDir(dep)
 	depGalaModPath := filepath.Join(srcDir, "gala.mod")
 
 	// depInternalPaths maps requirePath -> internalModulePath for the dep's GALA dependencies
@@ -313,8 +313,8 @@ func (dt *DepTranspiler) generateDepGoMod(dep mod.Require, outDir string, transp
 			absPath := filepath.ToSlash(dir)
 			sb.WriteString(fmt.Sprintf("replace %s => %s\n", entry.importPath, absPath))
 		} else {
-			// Fallback to source cache
-			absPath := filepath.ToSlash(dt.config.GalaModulePath(entry.req.Path, entry.req.Version))
+			// Fallback to source cache (or local replacement)
+			absPath := filepath.ToSlash(dt.effectiveDepDir(entry.req))
 			sb.WriteString(fmt.Sprintf("replace %s => %s\n", entry.importPath, absPath))
 		}
 	}

--- a/internal/build/gomod.go
+++ b/internal/build/gomod.go
@@ -13,11 +13,59 @@ import (
 // GoModGenerator generates go.mod files for build workspaces.
 type GoModGenerator struct {
 	config *Config
+	// projectDir is the directory containing the user's gala.mod; it is used
+	// to resolve relative paths in local replace directives. A zero value
+	// disables local-replace resolution (the generator falls back to the
+	// module cache path).
+	projectDir string
 }
 
 // NewGoModGenerator creates a new go.mod generator.
 func NewGoModGenerator(config *Config) *GoModGenerator {
 	return &GoModGenerator{config: config}
+}
+
+// SetProjectDir configures the project directory used to resolve relative
+// paths in replace directives. Must be called before GenerateGoMod if the
+// project's gala.mod uses local replaces.
+func (g *GoModGenerator) SetProjectDir(dir string) {
+	g.projectDir = dir
+}
+
+// effectiveDepDir returns the on-disk source directory for a GALA dep,
+// honoring replace directives in the active gala.mod. Callers that don't
+// have a project directory (empty projectDir) always see the cached
+// module path.
+func (g *GoModGenerator) effectiveDepDir(galaMod *mod.File, req mod.Require) string {
+	return resolveEffectiveDepDir(g.config, galaMod, g.projectDir, req)
+}
+
+// resolveEffectiveDepDir is the single source of truth for translating a
+// GALA require into a source directory. It first checks the active gala.mod
+// for a matching replace directive — local replacements resolve relative
+// to projectDir, while module replacements redirect to the replacement's
+// cached path — and falls back to the normal cache location for unmatched
+// requires.
+func resolveEffectiveDepDir(config *Config, galaMod *mod.File, projectDir string, req mod.Require) string {
+	if galaMod != nil {
+		for _, rep := range galaMod.Replace {
+			if rep.Old.Path != req.Path {
+				continue
+			}
+			if rep.Old.Version != "" && rep.Old.Version != req.Version {
+				continue
+			}
+			if rep.New.IsLocal() {
+				resolved := rep.New.Path
+				if !filepath.IsAbs(resolved) && projectDir != "" {
+					resolved = filepath.Join(projectDir, resolved)
+				}
+				return filepath.Clean(resolved)
+			}
+			return config.GalaModulePath(rep.New.Path, rep.New.Version)
+		}
+	}
+	return config.GalaModulePath(req.Path, req.Version)
 }
 
 // StdlibPackages lists all GALA stdlib packages.
@@ -88,7 +136,7 @@ func (g *GoModGenerator) GenerateGoMod(galaMod *mod.File, stdlibVersion string, 
 	}
 
 	// Collect transitive dependencies from GALA packages
-	transitiveGoDeps, transitiveGalaDeps := g.collectTransitiveDeps(galaReqs)
+	transitiveGoDeps, transitiveGalaDeps := g.collectTransitiveDeps(galaMod, galaReqs)
 	for path, version := range transitiveGoDeps {
 		// Don't duplicate if already in goReqs
 		found := false
@@ -119,7 +167,7 @@ func (g *GoModGenerator) GenerateGoMod(galaMod *mod.File, stdlibVersion string, 
 	// Build mapping from require path (GitHub URL) -> internal module path
 	// by reading each dep's gala.mod. The transpiled Go code uses the internal
 	// module path for imports, so the go.mod must use it too.
-	internalModulePaths := g.resolveInternalModulePaths(galaReqs)
+	internalModulePaths := g.resolveInternalModulePaths(galaMod, galaReqs)
 
 	// Write require block
 	sb.WriteString("require (\n")
@@ -168,9 +216,10 @@ func (g *GoModGenerator) GenerateGoMod(galaMod *mod.File, stdlibVersion string, 
 				continue
 			}
 		}
-		// Fallback to source cache (pure Go package or no transpilation needed)
-		absPath := g.config.GalaModulePath(req.Path, req.Version)
-		absPath = filepath.ToSlash(absPath)
+		// Fallback to source cache (pure Go package or no transpilation needed).
+		// effectiveDepDir consults replace directives so a local replace still
+		// wins even when the dep is not transpiled (e.g. pure-Go library).
+		absPath := filepath.ToSlash(g.effectiveDepDir(galaMod, req))
 		sb.WriteString(fmt.Sprintf("replace %s => %s\n", modPath, absPath))
 	}
 
@@ -182,10 +231,10 @@ func (g *GoModGenerator) GenerateGoMod(galaMod *mod.File, stdlibVersion string, 
 // resolveInternalModulePaths reads each GALA dependency's gala.mod to discover
 // its declared module path (which may differ from the GitHub URL used in the
 // parent's require directive). Returns a map of requirePath -> internalModulePath.
-func (g *GoModGenerator) resolveInternalModulePaths(galaReqs []mod.Require) map[string]string {
+func (g *GoModGenerator) resolveInternalModulePaths(galaMod *mod.File, galaReqs []mod.Require) map[string]string {
 	result := make(map[string]string)
 	for _, req := range galaReqs {
-		pkgDir := g.config.GalaModulePath(req.Path, req.Version)
+		pkgDir := g.effectiveDepDir(galaMod, req)
 		galaModPath := filepath.Join(pkgDir, "gala.mod")
 		if depMod, err := mod.ParseFile(galaModPath); err == nil {
 			if depMod.Module.Path != "" && depMod.Module.Path != req.Path {
@@ -206,28 +255,30 @@ func (g *GoModGenerator) effectiveModulePath(reqPath string, internalPaths map[s
 }
 
 // collectTransitiveDeps scans GALA packages for their Go and GALA dependencies.
-// Returns (goDeps, galaDeps).
-func (g *GoModGenerator) collectTransitiveDeps(galaReqs []mod.Require) (map[string]string, []mod.Require) {
+// Returns (goDeps, galaDeps). The galaMod argument is the active (root)
+// gala.mod; its replace directives are consulted when resolving the source
+// directory of each transitive requirement.
+func (g *GoModGenerator) collectTransitiveDeps(galaMod *mod.File, galaReqs []mod.Require) (map[string]string, []mod.Require) {
 	goDeps := make(map[string]string)
 	var galaDeps []mod.Require
 	seen := make(map[string]bool)
 
 	for _, req := range galaReqs {
-		g.collectTransitiveDepsRecursive(req, goDeps, &galaDeps, seen)
+		g.collectTransitiveDepsRecursive(galaMod, req, goDeps, &galaDeps, seen)
 	}
 
 	return goDeps, galaDeps
 }
 
 // collectTransitiveDepsRecursive recursively collects transitive deps from a GALA package.
-func (g *GoModGenerator) collectTransitiveDepsRecursive(req mod.Require, goDeps map[string]string, galaDeps *[]mod.Require, seen map[string]bool) {
+func (g *GoModGenerator) collectTransitiveDepsRecursive(galaMod *mod.File, req mod.Require, goDeps map[string]string, galaDeps *[]mod.Require, seen map[string]bool) {
 	key := req.Path + "@" + req.Version
 	if seen[key] {
 		return
 	}
 	seen[key] = true
 
-	pkgDir := g.config.GalaModulePath(req.Path, req.Version)
+	pkgDir := g.effectiveDepDir(galaMod, req)
 
 	// Try gala.mod first
 	galaModPath := filepath.Join(pkgDir, "gala.mod")
@@ -238,7 +289,7 @@ func (g *GoModGenerator) collectTransitiveDepsRecursive(req mod.Require, goDeps 
 			} else {
 				*galaDeps = append(*galaDeps, r)
 				// Recurse for transitive GALA deps
-				g.collectTransitiveDepsRecursive(r, goDeps, galaDeps, seen)
+				g.collectTransitiveDepsRecursive(galaMod, r, goDeps, galaDeps, seen)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes **FIX-012**: \`gala build\` ignores the \`replace\` directive and tries to git-fetch from the remote anyway.

**Category**: TRANSPILER_BUG
**Priority**: P1
**Found in**: gala_tui battle test (BUG-gala_tui-012)

## Root Cause

\`Builder.ensureDeps\` iterated over \`galaReqs\` and called \`fetcher.Fetch(req.Path, req.Version)\` without ever consulting \`b.galaMod.Replaces()\`. A \`replace => ../local-dir\` directive in \`gala.mod\` therefore had no effect — the builder would still try to clone from GitHub, fail with "authentication required / repository not found," and abort the build. This blocked every multi-module local-development workflow.

## Changes

- \`internal/build/builder.go\` — \`ensureDeps\` now consults the replace map and skips \`fetcher.Fetch\` entirely for local replaces; redirects to replacement coordinates for module replaces.
- \`internal/build/deptranspiler.go\`, \`internal/build/gomod.go\` — all downstream dep lookups route through \`resolveEffectiveDepDir\` as the single source of truth.
- \`.gala-deps-hash\` now includes replace directives so retargeting a replace invalidates the cache.
- \`internal/build/builder_test.go\` — four new tests: \`TestResolveEffectiveDepDir_LocalReplace\`, \`TestResolveEffectiveDepDir_NoMatch\`, \`TestResolveEffectiveDepDir_ModuleReplace\`, \`TestEnsureDeps_LocalReplaceSkipsFetch\`.

## Verification

- \`bazel build //...\` passes
- \`bazel test //...\` passes (265 tests)
- Manual repro: two-module project with \`replace => ../parent\` now builds without network access.

## Repro (before fix)

\`\`\`
sub/gala.mod:
  require example.com/parent v0.0.0
  replace example.com/parent => ../parent
\`\`\`
\`gala build\` → \`fetching dependencies: failed to clone repository ...: authentication required\`.

## Dependencies

None.

## Battle Test Report Reference

Originally reported as BUG-gala_tui-012.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)