### PR TITLE
fix(resolver): prefer gala.mod over walked-up go.mod and recognise replace deps

### DIFF
--- a/internal/build/builder_test.go
+++ b/internal/build/builder_test.go
@@ -346,3 +346,110 @@ func TestEnsureDeps_LocalReplaceSkipsFetch(t *testing.T) {
 	got := b.effectiveDepDir(mod.Require{Path: "example.com/parent", Version: "v0.0.0"})
 	require.Equal(t, filepath.Clean(parent), got)
 }
+
+// TestTranspile_CrossModuleSealedCaseEmitsApply verifies that a consumer
+// project consuming a sealed type from a separately declared GALA module
+// (via require + local replace in gala.mod) lowers a sealed-case constructor
+// call as `Type[T]{}.Apply(...)` rather than as a bare type conversion
+// `Type[T](...)` that Go rejects on a zero-field struct.
+//
+// Layout (all under t.TempDir()):
+//
+//	parent/
+//	  gala.mod          module example.com/qalib
+//	  effects.gala      sealed type Effect[T] { case Halt() ... }
+//	consumer/
+//	  gala.mod          module example.com/qaconsumer
+//	                    require example.com/qalib v0.0.0
+//	                    replace example.com/qalib => ../parent
+//	  main.gala         import . "example.com/qalib"
+//	                    func mkHalt() Effect[int] = Halt[int]()
+//	                    func main() { val h = mkHalt(); Println(h.String()) }
+//
+// The bug being guarded: cross-module GALA dependencies served via local
+// replace were being misclassified as Go packages because the module-root
+// discovery preferred a stray parent go.mod over the project's gala.mod and
+// because IsGalaPackage relied on a cache lookup that fails for never-fetched
+// modules. As a result the consumer's analyzer dropped the dependency's
+// sealed-type Apply method metadata, and the transformer emitted
+// `Halt[int]()` which Go rejects with "missing argument in conversion".
+func TestTranspile_CrossModuleSealedCaseEmitsApply(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Library module with the sealed type.
+	libDir := filepath.Join(tmp, "qa_lib")
+	require.NoError(t, os.MkdirAll(libDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(libDir, "gala.mod"),
+		[]byte("module example.com/qalib\n\ngala 0.0.0\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(libDir, "effects.gala"),
+		[]byte("package qalib\n\nsealed type Effect[T any] {\n    case Halt()\n    case Yield(Val T)\n}\n"),
+		0644))
+
+	// Consumer module using the lib via local replace.
+	consumerDir := filepath.Join(tmp, "qa_consumer")
+	require.NoError(t, os.MkdirAll(consumerDir, 0755))
+	consumerGalaMod := `module example.com/qaconsumer
+
+gala 0.0.0
+
+require example.com/qalib v0.0.0
+
+replace example.com/qalib => ../qa_lib
+`
+	require.NoError(t, os.WriteFile(filepath.Join(consumerDir, "gala.mod"),
+		[]byte(consumerGalaMod), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(consumerDir, "main.gala"),
+		[]byte("package main\n\nimport . \"example.com/qalib\"\n\nfunc mkHalt() Effect[int] = Halt[int]()\n\nfunc main() {\n    val h = mkHalt()\n    Println(h.String())\n}\n"),
+		0644))
+
+	// Isolate any per-user gala state to t.TempDir() to avoid clobbering the
+	// developer's real ~/.gala cache and to keep the test hermetic.
+	origHome, hadHome := os.LookupEnv("HOME")
+	origUserProfile, hadProfile := os.LookupEnv("USERPROFILE")
+	isolated := t.TempDir()
+	os.Setenv("HOME", isolated)
+	os.Setenv("USERPROFILE", isolated)
+	t.Cleanup(func() {
+		if hadHome {
+			os.Setenv("HOME", origHome)
+		} else {
+			os.Unsetenv("HOME")
+		}
+		if hadProfile {
+			os.Setenv("USERPROFILE", origUserProfile)
+		} else {
+			os.Unsetenv("USERPROFILE")
+		}
+	})
+
+	// Make cwd the consumer dir so resolver discovery walks up from there.
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(originalWd) })
+	require.NoError(t, os.Chdir(consumerDir))
+
+	b, err := NewBuilder(consumerDir, "test", false)
+	require.NoError(t, err)
+	require.NoError(t, b.workspace.Ensure())
+
+	// transpileDeps populates the dep workspace with effects.gen.go.
+	require.NoError(t, b.ensureStdlib())
+	require.NoError(t, b.transpileDeps())
+
+	// Transpile the consumer. This is the step that hits the resolver and
+	// must classify example.com/qalib as a GALA package via the local
+	// replace directive.
+	require.NoError(t, b.transpile())
+
+	// Read the generated consumer Go file and assert it lowers the sealed
+	// case constructor as `Halt[int]{}.Apply()`, not as a bare conversion.
+	mainGen := filepath.Join(b.workspace.GenDir, "main.gen.go")
+	data, err := os.ReadFile(mainGen)
+	require.NoError(t, err, "consumer main.gen.go must be produced")
+	got := string(data)
+
+	require.Contains(t, got, "Halt[int]{}.Apply()",
+		"sealed case constructor must lower to {}.Apply() form, got:\n%s", got)
+	require.NotContains(t, got, "Halt[int]()",
+		"sealed case constructor must not lower to a bare type conversion, got:\n%s", got)
+}

