### PR TITLE
fix: detect dot-import collisions from Go var re-exports in mixed packages

### DIFF
--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -1980,17 +1980,13 @@ func (a *galaAnalyzer) analyzePackage(relPath string) (*transpiler.RichAST, erro
 	}
 
 	// Scan .go files for exported symbols and type information.
-	hasGalaFiles := false
-	for _, f := range files {
-		if !f.IsDir() && filepath.Ext(f.Name()) == ".gala" {
-			hasGalaFiles = true
-			break
-		}
-	}
-	if !hasGalaFiles {
-		// For Go-only packages, also extract exported symbol names for collision warnings.
-		a.extractGoFileExports(files, dirPath, relPath, pkgAST)
-	}
+	// Extract GoExports unconditionally. Even in mixed GALA+Go packages
+	// we need to know the full set of exported Go-level symbols for
+	// dot-import collision detection — otherwise facade packages that
+	// re-export callables from another Go package via `var X = other.X`
+	// (e.g. concurrent re-exporting go_interop's helpers) silently collide
+	// at Go compile time instead of producing a clean GALA-level error.
+	a.extractGoFileExports(files, dirPath, relPath, pkgAST)
 	// Always extract Go type information from .go files, even in mixed GALA+Go packages.
 	// This ensures Go-defined functions and variables (e.g., concurrent.Spawn) are available
 	// for type inference when GALA code calls them.
@@ -2070,7 +2066,19 @@ func canonicalPath(path string) string {
 var goExportedFuncRe = regexp.MustCompile(`(?m)^func\s+([A-Z]\w*)\s*[\[(]`)
 
 // goExportedTypeRe matches exported type declarations in Go files.
-var goExportedTypeRe = regexp.MustCompile(`(?m)^type\s+([A-Z]\w*)\s+`)
+// Covers plain `type Name struct { ... }` as well as alias form `type Name = other.Name`.
+var goExportedTypeRe = regexp.MustCompile(`(?m)^type\s+([A-Z]\w*)(\s+|\s*=)`)
+
+// goExportedVarRe matches exported package-level variable declarations in Go files.
+// Captures forms like `var GlobalEC = go_interop.GlobalEC`, which act as function-valued
+// re-exports. Without this, facade packages that re-export callables via `var` (e.g.
+// concurrent re-exporting go_interop helpers) would silently shadow the original
+// exporter under dot-import, causing "X redeclared in this block" at Go compile time
+// rather than a clean GALA-level collision error.
+var goExportedVarRe = regexp.MustCompile(`(?m)^var\s+([A-Z]\w*)\s*(=|\w)`)
+
+// goExportedConstRe matches exported package-level constant declarations.
+var goExportedConstRe = regexp.MustCompile(`(?m)^const\s+([A-Z]\w*)\s*(=|\w)`)
 
 // goPkgNameRe matches the package declaration in Go files.
 var goPkgNameRe = regexp.MustCompile(`(?m)^package\s+(\w+)`)
@@ -2107,8 +2115,25 @@ func (a *galaAnalyzer) extractGoFileExports(files []os.FileInfo, dirPath, relPat
 			}
 		}
 
-		// Extract exported type names
+		// Extract exported type names (including `type X = ...` aliases).
 		for _, m := range goExportedTypeRe.FindAllStringSubmatch(src, -1) {
+			if !seen[m[1]] {
+				seen[m[1]] = true
+				symbols = append(symbols, m[1])
+			}
+		}
+
+		// Extract exported package-level `var` names (facade re-exports such as
+		// `var NewSingleThreadEC = go_interop.NewSingleThreadEC`).
+		for _, m := range goExportedVarRe.FindAllStringSubmatch(src, -1) {
+			if !seen[m[1]] {
+				seen[m[1]] = true
+				symbols = append(symbols, m[1])
+			}
+		}
+
+		// Extract exported package-level `const` names.
+		for _, m := range goExportedConstRe.FindAllStringSubmatch(src, -1) {
 			if !seen[m[1]] {
 				seen[m[1]] = true
 				symbols = append(symbols, m[1])

--- a/internal/transpiler/transformer/dot_import_test.go
+++ b/internal/transpiler/transformer/dot_import_test.go
@@ -120,6 +120,82 @@ func test() int {
 	assert.Contains(t, transpileErr.Error(), "pkg_b")
 }
 
+// TestDotImportVarReExportClash checks that when a Go package re-exports
+// symbols from another package via `var X = other.X` (a common facade
+// pattern, e.g. concurrent re-exporting go_interop helpers), and the user
+// dot-imports BOTH packages, the collision is detected at the GALA level
+// instead of deferred to the Go compiler's opaque "X redeclared in this
+// block" error.
+func TestDotImportVarReExportClash(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "dot_import_var_reexport_test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	err = os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte("module testmod\n\ngo 1.22\n"), 0644)
+	assert.NoError(t, err)
+
+	// pkg_origin declares Helper as a function.
+	originDir := filepath.Join(tempDir, "pkg_origin")
+	err = os.MkdirAll(originDir, 0755)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(originDir, "origin.go"), []byte(`package pkg_origin
+
+func Helper() int { return 7 }
+`), 0644)
+	assert.NoError(t, err)
+
+	// pkg_facade re-exports pkg_origin.Helper via a var. Mixed with a .gala
+	// file so the extraction path that is gated on "Go-only package" is
+	// NOT the one that produces the Helper symbol — the var re-export
+	// regex must fire unconditionally.
+	facadeDir := filepath.Join(tempDir, "pkg_facade")
+	err = os.MkdirAll(facadeDir, 0755)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(facadeDir, "facade.go"), []byte(`package pkg_facade
+
+import "testmod/pkg_origin"
+
+var Helper = pkg_origin.Helper
+`), 0644)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(facadeDir, "extra.gala"), []byte(`package pkg_facade
+
+func Other() int = 1
+`), 0644)
+	assert.NoError(t, err)
+
+	originalWd, err := os.Getwd()
+	assert.NoError(t, err)
+	defer os.Chdir(originalWd)
+	err = os.Chdir(tempDir)
+	assert.NoError(t, err)
+
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, nil)
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	input := `package testpkg
+
+import (
+    . "testmod/pkg_origin"
+    . "testmod/pkg_facade"
+)
+
+func test() int {
+    return 42
+}
+`
+
+	_, transpileErr := trans.Transpile(input, "")
+	assert.Error(t, transpileErr)
+	assert.Contains(t, transpileErr.Error(), "dot-import symbol collision")
+	assert.Contains(t, transpileErr.Error(), "Helper")
+	assert.Contains(t, transpileErr.Error(), "pkg_origin")
+	assert.Contains(t, transpileErr.Error(), "pkg_facade")
+}
+
 func TestDotImportNoQualifiedReferences(t *testing.T) {
 	p := transpiler.NewAntlrGalaParser()
 	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())

