### PR TITLE
fix(resolver): cross-module sealed-case lowering broken when consumer's gala.mod has require without replace

### DIFF
--- a/bazel_test_fixtures/xmod_consumer_galamod/BUILD.bazel
+++ b/bazel_test_fixtures/xmod_consumer_galamod/BUILD.bazel
@@ -1,0 +1,56 @@
+"""Cross-module Bazel regression test for the BUG-10/BUG-15/BUG-16 trio.
+
+Unlike the sibling external_gala_consumer fixture, this consumer declares its
+own gala.mod with a `require` entry pointing at the dep's module path:
+
+    module example.com/consumer_with_galamod
+    gala dev
+    require martianoff/external_gala_module v0.0.0
+
+There is deliberately NO `replace` directive — bazel_dep + local_path_override
+in MODULE.bazel supply the dep at link time, and gala.mod just records the
+version. This is the same shape gala-server uses for its
+`require github.com/martianoff/gala-tui v0.1.0` entry that triggered the
+real-world regression.
+
+Routing the gala.mod through `extra_srcs` materialises it inside the genrule
+sandbox at the same workspace-relative path the .gala source lives at, so
+the gala CLI's autoResolveSearchPaths walk-up from the input file's
+directory finds the consumer's gala.mod and triggers the require-list code
+path that the original synthetic fixture missed.
+
+The downstream go_test asserts the generated Go contains the correct
+{}.Apply() / std.NewImmutable / concrete-typed lambda lowerings, locking in
+the fix for the require-list short-circuit in resolver.go::IsGalaPackage
+plus the search-path-precedence fix in transpile.go::autoResolveSearchPaths.
+
+The directory name is deliberately short — the full Windows runfiles path
+('<exec-root>/.../<test-bin-dir>/<test-bin>.runfiles/_main/<test-bin-dir>/<test-bin>')
+contains the fixture directory name three times, so a long name here pushes
+the path past the Windows MAX_PATH limit (260 chars) and bazel test fails
+with 'fork/exec: The parameter is incorrect'.
+"""
+
+load("@gala//:gala.bzl", "gala_transpile")
+load("@rules_go//go:def.bzl", "go_test")
+
+# Gazelle would otherwise auto-generate a duplicate go_test target.
+# gazelle:exclude lowering_test.go
+
+gala_transpile(
+    name = "transpile",
+    src = "main.gala",
+    out = "main.gen.go",
+    extra_srcs = ["gala.mod"],
+    gala_deps = ["@external_gala_module//effects"],
+)
+
+go_test(
+    name = "lowering_test",
+    srcs = ["lowering_test.go"],
+    data = [":transpile"],
+    deps = [
+        "@com_github_stretchr_testify//require",
+        "@rules_go//go/tools/bazel:go_default_library",
+    ],
+)

--- a/bazel_test_fixtures/xmod_consumer_galamod/gala.mod
+++ b/bazel_test_fixtures/xmod_consumer_galamod/gala.mod
@@ -1,0 +1,5 @@
+module example.com/consumer_with_galamod
+
+gala dev
+
+require martianoff/external_gala_module v0.0.0

