### PR TITLE
perf(lsp): skip transpile-to-disk + stamp ServerInfo version

### DIFF
--- a/cmd/gala/commands/lsp.go
+++ b/cmd/gala/commands/lsp.go
@@ -35,6 +35,11 @@ func init() {
 func runLsp(cmd *cobra.Command, args []string) {
 	handler := lsp.NewGalaHandler()
 
+	// Stamp the LSP server version with the build-time GALA release.
+	// `Version` is set via x_defs in cmd/gala/BUILD.bazel from
+	// STABLE_GALA_VERSION; falls back to "dev" for unstamped builds.
+	handler.SetVersion(Version)
+
 	// Auto-resolve stdlib and GALA dependency search paths so the LSP can
 	// find standard packages (std, collection_immutable, etc.) from any project.
 	handler.SetSearchPaths(autoResolveLSPSearchPaths())

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -34,6 +34,13 @@ import (
 type GalaHandler struct {
 	rootPath string
 
+	// Version reported in the LSP Initialize response (ServerInfo.Version).
+	// Set by SetVersion from cmd/gala/commands.Version, which is x_defs-stamped
+	// at build time from STABLE_GALA_VERSION (see cmd/gala/BUILD.bazel). Falls
+	// back to "dev" when the LSP is exercised through tests or invoked outside
+	// the stamped binary.
+	version string
+
 	parser    transpiler.GalaParser
 	generator transpiler.CodeGenerator
 
@@ -63,6 +70,23 @@ func (h *GalaHandler) SetClient(client *golsp.Client) {
 // SetSearchPaths adds additional search paths for the analyzer (for testing).
 func (h *GalaHandler) SetSearchPaths(paths []string) {
 	h.extraSearchPaths = paths
+}
+
+// SetVersion sets the version reported in the LSP Initialize response.
+// Callers should pass the build-time stamped commands.Version so the IDE
+// can surface the actual GALA release the user is running.
+func (h *GalaHandler) SetVersion(v string) {
+	h.version = v
+}
+
+// serverVersion returns the version to advertise in ServerInfo. Falls back
+// to "dev" when SetVersion was not called (test harnesses, manual launches
+// outside the stamped binary, etc.).
+func (h *GalaHandler) serverVersion() string {
+	if h.version == "" {
+		return "dev"
+	}
+	return h.version
 }
 
 // DebugRichAST returns the cached RichAST for a given URI (for testing).
@@ -143,7 +167,7 @@ func (h *GalaHandler) Initialize(ctx context.Context, params *lsp.InitializePara
 		},
 		ServerInfo: &lsp.ServerInfo{
 			Name:    "gala-lsp",
-			Version: "0.2.0",
+			Version: h.serverVersion(),
 		},
 	}, nil
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -289,7 +289,7 @@ func (h *GalaHandler) analyzeFile(uri, filePath, text string) []lsp.Diagnostic {
 	}
 
 	searchPaths := h.getSearchPaths(filePath)
-	a := analyzer.NewGalaAnalyzer(h.parser, searchPaths)
+	a := analyzer.NewGalaAnalyzerForLSP(h.parser, searchPaths)
 	richAST, err := a.Analyze(tree, filePath)
 	if err != nil {
 		diagnostics = append(diagnostics, errorsToDiagnostics(err)...)
@@ -404,7 +404,7 @@ func (h *GalaHandler) tryAnalyzePartial(uri, filePath string, tree antlr.Tree) {
 	defer func() { recover() }()
 
 	searchPaths := h.getSearchPaths(filePath)
-	a := analyzer.NewGalaAnalyzer(h.parser, searchPaths)
+	a := analyzer.NewGalaAnalyzerForLSP(h.parser, searchPaths)
 	richAST, err := a.Analyze(tree, filePath)
 	if err != nil || richAST == nil {
 		return
@@ -518,7 +518,7 @@ func (h *GalaHandler) analyzeAndCache(uri, cleanText, caller string) {
 
 	filePath := uriToPath(uri)
 	searchPaths := h.getSearchPaths(filePath)
-	a := analyzer.NewGalaAnalyzer(h.parser, searchPaths)
+	a := analyzer.NewGalaAnalyzerForLSP(h.parser, searchPaths)
 	richAST, aerr := a.Analyze(tree, filePath)
 	if aerr != nil {
 		fmt.Fprintf(os.Stderr, "[%s] analyze failed: %v\n", caller, aerr)

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -77,6 +77,13 @@ type galaAnalyzer struct {
 	// total transpile time for collection_immutable/list.gala, baseline
 	// 2.6s on Windows).
 	siblingTreeCache map[string]*siblingCacheEntry
+
+	// When true, ensureTranspiled is a no-op — used by the LSP, where the
+	// generated .gen.go files are never consumed (analyzePackage reads .gala
+	// directly to extract the metadata diagnostics need). The disk write is
+	// dead work in LSP context and contends heavily under parallel analyzers
+	// on Windows.
+	skipTranspileToDisk bool
 }
 
 // siblingCacheEntry is the value stored in galaAnalyzer.siblingTreeCache.
@@ -159,6 +166,29 @@ func NewGalaAnalyzerWithPackageFiles(p transpiler.GalaParser, searchPaths []stri
 		siblingTreeCache: make(map[string]*siblingCacheEntry),
 		resolver:     module.NewResolver(searchPaths),
 		cache:        newAnalysisCache(resolveCacheRoot(root)),
+	}
+}
+
+// NewGalaAnalyzerForLSP creates an analyzer configured for LSP use: the heavy
+// disk-writing transpile-on-import side effect (ensureTranspiled) is disabled
+// because its output (.gen.go files) is never consumed by the LSP pipeline.
+// analyzePackage produces all the metadata diagnostics need directly from
+// .gala sources. See the docstring on galaAnalyzer.skipTranspileToDisk and
+// the no-op guard in ensureTranspiled for details.
+func NewGalaAnalyzerForLSP(p transpiler.GalaParser, searchPaths []string, projectRoot ...string) transpiler.Analyzer {
+	root := ""
+	if len(projectRoot) > 0 {
+		root = projectRoot[0]
+	}
+	return &galaAnalyzer{
+		parser:              p,
+		searchPaths:         searchPaths,
+		analyzedPkgs:        make(map[string]*transpiler.RichAST),
+		checkedDirs:         make(map[string]bool),
+		siblingTreeCache:    make(map[string]*siblingCacheEntry),
+		resolver:            module.NewResolver(searchPaths),
+		cache:               newAnalysisCache(resolveCacheRoot(root)),
+		skipTranspileToDisk: true,
 	}
 }
 
@@ -2157,6 +2187,17 @@ func (a *galaAnalyzer) extractGoFileExports(files []os.FileInfo, dirPath, relPat
 // and transpiles it if necessary. The transpiled .go files are written
 // to the same cache directory as the .gala source files.
 func (a *galaAnalyzer) ensureTranspiled(importPath string) error {
+	// LSP mode skips this entirely: the generated .gen.go files are never
+	// read back by the LSP pipeline (analyzePackage produces all the metadata
+	// needed for diagnostics directly from the .gala source). Performing the
+	// transpile + os.WriteFile here once per import on every DidOpen is the
+	// dominant cost of cross-package diagnostics under parallel load on
+	// Windows; skipping it brings the test from ~7s back to ~2s under the
+	// `--runs_per_test=20 --jobs=20` benchmark.
+	if a.skipTranspileToDisk {
+		return nil
+	}
+
 	// Find the package directory in the cache
 	dirPath, err := a.resolver.ResolvePackagePath(importPath)
 	if err != nil {

--- a/internal/transpiler/transpiler.go
+++ b/internal/transpiler/transpiler.go
@@ -77,6 +77,17 @@ type RichAST struct {
 }
 
 // Merge combines metadata from another RichAST into this one.
+//
+// IMPORTANT: this is NOT a pure read on `other`. Merge stores `other`'s
+// TypeMetadata pointers directly into r.Types (no copy), and when a key
+// exists in both `r` and `other`, it writes back into the shared
+// TypeMetadata's Methods map. The implication for callers: a RichAST
+// produced by Analyze() is *not* safe to share (e.g., as a pre-loaded
+// std cache) across goroutines that then call Merge against their own
+// richASTs — the merges race on the shared Methods/Fields/etc. and will
+// corrupt the source. Either deep-clone before sharing, or guard with
+// a mutex. See the LSP perf branch (518bd98) for the failed shared-std
+// experiment that hit this.
 func (r *RichAST) Merge(other *RichAST) {
 	if other == nil {
 		return


### PR DESCRIPTION
## Summary

Three independent improvements on the LSP path, surfaced while investigating the `TestMultiPackage_NoDiagnosticsFalsePositives` flake under heavy parallel test load on Windows.

| Commit | Change | Impact |
|--------|--------|--------|
| `518bd98` | LSP analyzer skips \`ensureTranspiled\` disk-write | Cross-package diagnostics: max 6.9s → 3.1s under \`--runs_per_test=20\` |
| \`ba9eb02\` | Document that \`RichAST.Merge\` mutates pointers in \`other\` | Prevents future "shared cache" footguns |
| \`dcbfc79\` | LSP \`ServerInfo.Version\` reflects build-time release | Editors show real GALA version, not "0.2.0" |

## 1. Skip \`ensureTranspiled\` in LSP mode

\`ensureTranspiled\` writes \`.gen.go\` files into imported packages' source directories whenever the LSP analyzes a file with cross-package imports. The output is **never read back by the LSP** — \`analyzePackage\` produces all the type metadata diagnostics need directly from \`.gala\` source. The write is dead work, and contended heavily on the Windows filesystem under parallel analyzers.

**Fix**: \`skipTranspileToDisk\` flag on \`galaAnalyzer\`, set by a new \`NewGalaAnalyzerForLSP\` factory. The three LSP analyzer construction sites use the new factory. CLI/build paths still go through \`NewGalaAnalyzer\` / \`NewBatchAnalyzer\` which keep \`ensureTranspiled\` active.

**Benchmark** (\`bazel test //internal/lsp:lsp_test --runs_per_test=20 --test_filter=TestMultiPackage_NoDiagnosticsFalsePositives --jobs=20\`):

| | min | avg | max | σ | Verdict |
|---|---|---|---|---|---|
| Before | 4.2s | 5.9s | 6.9s | 0.8s | At 20-jobs the test fails its 5s ctx timeout (\`context deadline exceeded\` after ~13s) |
| After  | 0.6s | 2.2s | 3.1s | 0.9s | Comfortable headroom |

In isolation: 1.75s → 0.05s.

## 2. Document \`RichAST.Merge\` non-immutability

Discovered while attempting a complementary "share std AST across LSP analyzers" optimization (Fix B in the original plan). \`Merge\` writes to \`existing.Methods\` which is a pointer shared with the source — concurrent merges from multiple analyzers corrupt the source AST. Caught by the LSP test suite going from 29s to a 300s timeout, with \`TestDefinition_TupleFieldV1V2_Repro\` failing with "richAST is nil" because the std AST's TypeMetadata was getting corrupted mid-flight.

The shared-cache optimization is reverted; the comment on \`Merge\` documents the constraint so future contributors don't re-walk into it.

## 3. Stamp \`ServerInfo.Version\` from build-time release

The LSP Initialize response was hardcoded \`"0.2.0"\`. Replace with the same x_defs-stamped \`commands.Version\` already used by \`gala version\`. Falls back to \`"dev"\` for unstamped/test invocations.

\`bazel build --stamp //cmd/gala\` produces e.g. \`0.33.0-4-gba9eb02\`. Editors connecting to the LSP now see the actual GALA release the user is running.

## Verification

- \`bazel build //...\` passes
- \`bazel test //...\` passes — 277/277 tests
- \`gala version\` output unchanged for unstamped builds; correct release for stamped

## Why split / why one PR

All three changes share the same investigation ("why is the LSP slow / why does this test flake under load") and touch overlapping files (\`internal/lsp/server.go\`). Bundling keeps the context together; commits are clean and revertable individually.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)