--- a/internal/transpiler/transformer/imports.go
+++ b/internal/transpiler/transformer/imports.go
@@ -502,7 +502,11 @@ func (m *ImportManager) ValidateDotImports(richAST *transpiler.RichAST, line, co
 	}
 
 	if len(clashes) > 0 {
-		msg := "dot-import symbol collision(s) detected:\n" + strings.Join(clashes, "\n") + "\nUse an aliased import for one of the packages to resolve the conflict."
+		msg := "dot-import symbol collision(s) detected:\n" + strings.Join(clashes, "\n") +
+			"\nUse a qualified or aliased import for one of the packages to resolve the conflict." +
+			"\n(Some stdlib packages intentionally re-export names from another package as a convenience facade —" +
+			" e.g. `concurrent` re-exports `go_interop`'s execution-context helpers — so dot-importing both is never" +
+			" meaningful. Pick the facade you want.)"
 		return galaerr.NewSemanticErrorAt(line, col, msg)
 	}
 	return nil


### PR DESCRIPTION
## Summary

Fixes **FIX-002** (reported as BUG-3 from gala_tui battle test): dot-importing two packages that both export the same names (e.g. `concurrent` re-exporting `go_interop`'s `NewSingleThreadEC`, `GlobalEC`, `Spawn`, etc.) produced an opaque Go-level error (`NewSingleThreadEC redeclared in this block`) instead of a clean GALA-level dot-import collision.

**Category**: USABILITY
**Priority**: P2
**Found in**: gala_tui battle test

## Root Cause

Two independent issues prevented detection:

1. `extractGoFileExports` only ran for Go-only packages (gated on `!hasGalaFiles`). Mixed GALA+Go packages such as `concurrent` (which has both `future.gala` and `execution_context.go`) were skipped, so their Go-level exports never made it into `RichAST.GoExports`.
2. The extraction regexes only matched `func` and `type` declarations. The facade pattern `var X = other.X` (used intentionally by `concurrent` to re-export `go_interop`'s helpers) was invisible to the collision detector.

## Changes

- `internal/transpiler/analyzer/analyzer.go` — run `extractGoFileExports` unconditionally; add `goExportedVarRe` and `goExportedConstRe`; extend `goExportedTypeRe` to cover `type X = ...` aliases.
- `internal/transpiler/transformer/imports.go` — expand the collision error message to explain the facade-re-export idiom, so users know the fix is to pick one facade (not hunt for a "real" clash).
- `internal/transpiler/transformer/dot_import_test.go` — new `TestDotImportVarReExportClash` exercises a mixed GALA+Go facade whose `var` re-export clashes with the originating package.

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (269 tests)

## Repro (before fix)

```gala
import (
    . "martianoff/gala/concurrent"
    . "martianoff/gala/go_interop"
)

func main() {
    val ec = NewSingleThreadEC()  // both packages export this
    val f = FutureApply(() => 42)
    ec.Shutdown()
}
```

Before: opaque `NewSingleThreadEC redeclared in this block` at `go build` time.
After: GALA-level error listing every colliding symbol plus guidance on the facade idiom.

## Design Note

`concurrent` intentionally re-exports `go_interop`'s execution-context helpers as a convenience facade. Removing those re-exports would break every user of `concurrent` alone, so the fix improves the **detection** of the collision rather than eliminating it. Dot-importing both packages is never meaningful — pick one.

## Dependencies

None.

## Battle Test Report Reference

BUG-3 from gala-fix task prompt (gala_tui battle test).

---
Generated with [Claude Code](https://claude.com/claude-code)