### PR TITLE
fix(transformer): auto-unwrap Immutable field access after a call expression

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -346,6 +346,13 @@ gala_test(
 )
 
 gala_test(
+    name = "tuple_call_field_unwrap",
+    src = "tuple_call_field_unwrap.gala",
+    expected = "tuple_call_field_unwrap.out",
+    deps = ["//examples/tuple_call_lib"],
+)
+
+gala_test(
     name = "list_pattern_match",
     src = "list_pattern_match.gala",
     expected = "list_pattern_match.out",

--- a/examples/tuple_call_field_unwrap.gala
+++ b/examples/tuple_call_field_unwrap.gala
@@ -1,0 +1,23 @@
+package main
+
+import (
+    "fmt"
+    . "martianoff/gala/examples/tuple_call_lib"
+)
+
+// TermSize() comes from a dot-imported GALA library and returns Tuple[int, int]
+// whose V1/V2 fields are std.Immutable[int]. CallExpr-rooted field access
+// (e.g. TermSize().V2 - overhead) must auto-unwrap the field with .Get() so
+// the result has type int — otherwise Go rejects the expression with a
+// "mismatched types std.Immutable[int] and int" error.
+
+val overhead = 14
+
+func availHeight() int = TermSize().V2 - overhead
+
+func availWidth() int = TermSize().V1 + 1
+
+func main() {
+    fmt.Printf("avail=%d\n", availHeight())
+    fmt.Printf("width=%d\n", availWidth())
+}

--- a/examples/tuple_call_field_unwrap.out
+++ b/examples/tuple_call_field_unwrap.out
@@ -1,0 +1,2 @@
+avail=10
+width=81

--- a/examples/tuple_call_lib/BUILD.bazel
+++ b/examples/tuple_call_lib/BUILD.bazel
@@ -1,0 +1,8 @@
+load("//:gala.bzl", "gala_library")
+
+gala_library(
+    name = "tuple_call_lib",
+    src = "termlib.gala",
+    importpath = "martianoff/gala/examples/tuple_call_lib",
+    visibility = ["//visibility:public"],
+)

--- a/examples/tuple_call_lib/termlib.gala
+++ b/examples/tuple_call_lib/termlib.gala
@@ -1,0 +1,7 @@
+package tuple_call_lib
+
+// TermSize mimics a small TUI library helper. It returns a Tuple[int, int]
+// whose V1/V2 fields are auto-wrapped as Immutable[int] by the transpiler.
+// Callers that consume the result via field access (e.g.
+// `TermSize().V2 - 1`) must auto-unwrap the field via .Get().
+func TermSize() Tuple[int, int] = (80, 24)

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -75,6 +75,7 @@ go_test(
         "sealed_string_func_field_test.go",
         "structs_test.go",
         "test_helper.go",
+        "tuple_call_unwrap_test.go",
         "tuple_either_test.go",
         "tuple_field_unwrap_repro_test.go",
         "type_inference_regression_test.go",

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -198,9 +198,137 @@ func (t *galaASTTransformer) isImmutableField(xType transpiler.Type, selExpr *as
 				}
 			}
 		}
+
+		// Fallback: when the receiver type is unknown but the LHS is a bare
+		// function call (e.g., `TermSize().V2`), resolve the call's declared
+		// return type via function metadata. The Go importer can fail to
+		// resolve transitive imports for a dot-imported Go package consumed
+		// only as compiled artifacts (no source on the module path) — when
+		// that happens, `getExprTypeName` returns NilType and the early
+		// checks above all miss, even though the function's return type is
+		// recorded in metadata. Looking up by function name still gives us a
+		// struct name we can match against typeMetas/structFields.
+		if ce, ok := selExpr.X.(*ast.CallExpr); ok {
+			if retType := t.callExprReturnType(ce); !retType.IsNil() {
+				retName := retType.String()
+				if idx := strings.Index(retName, "["); idx != -1 {
+					retName = retName[:idx]
+				}
+				retName = strings.TrimPrefix(retName, "*")
+				resolvedRet := t.resolveStructTypeName(retName)
+				if fields, ok := t.structFields[resolvedRet]; ok {
+					for i, f := range fields {
+						if f == selName {
+							return t.structImmutFields[resolvedRet][i]
+						}
+					}
+				}
+				if typeMeta := t.getTypeMeta(retName); typeMeta != nil {
+					for i, f := range typeMeta.FieldNames {
+						if f == selName {
+							return i < len(typeMeta.ImmutFlags) && typeMeta.ImmutFlags[i]
+						}
+					}
+				}
+			}
+			// Last-resort fallback: when even function metadata is unavailable
+			// (e.g., a dot-imported Go module fetched but not analyzed) and the
+			// field name matches the std.Tuple component shape (V1..V10), check
+			// any std.Tuple* typeMeta. All std.Tuple variants register their
+			// V_N fields as Immutable, so a positive hit is unambiguous and
+			// avoids the failure mode where `funcReturningTuple().V2` reaches
+			// arithmetic without an injected .Get().
+			if isTupleFieldName(selName) && t.isImmutableTupleField(selName) {
+				return true
+			}
+		}
 	}
 
 	return false
