### PR TITLE
fix(bazel): pass real filesystem paths to gala --search for cross-module deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,6 +25,18 @@ go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 use_repo(go_deps, "com_github_antlr4_go_antlr_v4", "com_github_go_git_go_git_v5", "com_github_owenrumney_go_lsp", "com_github_spf13_cobra", "com_github_stretchr_testify")
 
+# Synthetic external module used by the cross-module gala_transpile
+# regression test under //bazel_test_fixtures/external_gala_consumer.
+# Routing the dep through bazel_dep + local_path_override forces Bazel
+# to materialise the dep's source files under bazel-out/.../external/
+# external_gala_module+/..., matching the layout of a real cross-
+# repository GALA dependency.
+bazel_dep(name = "external_gala_module", version = "0.0.0")
+local_path_override(
+    module_name = "external_gala_module",
+    path = "bazel_test_fixtures/external_gala_module",
+)
+
 # ANTLR tool jar (not in BCR, loaded via use_repo_rule)
 http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
 

--- a/bazel_test_fixtures/external_gala_consumer/BUILD.bazel
+++ b/bazel_test_fixtures/external_gala_consumer/BUILD.bazel
@@ -1,0 +1,45 @@
+"""Cross-module Bazel regression test for the gala_transpile macro.
+
+The dep label @external_gala_module//effects forces Bazel to materialise
+the dep's source files at bazel-out/.../external/external_gala_module+/...,
+exercising the same external-repository code path that genuine cross-
+module GALA dependencies use. The previous gala_transpile macro derived
+its --search entries from the raw Starlark dep label, returning the token
+@external_gala_module that is not a filesystem path. The transpiler's
+resolver then could not classify the dep as a GALA package and silently
+dropped its sealed-type / struct metadata, so the generated Go regressed
+to bare type conversions and func(any, any) lambda parameters.
+
+This consumer drives all three lowering shapes that broke under that
+regression: zero-field sealed case (Halt), fielded sealed case (Yield),
+and a struct with a lambda field constructed via named arguments
+(Container). The test target downstream of the gala_binary asserts the
+generated Go contains the correct {}.Apply() forms and concrete-typed
+lambdas.
+"""
+
+load("@gala//:gala.bzl", "gala_binary")
+load("@rules_go//go:def.bzl", "go_test")
+
+# Gazelle would otherwise auto-generate a duplicate go_test target named
+# external_gala_consumer_test for the same test source. The hand-written
+# consumer_lowering_test below already wires the genrule's gen.go file
+# into runfiles via a data dep, so the gazelle target is redundant.
+# gazelle:exclude consumer_lowering_test.go
+
+gala_binary(
+    name = "consumer",
+    src = "main.gala",
+    gala_deps = ["@external_gala_module//effects"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "consumer_lowering_test",
+    srcs = ["consumer_lowering_test.go"],
+    data = [":consumer_transpile_0"],
+    deps = [
+        "@com_github_stretchr_testify//require",
+        "@rules_go//go/tools/bazel:go_default_library",
+    ],
+)

--- a/bazel_test_fixtures/external_gala_consumer/consumer_lowering_test.go
+++ b/bazel_test_fixtures/external_gala_consumer/consumer_lowering_test.go
@@ -1,0 +1,83 @@
+package consumer_lowering_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCrossModuleApplyLoweringForExternalRepoDep verifies that
+// gala_transpile lowers sealed-type and struct constructors correctly
+// when the dep is an external Bazel module (rather than an in-repo
+// gala_library). The fixture under bazel_test_fixtures/external_gala_module
+// is wired into the workspace via bazel_dep + local_path_override so the
+// dep's source files are materialised under bazel-out/.../external/
+// external_gala_module+/..., faithfully exercising the cross-repository
+// path through Bazel's external-repository machinery.
+//
+// On the broken macro the gala CLI received --search entries derived
+// from the raw label string (token "@external_gala_module"), the
+// transpiler's resolver could not walk that as a filesystem path, the
+// dep was misclassified as a Go package, and the consumer regressed to
+// emitting Halt[int]() / Yield[int]{Val: 42} / Container[int]{... func(any, any) ...}.
+// The fixed macro hands the CLI the actual on-disk parent directories
+// of the dep's source files, so the resolver finds the GALA package and
+// preserves its sealed/struct metadata.
+func TestCrossModuleApplyLoweringForExternalRepoDep(t *testing.T) {
+	genFile, err := bazel.Runfile("bazel_test_fixtures/external_gala_consumer/consumer_0.gen.go")
+	require.NoError(t, err, "consumer_0.gen.go must be present in runfiles")
+
+	data, err := os.ReadFile(genFile)
+	require.NoError(t, err)
+	got := string(data)
+	t.Logf("generated consumer_0.gen.go:\n%s", got)
+
+	// Zero-field sealed case must lower to {}.Apply(), never to a bare
+	// type conversion that Go rejects on a struct with no fields.
+	require.True(t, strings.Contains(got, "Halt[int]{}.Apply()"),
+		"expected Halt[int]{}.Apply() in generated Go, got:\n%s", got)
+	require.False(t, containsBareConversion(got, "Halt[int]"),
+		"unexpected bare conversion Halt[int]() in generated Go, got:\n%s", got)
+
+	// Fielded sealed case must lower to {}.Apply(arg), never to a bare
+	// struct literal Yield[int]{Val: 42} which would still compile but
+	// breaks the variant's invariants (skips the Apply lowering pass).
+	require.True(t, strings.Contains(got, "Yield[int]{}.Apply("),
+		"expected Yield[int]{}.Apply(...) in generated Go, got:\n%s", got)
+	require.False(t, strings.Contains(got, "Yield[int]{Val:"),
+		"unexpected bare struct literal Yield[int]{Val: ...} in generated Go, got:\n%s", got)
+
+	// Plain struct must keep concrete-typed lambda parameters. The bug
+	// surface for cross-module deps was that the resolver lost the
+	// struct's field-type metadata and the lambda regressed to func(any) any.
+	require.True(t, strings.Contains(got, "Container[int]{"),
+		"expected Container[int]{...} in generated Go, got:\n%s", got)
+	require.False(t, strings.Contains(got, "func(x any) any"),
+		"lambda parameter must not collapse to func(any) any, got:\n%s", got)
+	require.True(t, strings.Contains(got, "func(x int) int"),
+		"expected concrete-typed lambda func(x int) int in generated Go, got:\n%s", got)
+}
+
+// containsBareConversion reports whether the source text contains a bare
+// type-conversion call of the form `<typeExpr>()` (zero arguments) that
+// would silently bypass the sealed-case Apply lowering. The check
+// excludes the `<typeExpr>{}.Apply()` form, which is the correct
+// lowering and shares a textual prefix with the broken shape.
+func containsBareConversion(source, typeExpr string) bool {
+	needle := typeExpr + "("
+	idx := 0
+	for {
+		offset := strings.Index(source[idx:], needle)
+		if offset < 0 {
+			return false
+		}
+		hitEnd := idx + offset + len(needle)
+		if hitEnd <= len(source) && source[hitEnd-1] == '(' && hitEnd < len(source) && source[hitEnd] == ')' {
+			return true
+		}
+		idx = idx + offset + len(needle)
+	}
+}

--- a/bazel_test_fixtures/external_gala_consumer/main.gala
+++ b/bazel_test_fixtures/external_gala_consumer/main.gala
@@ -1,0 +1,29 @@
+package main
+
+import . "martianoff/external_gala_module/effects"
+
+// Cross-module consumer of the synthetic external_gala_module library.
+//
+// This file is transpiled by gala_transpile with
+// gala_deps = ["@external_gala_module//effects"] which routes the
+// dep through Bazel's external-repository mechanism. The generated Go
+// must lower:
+//
+//   - Halt[int]()                    -> Halt[int]{}.Apply()
+//   - Yield[int](Val = 42)           -> Yield[int]{}.Apply(42)
+//   - Container[int](Field = 7,      -> Container[int]{Field: ...,
+//                    Cb = (x) =>            Cb: std.NewImmutable(
+//                         x + 1)               func(x int) int { ... })}
+//
+// Without the macro fix the dep's source files are not on the gala
+// resolver's search path and its sealed/struct metadata is silently
+// dropped, so the same shapes regress to broken forms.
+func main() {
+    val h = Halt[int]()
+    val y = Yield[int](Val = 42)
+    val c = Container[int](
+        Field = 7,
+        Cb = (x) => x + 1,
+    )
+    Println(s"h=${h.String()} y=${y.String()} c=${c.Field}")
+}

--- a/bazel_test_fixtures/external_gala_module/BUILD.bazel
+++ b/bazel_test_fixtures/external_gala_module/BUILD.bazel
@@ -1,0 +1,1 @@
+# Empty BUILD file at module root; the actual library is under effects/.

--- a/bazel_test_fixtures/external_gala_module/MODULE.bazel
+++ b/bazel_test_fixtures/external_gala_module/MODULE.bazel
@@ -1,0 +1,19 @@
+"""Synthetic Bazel module that simulates a separately published GALA library.
+
+The main gala_simple workspace registers this directory as a Bazel external
+module via bazel_dep + local_path_override so that any consumer referencing
+@external_gala_module//... drives the genrule's --search machinery through
+the same code path Bazel uses for genuine cross-repository dependencies
+(source files end up in bazel-out/.../external/<repo>+/...).
+
+This is the fixture half of the cross-module Apply lowering regression test:
+the consumer lives at //bazel_test_fixtures/external_gala_consumer.
+"""
+
+module(
+    name = "external_gala_module",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "gala", version = "1.0.0")
+bazel_dep(name = "rules_go", version = "0.59.0")

--- a/bazel_test_fixtures/external_gala_module/effects/BUILD.bazel
+++ b/bazel_test_fixtures/external_gala_module/effects/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@gala//:gala.bzl", "gala_library")
+
+gala_library(
+    name = "effects",
+    srcs = ["effects.gala"],
+    importpath = "martianoff/external_gala_module/effects",
+    visibility = ["//visibility:public"],
+)

--- a/bazel_test_fixtures/external_gala_module/effects/effects.gala
+++ b/bazel_test_fixtures/external_gala_module/effects/effects.gala
@@ -1,0 +1,19 @@
+package effects
+
+// Sealed type with a zero-field case and a fielded case. A consumer
+// importing this from a separately declared Bazel module must lower
+// constructor calls as Halt[T]{}.Apply() and Yield[T]{}.Apply(arg)
+// rather than as bare type conversions or struct literals.
+sealed type Effect[T any] {
+    case Halt()
+    case Yield(Val T)
+}
+
+// Plain struct with a generic field and a lambda field. A consumer
+// constructing this with named arguments must keep the lambda's
+// parameter type concrete (e.g. func(int) int) instead of collapsing
+// to func(any) any.
+struct Container[T any](
+    Field T,
+    Cb func(T) T,
+)

--- a/bazel_test_fixtures/external_gala_module/gala.mod
+++ b/bazel_test_fixtures/external_gala_module/gala.mod
@@ -1,0 +1,3 @@
+module martianoff/external_gala_module
+
+gala 0.0.0

--- a/gala.bzl
+++ b/gala.bzl
@@ -61,22 +61,46 @@ def _gala_sources_label(dep):
     name = dep.split("/")[-1]
     return dep + ":" + name + "_gala_sources"
 
-def _dep_parent_dir(dep):
-    """Extract the parent directory from a dependency label for --search.
+def _dep_search_shell_prelude(gala_deps):
+    """Build a shell prelude that populates the _dep_search variable.
 
-    For //examples/cross_file_block_lambda/crossfile, returns
-    examples/cross_file_block_lambda so the resolver can find crossfile/
-    as a subdirectory.
+    For each GALA dep, expand $(locations <_gala_sources>) to the actual
+    on-disk file paths produced by Bazel, take the first one, and derive
+    both its parent directory (the dep package dir) and grandparent
+    directory (typically the dep module root containing gala.mod/go.mod).
+    Both are appended to _dep_search as comma-separated entries.
+
+    This works uniformly for in-repo deps (paths like
+    examples/cross_file_block_lambda/crossfile/methods.gala) and
+    cross-module deps (paths like
+    bazel-out/.../external/<repo>+/some_pkg/foo.gala) because Bazel
+    resolves the locations to real filesystem paths inside the genrule
+    sandbox at execution time. The previous label-string-derived
+    approach returned tokens like @<repo> that are not filesystem
+    paths and could not be walked by the transpiler's resolver, so
+    cross-repository GALA deps were misclassified as Go packages and
+    their sealed-type / struct metadata was silently dropped.
+
+    Returns the shell snippet (terminated with ' ; ' so it can be
+    prepended to the existing cmd) plus the shell expansion to splice
+    into the --search argument. Both are empty when gala_deps is empty.
     """
-    if ":" in dep:
-        pkg = dep.split(":")[0]
-    else:
-        pkg = dep
-    pkg = pkg.lstrip("/")
-    parts = pkg.rsplit("/", 1)
-    if len(parts) > 1:
-        return parts[0]
-    return "."
+    if not gala_deps:
+        return "", ""
+
+    parts = ["_dep_search=\"\""]
+    for dep in gala_deps:
+        src_label = _gala_sources_label(dep)
+        # _locs is the space-separated list of dep source file paths.
+        # _first is the first path; _pkg_dir is its directory; the
+        # grandparent typically equals the module root.
+        parts.append("_locs=\"$(locations %s)\"" % src_label)
+        parts.append("_first=\"$${_locs%% *}\"")
+        parts.append("_pkg_dir=\"$$(dirname \"$$_first\")\"")
+        parts.append("_dep_search=\"$${_dep_search},$${_pkg_dir},$$(dirname \"$$_pkg_dir\")\"")
+
+    prelude = " ; ".join(parts) + " ; "
+    return prelude, "$${_dep_search}"
 
 def gala_transpile(name, src, out = None, package_files = [], extra_srcs = [], gala_deps = []):
     """Transpile a GALA source file to Go using the full gala binary.
@@ -101,11 +125,10 @@ def gala_transpile(name, src, out = None, package_files = [], extra_srcs = [], g
     # Auto-include GALA source files from dependencies for cross-package type resolution
     dep_srcs = [_gala_sources_label(dep) for dep in gala_deps]
 
-    # Build search path: repo root + parent dirs of dependencies
-    dep_search = ""
-    if gala_deps:
-        parents = [_dep_parent_dir(dep) for dep in gala_deps]
-        dep_search = "," + ",".join(parents)
+    # Build a shell prelude that derives --search paths from the actual
+    # Bazel-resolved dep source file locations (so cross-module deps in
+    # external Bazel repositories work the same as in-repo deps).
+    dep_prelude, dep_search_expansion = _dep_search_shell_prelude(gala_deps)
 
     # Use go.mod location to find the repository root for search path.
     # Pass GOROOT via --goroot flag so the transpiler can use go/importer
@@ -114,11 +137,12 @@ def gala_transpile(name, src, out = None, package_files = [], extra_srcs = [], g
         name = name,
         srcs = [src] + package_files + extra_srcs + dep_srcs + [Label("//:all_gala_sources"), Label("//:go.mod")],
         outs = [out],
-        cmd = "_gomod=$(location {gomod}) ; $(location {tool}) --input $(location {src}) --output $@ --search $${{_gomod%/*}}{dep_search}{pf} --goroot=$${{GOROOT:-}}".format(
+        cmd = "_gomod=$(location {gomod}) ; {dep_prelude}$(location {tool}) --input $(location {src}) --output $@ --search $${{_gomod%/*}}{dep_search}{pf} --goroot=$${{GOROOT:-}}".format(
             tool = Label("//cmd/gala"),
             src = src,
             gomod = Label("//:go.mod"),
-            dep_search = dep_search,
+            dep_prelude = dep_prelude,
+            dep_search = dep_search_expansion,
             pf = pf_flag,
         ),
         tools = [Label("//cmd/gala")],
@@ -149,11 +173,10 @@ def gala_transpile_package(name, srcs, outs = None, extra_srcs = [], gala_deps =
     # Auto-include GALA source files from dependencies for cross-package type resolution
     dep_srcs = [_gala_sources_label(dep) for dep in gala_deps]
 
-    # Build search path: repo root + parent dirs of dependencies
-    dep_search = ""
-    if gala_deps:
-        parents = [_dep_parent_dir(dep) for dep in gala_deps]
-        dep_search = "," + ",".join(parents)
+    # Build a shell prelude that derives --search paths from the actual
+    # Bazel-resolved dep source file locations (so cross-module deps in
+    # external Bazel repositories work the same as in-repo deps).
+    dep_prelude, dep_search_expansion = _dep_search_shell_prelude(gala_deps)
 
     inputs_flag = ",".join(["$(location %s)" % s for s in srcs])
     outputs_flag = ",".join(["$(location %s)" % o for o in outs])
@@ -162,12 +185,13 @@ def gala_transpile_package(name, srcs, outs = None, extra_srcs = [], gala_deps =
         name = name,
         srcs = srcs + extra_srcs + dep_srcs + [Label("//:all_gala_sources"), Label("//:go.mod")],
         outs = outs,
-        cmd = "_gomod=$(location {gomod}) ; $(location {tool}) transpile-package --inputs {inputs} --outputs {outputs} --search $${{_gomod%/*}}{dep_search} --goroot=$${{GOROOT:-}}".format(
+        cmd = "_gomod=$(location {gomod}) ; {dep_prelude}$(location {tool}) transpile-package --inputs {inputs} --outputs {outputs} --search $${{_gomod%/*}}{dep_search} --goroot=$${{GOROOT:-}}".format(
             tool = Label("//cmd/gala"),
             inputs = inputs_flag,
             outputs = outputs_flag,
             gomod = Label("//:go.mod"),
-            dep_search = dep_search,
+            dep_prelude = dep_prelude,
+            dep_search = dep_search_expansion,
         ),
         tools = [Label("//cmd/gala")],
         visibility = ["//visibility:public"],


### PR DESCRIPTION
## Summary

Fixes BUG-10 (reopened), BUG-15, and BUG-16 from gala-tui's `TRANSPILER_BUGS.md` — three cross-module symptoms that all reproduce in real Bazel `gala_transpile` consumers but NOT via `gala build` CLI. The fault was entirely in the Bazel macro: it derived `--search` paths via `_dep_parent_dir(dep)` at Starlark evaluation time, returning strings derived from the label (e.g. `@external_gala_module` for cross-repo deps). Those aren't real filesystem paths, so gala's resolver couldn't classify the dep as a GALA package and cross-module sealed/struct metadata was silently dropped.

`gala build` already works correctly (PR #234) because `gala.mod replace` directives resolve to real on-disk paths. This PR makes the Bazel flow give the gala CLI the same kind of input.

## Root Cause

`gala.bzl::_dep_parent_dir` extracted parent directories from Bazel labels at macro-evaluation time:

```python
# Before: returns "@external_gala_module" for @external_gala_module//:lib
def _dep_parent_dir(dep):
    pkg = dep.split(":")[0].lstrip("/")
    parts = pkg.rsplit("/", 1)
    return parts[0] if len(parts) > 1 else "."
```

For in-repo deps like `//examples/cross_file_block_lambda/crossfile`, this returned `examples/cross_file_block_lambda` — a real workspace-relative path. For cross-repo deps via `bazel_dep` + `local_path_override`, it returned tokens like `@external_gala_module` — Bazel external-repo strings, not filesystem paths.

## Fix

New `_dep_search_shell_prelude` emits a tiny shell snippet that runs inside the genrule and uses `$(locations <dep_gala_sources>)`. Bazel resolves these at execution time to the actual on-disk file paths — identical for in-repo (`examples/.../crossfile/methods.gala`) and cross-repo (`bazel-out/.../external/<repo>+/.../foo.gala`) deps. The shell extracts both the package directory and its parent (typically the dep module root) and appends them to `--search`, so gala's resolver's `FindModuleRoot` walk finds `gala.mod`/`go.mod` and the regular `analyzePackage` path runs.

No gala core code was modified — `internal/transpiler/`, `internal/build/`, and `cmd/gala/` are untouched. The fix lives entirely in the Bazel macro layer.

## Changes

- `gala.bzl`: replaced `_dep_parent_dir` with `_dep_search_shell_prelude`; updated `gala_transpile` and `gala_transpile_package` to use the shell-time resolution.
- `MODULE.bazel`: declares the cross-module test fixture as a `bazel_dep` via `local_path_override` so the test exercises the genuine cross-repo code path.
- New `bazel_test_fixtures/external_gala_module/` — fixture GALA module with sealed types (`Halt`, `Yield`) and Go-style struct (`Container`).
- New `bazel_test_fixtures/external_gala_consumer/` — consumer that constructs all three variants. New `consumer_lowering_test.go` reads the generated Go output and asserts the correct lowering shapes.

## Verification

**Bug reproduces on master** (confirmed by reverting `gala.bzl` with the new fixture in place):
```go
var h = std.NewImmutable(Halt[int]())                          // bare conversion (broken)
var y = std.NewImmutable(Yield[int]{Val: 42})                   // bare struct literal (no Apply)
var c = std.NewImmutable(Container[int]{Cb: func(x any) any {   // any/any lambda
    return x + 1
}, Field: 7})
```

**Fix branch** produces correct output:
```go
var h = std.NewImmutable(Halt[int]{}.Apply())
var y = std.NewImmutable(Yield[int]{}.Apply(42))
var c = std.NewImmutable(Container[int]{
    Field: std.NewImmutable(7),
    Cb:    std.NewImmutable(func(x int) int { return x + 1 }),
})
```

- `bazel build //...` passes (1035/1037 — 2 pre-existing failures on `examples:go_generic_struct_dot_import_only_generic_bin` and its test reproduce identically on master with this PR's `gala.bzl` reverted; unrelated to this fix)
- `bazel test //...` passes (285/286 — same pre-existing test)
- PR #234's `TestTranspile_CrossModuleSealedCaseEmitsApply` still passes (`gala build` flow unaffected)

## Why an in-repo simulation didn't reproduce the bug

`findPackageDirByName` (in gala's resolver) skips `external/` and `bazel-out/` during recursive walks. Using `local_path_override` to declare the fixture as a real Bazel external module is the only way to drive the bug's actual code path inside the Bazel test sandbox.

## Dependencies

None — independent of any open PR. PR #239 (cleanup of PR #230's dead infrastructure) targets a different layer and can land in either order.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)