--- a/bazel_test_fixtures/xmod_consumer_galamod/lowering_test.go
+++ b/bazel_test_fixtures/xmod_consumer_galamod/lowering_test.go
@@ -1,0 +1,88 @@
+package lowering_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCrossModuleApplyLoweringWithRequireDirective verifies that the
+// gala_transpile genrule lowers sealed-case and Go-style struct constructors
+// correctly when the consumer ships its own gala.mod with a `require`
+// directive (no `replace`) and the dep is supplied via Bazel's
+// bazel_dep + local_path_override mechanism.
+//
+// This is the regression test for the BUG-10/BUG-15/BUG-16 trio reported
+// against gala-server. The earlier external_gala_consumer fixture passed
+// because its consumer had no gala.mod at all, so the resolver never
+// walked the require list and the bug never fired in that fixture. This
+// fixture differs in exactly one way: gala.mod is present with a require
+// entry pointing at the dep's module path. That's enough to drive the
+// resolver into the `isGalaPackageInCache` branch — which under Bazel
+// always misses (the cache at ~/.gala/cache is empty in the sandbox)
+// and, before the fix, short-circuited IsGalaPackage to false.
+//
+// With IsGalaPackage falsely returning false the analyzer routed the
+// dep through AnalyzeGoPackage and discarded its sealed-case Apply
+// metadata and struct field types, producing all three broken
+// lowerings on the consumer side: bare `Case[T]()` conversions for
+// zero-field variants, named-field struct literals on zero-field
+// variant structs (which Go reports as "unknown field" or "too many
+// arguments in conversion"), and Go-style structs with raw field
+// values plus lambda parameters typed `any` instead of the concrete
+// element type.
+func TestCrossModuleApplyLoweringWithRequireDirective(t *testing.T) {
+	genFile, err := bazel.Runfile("bazel_test_fixtures/xmod_consumer_galamod/main.gen.go")
+	require.NoError(t, err, "main.gen.go must be present in runfiles")
+
+	data, err := os.ReadFile(genFile)
+	require.NoError(t, err)
+	got := string(data)
+
+	// BUG-10: zero-field sealed case must lower to {}.Apply().
+	require.True(t, strings.Contains(got, "Halt[int]{}.Apply()"),
+		"expected Halt[int]{}.Apply() in generated Go, got:\n%s", got)
+	require.False(t, containsBareConversion(got, "Halt[int]"),
+		"unexpected bare conversion Halt[int]() in generated Go, got:\n%s", got)
+
+	// BUG-16: fielded sealed case must lower to {}.Apply(arg), never
+	// to a named-field struct literal against the zero-field variant struct.
+	require.True(t, strings.Contains(got, "Yield[int]{}.Apply("),
+		"expected Yield[int]{}.Apply(...) in generated Go, got:\n%s", got)
+	require.False(t, strings.Contains(got, "Yield[int]{Val:"),
+		"unexpected named-field struct literal Yield[int]{Val: ...} on zero-field variant struct, got:\n%s", got)
+
+	// BUG-15: plain struct must keep concrete-typed lambda parameters.
+	// Cross-module struct field metadata must be loaded so the consumer
+	// emits `func(x int) int` rather than `func(x any) any`.
+	require.True(t, strings.Contains(got, "Container[int]{"),
+		"expected Container[int]{...} in generated Go, got:\n%s", got)
+	require.False(t, strings.Contains(got, "func(x any) any"),
+		"lambda parameter must not collapse to func(any) any, got:\n%s", got)
+	require.True(t, strings.Contains(got, "func(x int) int"),
+		"expected concrete-typed lambda func(x int) int in generated Go, got:\n%s", got)
+}
+
+// containsBareConversion reports whether the source text contains a bare
+// type-conversion call of the form `<typeExpr>()` (zero arguments) that
+// would silently bypass the sealed-case Apply lowering. Excludes the
+// `<typeExpr>{}.Apply()` form which is the correct lowering and shares a
+// textual prefix.
+func containsBareConversion(source, typeExpr string) bool {
+	needle := typeExpr + "("
+	idx := 0
+	for {
+		offset := strings.Index(source[idx:], needle)
+		if offset < 0 {
+			return false
+		}
+		hitEnd := idx + offset + len(needle)
+		if hitEnd <= len(source) && source[hitEnd-1] == '(' && hitEnd < len(source) && source[hitEnd] == ')' {
+			return true
+		}
+		idx = idx + offset + len(needle)
+	}
+}

