### PR TITLE
fix(transformer): preserve generic return type in match-as-IIFE

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -626,6 +626,12 @@ gala_test(
     expected = "match_generic_inference.out",
 )
 
+gala_test(
+    name = "match_generic_return_dispatch",
+    src = "match_generic_return_dispatch.gala",
+    expected = "match_generic_return_dispatch.out",
+)
+
 # Transpiler issue repro tests
 gala_test(
     name = "tuple_field_unwrap",

--- a/examples/match_generic_return_dispatch.gala
+++ b/examples/match_generic_return_dispatch.gala
@@ -1,0 +1,29 @@
+package main
+
+import "fmt"
+
+sealed type Event {
+    case Press(Key string)
+    case Release
+}
+
+// Generic dispatcher: every branch returns T (the function's type parameter).
+// Regression for FIX-005: previously the match-as-IIFE collapsed the result
+// type to `any`, so the Go compiler rejected the IIFE result with
+// "cannot use ... (value of type any) as T value in return statement".
+// Fix: when every branch is typed as a type parameter and the enclosing
+// function declares a matching return type, the IIFE adopts that type.
+func dispatch[T any](e Event, fn func(string) T) T {
+    return e match {
+        case Press(k)  => fn(k)
+        case Release() => fn("none")
+    }
+}
+
+func main() {
+    val e1 = Press("ctrl+a")
+    val e2 = Release()
+    fmt.Println(dispatch[string](e1, (s string) => "key=" + s))
+    fmt.Println(dispatch[string](e2, (s string) => "key=" + s))
+    fmt.Println(dispatch[int](e1, (s string) => 42))
+}

--- a/examples/match_generic_return_dispatch.out
+++ b/examples/match_generic_return_dispatch.out
@@ -1,0 +1,3 @@
+key=ctrl+a
+key=none
+42

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -836,7 +836,22 @@ func (t *galaASTTransformer) inferCommonResultType(types []transpiler.Type, patt
 			t.traceType(nil, transpiler.VoidType{}, "match-result-fallback-to-void-dispatch")
 			return transpiler.VoidType{}, nil
 		}
-		// Type parameters or mixed type-param/nil: use 'any' as the Go type erasure
+		// Type parameters or mixed type-param/nil: prefer the enclosing
+		// function's return type when it matches one of the branch types.
+		// This handles `func f[T any](...) T { return e match { case ... => fnReturningT(...) } }`,
+		// where every branch yields the same type parameter T as the
+		// declared return — emitting `func(...) any` for the IIFE breaks
+		// the Go compile because `any` does not satisfy `T`.
+		// Fall back to `any` only when no branch type matches the enclosing return.
+		if t.currentFuncReturnType != nil && !t.currentFuncReturnType.IsNil() {
+			enclosingName := t.currentFuncReturnType.String()
+			for _, typ := range types {
+				if typ != nil && !typ.IsNil() && typ.String() == enclosingName {
+					t.traceType(nil, t.currentFuncReturnType, "match-result-fallback-to-enclosing-typeparam-return")
+					return t.currentFuncReturnType, nil
+				}
+			}
+		}
 		t.warnInference("match expression defaulting to 'any' return type (all branches are type parameters)")
 		return transpiler.BasicType{Name: "any"}, nil
 	}


### PR DESCRIPTION
## Summary

Fixes a codegen bug where a match expression in a generic function's return position emits an IIFE typed `any` instead of the function's type parameter `T`, causing the Go compiler to reject the result with `cannot use ... (value of type any) as T value in return statement`.

**Category**: TRANSPILER_BUG
**Priority**: P1 (blocks compilation of generic dispatch patterns)
**Surfaced**: battle-testing gala-tui's `harness.gala`

## Root cause

`inferCommonResultType` in `internal/transpiler/transformer/match.go` skips type-parameter branches (e.g., `T`, `U`) when picking the IIFE's reference type. When every branch yields the same type parameter, no reference is found, and the function falls through to a `BasicType{Name: "any"}` fallback. But because the enclosing function returns the same `T`, the IIFE collapse to `any` produces invalid Go.

There was already a similar fallback for the all-NilType case at the same call site (line 826) that consults `t.currentFuncReturnType`. This PR extends that pattern to the type-parameter case: if the enclosing function's declared return type matches one of the branch types by name, adopt it for the IIFE. Otherwise the existing `any` warning fallback kicks in.

## Repro (before fix)

```gala
sealed type Event {
    case Press(Key string)
    case Release
}

func dispatch[T any](e Event, fn func(string) T) T {
    return e match {
        case Press(k)  => fn(k)
        case Release() => fn(\"none\")
    }
}
```

Generated Go (broken):
```go
func dispatch[T any](e Event, fn func(string) T) T {
    return func(obj Event) any {  // <-- should be T
        ...
    }(e)
}
```

Go compiler error: `cannot use ... (value of type any) as T value in return statement: need type assertion`.

## After the fix

```go
func dispatch[T any](e Event, fn func(string) T) T {
    return func(obj Event) T {  // <-- now uses T
        ...
    }(e)
}
```

## Changes

- ` + "`internal/transpiler/transformer/match.go`" + ` — when all branch types are type parameters, prefer the enclosing function's return type if it matches a branch type by name (string equality on `Type.String()`); fall back to `any` with the existing inference warning otherwise.
- ` + "`examples/match_generic_return_dispatch.gala`" + ` (new) — minimal regression case: sealed `Event` with `dispatch[T any]` returning `T` from a match where every arm yields `T`.
- ` + "`examples/match_generic_return_dispatch.out`" + ` (new) — expected output.
- ` + "`examples/BUILD.bazel`" + ` — wires the new test target.

## Verification

- ` + "`bazel test //...`" + ` — **278/278 pass** (one more than master; the new regression target).
- ` + "`bazel test examples:match_generic_return_dispatch`" + ` — fails to compile before the fix, passes after.
- Battle-tested against ` + "`gala_tui`" + `: combined with PR for FIX-004 (perf), the gala-tui main library and ` + "`state`" + ` subpackage now build and test cleanly. (Demo subpackage has unrelated user-code issues.)

## Dependencies

None — this PR is independent of the FIX-004 perf PR. They both target ` + "`master`" + ` and can be reviewed/merged in any order.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)