### PR TITLE
fix(transformer): bounds-check structImmutFields lookup in isImmutableField

### DIFF
--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -122,9 +122,19 @@ func (t *galaASTTransformer) isImmutableField(xType transpiler.Type, selExpr *as
 	// Check structFields (current package types)
 	resolvedTypeName := t.resolveStructTypeName(baseTypeName)
 	if fields, ok := t.structFields[resolvedTypeName]; ok {
+		immut := t.structImmutFields[resolvedTypeName]
 		for i, f := range fields {
 			if f == selName {
-				return t.structImmutFields[resolvedTypeName][i]
+				// Some registration paths populate structFields but not
+				// structImmutFields (e.g. a struct synthesized from a Go
+				// `type X struct {…}` declaration in a hand-written .go
+				// file or a cross-package metadata path that only fills
+				// names). Treat missing entries as not-immutable rather
+				// than panicking with index-out-of-range.
+				if i < len(immut) {
+					return immut[i]
+				}
+				return false
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

`isImmutableField` (postfix.go:127) crashed with \`panic: runtime error: index out of range\` when \`structFields[T]\` had N entries but \`structImmutFields[T]\` was empty or shorter. The mismatch is reachable from registration paths that fill field names without filling immut flags (e.g. cross-package metadata synthesis or in-package struct registration where the immut-flag slice didn't get populated alongside the names).

## Reproduction (master at \`a03e079\` + gala-tui v0.2.0)

```bash
git clone https://github.com/martianoff/gala-server -b feat/gala-dashboard ./gala-server
cd gala-server
gala build
```

```
panic: runtime error: index out of range [0] with length 0
  martianoff/gala/internal/transpiler/transformer.(*galaASTTransformer).isImmutableField
    internal/transpiler/transformer/postfix.go:127
  martianoff/gala/internal/transpiler/transformer.(*galaASTTransformer).resolveFieldAccess
    internal/transpiler/transformer/postfix.go:108
```

The trigger: \`tui/dashboard.gala\` accesses \`m.Total\` on its \`DashboardModel\` struct (which has \`*Bus\` and \`HashMap[string, RouteStats]\` fields). On master + 0.35.4, the field-name lookup walks the structFields slice, finds \"Total\" at index 9, indexes into the empty \`structImmutFields[T]\` slice, crashes.

## Fix

Read the immut slice once, iterate fields, and only index when \`i < len(immut)\`. Missing entries default to \`false\` (not immutable) — matches the behaviour for unregistered types and is safe because the auto-unwrap pass is purely for ergonomics: emitting \`.Get()\` always works on \`Immutable[T]\` and emitting nothing always works on \`T\`.

## Test plan

- [x] Local: \`gala build\` against the gala-server reproduction succeeds (was panicking).
- [x] Local: \`bazel build //tui:tui\` continues to succeed.
- [ ] CI: re-run gala-server's CI workflow against this branch (or a 0.35.5 release) — should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)