### PR TITLE
perf(transpiler): share BatchAnalyzer + cache parsed sibling .gala trees

### DIFF
--- a/internal/build/BUILD.bazel
+++ b/internal/build/BUILD.bazel
@@ -29,11 +29,14 @@ go_test(
         "builder_test.go",
         "deptranspiler_test.go",
         "go_toolchain_test.go",
+        "transpile_batch_static_test.go",
     ],
+    data = ["builder.go"],  # transpile_batch_static_test.go does AST analysis
     embed = [":build"],
     deps = [
         "//internal/depman/mod",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@rules_go//go/tools/bazel:go_default_library",
     ],
 )

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -504,7 +504,10 @@ func (b *Builder) transpileWithSourceDir() error {
 	tr := transformer.NewGalaASTTransformer()
 	g := generator.NewGoCodeGenerator()
 
-	// Step 1: Transpile library files (project root) into gen/
+	// Step 1: Transpile library files (project root) into gen/.
+	// One BatchAnalyzer for all library files so analyzedPkgs (std,
+	// collection_immutable, etc.) and parsedFileCache (sibling .gala
+	// trees) are shared across the loop instead of paid per file.
 	libFiles, err := findGalaFiles(b.workspace.ProjectDir)
 	if err != nil {
 		return fmt.Errorf("finding library files: %w", err)
@@ -512,6 +515,7 @@ func (b *Builder) transpileWithSourceDir() error {
 	if b.verbose {
 		fmt.Printf("  Transpiling %d library files...\n", len(libFiles))
 	}
+	libBatch := analyzer.NewBatchAnalyzer(p, searchPaths, b.workspace.ProjectDir)
 	for _, galaFile := range libFiles {
 		content, err := os.ReadFile(galaFile)
 		if err != nil {
@@ -523,13 +527,8 @@ func (b *Builder) transpileWithSourceDir() error {
 				siblings = append(siblings, other)
 			}
 		}
-		var a transpiler.Analyzer
-		if len(siblings) > 0 {
-			a = analyzer.NewGalaAnalyzerWithPackageFiles(p, searchPaths, siblings, b.workspace.ProjectDir)
-		} else {
-			a = analyzer.NewGalaAnalyzer(p, searchPaths, b.workspace.ProjectDir)
-		}
-		t := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+		libBatch.SetPackageFiles(siblings)
+		t := transpiler.NewGalaToGoTranspiler(p, libBatch, tr, g)
 		goCode, err := t.Transpile(string(content), galaFile)
 		if err != nil {
 			return fmt.Errorf("transpiling %s: %w", galaFile, err)
@@ -565,6 +564,13 @@ func (b *Builder) transpileWithSourceDir() error {
 		return fmt.Errorf("creating consumer dir: %w", err)
 	}
 
+	// Reuse libBatch for consumer files: SetPackageFiles is per-call so
+	// the consumer's sibling list does not collide with the library's.
+	// The win is that analyzedPkgs (std, collection_immutable, etc.) and
+	// parsedFileCache (every library .gala already parsed during Step 1)
+	// carry over — so the consumer's `import "<project>"` resolution does
+	// not re-read or re-parse the library files when it analyzePackages
+	// the project's own module.
 	for _, galaFile := range consumerFiles {
 		content, err := os.ReadFile(galaFile)
 		if err != nil {
@@ -576,13 +582,8 @@ func (b *Builder) transpileWithSourceDir() error {
 				siblings = append(siblings, other)
 			}
 		}
-		var a transpiler.Analyzer
-		if len(siblings) > 0 {
-			a = analyzer.NewGalaAnalyzerWithPackageFiles(p, searchPaths, siblings, b.workspace.ProjectDir)
-		} else {
-			a = analyzer.NewGalaAnalyzer(p, searchPaths, b.workspace.ProjectDir)
-		}
-		t := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+		libBatch.SetPackageFiles(siblings)
+		t := transpiler.NewGalaToGoTranspiler(p, libBatch, tr, g)
 		goCode, err := t.Transpile(string(content), galaFile)
 		if err != nil {
 			return fmt.Errorf("transpiling %s: %w", galaFile, err)

--- a/internal/build/transpile_batch_static_test.go
+++ b/internal/build/transpile_batch_static_test.go
@@ -1,0 +1,143 @@
+package build
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+)
+
+// findBuilderSource locates builder.go on disk for static analysis.
+// Under Bazel, the source is declared as test data and accessible via
+// runfiles. Outside Bazel, we walk up from the cwd to the repo root.
+func findBuilderSource(t *testing.T) string {
+	t.Helper()
+	if p, err := bazel.Runfile("internal/build/builder.go"); err == nil {
+		return p
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cwd: %v", err)
+	}
+	dir := cwd
+	for {
+		candidate := filepath.Join(dir, "internal", "build", "builder.go")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not locate builder.go on disk or in runfiles")
+		}
+		dir = parent
+	}
+}
+
+// TestTranspileWithSourceDir_UsesBatchAnalyzer is a static (AST) regression
+// guard for the gala_tui-class perf fix: transpileWithSourceDir must use
+// one BatchAnalyzer reused across files, not allocate a fresh galaAnalyzer
+// per file. The latter pattern caused 67s cold builds because every file
+// re-analyzed std (~1.3s each) instead of sharing analyzedPkgs across the
+// loop.
+//
+// Regression signature it catches: a future change that reverts to
+// `analyzer.NewGalaAnalyzer*` inside a for loop within
+// transpileWithSourceDir. The test parses builder.go itself, finds the
+// function, walks its body, and asserts:
+//
+//  1. NewBatchAnalyzer is called at least once (the optimization is in
+//     place), AND
+//  2. Inside any for-loop in the function body, no NewGalaAnalyzer or
+//     NewGalaAnalyzerWithPackageFiles call appears (the regression is
+//     not present).
+//
+// This is brittle by design — touching the function deliberately to
+// rewrite the strategy is fine; reverting unintentionally fails loudly.
+func TestTranspileWithSourceDir_UsesBatchAnalyzer(t *testing.T) {
+	fset := token.NewFileSet()
+	src := findBuilderSource(t)
+	file, err := parser.ParseFile(fset, src, nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse builder.go: %v", err)
+	}
+
+	var fn *ast.FuncDecl
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fd.Name.Name == "transpileWithSourceDir" && fd.Recv != nil {
+			fn = fd
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatal("could not find (b *Builder) transpileWithSourceDir in builder.go")
+	}
+
+	// Pass 1: assert NewBatchAnalyzer is called somewhere in the body.
+	sawBatch := false
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if name := callName(call); strings.HasSuffix(name, ".NewBatchAnalyzer") || name == "NewBatchAnalyzer" {
+			sawBatch = true
+		}
+		return true
+	})
+	if !sawBatch {
+		t.Error("transpileWithSourceDir does not call analyzer.NewBatchAnalyzer; the perf fix may have been reverted (gala_tui cold build regressed from ~18s back to ~67s)")
+	}
+
+	// Pass 2: walk every for-loop inside the function body and assert
+	// no per-file NewGalaAnalyzer* allocation appears within.
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		fl, ok := n.(*ast.RangeStmt)
+		if !ok {
+			return true
+		}
+		ast.Inspect(fl.Body, func(inner ast.Node) bool {
+			call, ok := inner.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name := callName(call)
+			short := name
+			if dot := strings.LastIndex(name, "."); dot >= 0 {
+				short = name[dot+1:]
+			}
+			switch short {
+			case "NewGalaAnalyzer", "NewGalaAnalyzerWithPackageFiles", "NewGalaAnalyzerWithBase":
+				pos := fset.Position(call.Pos())
+				t.Errorf("transpileWithSourceDir allocates a fresh analyzer per loop iteration at %s: %s — this is the regression that turned gala_tui cold builds into 67s. Use the shared BatchAnalyzer instead.", pos, name)
+			}
+			return true
+		})
+		return true
+	})
+}
+
+// callName returns the textual name of a call expression's callee.
+// Handles plain identifiers ("Foo") and selectors ("pkg.Foo", "x.Foo").
+// Returns "" for indirect calls we can't statically resolve — this test
+// only cares about direct factory calls.
+func callName(call *ast.CallExpr) string {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name
+	case *ast.SelectorExpr:
+		if x, ok := fn.X.(*ast.Ident); ok {
+			return x.Name + "." + fn.Sel.Name
+		}
+		return "." + fn.Sel.Name
+	}
+	return ""
+}

