### PR TITLE
fix: gala test recurses into subpackages without panicking

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -36,6 +36,8 @@ filegroup(
         "multi_file_option/main.gala",
         "multi_file_types/main.gala",
         "multi_file_types/model.gala",
+        "multipackage_subpkg/main.gala",
+        "multipackage_subpkg/state/state.gala",
         "newimmutable_nil.gala",
         "slice_unwrap/main.gala",
         "slice_unwrap/model.gala",
@@ -1427,6 +1429,24 @@ gala_library(
     srcs = ["cross_pkg_try_match/corelib/corelib.gala"],
     importpath = "martianoff/gala/examples/cross_pkg_try_match/corelib",
     visibility = ["//visibility:public"],
+)
+
+# Regression: library-with-sublibrary layout used to panic the analyzer
+# (FIX-001). The example keeps a main package at examples/multipackage_subpkg/
+# with a sibling subpackage in examples/multipackage_subpkg/state/ — the
+# combination that reproduced the ANTLR nil-pointer dereference.
+gala_library(
+    name = "multipackage_subpkg_state",
+    srcs = ["multipackage_subpkg/state/state.gala"],
+    importpath = "martianoff/gala/examples/multipackage_subpkg/state",
+    visibility = ["//visibility:public"],
+)
+
+gala_test(
+    name = "multipackage_subpkg",
+    src = "multipackage_subpkg/main.gala",
+    expected = "multipackage_subpkg/main.out",
+    gala_deps = [":multipackage_subpkg_state"],
 )
 
 gala_test(

--- a/examples/multipackage_subpkg/main.gala
+++ b/examples/multipackage_subpkg/main.gala
@@ -1,0 +1,13 @@
+package main
+
+import . "martianoff/gala/std"
+import "martianoff/gala/examples/multipackage_subpkg/state"
+
+// Verifies that a project with one root package and one sub-directory package
+// (`state/state.gala`) is transpiled cleanly. Before FIX-001, feeding the two
+// files through a single batch analyzer tripped an ANTLR nil-pointer panic;
+// this example keeps that regression out.
+func main() {
+    val s = state.NewState("root")
+    Println(s.Greet())
+}

--- a/examples/multipackage_subpkg/main.out
+++ b/examples/multipackage_subpkg/main.out
@@ -1,0 +1,1 @@
+Hello from state/root with count 0

--- a/examples/multipackage_subpkg/state/state.gala
+++ b/examples/multipackage_subpkg/state/state.gala
@@ -1,0 +1,12 @@
+package state
+
+import . "martianoff/gala/std"
+
+// Simple library in a subpackage — exercises library-with-sublibrary layouts
+// (FIX-001). The root consumer at examples/multipackage_subpkg/main.gala
+// imports this file and prints values returned from it.
+struct AppState(Count int, Label string)
+
+func NewState(label string) AppState = AppState(Count = 0, Label = label)
+
+func (s AppState) Greet() string = s"Hello from state/${s.Label} with count ${s.Count}"

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -716,7 +716,12 @@ func (b *Builder) rewriteProjectModuleImports(dir string) error {
 		return nil // No module path known, nothing to rewrite
 	}
 
-	// Check if there are any local Go subdirectories worth rewriting for
+	// Check if there are any local subdirectories — whether Go or GALA —
+	// that could be imported under the project module path. Pure GALA
+	// subpackages still need rewriting because their imports are emitted
+	// using the project module path (e.g. "github.com/user/proj/sub") and
+	// must be redirected to the workspace gen/ layout before `go build`
+	// can resolve them.
 	hasSubDirs := false
 	entries, err := os.ReadDir(b.workspace.ProjectDir)
 	if err == nil {
@@ -724,7 +729,7 @@ func (b *Builder) rewriteProjectModuleImports(dir string) error {
 			if e.IsDir() && !strings.HasPrefix(e.Name(), ".") && e.Name() != "vendor" &&
 				!strings.HasPrefix(e.Name(), "bazel-") {
 				subPath := filepath.Join(b.workspace.ProjectDir, e.Name())
-				if hasGoFiles(subPath) {
+				if hasGoFiles(subPath) || hasGalaFilesShallow(subPath) {
 					hasSubDirs = true
 					break
 				}
@@ -732,7 +737,7 @@ func (b *Builder) rewriteProjectModuleImports(dir string) error {
 		}
 	}
 	if !hasSubDirs {
-		return nil // No local Go subpackages, skip rewriting
+		return nil // No local subpackages, skip rewriting
 	}
 
 	if b.verbose {
@@ -780,6 +785,23 @@ func hasGoFiles(dir string) bool {
 	}
 	for _, e := range entries {
 		if !e.IsDir() && strings.HasSuffix(e.Name(), ".go") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasGalaFilesShallow reports whether dir contains at least one .gala file at
+// its top level. Used when deciding whether the project module's import paths
+// need to be rewritten to point at the workspace gen/ directory — GALA
+// subpackages must be covered too, not just Go subpackages.
+func hasGalaFilesShallow(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".gala") {
 			return true
 		}
 	}
@@ -1028,8 +1050,12 @@ func (b *Builder) goBuild(outputPath string) (string, error) {
 		outputPath += ".exe"
 	}
 
-	// Build command — in multi-package mode, build the consumer subpackage
-	buildTarget := "./gen/..."
+	// Build command — in multi-package mode, build the consumer subpackage.
+	// `go build -o <path> ./gen/...` fails with "cannot write multiple
+	// packages to non-directory" when gen/ contains a main package alongside
+	// library subpackages, so we narrow the target to the root gen package
+	// (which is main, assuming the project itself is executable).
+	buildTarget := "./gen"
 	if b.sourceDir != "" && b.sourceDir != b.workspace.ProjectDir {
 		buildTarget = "./gen/cmd/main"
 	}
@@ -1246,13 +1272,16 @@ func (b *Builder) Test(verbose bool) error {
 		return fmt.Errorf("transpiling dependencies: %w", err)
 	}
 
-	// Step 3: Find source and test files
-	sourceFiles, err := findGalaFiles(b.workspace.ProjectDir)
+	// Step 3: Find source and test files. We recurse so that subpackages
+	// (e.g. `state/state.gala`, `state/state_test.gala`) are picked up
+	// alongside the project root — otherwise `go test ./gen/...` would
+	// silently miss them, or the root package would fail to import them.
+	sourceFiles, err := findGalaFilesRecursive(b.workspace.ProjectDir)
 	if err != nil {
 		return fmt.Errorf("finding source files: %w", err)
 	}
 
-	testFiles, err := findGalaTestFiles(b.workspace.ProjectDir)
+	testFiles, err := findGalaTestFilesRecursive(b.workspace.ProjectDir)
 	if err != nil {
 		return fmt.Errorf("finding test files: %w", err)
 	}
@@ -1270,16 +1299,16 @@ func (b *Builder) Test(verbose bool) error {
 		return nil
 	}
 
-	// Step 4: Determine package layout
+	// Step 4: Determine package layout based on the project root package.
 	// Test files in GALA are always package main and import the library under test.
 	// Source files can be package main (executable) or a library package.
 	// For package main projects: transpile source + test files together.
 	// For library projects: transpile source files as library, test files separately as main.
-	isLib := false
-	if len(sourceFiles) > 0 {
-		pkgName := detectPackageName(sourceFiles[0])
-		isLib = pkgName != "" && pkgName != "main"
-	}
+	// We look at a file that actually lives in the project root (not a
+	// subpackage) to classify the project — subpackages always are libraries
+	// and must not influence the root classification.
+	rootPkgName := rootPackageName(sourceFiles, b.workspace.ProjectDir)
+	isLib := rootPkgName != "" && rootPkgName != "main"
 
 	// Always force-retranspile for tests (test files change independently)
 	if err := b.workspace.CleanGen(); err != nil {
@@ -1322,17 +1351,17 @@ func (b *Builder) Test(verbose bool) error {
 
 	// Step 8: Generate test harness
 	if isLib {
-		// For library packages: generate a _test.go harness that uses Go's testing
-		// framework with TestMain. This enables internal tests (same package) that
-		// can access unexported identifiers. Tests run via `go test`.
-		pkgName := detectPackageName(sourceFiles[0])
-		harnessCode := GenerateGoTestHarness(pkgName, allTestFuncs)
-		harnessPath := filepath.Join(b.workspace.GenDir, "gala_test_harness_test.go")
-		if err := os.WriteFile(harnessPath, []byte(harnessCode), 0644); err != nil {
-			return fmt.Errorf("writing gala_test_harness_test.go: %w", err)
+		// For library packages: generate a _test.go harness per package that
+		// hosts test files. Each harness uses Go's testing framework with
+		// TestMain and references only the TestXxx functions declared in its
+		// own package — otherwise the root harness would fail to compile when
+		// a subpackage owns a test function that the root package cannot see.
+		// Tests run via `go test ./gen/...`.
+		if err := b.writeLibraryTestHarnesses(testFiles); err != nil {
+			return fmt.Errorf("writing test harnesses: %w", err)
 		}
 		if b.verbose {
-			fmt.Println("Generated gala_test_harness_test.go")
+			fmt.Println("Generated test harnesses")
 		}
 
 		// Step 9: Run tests via `go test`
@@ -1375,7 +1404,11 @@ func (b *Builder) Test(verbose bool) error {
 			testBinary += ".exe"
 		}
 
-		args := []string{"build", "-o", testBinary, "./gen/..."}
+		// Build only the synthesized main package at gen/ root. Library
+		// subpackages under gen/<sub>/ are pulled in transitively via
+		// imports; targeting "./gen/..." would ask `go build -o` to write
+		// multiple package outputs, which fails.
+		args := []string{"build", "-o", testBinary, "./gen"}
 		cmd := exec.Command("go", args...)
 		cmd.Dir = b.workspace.Dir
 		cmd.Env = append(os.Environ(), "GOMODCACHE="+b.config.GoPkgDir)
@@ -1454,40 +1487,43 @@ func (b *Builder) transpileTestMain(sourceFiles, testFiles []string) error {
 }
 
 // testGenFileName mirrors the naming that transpileFilesToDir applies when
-// emitting .gen.go outputs (subdir separators folded to `_`). It returns the
-// bare filename (without the gen dir prefix).
+// emitting .gen.go outputs. The returned path is relative to the gen dir and
+// uses OS-native separators, mirroring the subdirectory layout of the
+// original .gala source so subpackages land in their own gen/<sub>/ folder.
 func testGenFileName(projectDir, galaFile string) string {
 	relPath, err := filepath.Rel(projectDir, galaFile)
 	if err != nil {
 		relPath = filepath.Base(galaFile)
 	}
-	outName := strings.TrimSuffix(relPath, ".gala") + ".gen.go"
-	return strings.ReplaceAll(outName, string(filepath.Separator), "_")
+	return strings.TrimSuffix(relPath, ".gala") + ".gen.go"
 }
 
-// renameUserMainInDir scans the given .gen.go files in dir and renames any
-// top-level `func main()` declaration to `_galaUserMain` so it does not
+// renameUserMainInDir scans .gen.go files under dir (recursively) and renames
+// any top-level `func main()` declaration to `_galaUserMain` so it does not
 // conflict with the synthesized test runner's main(). The renamed function
 // is never called by anyone — the Go compiler tree-shakes it out — but
 // preserving it keeps other symbols in the same file (type decls, helpers,
 // etc.) compiling cleanly.
 //
-// Only files whose basename appears in sourceNames are touched; generated
-// test_main.gen.go and the transpiled test files must keep their declarations.
+// Only files whose path (relative to dir, using the OS separator) appears in
+// sourceNames are touched; generated test_main.gen.go and the transpiled test
+// files must keep their declarations.
 func renameUserMainInDir(dir string, sourceNames map[string]bool, verbose bool) error {
 	funcMainRegex := "func main()"
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return err
-	}
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".gen.go") {
-			continue
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
 		}
-		if !sourceNames[entry.Name()] {
-			continue
+		if info.IsDir() || !strings.HasSuffix(info.Name(), ".gen.go") {
+			return nil
 		}
-		path := filepath.Join(dir, entry.Name())
+		relPath, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			relPath = info.Name()
+		}
+		if !sourceNames[relPath] {
+			return nil
+		}
 		content, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("reading %s: %w", path, err)
@@ -1500,20 +1536,75 @@ func renameUserMainInDir(dir string, sourceNames map[string]bool, verbose bool) 
 		// writes a package main with a main entry point.
 		idx := strings.Index(text, "\n"+funcMainRegex)
 		if idx < 0 && !strings.HasPrefix(text, funcMainRegex) {
-			continue
+			return nil
 		}
 		rewritten := strings.Replace(text, "\nfunc main()", "\nfunc _galaUserMain()", 1)
 		if strings.HasPrefix(rewritten, "func main()") {
 			rewritten = "func _galaUserMain()" + rewritten[len("func main()"):]
 		}
 		if rewritten == text {
-			continue
+			return nil
 		}
 		if err := os.WriteFile(path, []byte(rewritten), 0644); err != nil {
 			return fmt.Errorf("writing %s: %w", path, err)
 		}
 		if verbose {
-			fmt.Printf("  test: renamed user func main() in %s\n", entry.Name())
+			fmt.Printf("  test: renamed user func main() in %s\n", relPath)
+		}
+		return nil
+	})
+}
+
+// writeLibraryTestHarnesses emits one gala_test_harness_test.go per package
+// that contains at least one TestXxx function. The harness lives next to the
+// transpiled files in gen/ (preserving subpackage layout) so that `go test
+// ./gen/...` picks up each package's tests independently. Each harness only
+// references tests declared in its own source directory — bundling all test
+// funcs into a single root-level harness would fail to compile when a
+// subpackage owns a test that the root package cannot see.
+func (b *Builder) writeLibraryTestHarnesses(testFiles []string) error {
+	// Group tests by the gen subdirectory they will land in.
+	type bucket struct {
+		pkgName string
+		funcs   []string
+	}
+	byDir := make(map[string]*bucket)
+	for _, tf := range testFiles {
+		funcs, err := FindTestFunctions(tf)
+		if err != nil {
+			return fmt.Errorf("scanning %s for test functions: %w", tf, err)
+		}
+		if len(funcs) == 0 {
+			continue
+		}
+		relDir, err := filepath.Rel(b.workspace.ProjectDir, filepath.Dir(tf))
+		if err != nil {
+			relDir = "."
+		}
+		pkgName := detectPackageName(tf)
+		key := filepath.Clean(relDir)
+		if bkt, ok := byDir[key]; ok {
+			bkt.funcs = append(bkt.funcs, funcs...)
+		} else {
+			byDir[key] = &bucket{pkgName: pkgName, funcs: append([]string(nil), funcs...)}
+		}
+	}
+
+	for relDir, bkt := range byDir {
+		if bkt.pkgName == "" {
+			continue
+		}
+		harnessDir := b.workspace.GenDir
+		if relDir != "." && relDir != "" {
+			harnessDir = filepath.Join(b.workspace.GenDir, relDir)
+		}
+		if err := os.MkdirAll(harnessDir, 0755); err != nil {
+			return fmt.Errorf("creating harness dir %s: %w", harnessDir, err)
+		}
+		harnessPath := filepath.Join(harnessDir, "gala_test_harness_test.go")
+		harnessCode := GenerateGoTestHarness(bkt.pkgName, bkt.funcs)
+		if err := os.WriteFile(harnessPath, []byte(harnessCode), 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", harnessPath, err)
 		}
 	}
 	return nil
@@ -1655,6 +1746,15 @@ func (b *Builder) transpileFiles(files []string, allSiblings []string) error {
 }
 
 // transpileFilesToDir transpiles the given files into the specified output directory.
+//
+// When the input set spans multiple source directories (e.g. a library with
+// subpackages), each file is only given siblings from the SAME directory.
+// Mixing files from different Go-level packages into one sibling list would
+// feed the batch analyzer parse trees that disagree on `package <name>`, which
+// in turn bubbles up as an ANTLR prediction-context panic once the analyzer
+// tries to cross-reference those trees. The sub-directory layout is preserved
+// under outDir so that `go test ./...` can see each subpackage as its own Go
+// package.
 func (b *Builder) transpileFilesToDir(files []string, allSiblings []string, outDir string) error {
 	stdlibDir := b.config.StdlibVersionDir(b.stdlibVersion)
 	searchPaths := []string{b.workspace.ProjectDir, stdlibDir}
@@ -1668,6 +1768,15 @@ func (b *Builder) transpileFilesToDir(files []string, allSiblings []string, outD
 	g := generator.NewGoCodeGenerator()
 	batchAnalyzer := analyzer.NewBatchAnalyzer(p, searchPaths, b.workspace.ProjectDir)
 
+	// Group sibling candidates by source directory so we can cheaply look up
+	// "other .gala files in my own package" without re-scanning allSiblings on
+	// every iteration.
+	siblingsByDir := make(map[string][]string)
+	for _, s := range allSiblings {
+		d := filepath.Dir(s)
+		siblingsByDir[d] = append(siblingsByDir[d], s)
+	}
+
 	for _, galaFile := range files {
 		content, err := os.ReadFile(galaFile)
 		if err != nil {
@@ -1675,7 +1784,7 @@ func (b *Builder) transpileFilesToDir(files []string, allSiblings []string, outD
 		}
 
 		var siblings []string
-		for _, other := range allSiblings {
+		for _, other := range siblingsByDir[filepath.Dir(galaFile)] {
 			if other != galaFile {
 				siblings = append(siblings, other)
 			}
@@ -1693,10 +1802,15 @@ func (b *Builder) transpileFilesToDir(files []string, allSiblings []string, outD
 		if err != nil {
 			relPath = filepath.Base(galaFile)
 		}
+		// Preserve subdirectory layout under outDir. Each GALA subpackage
+		// lands in its own directory so Go can resolve imports of the form
+		// "gala-build-workspace/gen/<sub>" cleanly.
 		outName := strings.TrimSuffix(relPath, ".gala") + ".gen.go"
-		outName = strings.ReplaceAll(outName, string(filepath.Separator), "_")
-
 		outPath := filepath.Join(outDir, outName)
+
+		if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+			return fmt.Errorf("creating gen dir for %s: %w", outName, err)
+		}
 		if err := os.WriteFile(outPath, []byte(goCode), 0644); err != nil {
 			return fmt.Errorf("writing %s: %w", outPath, err)
 		}
@@ -1707,6 +1821,24 @@ func (b *Builder) transpileFilesToDir(files []string, allSiblings []string, outD
 	}
 
 	return nil
+}
+
+// rootPackageName returns the GALA package name declared by a source file
+// that lives in projectDir (i.e. not under a subdirectory). If no such file
+// exists the function falls back to the first source file, preserving the
+// original single-package behaviour. Returns "" when no source files exist.
+func rootPackageName(sourceFiles []string, projectDir string) string {
+	absRoot, _ := filepath.Abs(projectDir)
+	for _, f := range sourceFiles {
+		abs, _ := filepath.Abs(f)
+		if filepath.Dir(abs) == absRoot {
+			return detectPackageName(f)
+		}
+	}
+	if len(sourceFiles) > 0 {
+		return detectPackageName(sourceFiles[0])
+	}
+	return ""
 }
 
 // detectPackageName reads the first line matching "package <name>" from a .gala file.
@@ -1743,6 +1875,37 @@ func findGalaTestFiles(dir string) ([]string, error) {
 	}
 
 	return files, nil
+}
+
+// findGalaTestFilesRecursive finds all _test.gala files recursively, skipping
+// the same set of hidden/build directories as findGalaFilesRecursive. This is
+// used by `gala test` so that tests declared in a subpackage (e.g.
+// state/state_test.gala) are discovered alongside tests at the project root.
+func findGalaTestFilesRecursive(dir string) ([]string, error) {
+	var files []string
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			name := info.Name()
+			if name != "." && (strings.HasPrefix(name, ".") || name == "vendor" ||
+				name == "testdata" || strings.HasPrefix(name, "bazel-") || name == "_gala") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if strings.HasSuffix(path, "_test.gala") {
+			files = append(files, path)
+		}
+
+		return nil
+	})
+
+	return files, err
 }
 
 // isWindows returns true if running on Windows.

--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -116,8 +116,9 @@ func TestX() {}
 }
 
 // TestTestGenFileName verifies that the helper matches the naming used by
-// transpileFilesToDir (subdir separators folded to '_', .gala suffix replaced
-// by .gen.go).
+// transpileFilesToDir. Subdirectory layout is preserved so that each GALA
+// subpackage lands in its own gen/<sub>/ folder and Go can resolve
+// cross-package imports without flattening.
 func TestTestGenFileName(t *testing.T) {
 	projectDir := filepath.Clean("/p")
 	cases := []struct {
@@ -126,7 +127,7 @@ func TestTestGenFileName(t *testing.T) {
 		want string
 	}{
 		{"root file", filepath.Join(projectDir, "main.gala"), "main.gen.go"},
-		{"subdir file", filepath.Join(projectDir, "sub", "lib.gala"), "sub_lib.gen.go"},
+		{"subdir file", filepath.Join(projectDir, "sub", "lib.gala"), filepath.Join("sub", "lib.gen.go")},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -168,6 +169,69 @@ func TestFindGalaFilesRecursive_IncludesSubdirs(t *testing.T) {
 	}
 	sort.Strings(want)
 	require.Equal(t, want, got)
+}
+
+// TestFindGalaTestFilesRecursive_IncludesSubdirs verifies that the recursive
+// test-file walker used by `gala test` discovers _test.gala files in
+// subpackages so that a library layout with state/state_test.gala is not
+// silently ignored.
+func TestFindGalaTestFilesRecursive_IncludesSubdirs(t *testing.T) {
+	projectDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "root_test.gala"),
+		[]byte("package repro\nfunc TestRoot() {}"), 0644))
+
+	subDir := filepath.Join(projectDir, "state")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "state_test.gala"),
+		[]byte("package state\nfunc TestState() {}"), 0644))
+
+	// Non-test files must NOT be returned.
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "state.gala"),
+		[]byte("package state\nfunc StateFn() string = \"hi\""), 0644))
+
+	got, err := findGalaTestFilesRecursive(projectDir)
+	require.NoError(t, err)
+
+	sort.Strings(got)
+	want := []string{
+		filepath.Join(projectDir, "root_test.gala"),
+		filepath.Join(subDir, "state_test.gala"),
+	}
+	sort.Strings(want)
+	require.Equal(t, want, got)
+}
+
+// TestRootPackageName_PrefersRootDirFile verifies that classification of the
+// project kind (main vs library) looks at a file that actually lives in the
+// project root — a subpackage named `main` (unusual, but possible) must not
+// flip the whole project into main-package mode.
+func TestRootPackageName_PrefersRootDirFile(t *testing.T) {
+	projectDir := filepath.Clean("/p")
+	sources := []string{
+		filepath.Join(projectDir, "sub", "lib.gala"),
+		filepath.Join(projectDir, "root.gala"),
+	}
+
+	// rootPackageName opens the file to read the package clause, so we can't
+	// test against synthetic paths directly. Build a real temp layout.
+	tmp := t.TempDir()
+	rootFile := filepath.Join(tmp, "root.gala")
+	require.NoError(t, os.WriteFile(rootFile, []byte("package repro\n"), 0644))
+	subDir := filepath.Join(tmp, "sub")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+	subFile := filepath.Join(subDir, "lib.gala")
+	require.NoError(t, os.WriteFile(subFile, []byte("package sub\n"), 0644))
+
+	// Iteration order matters: put the subpackage first to ensure we still
+	// surface the root package name.
+	got := rootPackageName([]string{subFile, rootFile}, tmp)
+	require.Equal(t, "repro", got, "root package should be preferred over sub packages")
+
+	// Sanity check that the test's projectDir/sources vars compile (kept to
+	// satisfy the linter and document intent).
+	_ = sources
+	_ = projectDir
 }
 
 // TestResolveEffectiveDepDir_LocalReplace verifies that a `replace` directive

--- a/internal/transpiler/analyzer/BUILD.bazel
+++ b/internal/transpiler/analyzer/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "analyzer_test.go",
         "go_types_debug_test.go",
         "go_types_test.go",
+        "multipackage_panic_test.go",
         "test_helper.go",
         "validation_test.go",
     ],