--- a/bazel_test_fixtures/xmod_consumer_galamod/main.gala
+++ b/bazel_test_fixtures/xmod_consumer_galamod/main.gala
@@ -1,0 +1,40 @@
+package main
+
+import . "martianoff/external_gala_module/effects"
+
+// Cross-module consumer that, unlike its sibling external_gala_consumer,
+// declares its own gala.mod with a `require` entry pointing at the dep's
+// module path. This exercises the resolver code path that gala-server
+// hits in the wild: bazel_dep + local_path_override supply the dep at
+// link time, gala.mod records the version (no `replace` directive), and
+// the GALA cache at ~/.gala/cache is empty inside the genrule sandbox.
+//
+// Without the resolver fix, IsGalaPackage walks the require list, calls
+// isGalaPackageInCache, gets false (cache miss), and short-circuits
+// to false — misclassifying the dep as a Go package. The analyzer then
+// drops the dep's sealed-case Apply metadata and struct field metadata,
+// and the transformer regresses to:
+//
+//   - Halt[int]()                  (bare conversion, Go rejects it as
+//                                   "missing argument in conversion to
+//                                   external.Halt[int]")
+//   - Yield[int]{Val: 42}          (struct literal with named fields on a
+//                                   zero-field variant struct, "unknown
+//                                   field" / "too many arguments" error)
+//   - Container[int]{Field: 7,     (raw values where std.Immutable[T] is
+//                    Cb: func(x any) any { ... }}    expected, plus lambda
+//                                   parameter type collapsed to any)
+//
+// The corrected lowering — guaranteed by consumer_lowering_test.go in
+// this directory — is `Halt[int]{}.Apply()`, `Yield[int]{}.Apply(42)`,
+// and `Container[int]{Field: std.NewImmutable(7), Cb: std.NewImmutable(
+// func(x int) int { ... })}`.
+func main() {
+    val h = Halt[int]()
+    val y = Yield[int](Val = 42)
+    val c = Container[int](
+        Field = 7,
+        Cb = (x) => x + 1,
+    )
+    Println(s"h=${h.String()} y=${y.String()} c=${c.Field}")
+}