--- a/internal/transpiler/module/resolver.go
+++ b/internal/transpiler/module/resolver.go
@@ -37,29 +37,43 @@ type Resolver struct {
 // 4. Load gala.mod if present (for replace directives and dependencies)
 // 5. Initialize the GALA dependency cache
 func NewResolver(searchPaths []string) *Resolver {
-	moduleRoot, moduleName := findModuleRootFromCwdOrPaths(searchPaths)
-
 	r := &Resolver{
-		moduleRoot:  moduleRoot,
-		moduleName:  moduleName,
 		searchPaths: searchPaths,
 		cache:       fetch.NewCache(fetch.DefaultConfig()),
 	}
 
-	// Try to load gala.mod if module root was found
-	if moduleRoot != "" {
-		r.loadGalaMod(moduleRoot)
-	} else {
-		// If no go.mod found, try to find gala.mod directly
-		galaModRoot := findGalaModRoot(searchPaths)
-		if galaModRoot != "" {
-			r.moduleRoot = galaModRoot
-			r.loadGalaMod(galaModRoot)
-			// If gala.mod was loaded, use its module name
-			if r.galaMod != nil {
-				r.moduleName = r.galaMod.Module.Path
+	// Prefer a gala.mod located in (or above) one of the search paths over an
+	// unrelated parent go.mod found by walking up from cwd. The first search
+	// path is the project directory; if it (or one of its ancestors stopping
+	// at a gala.mod) declares the module, that is the authoritative module
+	// for this build. Without this preference a project under e.g.
+	// /tmp/qa_consumer that has no go.mod will inherit a stale parent go.mod
+	// (e.g. /tmp/go.mod), and require/replace directives in the project's
+	// gala.mod will be invisible — so cross-module GALA dependencies are
+	// silently demoted to "Go package" and their TypeMetadata is dropped.
+	galaModRoot := findGalaModRoot(searchPaths)
+	if galaModRoot != "" {
+		r.moduleRoot = galaModRoot
+		r.loadGalaMod(galaModRoot)
+		if r.galaMod != nil && r.galaMod.Module.Path != "" {
+			r.moduleName = r.galaMod.Module.Path
+		}
+		// Fall back to go.mod-derived module name only if gala.mod did not
+		// declare one (rare).
+		if r.moduleName == "" {
+			if _, modName := FindModuleRoot(galaModRoot); modName != "" {
+				r.moduleName = modName
 			}
 		}
+		return r
+	}
+
+	// No gala.mod anywhere — fall back to go.mod discovery (legacy behaviour).
+	moduleRoot, moduleName := findModuleRootFromCwdOrPaths(searchPaths)
+	r.moduleRoot = moduleRoot
+	r.moduleName = moduleName
+	if moduleRoot != "" {
+		r.loadGalaMod(moduleRoot)
 	}
 
 	return r
@@ -330,6 +344,20 @@ func (r *Resolver) IsGalaPackage(importPath string) bool {
 		return ok
 	}()) {
 		return true
+	}
+
+	// Check replace directives first: a require like
+	//     require example.com/qalib v0.0.0
+	//     replace example.com/qalib => ../qa_lib
+	// resolves through the local path, never touching the cache. Without
+	// this branch IsGalaPackage falls back to isGalaPackageInCache, which
+	// fails because the dependency was never fetched, and the dep is then
+	// misclassified as a Go package — its .gala-derived TypeMetadata is
+	// then dropped on the consumer side (sealed-case Apply lowering breaks).
+	if r.galaMod != nil {
+		if replaced := r.applyReplace(importPath); replaced != "" {
+			return isGalaDir(replaced)
+		}
 	}
 
 	// Check gala.mod require list
@@ -700,4 +728,17 @@ func hasGalaFiles(dirPath string) bool {
 		}
 	}
 	return false
+}
+
+// isGalaDir reports whether the given directory contains a gala.mod or
+// any .gala source file (signalling that the resolved replacement points
+// at a real GALA package, not at a Go-only directory).
+func isGalaDir(dirPath string) bool {
+	if !isValidPackageDir(dirPath) {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(dirPath, "gala.mod")); err == nil {
+		return true
+	}
+	return hasGalaFiles(dirPath)
 }

--- a/internal/transpiler/module/resolver_test.go
+++ b/internal/transpiler/module/resolver_test.go
@@ -242,3 +242,90 @@ replace github.com/example/utils => ../local-utils
 	require.NoError(t, err)
 	assert.Equal(t, localPkgDir, filepath.Clean(path))
 }
+
+// TestResolver_IsGalaPackage_LocalReplace verifies that a require + replace
+// pointing at a local directory containing .gala files (or a gala.mod) is
+// classified as a GALA package. Without this, cross-module GALA dependencies
+// served via local replace would be misclassified as Go packages because the
+// cache lookup fails for never-fetched modules.
+func TestResolver_IsGalaPackage_LocalReplace(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "resolver_xmod_local_replace_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Local GALA library with gala.mod and a .gala source file.
+	libDir := filepath.Join(tempDir, "qa_lib")
+	require.NoError(t, os.MkdirAll(libDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(libDir, "gala.mod"),
+		[]byte("module example.com/qalib\n\ngala dev\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(libDir, "effects.gala"),
+		[]byte("package qalib\n"), 0644))
+
+	// Consumer with gala.mod that requires the lib via local replace.
+	consumerDir := filepath.Join(tempDir, "qa_consumer")
+	require.NoError(t, os.MkdirAll(consumerDir, 0755))
+	galaModContent := `module example.com/qaconsumer
+
+gala dev
+
+require example.com/qalib v0.0.0
+
+replace example.com/qalib => ../qa_lib
+`
+	require.NoError(t, os.WriteFile(filepath.Join(consumerDir, "gala.mod"),
+		[]byte(galaModContent), 0644))
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalWd)
+	require.NoError(t, os.Chdir(consumerDir))
+
+	resolver := NewResolver(nil)
+	require.True(t, resolver.HasGalaMod(),
+		"consumer's gala.mod must be loaded — otherwise replace directives are invisible")
+	require.Equal(t, "example.com/qaconsumer", resolver.ModuleName(),
+		"module name must come from gala.mod, not a stray parent go.mod")
+
+	// The consumer's GALA dependency, served via local replace, must classify
+	// as a GALA package. If this returns false the analyzer routes the dep
+	// through AnalyzeGoPackage and drops sealed-type Apply method metadata,
+	// causing the transformer to emit a bare conversion call on the consumer
+	// side instead of `Type[T]{}.Apply(...)`.
+	assert.True(t, resolver.IsGalaPackage("example.com/qalib"),
+		"locally replaced GALA dependency must be recognised as a GALA package")
+}
+
+// TestResolver_PrefersGalaModOverParentGoMod verifies that when a project
+// directory has gala.mod but lives under an unrelated parent go.mod, the
+// resolver picks the project's gala.mod as the authoritative module root
+// rather than the parent go.mod. This ensures the project's replace and
+// require directives are loaded.
+func TestResolver_PrefersGalaModOverParentGoMod(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "resolver_prefer_galamod_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Unrelated parent go.mod above the project — simulates running gala
+	// build inside e.g. /tmp/my_project where /tmp/go.mod exists.
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "go.mod"),
+		[]byte("module unrelated/parent\n\ngo 1.22\n"), 0644))
+
+	// Project directory: only gala.mod, no go.mod.
+	projectDir := filepath.Join(tempDir, "project")
+	require.NoError(t, os.MkdirAll(projectDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "gala.mod"),
+		[]byte("module example.com/project\n\ngala dev\n"), 0644))
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalWd)
+	require.NoError(t, os.Chdir(projectDir))
+
+	resolver := NewResolver(nil)
+	require.True(t, resolver.HasGalaMod(),
+		"project's gala.mod must be loaded, not the parent go.mod")
+	assert.Equal(t, "example.com/project", resolver.ModuleName(),
+		"module name must come from gala.mod (example.com/project), not parent go.mod (unrelated/parent)")
+	assert.Equal(t, projectDir, resolver.ModuleRoot(),
+		"module root must be the project directory, not the parent")
+}