--- a/internal/transpiler/analyzer/BUILD.bazel
+++ b/internal/transpiler/analyzer/BUILD.bazel
@@ -28,9 +28,11 @@ go_test(
     name = "analyzer_test",
     srcs = [
         "analyzer_test.go",
+        "batch_reuse_test.go",
         "go_types_debug_test.go",
         "go_types_test.go",
         "multipackage_panic_test.go",
+        "parsedfile_cache_test.go",
         "test_helper.go",
         "validation_test.go",
     ],
@@ -40,6 +42,7 @@ go_test(
     deps = [
         ":analyzer",
         "//internal/transpiler",
+        "@com_github_antlr4_go_antlr_v4//:antlr",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@rules_go//go/tools/bazel:go_default_library",

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -26,12 +26,13 @@ import (
 // In normal compilation flow, std is loaded via implicit import in Analyze().
 func GetBaseMetadata(p transpiler.GalaParser, searchPaths []string) *transpiler.RichAST {
 	a := &galaAnalyzer{
-		parser:       p,
-		searchPaths:  searchPaths,
-		analyzedPkgs: make(map[string]*transpiler.RichAST),
+		parser:           p,
+		searchPaths:      searchPaths,
+		analyzedPkgs:     make(map[string]*transpiler.RichAST),
 		checkedDirs:      make(map[string]bool),
 		siblingTreeCache: make(map[string]*siblingCacheEntry),
-		resolver:     module.NewResolver(searchPaths),
+		parsedFileCache:  make(map[string]*parsedFileEntry),
+		resolver:         module.NewResolver(searchPaths),
 	}
 
 	stdAST, err := a.analyzePackage(registry.StdPackageName)
@@ -78,6 +79,13 @@ type galaAnalyzer struct {
 	// 2.6s on Windows).
 	siblingTreeCache map[string]*siblingCacheEntry
 
+	// Per-file parse cache used by the explicit-package-files branch (and
+	// reusable by anyone else that wants to load + parse a .gala by path).
+	// Keyed by canonical absolute path; invalidated by mtime+size mismatch.
+	// Survives BatchAnalyzer.SetPackageFiles so a 37-file package amortizes
+	// sibling parsing to roughly N parses instead of N×(N−1).
+	parsedFileCache map[string]*parsedFileEntry
+
 	// When true, ensureTranspiled is a no-op — used by the LSP, where the
 	// generated .gen.go files are never consumed (analyzePackage reads .gala
 	// directly to extract the metadata diagnostics need). The disk write is
@@ -95,6 +103,16 @@ type siblingCacheEntry struct {
 	trees   []*grammar.SourceFileContext
 	paths   []string
 	dirSize int
+}
+
+// parsedFileEntry is one slot in galaAnalyzer.parsedFileCache. The
+// (mtime, size) pair is the staleness check: if either changes between
+// stat calls, the cached tree is dropped and the file is re-parsed.
+type parsedFileEntry struct {
+	tree    *grammar.SourceFileContext
+	pkgName string
+	mtime   time.Time
+	size    int64
 }
 
 // resolveCacheRoot returns the project root for the analysis disk cache.
@@ -117,13 +135,14 @@ func NewGalaAnalyzer(p transpiler.GalaParser, searchPaths []string, projectRoot 
 		root = projectRoot[0]
 	}
 	return &galaAnalyzer{
-		parser:       p,
-		searchPaths:  searchPaths,
-		analyzedPkgs: make(map[string]*transpiler.RichAST),
+		parser:           p,
+		searchPaths:      searchPaths,
+		analyzedPkgs:     make(map[string]*transpiler.RichAST),
 		checkedDirs:      make(map[string]bool),
 		siblingTreeCache: make(map[string]*siblingCacheEntry),
-		resolver:     module.NewResolver(searchPaths),
-		cache:        newAnalysisCache(resolveCacheRoot(root)),
+		parsedFileCache:  make(map[string]*parsedFileEntry),
+		resolver:         module.NewResolver(searchPaths),
+		cache:            newAnalysisCache(resolveCacheRoot(root)),
 	}
 }
 
@@ -136,14 +155,15 @@ func NewGalaAnalyzerWithBase(base *transpiler.RichAST, p transpiler.GalaParser, 
 		root = projectRoot[0]
 	}
 	return &galaAnalyzer{
-		baseMetadata: base,
-		parser:       p,
-		searchPaths:  searchPaths,
-		analyzedPkgs: make(map[string]*transpiler.RichAST),
+		baseMetadata:     base,
+		parser:           p,
+		searchPaths:      searchPaths,
+		analyzedPkgs:     make(map[string]*transpiler.RichAST),
 		checkedDirs:      make(map[string]bool),
 		siblingTreeCache: make(map[string]*siblingCacheEntry),
-		resolver:     module.NewResolver(searchPaths),
-		cache:        newAnalysisCache(resolveCacheRoot(root)),
+		parsedFileCache:  make(map[string]*parsedFileEntry),
+		resolver:         module.NewResolver(searchPaths),
+		cache:            newAnalysisCache(resolveCacheRoot(root)),
 	}
 }
 
@@ -158,14 +178,15 @@ func NewGalaAnalyzerWithPackageFiles(p transpiler.GalaParser, searchPaths []stri
 		root = projectRoot[0]
 	}
 	return &galaAnalyzer{
-		parser:       p,
-		searchPaths:  searchPaths,
-		packageFiles: packageFiles,
-		analyzedPkgs: make(map[string]*transpiler.RichAST),
+		parser:           p,
+		searchPaths:      searchPaths,
+		packageFiles:     packageFiles,
+		analyzedPkgs:     make(map[string]*transpiler.RichAST),
 		checkedDirs:      make(map[string]bool),
 		siblingTreeCache: make(map[string]*siblingCacheEntry),
-		resolver:     module.NewResolver(searchPaths),
-		cache:        newAnalysisCache(resolveCacheRoot(root)),
+		parsedFileCache:  make(map[string]*parsedFileEntry),
+		resolver:         module.NewResolver(searchPaths),
+		cache:            newAnalysisCache(resolveCacheRoot(root)),
 	}
 }
 
@@ -186,6 +207,7 @@ func NewGalaAnalyzerForLSP(p transpiler.GalaParser, searchPaths []string, projec
 		analyzedPkgs:        make(map[string]*transpiler.RichAST),
 		checkedDirs:         make(map[string]bool),
 		siblingTreeCache:    make(map[string]*siblingCacheEntry),
+		parsedFileCache:     make(map[string]*parsedFileEntry),
 		resolver:            module.NewResolver(searchPaths),
 		cache:               newAnalysisCache(resolveCacheRoot(root)),
 		skipTranspileToDisk: true,
@@ -210,13 +232,14 @@ func NewBatchAnalyzer(p transpiler.GalaParser, searchPaths []string, projectRoot
 	}
 	return &BatchAnalyzer{
 		inner: &galaAnalyzer{
-			parser:       p,
-			searchPaths:  searchPaths,
-			analyzedPkgs: make(map[string]*transpiler.RichAST),
+			parser:           p,
+			searchPaths:      searchPaths,
+			analyzedPkgs:     make(map[string]*transpiler.RichAST),
 			checkedDirs:      make(map[string]bool),
-		siblingTreeCache: make(map[string]*siblingCacheEntry),
-			resolver:     module.NewResolver(searchPaths),
-			cache:        newAnalysisCache(resolveCacheRoot(root)),
+			siblingTreeCache: make(map[string]*siblingCacheEntry),
+			parsedFileCache:  make(map[string]*parsedFileEntry),
+			resolver:         module.NewResolver(searchPaths),
+			cache:            newAnalysisCache(resolveCacheRoot(root)),
 		},
 	}
 }
@@ -263,26 +286,23 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 	var siblingTrees []*grammar.SourceFileContext
 	var siblingPaths []string // parallel slice: file path for each siblingTree
 	if len(a.packageFiles) > 0 {
-		// Explicit package files: parse each one, validate package name, add to siblings
+		// Explicit package files: parse each one (with cache), validate
+		// package name, add to siblings. The cache is content-addressed by
+		// (path, mtime, size) and survives across SetPackageFiles calls so
+		// a 37-file package amortizes sibling parsing across the batch.
 		for _, pf := range a.packageFiles {
 			if isSameFile(pf, filePath) {
 				continue // skip self (resolves symlinks for Bazel on Linux)
 			}
-			content, err := ioutil.ReadFile(pf)
+			otherSF, otherPkgName, err := a.parseFileCached(pf)
 			if err != nil {
+				return nil, err
+			}
+			if otherSF == nil {
 				continue
 			}
-			tree, err := a.parser.Parse(string(content))
-			if err != nil {
-				continue
-			}
-			otherSF, ok := tree.(*grammar.SourceFileContext)
-			if !ok {
-				continue
-			}
-			pkgClause := otherSF.PackageClause().(*grammar.PackageClauseContext)
-			otherPkgName := pkgClause.Identifier().GetText()
 			if otherPkgName != pkgName {
+				pkgClause := otherSF.PackageClause().(*grammar.PackageClauseContext)
 				return nil, galaerr.NewCodedSemanticError(
 					galaerr.CodeDuplicatePackageName,
 					pkgClause.GetStart().GetLine(), pkgClause.GetStart().GetColumn(),
@@ -1953,12 +1973,11 @@ func (a *galaAnalyzer) analyzePackage(relPath string) (*transpiler.RichAST, erro
 	for _, f := range files {
 		if !f.IsDir() && filepath.Ext(f.Name()) == ".gala" && !strings.HasSuffix(f.Name(), "_test.gala") {
 			filePath := filepath.Join(dirPath, f.Name())
-			content, err := ioutil.ReadFile(filePath)
-			if err != nil {
-				continue
-			}
-			tree, err := a.parser.Parse(string(content))
-			if err != nil {
+			// Use parseFileCached so when the same files were already parsed
+			// during a sibling pass (typical for the consumer step that
+			// imports the project's own library), the re-parse is skipped.
+			tree, _, err := a.parseFileCached(filePath)
+			if err != nil || tree == nil {
 				continue
 			}
 			res, err := a.Analyze(tree, filePath)
@@ -2251,12 +2270,13 @@ func (a *galaAnalyzer) ensureTranspiled(importPath string) error {
 		// Analyze without recursion by using a separate analyzer
 		// This avoids circular dependency issues
 		tempAnalyzer := &galaAnalyzer{
-			parser:       a.parser,
-			searchPaths:  a.searchPaths,
-			analyzedPkgs: make(map[string]*transpiler.RichAST),
+			parser:           a.parser,
+			searchPaths:      a.searchPaths,
+			analyzedPkgs:     make(map[string]*transpiler.RichAST),
 			checkedDirs:      make(map[string]bool),
-		siblingTreeCache: make(map[string]*siblingCacheEntry),
-			resolver:     a.resolver,
+			siblingTreeCache: make(map[string]*siblingCacheEntry),
+			parsedFileCache:  make(map[string]*parsedFileEntry),
+			resolver:         a.resolver,
 		}
 
 		richAST, err := tempAnalyzer.Analyze(tree, srcPath)
@@ -2874,6 +2894,63 @@ func typesCompatibleForDefault(paramType, literalType string) bool {
 }
 
 var _ transpiler.Analyzer = (*galaAnalyzer)(nil)
+
+// parseFileCached reads, parses, and validates a .gala file's package
+// clause, caching the result on the analyzer keyed by canonical absolute
+// path. Cache entries are invalidated when the file's mtime or size
+// changes between calls. Returns (nil, "", nil) for non-readable or
+// non-parseable files so the caller can decide whether that's fatal —
+// matching the silent-skip behavior of the inline parsing the
+// explicit-package-files branch used to do.
+//
+// Used by the explicit-package-files branch in Analyze (to amortize
+// sibling parsing across BatchAnalyzer calls) and by analyzePackage (so
+// when the same project files were just parsed during sibling discovery,
+// the import-resolution pass does not redo the work).
+func (a *galaAnalyzer) parseFileCached(path string) (*grammar.SourceFileContext, string, error) {
+	canonPath, err := filepath.Abs(path)
+	if err != nil {
+		canonPath = path
+	}
+	info, err := os.Stat(canonPath)
+	if err != nil {
+		return nil, "", nil
+	}
+	if a.parsedFileCache != nil {
+		if entry, ok := a.parsedFileCache[canonPath]; ok {
+			if entry.mtime.Equal(info.ModTime()) && entry.size == info.Size() {
+				return entry.tree, entry.pkgName, nil
+			}
+			delete(a.parsedFileCache, canonPath)
+		}
+	}
+	content, err := ioutil.ReadFile(canonPath)
+	if err != nil {
+		return nil, "", nil
+	}
+	tree, err := a.parser.Parse(string(content))
+	if err != nil {
+		return nil, "", nil
+	}
+	otherSF, ok := tree.(*grammar.SourceFileContext)
+	if !ok {
+		return nil, "", nil
+	}
+	pkgClause, ok := otherSF.PackageClause().(*grammar.PackageClauseContext)
+	if !ok || pkgClause.Identifier() == nil {
+		return nil, "", nil
+	}
+	pkgName := pkgClause.Identifier().GetText()
+	if a.parsedFileCache != nil {
+		a.parsedFileCache[canonPath] = &parsedFileEntry{
+			tree:    otherSF,
+			pkgName: pkgName,
+			mtime:   info.ModTime(),
+			size:    info.Size(),
+		}
+	}
+	return otherSF, pkgName, nil
+}
 
 // lookupSiblingCache returns parsed sibling trees from the in-memory
 // cache, filtered for the current file. Returns (nil, nil, nil) on a

--- a/internal/transpiler/analyzer/batch_reuse_test.go
+++ b/internal/transpiler/analyzer/batch_reuse_test.go
@@ -1,0 +1,95 @@
+package analyzer_test
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/antlr4-go/antlr/v4"
+	"github.com/stretchr/testify/require"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+)
+
+// countingParser wraps a GalaParser and counts how many times Parse fires.
+// Used by TestBatchAnalyzer_StdAnalyzedOnce to prove the BatchAnalyzer's
+// analyzedPkgs cache survives across SetPackageFiles calls — the property
+// that powers the gala_tui demo build going from ~67s to ~18s cold.
+type countingParser struct {
+	inner transpiler.GalaParser
+	calls int64
+}
+
+func (c *countingParser) Parse(input string) (antlr.Tree, error) {
+	atomic.AddInt64(&c.calls, 1)
+	return c.inner.Parse(input)
+}
+
+func (c *countingParser) ParseLenient(input string) (antlr.Tree, []error) {
+	atomic.AddInt64(&c.calls, 1)
+	return c.inner.ParseLenient(input)
+}
+
+// TestBatchAnalyzer_StdAnalyzedOnce locks in the invariant that powered
+// the perf fix in builder.go (transpileWithSourceDir): when one
+// BatchAnalyzer is reused across multiple Analyze calls, the std package
+// (and any other previously-loaded import) is analyzed exactly once. A
+// regression that resets analyzedPkgs per call — e.g. inside
+// SetPackageFiles, or by allocating a fresh galaAnalyzer per file —
+// would re-parse the entire std library on every Analyze and the per-file
+// time blows up by 1+ seconds.
+//
+// Strategy: wrap the parser with a counter, run two Analyze calls on
+// different files in different packages, snapshot the call count after
+// the first, and assert the second call does not re-parse std.
+func TestBatchAnalyzer_StdAnalyzedOnce(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.gala")
+	b := filepath.Join(dir, "b.gala")
+	require.NoError(t, os.WriteFile(a, []byte("package pkg\n\nval x = 1\n"), 0644))
+	require.NoError(t, os.WriteFile(b, []byte("package pkg\n\nval y = 2\n"), 0644))
+
+	innerParser := transpiler.NewAntlrGalaParser()
+	counter := &countingParser{inner: innerParser}
+	batch := analyzer.NewBatchAnalyzer(counter, getStdSearchPath(), dir)
+
+	parse := func(p string) antlr.Tree {
+		body, err := os.ReadFile(p)
+		require.NoError(t, err)
+		tree, err := innerParser.Parse(string(body))
+		require.NoError(t, err)
+		return tree
+	}
+
+	// First Analyze: std is loaded cold. Counter snapshots a high number.
+	batch.SetPackageFiles([]string{b})
+	_, err := batch.Analyze(parse(a), a)
+	require.NoError(t, err)
+	first := atomic.LoadInt64(&counter.calls)
+
+	// Second Analyze on a different file in the same package: std must
+	// already be cached in analyzedPkgs, so its many .gala files must NOT
+	// be re-parsed. A reasonable bound is "no more parses than there are
+	// sibling files in the test package" — i.e. 1 (just b.gala on the
+	// previous call's parsedFileCache, or 0 if cached).
+	atomic.StoreInt64(&counter.calls, 0)
+	batch.SetPackageFiles([]string{a})
+	_, err = batch.Analyze(parse(b), b)
+	require.NoError(t, err)
+	second := atomic.LoadInt64(&counter.calls)
+
+	// We measure: first must include std parses (>>2). Second must be
+	// drastically smaller — std is fully cached, only siblings might
+	// trigger re-parse. Use a generous bound: second must be < first/2
+	// so any regression that re-analyzes std (always >>10 .gala files)
+	// is caught.
+	if first <= 2 {
+		t.Fatalf("expected first Analyze to parse many std files (sanity check); got only %d", first)
+	}
+	if second >= first/2 {
+		t.Fatalf("BatchAnalyzer regression: second Analyze parsed %d files (first parsed %d); std should be cached after first call",
+			second, first)
+	}
+}

--- a/internal/transpiler/analyzer/parsedfile_cache_test.go
+++ b/internal/transpiler/analyzer/parsedfile_cache_test.go
@@ -1,0 +1,137 @@
+package analyzer_test
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/antlr4-go/antlr/v4"
+	"github.com/stretchr/testify/require"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+)
+
+// parsedFileCounter wraps a GalaParser and counts Parse invocations.
+type parsedFileCounter struct {
+	inner transpiler.GalaParser
+	calls int64
+}
+
+func (c *parsedFileCounter) Parse(input string) (antlr.Tree, error) {
+	atomic.AddInt64(&c.calls, 1)
+	return c.inner.Parse(input)
+}
+
+func (c *parsedFileCounter) ParseLenient(input string) (antlr.Tree, []error) {
+	atomic.AddInt64(&c.calls, 1)
+	return c.inner.ParseLenient(input)
+}
+
+// TestParsedFileCache_AmortizesAcrossBatch locks in the parsedFileCache
+// optimization. Without it, every Analyze call in the explicit-package-
+// files branch re-reads and re-parses every sibling — turning a 37-file
+// package's sibling-discovery cost from O(N) into O(N²). With the cache,
+// re-running the same set of Analyze calls is essentially free at the
+// parser level.
+//
+// Strategy: warm the cache by transpiling all files once (parses fire,
+// fill cache and analyzedPkgs). Reset the parse counter. Run the same
+// loop again. The second pass must produce ~zero parses; allow up to 1
+// for any analyzer-internal noise we don't control.
+func TestParsedFileCache_AmortizesAcrossBatch(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"a.gala": "package pkg\n\nval a = 1\n",
+		"b.gala": "package pkg\n\nval b = 2\n",
+		"c.gala": "package pkg\n\nval c = 3\n",
+		"d.gala": "package pkg\n\nval d = 4\n",
+	}
+	paths := make([]string, 0, len(files))
+	for name, body := range files {
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(p, []byte(body), 0644))
+		paths = append(paths, p)
+	}
+
+	innerParser := transpiler.NewAntlrGalaParser()
+	counter := &parsedFileCounter{inner: innerParser}
+	batch := analyzer.NewBatchAnalyzer(counter, getStdSearchPath(), dir)
+
+	bodies := make(map[string]antlr.Tree)
+	for _, p := range paths {
+		body, err := os.ReadFile(p)
+		require.NoError(t, err)
+		tree, err := innerParser.Parse(string(body))
+		require.NoError(t, err)
+		bodies[p] = tree
+	}
+
+	transpileAll := func() {
+		for _, current := range paths {
+			var siblings []string
+			for _, other := range paths {
+				if other != current {
+					siblings = append(siblings, other)
+				}
+			}
+			batch.SetPackageFiles(siblings)
+			_, err := batch.Analyze(bodies[current], current)
+			require.NoError(t, err)
+		}
+	}
+
+	transpileAll() // warm
+	atomic.StoreInt64(&counter.calls, 0)
+	transpileAll() // measure
+
+	got := atomic.LoadInt64(&counter.calls)
+	if got > 1 {
+		t.Fatalf("parsedFileCache regression: %d Parse calls on warm pass across %d files; expected ~0 (sibling caches must hit on warm pass)",
+			got, len(paths))
+	}
+}
+
+// TestParsedFileCache_InvalidatesOnSizeChange proves the (mtime, size)
+// invalidation triggers when a file changes. Otherwise the cache could
+// mask edits in long-lived processes (LSP, watch mode).
+func TestParsedFileCache_InvalidatesOnSizeChange(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.gala")
+	b := filepath.Join(dir, "b.gala")
+	require.NoError(t, os.WriteFile(a, []byte("package pkg\n\nval a = 1\n"), 0644))
+	require.NoError(t, os.WriteFile(b, []byte("package pkg\n\nval b = 2\n"), 0644))
+
+	innerParser := transpiler.NewAntlrGalaParser()
+	counter := &parsedFileCounter{inner: innerParser}
+	batch := analyzer.NewBatchAnalyzer(counter, getStdSearchPath(), dir)
+
+	parse := func(p string) antlr.Tree {
+		body, err := os.ReadFile(p)
+		require.NoError(t, err)
+		tree, err := innerParser.Parse(string(body))
+		require.NoError(t, err)
+		return tree
+	}
+
+	batch.SetPackageFiles([]string{b})
+	_, err := batch.Analyze(parse(a), a)
+	require.NoError(t, err)
+	first := atomic.LoadInt64(&counter.calls)
+
+	batch.SetPackageFiles([]string{b})
+	_, err = batch.Analyze(parse(a), a)
+	require.NoError(t, err)
+	require.Equal(t, first, atomic.LoadInt64(&counter.calls), "expected cache hit on unchanged file")
+
+	// Rewrite b with different size — invalidation must fire.
+	require.NoError(t, os.WriteFile(b, []byte("package pkg\n\nval b2 = 99\nval bExtra = 42\n"), 0644))
+
+	batch.SetPackageFiles([]string{b})
+	_, err = batch.Analyze(parse(a), a)
+	require.NoError(t, err)
+	if atomic.LoadInt64(&counter.calls) <= first {
+		t.Fatalf("expected re-parse after b.gala size changed; counter still at %d", atomic.LoadInt64(&counter.calls))
+	}
+}


### PR DESCRIPTION
## Summary

Two coupled perf wins that fix the dominant cold-build cost in `gala build <subdir>`-style multi-package projects (e.g. `gala_tui`):

- **`transpileWithSourceDir` shares one `BatchAnalyzer`** across the library and consumer loops instead of allocating a fresh `galaAnalyzer` per file. Without this, every file re-analyzed std (~1.3s each) and the import graph cold-loaded N times.
- **`galaAnalyzer.parsedFileCache`** caches parsed sibling ASTs by canonical absolute path, invalidated on `(mtime, size)` mismatch. Survives `BatchAnalyzer.SetPackageFiles` so a 37-file package amortizes sibling parsing to ~N parses instead of N×(N−1). Wired into both the explicit-package-files branch in `Analyze` and the per-file read-and-parse loop in `analyzePackage`.

### Measured impact

`gala_tui` demo (37-file package, Windows):

| Scenario | Before | After |
|---|---|---|
| Cold build (`gala cache clean` + fresh workspace) | **67 s** | **~16 s** |
| Warm cache + touch one file | **56 s** | **~9 s** |
| Per-file `[analyze] sibling-discovery` | 1.3 s | 25–70 ms |

### Regression tests

Four locks against future regressions:

- `TestBatchAnalyzer_StdAnalyzedOnce` — counter-based proof that std is parsed once across multiple `Analyze` calls.
- `TestParsedFileCache_AmortizesAcrossBatch` — warm-then-measure proof that a second pass over the same package fires ~0 `Parse` calls.
- `TestParsedFileCache_InvalidatesOnSizeChange` — rewriting a sibling triggers re-parse.
- `TestTranspileWithSourceDir_UsesBatchAnalyzer` — AST-level static check that no fresh per-file analyzer is allocated inside the `transpileWithSourceDir` loops.

## Test plan

- [ ] `bazel test //...` — full suite green (277/277 locally)
- [ ] `gala cache clean && time gala build ./demo` in a multi-package project — verify cold build ≥ 3× speedup
- [ ] Smoke-test that LSP responsiveness is unchanged (this PR doesn't touch the LSP-only path that landed in #222)

🤖 Generated with [Claude Code](https://claude.com/claude-code)