+}
+
+// isTupleFieldName reports whether name is V1..V10 — the field naming
+// convention used by std.Tuple/Tuple3/.../Tuple10.
+func isTupleFieldName(name string) bool {
+	if len(name) < 2 || name[0] != 'V' {
+		return false
+	}
+	rest := name[1:]
+	for _, c := range rest {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// isImmutableTupleField reports whether `selName` appears as an Immutable-
+// flagged field on any registered std.Tuple* metadata. Used only as a
+// last-resort fallback when no other lookup path can determine the field
+// type — see callers for the surrounding gate (CallExpr LHS, unknown xType).
+func (t *galaASTTransformer) isImmutableTupleField(selName string) bool {
+	for _, name := range []string{
+		transpiler.TypeTuple, transpiler.TypeTuple3, transpiler.TypeTuple4,
+		transpiler.TypeTuple5, transpiler.TypeTuple6, transpiler.TypeTuple7,
+		transpiler.TypeTuple8, transpiler.TypeTuple9, transpiler.TypeTuple10,
+	} {
+		typeMeta := t.getTypeMeta(name)
+		if typeMeta == nil {
+			continue
+		}
+		for i, f := range typeMeta.FieldNames {
+			if f == selName && i < len(typeMeta.ImmutFlags) && typeMeta.ImmutFlags[i] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// callExprReturnType resolves the declared return type of a bare-ident
+// function call by consulting metadata sources directly, without re-running
+// the type-inference path that already returned NilType. Used as a fallback
+// for auto-unwrap on `funcCall().Field` when type inference for the call
+// itself failed (e.g., dot-imported Go-only packages whose transitive imports
+// the Go SDK can't load from the analyzer's view).
+//
+// Sources, in order:
+//   - GALA function metadata (functions declared in any analyzed .gala source)
+//   - Go function metadata under the current package
+//   - Go function metadata under any dot-imported package
+func (t *galaASTTransformer) callExprReturnType(ce *ast.CallExpr) transpiler.Type {
+	fun := ce.Fun
+	// Strip explicit type arguments: TermSize[int]() -> TermSize
+	if idx, ok := fun.(*ast.IndexExpr); ok {
+		fun = idx.X
+	} else if idxList, ok := fun.(*ast.IndexListExpr); ok {
+		fun = idxList.X
+	}
+	id, ok := fun.(*ast.Ident)
+	if !ok {
+		return transpiler.NilType{}
+	}
+	// GALA function metadata first.
+	if fMeta := t.getFunction(id.Name); fMeta != nil && fMeta.ReturnType != nil && !fMeta.ReturnType.IsNil() {
+		return fMeta.ReturnType
+	}
+	// Go function metadata: current package, then dot-imported packages.
+	if t.packageName != "" {
+		if r := t.getGoFuncReturnType(t.packageName + "." + id.Name); !r.IsNil() {
+			return r
+		}
+	}
+	if t.importManager != nil {
+		for _, pkg := range t.importManager.GetDotImports() {
+			if pkg == "" || pkg == t.packageName {
+				continue
+			}
+			if r := t.getGoFuncReturnType(pkg + "." + id.Name); !r.IsNil() {
+				return r
+			}
+		}
+	}
+	return transpiler.NilType{}
 }
 
 // resolveIndexAccess handles index/subscript expressions with Immutable unwrapping.

--- a/internal/transpiler/transformer/tuple_call_unwrap_test.go
+++ b/internal/transpiler/transformer/tuple_call_unwrap_test.go
@@ -1,0 +1,74 @@
+package transformer_test
+
+import (
+	"strings"
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTupleCallFieldUnwrap covers auto-unwrap of Tuple's V_N field after a
+// CallExpr-rooted access. The companion case for the val-bound shape lives
+// in tuple_field_unwrap_repro_test.go; this one specifically targets the
+// `funcCall().V_N` shape that previously left std.Immutable[T] in
+// arithmetic context.
+func TestTupleCallFieldUnwrap(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name: "func returning Tuple — V1 in arithmetic",
+			input: `package main
+
+import "fmt"
+
+func termSize() Tuple[int, int] = (80, 24)
+
+func main() {
+    fmt.Println(termSize().V1 + 1)
+}
+`,
+			want: "termSize().V1.Get()",
+		},
+		{
+			name: "func returning Tuple — V2 used as int return",
+			input: `package main
+
+import "fmt"
+
+func termSize() Tuple[int, int] = (80, 24)
+
+val overhead = 14
+
+func availHeight() int = termSize().V2 - overhead
+
+func main() {
+    fmt.Println(availHeight())
+}
+`,
+			want: "termSize().V2.Get()",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := trans.Transpile(tt.input, "")
+			assert.NoError(t, err)
+			assert.True(t, strings.Contains(got, tt.want),
+				"expected %q in generated Go, got:\n%s", tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Auto-unwrap inserted `.Get()` after struct-field access on a val-bound identifier (BUG-7 fix in 0.35.0) but skipped the `CallExpr`-rooted shape:

```gala
val overhead = 14
func availHeight() int = TermSize().V2 - overhead
```

Generated Go on master: `TermSize().V2 - overhead.Get()` — Go rejects with `mismatched types std.Immutable[int] and int`.

After this PR: `TermSize().V2.Get() - overhead.Get()`.

## Root Cause

`isImmutableField` in `postfix.go` had a fallback for `{val}.Get().Field` (the BUG-7-era ident-rooted case) but no path for `funcCall().Field`. When the receiver type couldn't be resolved (NilType from `getExprTypeName`), every metadata lookup at the top of the function missed and the auto-unwrap silently dropped. In real-world consumption of dot-imported Go-only packages, the Go importer can't always load the dot-imported module's transitive metadata, so `getExprTypeName(TermSize())` collapses to NilType and `TermSize().V2` reaches arithmetic still wrapped as `std.Immutable[int]`.

## Changes

- `internal/transpiler/transformer/postfix.go::isImmutableField`:
  - Extended the `xType.IsNil()` branch with a CallExpr-aware sub-fallback that resolves the function's declared return type via three sources (GALA function metadata, current-package Go funcs, dot-imported Go funcs) — new `callExprReturnType` helper. With a return type in hand, the existing struct-field/typeMeta lookup runs.
  - Last-resort heuristic for cases where even that lookup fails (Go module fetched for compilation but not analyzed for type metadata): when the field name matches the `V1..V10` Tuple-component shape and any registered `std.Tuple*` typeMeta declares that field as Immutable, return true. Unambiguous because all `std.Tuple*` variants register their `V_N` fields as Immutable.
- New `examples/tuple_call_lib` + `examples/tuple_call_field_unwrap.gala`/`.out` regression example.
- New `internal/transpiler/transformer/tuple_call_unwrap_test.go::TestTupleCallFieldUnwrap` for direct transpiler-level coverage.

## Verification

- New regression example builds and runs correctly on this branch; fails to compile on master with the `mismatched types std.Immutable[int] and int` error.
- The original bug spec's `gala-tui` shape verified manually with `gala transpile`.
- `bazel build //...` passes (1038 targets)
- `bazel test //...` passes (284/284)

## Dependencies

None — this PR can be reviewed and merged independently.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)