### PR TITLE
fix(type-inference): infer sealed-case type args for qualified variant references

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -13,6 +13,8 @@ filegroup(
         "cross_file_unwrap/types.gala",
         "cross_file_unwrap_lib/ops.gala",
         "cross_file_unwrap_lib/types.gala",
+        "cross_pkg_sealed_var/step/step.gala",
+        "cross_pkg_sealed_var_test.gala",
         "cross_pkg_try_match/corelib/corelib.gala",
         "cross_pkg_try_match/main.gala",
         "foldleft_method/main.gala",
@@ -1521,6 +1523,26 @@ gala_test(
         ":cross_pkg_try_match_corelib",
         "//concurrent",
     ],
+)
+
+# Regression: cross-package generic sealed-case constructors must pick up the
+# parent's type parameter from the enclosing call context. The same-package
+# variant of this rewrite was added in the previous release; this verifies
+# the qualified-reference shape (`pkg.Variant(...)`) goes through the same
+# inference path.
+gala_library(
+    name = "cross_pkg_sealed_var_step",
+    srcs = ["cross_pkg_sealed_var/step/step.gala"],
+    importpath = "martianoff/gala/examples/cross_pkg_sealed_var/step",
+    visibility = ["//visibility:public"],
+)
+
+gala_test(
+    name = "cross_pkg_sealed_var_test",
+    src = "cross_pkg_sealed_var_test.gala",
+    expected = "cross_pkg_sealed_var_test.out",
+    gala_deps = [":cross_pkg_sealed_var_step"],
+    deps = ["//collection_immutable"],
 )
 
 # Repro: type alias for func type in library package + match through alias

--- a/examples/cross_pkg_sealed_var/step/step.gala
+++ b/examples/cross_pkg_sealed_var/step/step.gala
@@ -1,0 +1,9 @@
+package step
+
+// A generic sealed type whose type parameter does not appear in any case
+// field. The transpiler must still infer the parameter at the call site by
+// looking at the enclosing element type (e.g., ArrayOf[step.Step[int]](...)).
+sealed type Step[T any] {
+    case StepA(N int)
+    case StepB(Text string)
+}

--- a/examples/cross_pkg_sealed_var_test.gala
+++ b/examples/cross_pkg_sealed_var_test.gala
@@ -1,0 +1,29 @@
+package main
+
+import . "martianoff/gala/collection_immutable"
+import "martianoff/gala/examples/cross_pkg_sealed_var/step"
+
+// Verifies that a generic sealed type imported from another package picks up
+// its type parameter from the enclosing call context. Without the fix, the
+// bare `step.StepA(...)` reference fell through the type-arg injection (the
+// helper only handled bare *ast.Ident shapes) and Go rejected the result with
+// "cannot use generic type without instantiation".
+func main() {
+    val named = ArrayOf[step.Step[int]](
+        step.StepA(N = 1),
+        step.StepB(Text = "x"),
+    )
+    Println(s"named=${named.Length()}")
+
+    val positional = ArrayOf[step.Step[int]](
+        step.StepA(2),
+        step.StepB("y"),
+    )
+    Println(s"positional=${positional.Length()}")
+
+    val explicit = ArrayOf[step.Step[int]](
+        step.StepA[int](3),
+        step.StepB[int](Text = "z"),
+    )
+    Println(s"explicit=${explicit.Length()}")
+}

--- a/examples/cross_pkg_sealed_var_test.out
+++ b/examples/cross_pkg_sealed_var_test.out
@@ -1,0 +1,3 @@
+named=2
+positional=2
+explicit=2

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -1674,10 +1674,35 @@ func (t *galaASTTransformer) findSealedVariantFields(variantName string) []strin
 
 // findSealedParentForVariant returns the parent sealed type's metadata for a
 // given variant name, or nil if the name is not a known sealed variant.
