### PR TITLE
fix(type-inference): propagate parent sealed type's parameter into case constructors

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -851,6 +851,13 @@ gala_test(
 )
 
 gala_test(
+    name = "sealed_case_type_param_from_context",
+    src = "sealed_case_type_param_from_context.gala",
+    expected = "sealed_case_type_param_from_context.out",
+    deps = ["//collection_immutable"],
+)
+
+gala_test(
     name = "match_void_dispatch",
     src = "match_void_dispatch.gala",
     expected = "match_void_dispatch.out",

--- a/examples/sealed_case_type_param_from_context.gala
+++ b/examples/sealed_case_type_param_from_context.gala
@@ -1,0 +1,33 @@
+package main
+
+import . "martianoff/gala/collection_immutable"
+
+sealed type Step[T any] {
+    case StepA(N int)
+    case StepB(Text string)
+}
+
+func main() {
+    // Named-arg case constructors infer T from the enclosing
+    // ArrayOf[Step[int]] element type.
+    val steps = ArrayOf[Step[int]](
+        StepA(N = 1),
+        StepB(Text = "x"),
+    )
+    Println(s"named=${steps.Length()}")
+
+    // Positional case constructors infer T the same way.
+    val pos = ArrayOf[Step[int]](
+        StepA(2),
+        StepB("y"),
+    )
+    Println(s"positional=${pos.Length()}")
+
+    // Existing behavior: explicit type args on the variant still works
+    // (rewrite must not clobber an already-instantiated reference).
+    val explicit = ArrayOf[Step[int]](
+        StepA[int](3),
+        StepB[int](Text = "z"),
+    )
+    Println(s"explicit=${explicit.Length()}")
+}

--- a/examples/sealed_case_type_param_from_context.out
+++ b/examples/sealed_case_type_param_from_context.out
@@ -1,0 +1,3 @@
+named=2
+positional=2
+explicit=2

--- a/internal/transpiler/transformer/call_context.go
+++ b/internal/transpiler/transformer/call_context.go
@@ -120,6 +120,29 @@ func (t *galaASTTransformer) resolveExpectedFuncArgType(ctx callContext, argIdx 
 		}
 	}
 
