### PR TITLE
fix: lambdas accept optional explicit return type before '=>'

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -85,6 +85,12 @@ gala_test(
 )
 
 gala_test(
+    name = "lambda_explicit_return_type",
+    src = "lambda_explicit_return_type.gala",
+    expected = "lambda_explicit_return_type.out",
+)
+
+gala_test(
     name = "with_main",
     src = "with_main.gala",
     expected = "with_main.out",

--- a/examples/lambda_explicit_return_type.gala
+++ b/examples/lambda_explicit_return_type.gala
@@ -1,0 +1,32 @@
+package main
+
+// Regression example: lambdas may declare an explicit return type
+// between the parameter list and `=>`. Useful when storing a lambda
+// in a `val` (no typed target context to drive inference) or when the
+// author wants to assert the shape of the function for readability.
+//
+// Syntax: `(a int, b int) int => a + b`
+// Grammar: `lambdaExpression: parameters type? '=>' (expression | block);`
+
+func main() {
+    // Explicit return type on a val-bound lambda.
+    val concat = (l string, w string) string => l + " " + w
+    Println(concat("hello", "world"))
+
+    val add = (x int, y int) int => x + y
+    Println(add(3, 4))
+
+    // Explicit type with block body.
+    val describe = (n int) string => {
+        if n < 0 { return "negative" }
+        if n == 0 { return "zero" }
+        return "positive"
+    }
+    Println(describe(-5))
+    Println(describe(0))
+    Println(describe(42))
+
+    // Omitting the return type still works (existing behaviour).
+    val doubler = (x int) => x * 2
+    Println(doubler(7))
+}

--- a/examples/lambda_explicit_return_type.out
+++ b/examples/lambda_explicit_return_type.out
@@ -1,0 +1,6 @@
+hello world
+7
+negative
+zero
+positive
+14

--- a/internal/parser/grammar/gala.g4
+++ b/internal/parser/grammar/gala.g4
@@ -177,7 +177,11 @@ compositeLiteral: type ('{' (elementList ','?)? '}');
 elementList: keyedElement (',' keyedElement)*;
 keyedElement: (expression ':')? expression;
 
-lambdaExpression: parameters '=>' (expression | block);
+// Lambda expressions may optionally declare their return type before '=>'
+// — useful when storing a lambda in a `val` where the return type isn't
+// determined by a target context (e.g. a typed method parameter). When
+// omitted, the return type is inferred from the body expression.
+lambdaExpression: parameters type? '=>' (expression | block);
 
 caseClause: 'case' pattern (IF guard=expression)? '=>' (bodyStmt=simpleStatement | bodyBlock=block);
 

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -96,9 +96,26 @@ func (t *galaASTTransformer) transformLambdaWithExpectedType(ctx *grammar.Lambda
 	// We only use the expected type if it's more specific than "any"
 	isConcreteExpectedType := expectedRetType != nil && expectedRetType != ExpectedVoid && !containsAny(expectedRetType)
 
+	// Explicit return type declared on the lambda (e.g. `(x int) int => ...`).
+	// When present it wins over both the expected type supplied by the caller
+	// and any body-based inference: the user asked for a specific shape.
+	var explicitRetType ast.Expr
+	if ctx.Type_() != nil {
+		rt, err := t.transformType(ctx.Type_().(*grammar.TypeContext))
+		if err != nil {
+			return nil, err
+		}
+		explicitRetType = rt
+	}
+
 	// Use expected return type if provided and concrete
 	if isConcreteExpectedType {
 		retType = expectedRetType
+	}
+	// An explicit annotation trumps caller-supplied expectations.
+	if explicitRetType != nil {
+		retType = explicitRetType
+		isConcreteExpectedType = true
 	}
 
 	// Track the current function's return type for nested match expression fallback.


### PR DESCRIPTION
## Summary

Fixes **FIX-004** (reported as BUG-5): `val f = (l string, w string) string => ...` failed with `extraneous input 'string' expecting '=>'`. The grammar rule `lambdaExpression: parameters '=>' (expression | block);` offered no slot for the return type, so authors had to either drop the annotation (forcing body-based inference) or pass the lambda directly to a typed method.

**Category**: TRANSPILER_BUG
**Priority**: P2
**Found in**: gala_tui battle test

## Root Cause

Lambda syntax tracked function-parameter syntax but not function-signature syntax (which includes an optional trailing return type).

## Changes

- `internal/parser/grammar/gala.g4` — `lambdaExpression: parameters type? '=>' (expression | block);`.
- `internal/transpiler/transformer/lambdas.go` — when the lambda declares an explicit return type the transformer uses it verbatim as `FuncType.Results`, overriding both the caller-supplied expected type and body-based inference. The explicit annotation is the user's assertion about the lambda's shape.
- `examples/lambda_explicit_return_type.gala` + `.out` — covers explicit return type with single-expression body, explicit return type with block body and multiple returns, and continued support for the unannotated form.

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (269 tests)

## Repro (before fix)

```gala
val f = (l string, w string) string => l + " " + w
// -> [SyntaxError] extraneous input 'string' expecting '=>'
```

## Dependencies

None.

## Battle Test Report Reference

BUG-5 from gala-fix task prompt (gala_tui battle test).

---
Generated with [Claude Code](https://claude.com/claude-code)