### PR TITLE
test(parser): regression cases for hex integer literals

### DIFF
--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -141,6 +141,27 @@ type Box struct {
 			input:   `val x = 10`,
 			wantErr: true,
 		},
+		{
+			name: "Hex integer literal",
+			input: `package main
+
+val x = 0x1F`,
+			wantErr: false,
+		},
+		{
+			name: "Hex integer literal uppercase prefix",
+			input: `package main
+
+val x = 0X1f`,
+			wantErr: false,
+		},
+		{
+			name: "Hex integer literal in expression",
+			input: `package main
+
+val x = 0xFF + 0x01`,
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Add three grammar-level regression tests for hex integer literals (`0x1F`, `0X1f`, `0xFF + 0x01`) in `internal/parser/parser_test.go`.
- The shared `gala.g4` feeds both the Go transpiler parser and the IntelliJ plugin lexer, so these tests guard both sides against regressions. The IntelliJ plugin symptom (hex flagged as a syntax error) was caused by a stale installed zip predating the grammar fix; rebuilding the plugin picks up the change.

## Test plan
- [x] \`bazel test //internal/parser:parser_test\` — passes (3 new cases under \`TestGalaParser\`).
- [ ] \`bazel test //...\` on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)