-func (t *galaASTTransformer) findSealedParentForVariant(variantName string) *transpiler.TypeMetadata {
+//
+// pkgQualifier is the optional package qualifier from the call site (e.g.
+// "step" when the call target is `step.StepA(...)`). When non-empty it
+// restricts the search to sealed parents whose package matches the
+// qualifier; the qualifier is resolved through the import manager so an
+// alias (`import alias "real/pkg"`) maps to the canonical package name
+// before comparison.
+func (t *galaASTTransformer) findSealedParentForVariant(variantName, pkgQualifier string) *transpiler.TypeMetadata {
+	// Resolve a possible import alias to the actual package name; metadata
+	// is registered under the real package, not the alias.
+	actualPkg := pkgQualifier
+	if pkgQualifier != "" {
+		if resolved, ok := t.importManager.ResolveAlias(pkgQualifier); ok {
+			actualPkg = resolved
+		}
+	}
+
 	for _, meta := range t.typeMetas {
 		if !meta.IsSealed {
 			continue
+		}
+		if pkgQualifier != "" {
+			// Restrict to the named package — variants from other packages
+			// might happen to share a name (e.g. two `Some` variants), and
+			// using one parent's type args on another parent's variant
+			// would produce nonsense.
+			if meta.Package != pkgQualifier && meta.Package != actualPkg {
+				continue
+			}
 		}
 		for _, sv := range meta.SealedVariants {
 			if sv.Name == variantName {
@@ -1693,12 +1718,16 @@ func (t *galaASTTransformer) findSealedParentForVariant(variantName string) *tra
 // the equivalent generic instantiation when the expected type is the
 // variant's parent sealed type with concrete type arguments.
 //
-// For example, when the call site is `ArrayOf[Step[int]](StepA(N=1))`, the
-// argument's expected type is `Step[int]`. This helper rewrites the bare
-// `StepA` ident into `StepA[int]` so the downstream sealed-variant codegen
-// emits `StepA[int]{}.Apply(1)` instead of `StepA{}.Apply(1)` — Go cannot
-// otherwise infer the variant's vestigial type parameter from an empty
-// composite literal whose `T` does not appear in any field.
+// For same-package call sites (`ArrayOf[Step[int]](StepA(N=1))`), the
+// argument's expected type is `Step[int]` and `fun` is a bare `*ast.Ident`;
+// this helper rewrites it to `StepA[int]`. For cross-package call sites
+// (`ArrayOf[step.Step[int]](step.StepA(N=1))`) the variant reference is a
+// `*ast.SelectorExpr` and the rewrite wraps the whole selector in an
+// `*ast.IndexExpr`, producing `step.StepA[int]`. Either shape lets the
+// downstream sealed-variant codegen emit `<Variant>[int]{}.Apply(...)`
+// instead of an uninstantiated `<Variant>{}.Apply(...)` — Go cannot infer
+// the variant's vestigial type parameter from an empty composite literal
+// whose `T` does not appear in any field.
 //
 // Returns the rewritten expression and true on success; returns the original
 // expression and false when the rewrite does not apply.
@@ -1709,13 +1738,21 @@ func (t *galaASTTransformer) injectSealedVariantTypeArgs(fun ast.Expr, expected 
 		return fun, false
 	}
 
-	// Resolve the bare variant name from the call target.
-	var variantName string
+	// Resolve the bare variant name (and optional package qualifier) from
+	// the call target. SelectorExpr corresponds to qualified references
+	// like `step.StepA`; bare Ident covers same-package calls.
+	var (
+		variantName  string
+		pkgQualifier string
+	)
 	switch f := fun.(type) {
 	case *ast.Ident:
 		variantName = f.Name
 	case *ast.SelectorExpr:
 		variantName = f.Sel.Name
+		if pkgIdent, ok := f.X.(*ast.Ident); ok {
+			pkgQualifier = pkgIdent.Name
+		}
 	default:
 		return fun, false
 	}
@@ -1723,14 +1760,27 @@ func (t *galaASTTransformer) injectSealedVariantTypeArgs(fun ast.Expr, expected 
 		return fun, false
 	}
 
-	parent := t.findSealedParentForVariant(variantName)
+	parent := t.findSealedParentForVariant(variantName, pkgQualifier)
 	if parent == nil || len(parent.TypeParams) == 0 {
 		return fun, false
 	}
 
 	// Expected type must be the parent sealed generic with concrete params.
+	// The expected type's base is package-qualified for cross-package types
+	// (e.g. `step.Step`), but TypeMetadata stores Name and Package
+	// separately. Compare both forms so same-package references (where
+	// `gen.BaseName()` is just `Step`) still match.
 	gen, ok := expected.(transpiler.GenericType)
-	if !ok || gen.BaseName() != parent.Name {
+	if !ok {
+		return fun, false
+	}
+	expectedBase := gen.BaseName()
+	parentSimple := parent.Name
+	parentQualified := parent.Name
+	if parent.Package != "" {
+		parentQualified = parent.Package + "." + parent.Name
+	}
+	if expectedBase != parentSimple && expectedBase != parentQualified {
 		return fun, false
 	}
 	if len(gen.Params) != len(parent.TypeParams) {


### PR DESCRIPTION
## Summary

Extends PR #232's same-package fix to handle the cross-package shape:

```gala
import "example/sub"
val xs = ArrayOf[sub.Step[int]](
    sub.StepA(N = 1),       // [SemanticError] without instantiation
    sub.StepB(Text = "x"),
)
```

After this PR: bare `sub.StepA(...)` infers `sub.StepA[int]{}.Apply(1)` from the enclosing `ArrayOf[sub.Step[int]]` context.

## Root Cause

Two issues in `injectSealedVariantTypeArgs` / `findSealedParentForVariant` in `internal/transpiler/transformer/calls.go`:

1. `findSealedParentForVariant` looked up variants by simple name — for cross-package callsites a same-named variant from another package could win.
2. The expected-type comparison `gen.BaseName() != parent.Name` only worked for same-package references. For `step.Step[int]`, `gen.BaseName()` returns `"step.Step"` (NamedType.String() includes the package), but `parent.Name` is just `"Step"` — comparison failed and the rewrite was skipped.

## Changes

- `internal/transpiler/transformer/calls.go`:
  - `findSealedParentForVariant` accepts a `pkgQualifier` parameter; when the call site is `*ast.SelectorExpr` (`pkg.Variant`), the qualifier is extracted from `f.X` and resolved through `importManager.ResolveAlias` to the canonical package name. Lookup restricts to parents whose `meta.Package` matches.
  - `injectSealedVariantTypeArgs` computes both simple (`Step`) and qualified (`step.Step`) forms of the parent's name and accepts either when comparing against `gen.BaseName()`. The wrapping logic already worked for `SelectorExpr` — the result is `step.StepA[int]`, which downstream codegen lowers to `step.StepA[int]{}.Apply(...)`.
- New `examples/cross_pkg_sealed_var/step/step.gala` (sealed type in subpackage), `examples/cross_pkg_sealed_var_test.gala` (consumer), `.out`.

## Verification

- New `examples/cross_pkg_sealed_var_test` fails on master (`cannot use generic type step.StepA[T any] without instantiation`) and passes on this branch.
- PR #232's same-package test (`examples/sealed_case_type_param_from_context`) still passes.
- `bazel build //...` passes
- `bazel test //...` passes (284/284)

## Dependencies

None — this PR can be reviewed and merged independently.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)