--- a/cmd/gala/commands/transpile.go
+++ b/cmd/gala/commands/transpile.go
@@ -70,6 +70,22 @@ func autoResolveSearchPaths(inputPath string, basePaths []string) []string {
 
 	projectRoot := findGalaModDir(startDir)
 	if projectRoot != "" {
+		// PREPEND the consumer's gala.mod directory ahead of any other
+		// search path. The transpiler's resolver walks up from each search
+		// path looking for gala.mod (NewResolver.findGalaModRoot) and
+		// accepts the FIRST one it finds. If projectRoot is appended after
+		// dep search paths — which under Bazel typically point inside
+		// external/<repo>+/ directories that themselves contain the dep's
+		// own gala.mod — the dep's gala.mod gets loaded as if it were the
+		// project's, completely masking the consumer's require/replace
+		// directives. Without that masking the cross-module sealed-case
+		// Apply lowering and Go-style struct field metadata break (the
+		// BUG-10 / BUG-15 / BUG-16 trio against gala-tui consumers).
+		// The .gala source's gala.mod (the one walking up from inputPath
+		// finds) is unambiguously the right answer, so it must win the
+		// findGalaModRoot race.
+		basePaths = prependIfNew(basePaths, projectRoot)
+
 		galaModPath := filepath.Join(projectRoot, "gala.mod")
 		if galaMod, err := mod.ParseFile(galaModPath); err == nil {
 			for _, req := range galaMod.GalaRequires() {
@@ -107,6 +123,18 @@ func appendIfNew(slice []string, val string) []string {
 		}
 	}
 	return append(slice, val)
+}
+
+// prependIfNew prepends val to slice if not already present. Used when the
+// caller needs a search path tried first regardless of how callers ordered
+// the rest of the slice.
+func prependIfNew(slice []string, val string) []string {
+	for _, s := range slice {
+		if s == val {
+			return slice
+		}
+	}
+	return append([]string{val}, slice...)
 }
 
 func runTranspile(cmd *cobra.Command, args []string) {

--- a/internal/transpiler/module/resolver.go
+++ b/internal/transpiler/module/resolver.go
@@ -181,11 +181,7 @@ func (r *Resolver) ResolvePackagePath(importPath string) (string, error) {
 	// Also handles VCS host prefix mismatches (e.g., import "martianoff/gala-server"
 	// matching module "github.com/martianoff/gala-server").
 	for _, sp := range r.searchPaths {
-		spModRoot, spModName := FindModuleRoot(sp)
-		// Also try gala.mod if go.mod wasn't found (pure GALA packages may not have go.mod)
-		if spModName == "" {
-			spModRoot, spModName = findGalaModuleRoot(sp)
-		}
+		spModRoot, spModName := findModuleRootForSearchPath(sp)
 		if spModName == "" || spModRoot == r.moduleRoot {
 			continue // skip primary module (already handled in Strategy 1)
 		}
@@ -301,10 +297,7 @@ func hasModulePrefix(importPath, moduleName string) (relPath string, ok bool) {
 func (r *Resolver) ResolveGoImportPath(importPath string) string {
 	// Check search paths for module roots with VCS prefix differences
 	for _, sp := range r.searchPaths {
-		spModRoot, spModName := FindModuleRoot(sp)
-		if spModName == "" {
-			spModRoot, spModName = findGalaModuleRoot(sp)
-		}
+		spModRoot, spModName := findModuleRootForSearchPath(sp)
 		if spModName == "" || spModRoot == r.moduleRoot {
 			continue
 		}
@@ -360,7 +353,17 @@ func (r *Resolver) IsGalaPackage(importPath string) bool {
 		}
 	}
 
-	// Check gala.mod require list
+	// Check gala.mod require list. The cache check is authoritative when
+	// the dep is actually cached — but under Bazel (bazel_dep +
+	// local_path_override) the dep is materialised in
+	// execroot/external/<repo>+/ and the cache at ~/.gala/cache is never
+	// populated. In that situation isGalaPackageInCache returns false even
+	// though the dep IS a GALA package, just one that reaches the build
+	// via a search path instead of through the cache. So fall through to
+	// the search-path scan below when the cache check is negative — only
+	// treat the require entry as authoritative when the dep is explicitly
+	// marked Go (req.Go), which is a deliberate gala.mod declaration that
+	// should override search-path discovery.
 	if r.galaMod != nil {
 		for _, req := range r.galaMod.Require {
 			if matchesModuleName(importPath, req.Path) || func() bool {
@@ -371,20 +374,18 @@ func (r *Resolver) IsGalaPackage(importPath string) bool {
 				if req.Go {
 					return false
 				}
-				// Found in require list, now check if it's actually a GALA package
-				// by looking for .gala files or gala.mod in the cache
-				return r.isGalaPackageInCache(req.Path, req.Version)
+				if r.isGalaPackageInCache(req.Path, req.Version) {
+					return true
+				}
+				// Cache miss — let the search-path scan decide.
+				break
 			}
 		}
 	}
 
 	// Check if any search path is a module root whose name matches
 	for _, sp := range r.searchPaths {
-		spModRoot, spModName := FindModuleRoot(sp)
-		// Also try gala.mod if go.mod wasn't found (pure GALA packages may not have go.mod)
-		if spModName == "" {
-			spModRoot, spModName = findGalaModuleRoot(sp)
-		}
+		spModRoot, spModName := findModuleRootForSearchPath(sp)
 		if spModName == "" || spModName == r.moduleName {
 			continue
 		}
@@ -628,6 +629,23 @@ func FindModuleRoot(startPath string) (moduleRoot, moduleName string) {
 	}
 
 	return "", ""
+}
+
+// findModuleRootForSearchPath identifies the module root that owns a given
+// search path. It prefers a gala.mod found at the search path or any of its
+// ancestors (walking up) over a walked-up go.mod, so a GALA dep that lives
+// under an unrelated parent directory containing a stray go.mod is not
+// misclassified — common pitfalls include the system temp directory sitting
+// under someone's GOPATH, and Bazel's execroot junctions exposing unrelated
+// workspace module files. Falls back to FindModuleRoot's go.mod walk-up
+// when no gala.mod is reachable from sp.
+func findModuleRootForSearchPath(sp string) (moduleRoot, moduleName string) {
+	if galaModDir := findGalaModFromDir(sp); galaModDir != "" {
+		if root, name := findGalaModuleRoot(galaModDir); name != "" {
+			return root, name
+		}
+	}
+	return FindModuleRoot(sp)
 }
 
 // findGalaModuleRoot looks for gala.mod in the given directory (not walking up)

--- a/internal/transpiler/module/resolver_test.go
+++ b/internal/transpiler/module/resolver_test.go
@@ -329,3 +329,72 @@ func TestResolver_PrefersGalaModOverParentGoMod(t *testing.T) {
 	assert.Equal(t, projectDir, resolver.ModuleRoot(),
 		"module root must be the project directory, not the parent")
 }
+
+// TestResolver_IsGalaPackage_RequireWithoutCache_FallsThroughToSearchPath
+// captures the failure mode that breaks gala-server's cross-module Bazel build
+// (the BUG-10/BUG-15/BUG-16 trio). The consumer's gala.mod declares
+//
+//	require example.com/dep v0.1.0
+//
+// without a `replace` directive — Bazel's local_path_override materialises the
+// dep at execroot/external/<repo>+/, never populating the GALA cache at
+// ~/.gala/cache. The dep is therefore reachable only through a search path.
+//
+// Before the fix, IsGalaPackage hit the require entry, called
+// isGalaPackageInCache, got back false (cache empty), and returned false
+// straight away. The analyzer then routed the import through
+// AnalyzeGoPackage and discarded the dep's sealed-case and struct field
+// metadata, so the transformer emitted bare `Case[T]()` conversions and
+// `Struct{Field: rawValue}` literals on the consumer side.
+//
+// The fix lets the require check fall through to the search-path module-root
+// scan when isGalaPackageInCache returns false. The dep's gala.mod is then
+// found via the search path and the import is correctly classified as GALA.
+func TestResolver_IsGalaPackage_RequireWithoutCache_FallsThroughToSearchPath(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "resolver_require_no_cache_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// External GALA dep — has gala.mod and at least one .gala source.
+	// Simulates execroot/external/dep+/ under Bazel's local_path_override.
+	depDir := filepath.Join(tempDir, "external_dep")
+	require.NoError(t, os.MkdirAll(depDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(depDir, "gala.mod"),
+		[]byte("module example.com/dep\n\ngala dev\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(depDir, "lib.gala"),
+		[]byte("package dep\n"), 0644))
+
+	// Consumer with gala.mod that REQUIRES the dep but does NOT replace it.
+	// Under Bazel this is the realistic shape: bazel_dep + local_path_override
+	// supply the dep at link time, gala.mod just records the version.
+	consumerDir := filepath.Join(tempDir, "consumer")
+	require.NoError(t, os.MkdirAll(consumerDir, 0755))
+	galaModContent := `module example.com/consumer
+
+gala dev
+
+require example.com/dep v0.1.0
+`
+	require.NoError(t, os.WriteFile(filepath.Join(consumerDir, "gala.mod"),
+		[]byte(galaModContent), 0644))
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalWd)
+	require.NoError(t, os.Chdir(consumerDir))
+
+	// Search path points at the dep dir, mirroring what gala_transpile does
+	// from $(locations <dep>_gala_sources) inside the genrule sandbox.
+	resolver := NewResolver([]string{depDir})
+	require.True(t, resolver.HasGalaMod(),
+		"consumer's gala.mod must be loaded for the require entry to be visible")
+	require.Equal(t, "example.com/consumer", resolver.ModuleName())
+
+	// The dep must classify as a GALA package even though it isn't in the
+	// cache — because the search path leads to a directory whose gala.mod
+	// matches the import path. If this is false the analyzer routes the
+	// import through AnalyzeGoPackage and the consumer regresses to bare
+	// `Case[T]()` conversions for sealed-case constructors.
+	assert.True(t, resolver.IsGalaPackage("example.com/dep"),
+		"GALA dep required without a cached version must still classify as GALA when reachable via a search path")
+}


### PR DESCRIPTION
## Summary

Fixes the BUG-10 / BUG-15 / BUG-16 trio that reopened against the gala-server cross-module Bazel build (real-world consumer of gala-tui via `bazel_dep` + `local_path_override`). Synthetic fixtures have been passing since PR #240, but the actual gala-server build still emitted all three broken lowerings on master `eceb2b7`:

```go
// before
NoCmd[DashboardMsg]()                                    // BUG-10 — bare conversion
Program[…]{Initial: NewDashboardModel(b),                // BUG-15 — raw values + lambda any
           Update:  func(m any, msg any) … }
TickSub[DashboardMsg]{Interval: …, Make: …}              // BUG-16 — named-field literal
                                                         //          on zero-field variant
```

## Root cause

Two compounding issues that only align when the consumer ships its own `gala.mod` with a `require` entry but no `replace`:

1. **`Resolver.IsGalaPackage` short-circuits to false on cache miss.** Under Bazel, `local_path_override` materialises the dep in `external/<repo>+/` but never populates `~/.gala/cache`. The require-list code path called `isGalaPackageInCache`, got back `false`, and returned immediately — misclassifying the GALA dep as a Go package and dropping its sealed-case `Apply` metadata + struct field types.
2. **Search-path ordering loaded the wrong `gala.mod`.** `autoResolveSearchPaths` appended the consumer's `projectRoot` *after* dep search paths. `NewResolver.findGalaModRoot` walks up from each search path looking for `gala.mod` and accepts the first hit — so when a dep search path pointed inside `external/<repo>+/` (which itself contains the dep's own `gala.mod`), the dep's `gala.mod` was loaded as if it were the consumer's, masking the consumer's require/replace directives entirely.

The synthetic `external_gala_consumer` fixture passed because the consumer there has no `gala.mod`, so the require-list code path never fired.

## Changes

- `internal/transpiler/module/resolver.go` — `IsGalaPackage` falls through to the search-path scan on cache miss instead of returning `false`. Added `findModuleRootForSearchPath` helper that prefers a nearby `gala.mod` over a stray ancestor `go.mod`, so a pure-GALA dep with only `gala.mod` isn't misclassified by an unrelated parent `go.mod` (common pitfalls: system temp directory under someone's GOPATH, Bazel execroot junctions exposing unrelated workspace module files).
- `cmd/gala/commands/transpile.go` — `autoResolveSearchPaths` *prepends* the consumer's `projectRoot` so the consumer's `gala.mod` always wins `findGalaModRoot`'s race over a dep's `gala.mod`.

## Verification

- `bazel test //...` — 287/287 pass.
- gala-server clean build (`bazel clean --expunge && bazel build tui:tui`) succeeds end-to-end. Generated `dashboard.gen.go` now has `NoCmd[DashboardMsg]{}.Apply()`, `Program[…]{Initial: std.NewImmutable(...), Update: std.NewImmutable(func(m DashboardModel, msg DashboardMsg)…)}`, and `TickSub[DashboardMsg]{}.Apply(Milliseconds(250), func() DashboardMsg {...})`.

## Regression coverage (so it doesn't come back)

Both confirmed to fail before the fix and pass after:

- **Unit test**: `internal/transpiler/module/resolver_test.go::TestResolver_IsGalaPackage_RequireWithoutCache_FallsThroughToSearchPath` — exercises the resolver code path directly (consumer `gala.mod` with `require` + empty cache + dep reachable only via search path).
- **Bazel-level integration**: `bazel_test_fixtures/xmod_consumer_galamod/` — full fixture mirroring gala-server's exact setup. Consumer has its own `gala.mod` declaring `require martianoff/external_gala_module v0.0.0`, deliberately no `replace`, dep is delivered via `bazel_dep` + `local_path_override`. The `lowering_test` go_test asserts the generated Go contains `Halt[int]{}.Apply()`, `Yield[int]{}.Apply(...)`, `Container[int]{...}` with `func(x int) int`.

The fixture's directory name (`xmod_consumer_galamod`, not `external_gala_consumer_with_galamod`) is deliberately short — the Windows runfiles path contains the fixture name three times, so a longer name pushes the test binary path past Windows MAX_PATH (260 chars) and `bazel test` fails with `fork/exec: The parameter is incorrect`. The BUILD.bazel header documents this constraint.

## Repro (before fix)

In a Bazel project that consumes a GALA library via `bazel_dep` + `local_path_override` and ships its own `gala.mod` with a require directive:

```
# consumer/gala.mod
module example.com/consumer
gala dev
require martianoff/somelib v0.0.0
```

```gala
// consumer/main.gala
package main
import . "martianoff/somelib"
func main() {
    val h = SomeSealedCase[int]()  // emits SomeSealedCase[int]() — bare conversion
}
```

`bazel build //consumer:main` → `missing argument in conversion to somelib.SomeSealedCase[int]`.

## Battle Test Report Reference

Reported as BUG-10 / BUG-15 / BUG-16 in `gala_tui/TRANSPILER_BUGS.md` ("STILL REPRODUCES on a real-world consumer"). The earlier PR #234 / #240 fixed the synthetic fixture path; this PR fixes the actual gala-server consumer path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)