### PR DESCRIPTION
## Summary

Sealed-type case constructors codegen as invalid Go conversion form `Case[T](...)` instead of `Case[T]{}.Apply()` when the consumer's project consumes a separately declared GALA module via `gala.mod` `require` + local `replace`. PR #230 attempted to fix this via `synthesizeTypeMetadataFromGo` but its gate (`len(pkgAST.Types) == 0`) never fires in real cross-module setups because the resolver successfully reads the dependency's `.gala` source — so the bug remained.

This PR fixes the actual root cause one layer higher: the resolver was misclassifying `replace`-served GALA dependencies as Go packages.

## Root Cause

Two issues in `internal/transpiler/module/resolver.go`:

1. **`NewResolver` walked up from cwd looking for `go.mod` first** and only fell back to `gala.mod` when no `go.mod` was found. A consumer project with only `gala.mod` (no sibling `go.mod`) sitting under any unrelated parent `go.mod` (e.g. `/tmp/go.mod`) inherited that stray module root, so the project's `gala.mod` `require`/`replace` directives were never loaded.

2. **`IsGalaPackage` only checked the GALA dep cache** for non-prelude packages. A `require example.com/qalib v0.0.0; replace example.com/qalib => ../qa_lib` resolves through the local path and never touches the cache, so `IsGalaPackage` returned false and the cross-module GALA dependency was misclassified as a Go package — the analyzer then routed it through `AnalyzeGoPackage` which only consumes `.gen.go` artifacts, dropping the dependency's sealed-type Apply method metadata. The transformer's `getTypeMeta` then returned nil and the `{}.Apply()` lowering gate was skipped.