--- a/internal/transpiler/analyzer/multipackage_panic_test.go
+++ b/internal/transpiler/analyzer/multipackage_panic_test.go
@@ -1,0 +1,72 @@
+package analyzer_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+)
+
+// TestMultiPackageBatch_NoPanic reproduces the FIX-001 scenario where a
+// BatchAnalyzer is reused across files that belong to different Go-level
+// packages (e.g., root.gala in `package repro` and state/state.gala in
+// `package state`). Previously this triggered an ANTLR nil-pointer
+// dereference when sibling discovery mixed trees from different packages;
+// we expect a clean error or successful analysis instead.
+func TestMultiPackageBatch_NoPanic(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "gala.mod"), []byte("module example.com/repro\n\ngala dev\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rootFile := filepath.Join(tmp, "root.gala")
+	if err := os.WriteFile(rootFile, []byte("package repro\n\nfunc RootFn() string = \"hi\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := filepath.Join(tmp, "state")
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	stateFile := filepath.Join(stateDir, "state.gala")
+	if err := os.WriteFile(stateFile, []byte("package state\n\nfunc StateFn() string = \"world\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := transpiler.NewAntlrGalaParser()
+	searchPaths := append([]string{tmp}, getStdSearchPath()...)
+	batch := analyzer.NewBatchAnalyzer(p, searchPaths, tmp)
+
+	files := []string{rootFile, stateFile}
+	for _, fp := range files {
+		content, err := os.ReadFile(fp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tree, err := p.Parse(string(content))
+		if err != nil {
+			t.Fatalf("parse %s: %v", fp, err)
+		}
+		// Simulate the builder: pass ALL files as siblings regardless of package,
+		// mimicking the old (pre-FIX-007) code path.
+		var siblings []string
+		for _, other := range files {
+			if other != fp {
+				siblings = append(siblings, other)
+			}
+		}
+		batch.SetPackageFiles(siblings)
+
+		// The call must either succeed or return an error — never panic.
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("analyzer panicked on %s: %v", fp, r)
+			}
+		}()
+		if _, err := batch.Analyze(tree, fp); err != nil {
+			// A semantic error (e.g., package name mismatch) is acceptable —
+			// we only care that no panic escapes.
+			t.Logf("analyze %s returned error (expected for cross-package siblings): %v", fp, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **FIX-001**: Multi-package library layout panics the analyzer (ANTLR nil-pointer dereference)

**Category**: TRANSPILER_BUG
**Priority**: P1
**Found in**: gala-tui

## Root Cause

`gala test` used non-recursive file discovery and `transpileFilesToDir` fed cross-package files as siblings through a single batch analyzer, causing ANTLR to trip on mismatched parse trees and also flattening the gen/ layout so subpackages never compiled cleanly. The same treatment that commit `d4c2b4a` applied to `gala build` had not been propagated into the shared transpile helper.

## Changes

- `internal/build/builder.go` — recursive source & test-file discovery, per-package harness emission for library tests, narrower `go build -o ./gen` targeting so main-package + library-subpackage layouts don't hit "cannot write multiple packages"
- `internal/build/builder_test.go` — new tests: `TestFindGalaTestFilesRecursive_IncludesSubdirs`, `TestRootPackageName_PrefersRootDirFile`; updated `TestTestGenFileName`
- `internal/transpiler/analyzer/multipackage_panic_test.go` (new) — `TestMultiPackageBatch_NoPanic` invariant
- `examples/multipackage_subpkg/{main.gala,main.out,state/state.gala}` (new) — end-to-end regression example
- `examples/BUILD.bazel`, `internal/transpiler/analyzer/BUILD.bazel` — wiring

## Verification

- `bazel build //...` passes
- `bazel test //...` passes — 274/274 tests
- End-to-end manual repro: the bug's exact `mkdir -p /tmp/repro/state; gala test` case now transpiles both packages cleanly (\`ok gala-build-workspace/gen\`, \`ok gala-build-workspace/gen/state\`)
- A library-with-sublibrary project with tests in both packages runs all tests successfully

## Repro (before fix)

\`\`\`bash
mkdir -p /tmp/repro/state
cd /tmp/repro
cat > gala.mod <<EOM
module example.com/repro

gala dev
EOM
cat > root.gala <<EOM
package repro
func RootFn() string = "hi"
EOM
cat > state/state.gala <<EOM
package state
func StateFn() string = "world"
EOM
gala test
# panic: runtime error: invalid memory address or nil pointer dereference
# ... github.com/antlr4-go/antlr/v4.NewBaseSingletonPredictionContext
\`\`\`

## Note

The reporter captured an ANTLR `NewBaseSingletonPredictionContext` panic; on current `master` the minimal repro silently skips the subpackage due to non-recursive discovery instead of panicking, but the underlying architectural issue (mixing parse trees from different packages through a single batch analyzer) is the same. The new `TestMultiPackageBatch_NoPanic` unit test locks in the no-panic invariant directly against the analyzer.

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as: BUG-1 in `C:\Users\maxmr\GolandProjects\gala_tui\TRANSPILER_BUGS.md`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)