### PR TITLE
fix(analyzer): preserve sealed-type methods registered by sibling extraction

### DIFF
--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -1324,6 +1324,23 @@ func (a *galaAnalyzer) analyzeSealedType(ctx *grammar.SealedTypeDeclarationConte
 		parentMeta.SealedVariants = append(parentMeta.SealedVariants, sv)
 	}
 
+	// Preserve methods from any pre-existing placeholder entry. Sibling
+	// extraction may have processed a method on this sealed type from another
+	// file (e.g. `func (w Widget) AsFixed(...)` in fluent.gala) before this
+	// declaration was reached. That earlier pass creates a placeholder
+	// TypeMetadata at extractSiblingFullMetadata's method branch (the `else`
+	// arm where richAST.Types[fullBaseType] is created with just the method).
+	// Without this merge, the assignment below would clobber those methods,
+	// breaking return-type resolution at the call site — which in turn breaks
+	// auto-unwrap of Immutable[T] fields on chained results.
+	if existing, ok := richAST.Types[fullTypeName]; ok {
+		for name, m := range existing.Methods {
+			if _, dup := parentMeta.Methods[name]; !dup {
+				parentMeta.Methods[name] = m
+			}
+		}
+	}
+
 	richAST.Types[fullTypeName] = parentMeta
 
 	// For each variant, create companion type and register methods

--- a/internal/transpiler/analyzer/analyzer_test.go
+++ b/internal/transpiler/analyzer/analyzer_test.go
@@ -250,6 +250,42 @@ func Describe(s Shape) string = s match {
 		assert.True(t, ok, "shapes.Circle companion should exist")
 	})
 
+	t.Run("sealed type preserves methods when method file is processed first", func(t *testing.T) {
+		// Regression: when sibling extraction processes a file declaring a
+		// method on a sealed type BEFORE processing the file with the sealed
+		// type declaration itself, analyzeSealedType used to overwrite the
+		// placeholder entry in richAST.Types and drop the registered Methods.
+		// Downstream this lost the method's return type, leaving val-bound
+		// chained calls untyped and suppressing the auto-inserted .Get() on
+		// subsequent field accesses (manifests as a Go build failure on the
+		// generated code).
+		//
+		// We trigger the bad ordering by analyzing the *method* file as the
+		// main tree (so its sibling extraction registers the method onto a
+		// placeholder Shape entry first), and supplying the *types* file as
+		// a package sibling (so analyzeSealedType runs second and overwrites).
+		methodContent := `package shapes
+
+func (s Shape) Tag() string = s match {
+    case Circle(_) => "c"
+    case Rect(_, _) => "r"
+}
+`
+		methodPath := filepath.Join(tmpDir, "method.gala")
+		require.NoError(t, os.WriteFile(methodPath, []byte(methodContent), 0644))
+
+		a := analyzer.NewGalaAnalyzerWithPackageFiles(p, searchPaths, []string{typesPath})
+		tree, err := p.Parse(methodContent)
+		require.NoError(t, err)
+		richAST, err := a.Analyze(tree, methodPath)
+		require.NoError(t, err)
+
+		shapeMeta, ok := richAST.Types["shapes.Shape"]
+		require.True(t, ok, "shapes.Shape should exist after sealed-decl processed")
+		require.Contains(t, shapeMeta.Methods, "Tag", "Tag method registered before analyzeSealedType ran should survive")
+		assert.Equal(t, "string", shapeMeta.Methods["Tag"].ReturnType.String())
+	})
+
 	t.Run("main package sibling has full field metadata", func(t *testing.T) {
 		// Test with main package (which was previously blocked for directory scanning)
 		mainTypesContent := `package main


### PR DESCRIPTION
## Summary

Fixes a transpiler bug where a method defined on a sealed type in a sibling file would be silently dropped if that sibling was processed before the file declaring the sealed type. The lost method then caused chained-call val bindings to lose their return type, suppressing the auto-inserted `.Get()` on subsequent `Immutable[T]` field accesses and producing Go code that failed to compile.

## Root cause

`extractSiblingFullMetadata`'s method branch creates a placeholder `TypeMetadata{Methods: {methodName: methodMeta}, Fields: {}}` when the receiver type isn't yet in `richAST.Types`. Later, when the sealed-type declaration is processed, `analyzeSealedType` built `parentMeta` from scratch and assigned `richAST.Types[fullTypeName] = parentMeta`, dropping the previously-registered methods. The sibling-struct path already merged with existing methods (`analyzer.go:2402-2407`); the sealed path was the outlier.

## Reproduction

In a multi-file library where:
- `fluent.gala` defines `func (w Widget) AsFixed(n int) LayoutChild = ...`
- `widget.gala` defines `sealed type Widget { ... }` and `struct LayoutChild(Constraint Constraint, Widget Widget)`
- `_test.gala` does `val lc = Text("x").AsFixed(3); lc.Constraint match { case Length(v) => ... }`

The generated Go code emits `lc.Get().Constraint` instead of the required `lc.Get().Constraint.Get()`, failing with:

```
cannot use lc.Get().Constraint (value of type std.Immutable[Constraint])
as Constraint value in argument to func(obj Constraint) bool {…}
```

## Fix

In `analyzeSealedType`, before assigning `parentMeta` into `richAST.Types`, copy over any methods already registered by an earlier sibling-extraction pass. `parentMeta`'s own methods (currently none — Apply/Unapply/IsXxx companions are added later) are kept on conflict.

## Test plan

- [x] Added regression in `TestPackageFilesFullMetadata` that triggers the bad ordering deliberately and verifies the method survives — fails before the fix, passes after.
- [x] `bazel test //...` — all 279 tests pass.
- [x] Verified end-to-end against the original gala-tui reproduction (inline `lc.Constraint match` on a chained `Text("x").AsFixed(3)` result) — generated `.Get()` correctly emitted, test compiles and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)