+	// Non-FuncType expected type with resolved generic substitution: propagate
+	// the concrete element type so downstream inference (e.g. sealed-variant
+	// type-arg propagation in transformCallWithArgsCtx) can use it. For
+	// variadic functions, GALA records the trailing param as a single element
+	// type, so any arg index past the declared count falls back to the last
+	// param. Only emit when substitution actually produces a concrete type;
+	// passing through a bare type param like `T` is not useful here.
+	if expectedType.IsNil() && ctx.funcMeta != nil && len(ctx.typeSubst) > 0 && len(ctx.funcMeta.ParamTypes) > 0 {
+		paramIdx := argIdx
+		if paramIdx >= len(ctx.funcMeta.ParamTypes) {
+			paramIdx = len(ctx.funcMeta.ParamTypes) - 1
+		}
+		paramType := ctx.funcMeta.ParamTypes[paramIdx]
+		if !paramType.IsNil() {
+			if _, isFunc := paramType.(transpiler.FuncType); !isFunc {
+				substituted := t.substituteTranspilerTypeParams(paramType, ctx.typeSubst)
+				if substituted != nil && !substituted.IsNil() && substituted.String() != paramType.String() {
+					expectedType = substituted
+				}
+			}
+		}
+	}
+
 	// Fall back to Go type info for lambda expected types
 	if expectedType.IsNil() && ctx.goParamTypes != nil && argIdx < len(ctx.goParamTypes) {
 		if ft, ok := ctx.goParamTypes[argIdx].(transpiler.FuncType); ok {

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -1241,6 +1241,22 @@ func (t *galaASTTransformer) tryTransformValWithApply(fun ast.Expr, args []ast.E
 // rather than growing this dispatcher. Each helper is independently testable
 // and carries its own doc comment describing the sub-path it handles.
 func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *grammar.ArgumentListContext) (ast.Expr, error) {
+	// Consume the expected-type hint (set by transformArgumentWithExpectedType
+	// for the immediately-enclosing call). Cleared eagerly so nested arg
+	// transforms inside this call don't pick up the outer call's expectation.
+	pendingExpected := t.pendingExpectedArgType
+	t.pendingExpectedArgType = nil
+
+	// Sealed-variant type-arg propagation: when the expected type is a
+	// generic sealed parent (e.g. `Step[int]`) and `fun` names one of its
+	// variants without explicit type args (`StepA(...)`), inject the parent's
+	// type args into `fun` so downstream codegen emits `StepA[int]{}.Apply(...)`.
+	if pendingExpected != nil && !pendingExpected.IsNil() {
+		if rewritten, ok := t.injectSealedVariantTypeArgs(fun, pendingExpected); ok {
+			fun = rewritten
+		}
+	}
+
 	// --- Section 1: Copy method short-circuit ---
 	if sel, ok := fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Copy" {
 		return t.transformCopyCall(sel.X, argListCtx)
@@ -1656,6 +1672,84 @@ func (t *galaASTTransformer) findSealedVariantFields(variantName string) []strin
 	return nil
 }
 
+// findSealedParentForVariant returns the parent sealed type's metadata for a
+// given variant name, or nil if the name is not a known sealed variant.
+func (t *galaASTTransformer) findSealedParentForVariant(variantName string) *transpiler.TypeMetadata {
+	for _, meta := range t.typeMetas {
+		if !meta.IsSealed {
+			continue
+		}
+		for _, sv := range meta.SealedVariants {
+			if sv.Name == variantName {
+				return meta
+			}
+		}
+	}
+	return nil
+}
+
+// injectSealedVariantTypeArgs rewrites a bare sealed-variant reference (an
+// Ident or package-qualified SelectorExpr without explicit type args) into
+// the equivalent generic instantiation when the expected type is the
+// variant's parent sealed type with concrete type arguments.
+//
+// For example, when the call site is `ArrayOf[Step[int]](StepA(N=1))`, the
+// argument's expected type is `Step[int]`. This helper rewrites the bare
+// `StepA` ident into `StepA[int]` so the downstream sealed-variant codegen
+// emits `StepA[int]{}.Apply(1)` instead of `StepA{}.Apply(1)` — Go cannot
+// otherwise infer the variant's vestigial type parameter from an empty
+// composite literal whose `T` does not appear in any field.
+//
+// Returns the rewritten expression and true on success; returns the original
+// expression and false when the rewrite does not apply.
+func (t *galaASTTransformer) injectSealedVariantTypeArgs(fun ast.Expr, expected transpiler.Type) (ast.Expr, bool) {
+	// Already has explicit type args — nothing to do.
+	switch fun.(type) {
+	case *ast.IndexExpr, *ast.IndexListExpr:
+		return fun, false
+	}
+
+	// Resolve the bare variant name from the call target.
+	var variantName string
+	switch f := fun.(type) {
+	case *ast.Ident:
+		variantName = f.Name
+	case *ast.SelectorExpr:
+		variantName = f.Sel.Name
+	default:
+		return fun, false
+	}
+	if variantName == "" {
+		return fun, false
+	}
+
+	parent := t.findSealedParentForVariant(variantName)
+	if parent == nil || len(parent.TypeParams) == 0 {
+		return fun, false
+	}
+
+	// Expected type must be the parent sealed generic with concrete params.
+	gen, ok := expected.(transpiler.GenericType)
+	if !ok || gen.BaseName() != parent.Name {
+		return fun, false
+	}
+	if len(gen.Params) != len(parent.TypeParams) {
+		return fun, false
+	}
+
+	typeArgs := make([]ast.Expr, len(gen.Params))
+	for i, p := range gen.Params {
+		if p == nil || p.IsNil() {
+			return fun, false
+		}
+		typeArgs[i] = t.typeToExpr(p)
+	}
+	if len(typeArgs) == 1 {
+		return &ast.IndexExpr{X: fun, Index: typeArgs[0]}, true
+	}
+	return &ast.IndexListExpr{X: fun, Indices: typeArgs}, true
+}
+
 // parseDefaultExpr parses a GALA expression string (from a default parameter value)
 // into an ANTLR expression context that can be transformed by the normal pipeline.
 func (t *galaASTTransformer) parseDefaultExpr(exprText string) (grammar.IExpressionContext, error) {
@@ -1965,6 +2059,17 @@ func (t *galaASTTransformer) transformArgumentWithExpectedType(exprCtx grammar.I
 		return nil, err
 	} else if handled {
 		return expr, nil
+	}
+
+	// Bidirectional inference for sealed-variant constructors: stash the
+	// expected type so that a call expression nested directly inside this
+	// argument can pick up the parent sealed type's type arguments. The
+	// dispatcher in transformCallWithArgsCtx consumes-and-clears this value
+	// on entry, so deeper sub-expressions don't accidentally see it.
+	if expectedType != nil && !expectedType.IsNil() {
+		prev := t.pendingExpectedArgType
+		t.pendingExpectedArgType = expectedType
+		defer func() { t.pendingExpectedArgType = prev }()
 	}
 
 	// Not a lambda or partial function, transform normally

--- a/internal/transpiler/transformer/transformer.go
+++ b/internal/transpiler/transformer/transformer.go
@@ -61,6 +61,7 @@ type galaASTTransformer struct {
 	structMetas           map[string]*structMetaConfig  // generated StructMeta structs (keyed by generated name)
 	instanceInterfaceNames map[string]string            // type name -> actual generated interface name (for collision avoidance)
 	expectedIfExprType     ast.Expr                     // expected return type for if-expression IIFE (set by expression-bodied function handler)
+	pendingExpectedArgType transpiler.Type              // expected type for the next call expression being transformed (consumed and cleared by transformCallWithArgsCtx for sealed-variant type-arg propagation)
 	lspVarTypes            map[string]transpiler.Type   // LSP: collects all resolved var types during transformation
 	lspCurrentFunc         string                       // LSP: name of the function currently being transformed (for scoping)
 	lspLambdaParamHints    []transpiler.LambdaParamHint // LSP: positions of lambda params with inferred types


### PR DESCRIPTION
## Summary

Inside `ArrayOf[Parent[T]](Case(...), Case(...))`, sealed-case constructors had to spell out the parent's type parameter explicitly (`Case[T](...)`) — even when the type parameter wasn't present in any case-field's type and could only come from the enclosing element type. The transpiler emitted:

```
[SemanticError] cannot use generic type harness.StepKey[T any] without instantiation
```

This forced every test that scripted a sequence of inputs to repeat the type parameter on every step constructor.

## Root Cause

Sealed-variant calls reach either `handleNamedArgsCall → buildSealedVariantApplyCall` (named args) or `tryTransformCompanionApplyOrStructCtor` (positional). Both paths inferred type args only from the variant's own field types and the enclosing function's return type. When the variant has no field of type `T` (e.g. `StepKey(N int)` with parent `Step[T]`) and the call sits inside `ArrayOf[Step[int]](...)`, neither inference source can resolve `T`. The expected element type from the enclosing call was never plumbed down to the variant's typing pass — `resolveExpectedFuncArgType` only emitted `FuncType` expected types (a leftover from when expected types existed solely to feed lambda parameter inference).

## Changes

- `internal/transpiler/transformer/transformer.go` — new `pendingExpectedArgType transpiler.Type` (single-shot hint; consumed-and-cleared by `transformCallWithArgsCtx` on entry so nested sub-expressions don't see leaked state)
- `internal/transpiler/transformer/calls.go` — set the hint in `transformArgumentWithExpectedType`; consume + rewrite in `transformCallWithArgsCtx`; new `injectSealedVariantTypeArgs` and `findSealedParentForVariant` helpers
- `internal/transpiler/transformer/call_context.go` — extended expected-type cascade so non-`FuncType` expected types surface when the function has resolved generic substitutions (variadic-aware fallback for arg indices past the declared param count)
- `examples/sealed_case_type_param_from_context.gala` + `.out` — covers named-arg, positional, and explicit-type-args call shapes

## Verification

- New example exercises bare `StepA(N = 1)` and `StepB("x")` inside `ArrayOf[Step[int]](...)`. Generated Go shows `StepA[int]{}.Apply(1)` and `StepB[int]{}.Apply("x")`.
- Pre-existing explicit `StepA[int](3)` continues to work unchanged.
- `bazel build //...` passes
- `bazel test //...` passes (282/282)

Production code delta: ~115 lines.

## Repro (before fix)

```gala
import . "martianoff/gala/collection_immutable"

sealed type Step[T any] {
    case StepA(N int)
    case StepB(Text string)
}

val steps = ArrayOf[Step[int]](
    StepA(N = 1),       // [SemanticError] without instantiation
    StepB(Text = "x"),  // [SemanticError] without instantiation
)
```

## Dependencies

None — this PR can be reviewed and merged independently.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)