## Changes

- `internal/transpiler/module/resolver.go`:
  - `NewResolver` reordered: try `findGalaModRoot(searchPaths)` first; fall back to legacy `findModuleRootFromCwdOrPaths` only if no `gala.mod` is found anywhere.
  - `IsGalaPackage`: new replace-directive branch that resolves the local path via `applyReplace` and classifies via the new `isGalaDir` helper (presence of `gala.mod` or any `.gala` file).
  - New `isGalaDir(dirPath)` helper.
- `internal/transpiler/module/resolver_test.go`: two new unit tests:
  - `TestResolver_IsGalaPackage_LocalReplace` — replaced GALA deps classify as GALA without cache lookup.
  - `TestResolver_PrefersGalaModOverParentGoMod` — `gala.mod` takes precedence over an unrelated parent `go.mod`.
- `internal/build/builder_test.go`: new end-to-end test:
  - `TestTranspile_CrossModuleSealedCaseEmitsApply` — builds a two-module layout under `t.TempDir()` via the real GALA build pipeline (`ensureStdlib + transpileDeps + transpile`), asserts the consumer's `main.gen.go` contains `Halt[int]{}.Apply()` and not `Halt[int]()`. Isolates `HOME`/`USERPROFILE` so the test is hermetic.

## Verification

- The new end-to-end test FAILS on master and PASSES on this branch — independently confirmed.
- Real `gala build` CLI against the same two-module layout: master fails with `gen\main.gen.go:10:9: missing argument in conversion to qalib.Halt[int]`; this branch produces `Halt[int]{}.Apply()` and the consumer binary runs cleanly.
- `bazel build //...` passes
- `bazel test //...` passes (281/281)

## Repro (before fix)

```
/tmp/qa_lib/gala.mod          module example.com/qalib (gala dev)
/tmp/qa_lib/effects.gala      package qalib
                              sealed type Effect[T any] {
                                  case Halt()
                                  case Yield(Val T)
                              }

/tmp/qa_consumer/gala.mod     module example.com/qaconsumer
                              gala dev
                              require example.com/qalib v0.0.0
                              replace example.com/qalib => ../qa_lib
/tmp/qa_consumer/main.gala    package main
                              import . "example.com/qalib"
                              func mkHalt() Effect[int] = Halt[int]()
                              func main() { val h = mkHalt(); Println("ok") }
```

`cd /tmp/qa_consumer && gala build` on master generates:
```go
return Halt[int]()  // BAD — Go reads as type conversion on empty struct
```
Compile error: `missing argument in conversion to qalib.Halt[int]`.

After this PR:
```go
return Halt[int]{}.Apply()
```

## Notes

- PR #230's `synthesizeTypeMetadataFromGo` (in `analyzer.go`) remains in place. With this resolver fix, the dep's `.gala` source is now correctly scanned, so the synthesis gate `len(pkgAST.Types) == 0` no longer fires (it never fired in practice anyway). The synthesis code is harmless but can be removed in a separate cleanup PR.

## Dependencies

None — this PR can be reviewed and merged independently.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)