### PR TITLE
feat(subprocess): GALA stdlib package for child-process management

### DIFF
--- a/cmd/stdlib_gen/main.go
+++ b/cmd/stdlib_gen/main.go
@@ -23,6 +23,7 @@ func packageFromPath(path string) string {
 		"collection_mutable",
 		"go_interop",
 		"concurrent",
+		"subprocess",
 		"lazy",
 		"stream",
 		"string_utils",
@@ -144,6 +145,7 @@ var PackageImportPaths = map[string]string{
 	"regex":                "martianoff/gala/regex",
 	"io":                   "martianoff/gala/io",
 	"json":                 "martianoff/gala/json",
+	"subprocess":           "martianoff/gala/subprocess",
 	"test":                 "martianoff/gala/test",
 }
 `)

--- a/internal/build/gomod.go
+++ b/internal/build/gomod.go
@@ -82,6 +82,7 @@ var StdlibPackages = []string{
 	"regex",
 	"io",
 	"json",
+	"subprocess",
 	"test",
 }
 
@@ -99,6 +100,7 @@ var StdlibImportPaths = map[string]string{
 	"regex":                "martianoff/gala/regex",
 	"io":                   "martianoff/gala/io",
 	"json":                 "martianoff/gala/json",
+	"subprocess":           "martianoff/gala/subprocess",
 	"test":                 "martianoff/gala/test",
 }
 

--- a/internal/stdlib/BUILD.bazel
+++ b/internal/stdlib/BUILD.bazel
@@ -100,6 +100,10 @@ genrule(
         "//io:io_go",
         # io package - GALA source
         "//io:io.gala",
+        # subprocess package - GALA surface + Go-side helpers (errors.As / scanner buffer)
+        "//subprocess:subprocess_go",
+        "//subprocess:subprocess.gala",
+        "//subprocess:subprocess.go",
         # test package - transpiled Go
         "//test:assertions_go",
         "//test:bench_go",

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -143,6 +143,13 @@ func generatePackageGoMod(pkgName, importPath string) string {
 		content += ")\n"
 		content += "\nreplace martianoff/gala/std => ../std\n"
 		content += "replace martianoff/gala/collection_immutable => ../collection_immutable\n"
+	case "subprocess":
+		content += "\nrequire (\n"
+		content += "\tmartianoff/gala/std v0.0.0\n"
+		content += "\tmartianoff/gala/go_interop v0.0.0\n"
+		content += ")\n"
+		content += "\nreplace martianoff/gala/std => ../std\n"
+		content += "replace martianoff/gala/go_interop => ../go_interop\n"
 	}
 
 	return content

--- a/subprocess/BUILD.bazel
+++ b/subprocess/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+load("//:gala.bzl", "gala_bootstrap_transpile")
+
+exports_files([
+    "subprocess.gala",
+    "subprocess.go",
+])
+
+filegroup(
+    name = "gala_sources",
+    srcs = glob(
+        ["*.gala"],
+        exclude = ["*_test.gala"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+gala_bootstrap_transpile(
+    name = "subprocess_go",
+    src = "subprocess.gala",
+    out = "subprocess.gen.go",
+)
+
+go_library(
+    name = "subprocess",
+    srcs = [
+        "subprocess.gen.go",
+        "subprocess.go",
+    ],
+    importpath = "martianoff/gala/subprocess",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go_interop",
+        "//std",
+    ],
+)
+
+go_test(
+    name = "subprocess_test",
+    srcs = ["subprocess_test.go"],
+    data = ["//subprocess/testdata/echoecho"],
+    embed = [":subprocess"],
+    deps = ["@rules_go//go/runfiles"],
+)

--- a/subprocess/subprocess.gala
+++ b/subprocess/subprocess.gala
@@ -1,0 +1,197 @@
+package subprocess
+
+import (
+    "bufio"
+    "errors"
+    "io"
+    "os/exec"
+    . "martianoff/gala/std"
+    "martianoff/gala/go_interop"
+)
+
+// SpawnOpts is the bag of inputs to Spawn.
+//
+// Cmd  - executable name (looked up on PATH unless absolute).
+// Args - arguments, NOT including argv[0].
+// Env  - extra "KEY=VAL" entries appended to os.Environ; pass empty to inherit.
+// Dir  - working directory; empty inherits the parent's cwd.
+struct SpawnOpts(
+    Cmd  string,
+    Args []string,
+    Env  []string,
+    Dir  string,
+)
+
+// processState carries every mutable bit of a running child. Unexported so
+// GALA users only ever see the Process handle.
+type processState struct {
+    var cmd        *exec.Cmd
+    var stdin      io.WriteCloser
+    var stdoutScan *bufio.Scanner
+    var stderrScan *bufio.Scanner
+    var stdinMu    *go_interop.Mutex      // serialises WriteLine calls
+    var waitOnce   *go_interop.Once       // ensures cmd.Wait() runs at most once
+    var waitDone   go_interop.Signal      // closed when Wait returns
+    var waitErr    error
+    var exitCode   int
+}
+
+// Process is a running child plus its IO pipes. Value-type handle wrapping a
+// pointer to mutable state — copies share the same underlying child (mirrors
+// concurrent.Future[T]). Methods are safe to call from multiple goroutines
+// (Kill / Wait from one, ReadLine from another) but each ReadLine /
+// WriteLine call itself is sequential — the caller serialises reads.
+type Process struct {
+    var state *processState
+}
+
+// Spawn launches the child process described by opts and returns Try[Process].
+// On success the process is running and its stdin/stdout/stderr pipes are
+// connected. The returned Process is reaped only when Wait or Kill is called —
+// long-running consumers MUST call Wait or Kill exactly once when done.
+func Spawn(opts SpawnOpts) Try[Process] = Try[Process](() => {
+    if opts.Cmd == "" {
+        panic("subprocess.Spawn: empty Cmd")
+    }
+    val c = exec.Command(opts.Cmd, opts.Args...)
+    if opts.Dir != "" {
+        c.Dir = opts.Dir
+    }
+    if len(opts.Env) > 0 {
+        // Append rather than overwrite — replace mode would be a footgun
+        // (forgetting PATH breaks every spawn).
+        c.Env = append(c.Environ(), opts.Env...)
+    }
+    val sin, sErr = c.StdinPipe()
+    if sErr != nil { panic(sErr) }
+    val sout, oErr = c.StdoutPipe()
+    if oErr != nil { panic(oErr) }
+    val serr, eErr = c.StderrPipe()
+    if eErr != nil { panic(eErr) }
+    val startErr = c.Start()
+    if startErr != nil { panic(startErr) }
+    return Process(state = &processState{
+        cmd:        c,
+        stdin:      sin,
+        stdoutScan: newLineScanner(sout),
+        stderrScan: newLineScanner(serr),
+        stdinMu:    go_interop.NewMutex(),
+        waitOnce:   go_interop.NewOnce(),
+        waitDone:   go_interop.NewSignal(),
+    })
+})
+
+// WriteLine writes s + "\n" to the child's stdin, flushing immediately.
+// Concurrent callers are serialised so two writers can't interleave bytes.
+//
+// Returns Success(true) on a clean write. A failed write usually means the
+// child closed stdin or exited; Failure carries the underlying io error.
+func (p Process) WriteLine(s string) Try[bool] = Try[bool](() => {
+    val st = p.state
+    st.stdinMu.Lock()
+    defer st.stdinMu.Unlock()
+    val _, e1 = io.WriteString(st.stdin, s)
+    if e1 != nil { panic(e1) }
+    val _, e2 = io.WriteString(st.stdin, "\n")
+    if e2 != nil { panic(e2) }
+    return true
+})
+
+// ReadLine blocks until the child writes a complete line on stdout, then
+// returns it without the trailing newline. EOF (the child closed stdout, or
+// exited) returns Failure(io.EOF) — callers can recognise this via the std
+// Try API (e.g. .Recover) and treat it as "stream done", not as an error.
+func (p Process) ReadLine() Try[string] = Try[string](() => {
+    if !p.state.stdoutScan.Scan() {
+        val err = p.state.stdoutScan.Err()
+        if err != nil { panic(err) }
+        panic(io.EOF)
+    }
+    return p.state.stdoutScan.Text()
+})
+
+// ReadStderrLine is the stderr counterpart to ReadLine. Same EOF semantics.
+func (p Process) ReadStderrLine() Try[string] = Try[string](() => {
+    if !p.state.stderrScan.Scan() {
+        val err = p.state.stderrScan.Err()
+        if err != nil { panic(err) }
+        panic(io.EOF)
+    }
+    return p.state.stderrScan.Text()
+})
+
+// Wait blocks until the child exits and returns its exit code. Idempotent —
+// the underlying *exec.Cmd.Wait is called at most once. Subsequent Wait calls
+// return the cached result.
+//
+// Note: ReadLine / ReadStderrLine on the same Process should drain to EOF
+// before Wait, otherwise the child may block writing to a full pipe. The
+// scanner returning EOF naturally signals "you can Wait now".
+func (p Process) Wait() Try[int] = Try[int](() => {
+    val st = p.state
+    val _ = st.waitOnce.Do(() => {
+        val err = st.cmd.Wait()
+        // Be tidy — pipe may already be closed.
+        val _ = st.stdin.Close()
+        if err == nil {
+            st.exitCode = st.cmd.ProcessState.ExitCode()
+        } else {
+            // exec.ExitError still gives us a process state with a code.
+            // Non-zero exit is information, not a Failure — surface via
+            // Success(code). exitCodeFromError extracts the code or returns
+            // -1 plus the original error for true failures.
+            val code, residualErr = exitCodeFromError(err)
+            st.exitCode = code
+            st.waitErr = residualErr
+        }
+        go_interop.CloseSignal(st.waitDone)
+    })
+    go_interop.WaitSignal(st.waitDone)
+    if st.waitErr != nil { panic(st.waitErr) }
+    return st.exitCode
+})
+
+// Kill terminates the child immediately (SIGKILL on Unix, TerminateProcess on
+// Windows — exec.Cmd handles the platform difference). Idempotent against an
+// already-exited process: a kill after Wait returns Success(true) without
+// error. Caller is still responsible for invoking Wait afterwards to reap.
+func (p Process) Kill() Try[bool] = Try[bool](() => {
+    if !p.IsAlive() {
+        return true
+    }
+    val err = p.state.cmd.Process.Kill()
+    if err != nil {
+        // "process already finished" can race with the IsAlive check — treat
+        // as success rather than confusing the caller.
+        if isProcessFinished(err) { return true }
+        panic(err)
+    }
+    return true
+})
+
+// IsAlive returns true if the child is still running. Non-blocking; consults
+// the cached Wait result first, then falls back to a process-state poll.
+func (p Process) IsAlive() bool {
+    // WaitSignalTimeout(s, 0) is a non-blocking poll: returns true if the
+    // signal is closed, false otherwise.
+    if go_interop.WaitSignalTimeout(p.state.waitDone, 0) {
+        return false
+    }
+    if p.state.cmd.ProcessState != nil {
+        return false
+    }
+    return true
+}
+
+// Pid returns the OS process id; -1 if the child failed to start.
+func (p Process) Pid() int {
+    if p.state.cmd.Process == nil {
+        return -1
+    }
+    return p.state.cmd.Process.Pid
+}
+
+// errProcessFinished is the os/exec sentinel for "you tried to kill an
+// already-exited process". Used by isProcessFinished to recognise the race
+// between IsAlive and Kill.
+var errProcessFinished = errors.New("os: process already finished")

--- a/subprocess/subprocess.go
+++ b/subprocess/subprocess.go
@@ -1,0 +1,69 @@
+// Package subprocess — Go-side helpers for the things subprocess.gala can't
+// express (errors.As pointer pattern, bufio.Scanner buffer config). The
+// public API lives in subprocess.gala; everything in this file is
+// package-private and exists only because GALA's parser doesn't accept the
+// underlying Go syntax yet.
+package subprocess
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os/exec"
+
+	"martianoff/gala/std"
+)
+
+// NewSpawnOpts is a Go-friendly constructor for SpawnOpts. The GALA-emitted
+// struct uses Immutable[T] fields, so Go callers (tests, other Go-side
+// libraries) need this shim instead of a bare struct literal. GALA callers
+// just write SpawnOpts(Cmd = ..., ...) and the transpiler injects the
+// Immutable wrapping.
+func NewSpawnOpts(cmd string, args, env []string, dir string) SpawnOpts {
+	return SpawnOpts{
+		Cmd:  std.NewImmutable(cmd),
+		Args: std.NewImmutable(args),
+		Env:  std.NewImmutable(env),
+		Dir:  std.NewImmutable(dir),
+	}
+}
+
+// Maximum scanned line length for stdout/stderr. Stream-json output can
+// include long single-line JSON objects, so the default 64 KiB scanner
+// buffer is too small. 4 MiB matches what claude emits in practice with
+// room to spare.
+const maxLineBytes = 4 * 1024 * 1024
+
+// newLineScanner builds a bufio.Scanner whose internal buffer is sized to
+// hold a full claude stream-json line. Pulled out of the GALA caller because
+// bufio.Scanner.Buffer takes a `make([]byte, 0, N)` argument and GALA's
+// parser doesn't accept three-arg make on slices.
+func newLineScanner(r io.Reader) *bufio.Scanner {
+	s := bufio.NewScanner(r)
+	s.Buffer(make([]byte, 0, 64*1024), maxLineBytes)
+	return s
+}
+
+// exitCodeFromError unwraps an *exec.ExitError to its code; returns the code
+// and a nil residual error for non-zero exits, or -1 and the original error
+// for true failures (the child didn't even run, or a syscall failure).
+// errors.As needs a typed pointer that GALA can't construct directly.
+func exitCodeFromError(err error) (int, error) {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), nil
+	}
+	return -1, err
+}
+
+// isProcessFinished reports whether err is the os/exec sentinel raised when
+// Kill is called on an already-exited process. errors.Is alone would suffice,
+// but exporting it as a one-liner helper keeps the GALA caller readable.
+func isProcessFinished(err error) bool {
+	if errors.Is(err, errProcessFinished) {
+		return true
+	}
+	// The sentinel string is stable across Go versions and is what os/exec
+	// returns when Process.Kill races with the kernel's reap.
+	return err != nil && err.Error() == "os: process already finished"
+}

--- a/subprocess/subprocess_test.go
+++ b/subprocess/subprocess_test.go
@@ -1,0 +1,200 @@
+package subprocess
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/runfiles"
+)
+
+// echoechoPath returns the absolute path to the testdata fixture binary.
+// Under bazel test the binary lives in runfiles; under `go test` directly
+// the dev would have to build it themselves, so we skip cleanly in that case.
+//
+// rules_go puts go_binary outputs in a `<target>_/<target>` (or `.exe`)
+// subdir, so we try both that layout and the bare path for forward-compat.
+func echoechoPath(t *testing.T) string {
+	t.Helper()
+	exe := "echoecho"
+	if runtime.GOOS == "windows" {
+		exe += ".exe"
+	}
+	candidates := []string{
+		filepath.Join("_main", "subprocess", "testdata", "echoecho", "echoecho_", exe),
+		filepath.Join("_main", "subprocess", "testdata", "echoecho", exe),
+	}
+	for _, rel := range candidates {
+		if p, err := runfiles.Rlocation(rel); err == nil && p != "" {
+			if _, statErr := os.Stat(p); statErr == nil {
+				return p
+			}
+		}
+	}
+	// Fallback for `go test` without bazel — dev built it manually.
+	fb := filepath.Join("testdata", "echoecho", exe)
+	if _, statErr := os.Stat(fb); statErr == nil {
+		abs, _ := filepath.Abs(fb)
+		return abs
+	}
+	t.Skipf("echoecho fixture not found in runfiles or %s; run via bazel test", fb)
+	return ""
+}
+
+func TestSpawn_EmptyCmdReturnsFailure(t *testing.T) {
+	r := Spawn(NewSpawnOpts("", nil, nil, ""))
+	if r.IsSuccess() {
+		t.Fatalf("expected Failure for empty Cmd, got Success")
+	}
+	if !strings.Contains(r.GetError().Error(), "empty Cmd") {
+		t.Fatalf("expected 'empty Cmd' in error, got %v", r.GetError())
+	}
+}
+
+func TestSpawn_UnknownExecutable(t *testing.T) {
+	r := Spawn(NewSpawnOpts("this-binary-definitely-does-not-exist-xyz123", nil, nil, ""))
+	if r.IsSuccess() {
+		// Some platforms defer the lookup until Start; if Spawn succeeded the
+		// process should at least exit quickly with a non-zero code via Wait.
+		// But the typical and expected path is Failure here.
+		_ = r.Get().Kill()
+		t.Skip("platform deferred PATH lookup; not the typical path")
+	}
+	if r.GetError() == nil {
+		t.Fatalf("expected non-nil error")
+	}
+}
+
+func TestRoundTrip_StdoutAndStderr(t *testing.T) {
+	bin := echoechoPath(t)
+	res := Spawn(NewSpawnOpts(bin, nil, nil, ""))
+	if res.IsFailure() {
+		t.Fatalf("Spawn failed: %v", res.GetError())
+	}
+	p := res.Get()
+
+	if !p.IsAlive() {
+		t.Fatalf("process should be alive immediately after Spawn")
+	}
+	if p.Pid() <= 0 {
+		t.Fatalf("expected positive PID, got %d", p.Pid())
+	}
+
+	if w := p.WriteLine("hello"); w.IsFailure() {
+		t.Fatalf("WriteLine failed: %v", w.GetError())
+	}
+	if w := p.WriteLine("world"); w.IsFailure() {
+		t.Fatalf("WriteLine 2 failed: %v", w.GetError())
+	}
+
+	for _, want := range []string{"out: hello", "out: world"} {
+		got := p.ReadLine()
+		if got.IsFailure() {
+			t.Fatalf("ReadLine failed: %v", got.GetError())
+		}
+		if got.Get() != want {
+			t.Fatalf("ReadLine = %q, want %q", got.Get(), want)
+		}
+	}
+	for _, want := range []string{"err: hello", "err: world"} {
+		got := p.ReadStderrLine()
+		if got.IsFailure() {
+			t.Fatalf("ReadStderrLine failed: %v", got.GetError())
+		}
+		if got.Get() != want {
+			t.Fatalf("ReadStderrLine = %q, want %q", got.Get(), want)
+		}
+	}
+
+	// Tell echoecho to exit cleanly. After it does, both ReadLine streams
+	// should report EOF and Wait should yield exit code 0.
+	if w := p.WriteLine("BYE"); w.IsFailure() {
+		t.Fatalf("WriteLine BYE failed: %v", w.GetError())
+	}
+
+	// Drain to EOF on both streams.
+	if r := p.ReadLine(); r.IsSuccess() || !errors.Is(r.GetError(), io.EOF) {
+		t.Fatalf("expected EOF on stdout after BYE, got %v / %v", r.IsSuccess(), r.GetError())
+	}
+	if r := p.ReadStderrLine(); r.IsSuccess() || !errors.Is(r.GetError(), io.EOF) {
+		t.Fatalf("expected EOF on stderr after BYE, got %v / %v", r.IsSuccess(), r.GetError())
+	}
+
+	w := p.Wait()
+	if w.IsFailure() {
+		t.Fatalf("Wait failed: %v", w.GetError())
+	}
+	if w.Get() != 0 {
+		t.Fatalf("expected exit code 0, got %d", w.Get())
+	}
+	if p.IsAlive() {
+		t.Fatalf("IsAlive should be false after Wait")
+	}
+
+	// Wait is idempotent.
+	if w2 := p.Wait(); w2.IsFailure() || w2.Get() != 0 {
+		t.Fatalf("second Wait should match: %v / %d", w2.GetError(), w2.Get())
+	}
+}
+
+func TestNonZeroExit_SurfacedAsSuccessWithCode(t *testing.T) {
+	bin := echoechoPath(t)
+	p := Spawn(NewSpawnOpts(bin, nil, nil, "")).Get()
+
+	if w := p.WriteLine("FAIL"); w.IsFailure() {
+		t.Fatalf("WriteLine FAIL: %v", w.GetError())
+	}
+	// Drain.
+	for {
+		r := p.ReadLine()
+		if r.IsFailure() {
+			break
+		}
+	}
+
+	w := p.Wait()
+	if w.IsFailure() {
+		t.Fatalf("Wait should NOT be Failure for non-zero exit; got %v", w.GetError())
+	}
+	if w.Get() != 7 {
+		t.Fatalf("expected exit code 7, got %d", w.Get())
+	}
+}
+
+func TestKill_BeforeWait(t *testing.T) {
+	bin := echoechoPath(t)
+	p := Spawn(NewSpawnOpts(bin, nil, nil, "")).Get()
+
+	if k := p.Kill(); k.IsFailure() {
+		t.Fatalf("Kill failed: %v", k.GetError())
+	}
+
+	// Wait should still complete; exit code is platform-dependent (-1 on Unix
+	// when killed by signal, large value on Windows). We just want it to
+	// return without error.
+	if w := p.Wait(); w.IsFailure() {
+		t.Fatalf("Wait after Kill failed: %v", w.GetError())
+	}
+
+	// Kill is idempotent post-Wait.
+	if k := p.Kill(); k.IsFailure() {
+		t.Fatalf("second Kill should be no-op success, got %v", k.GetError())
+	}
+}
+
+func TestSpawn_Dir(t *testing.T) {
+	bin := echoechoPath(t)
+	tmp := t.TempDir()
+	p := Spawn(NewSpawnOpts(bin, nil, nil, tmp)).Get()
+	defer func() {
+		_ = p.Kill()
+		_ = p.Wait()
+	}()
+	if !p.IsAlive() {
+		t.Fatalf("process should be alive even with custom Dir")
+	}
+}

--- a/subprocess/testdata/echoecho/BUILD.bazel
+++ b/subprocess/testdata/echoecho/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "echoecho_lib",
+    srcs = ["main.go"],
+    importpath = "martianoff/gala/subprocess/testdata/echoecho",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "echoecho",
+    embed = [":echoecho_lib"],
+    visibility = ["//subprocess:__subpackages__"],
+)

--- a/subprocess/testdata/echoecho/main.go
+++ b/subprocess/testdata/echoecho/main.go
@@ -1,0 +1,37 @@
+// echoecho is a tiny fixture binary used by subprocess_test.go.
+//
+// It reads lines from stdin until EOF and, for each one, emits two responses:
+//   - "out: <line>" on stdout
+//   - "err: <line>" on stderr
+//
+// Special inputs:
+//   - "BYE"   → exit 0 immediately
+//   - "FAIL"  → exit 7 immediately
+//   - any other → echoed as above
+//
+// This shape covers every code path subprocess.go has: stdout reads, stderr
+// reads, multi-line writes, clean exit, non-zero exit, and EOF detection.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch line {
+		case "BYE":
+			return
+		case "FAIL":
+			os.Exit(7)
+		default:
+			fmt.Fprintln(os.Stdout, "out: "+line)
+			fmt.Fprintln(os.Stderr, "err: "+line)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- New `subprocess` stdlib package — synchronous, GALA-friendly wrapper around `os/exec` for spawning long-lived child processes (claude CLI, gh, git, …).
- `Process` is a value-type handle (mirrors `concurrent.Future[T]`) wrapping a pointer to internal mutable state — GALA callers never see `*Process`.
- All methods return `std.Try[T]`; blocking; no goroutines, no channels — concurrency stays in the caller's hands so the same primitive serves both Future-driven event loops (gala-tui's `AsyncTry`) and synchronous CLI glue.
- Public API: `Spawn(SpawnOpts) Try[Process]`, then `WriteLine`, `ReadLine`, `ReadStderrLine`, `Wait`, `Kill`, `IsAlive`, `Pid`. EOF returns `Failure(io.EOF)` so callers can `.Recover` it. Non-zero exits surface as `Success(code)`, not `Failure` — exit code is information, not an error. `Wait` is `sync.Once`-idempotent; `Kill` is safe pre- and post-`Wait`.
- Registered in the four canonical spots: `cmd/stdlib_gen/main.go`, `internal/build/gomod.go`, `internal/stdlib/stdlib.go`, `internal/stdlib/BUILD.bazel`.
- First brick of an upcoming `gala_team` orchestrator that drives multiple `claude` sessions through the same primitive.

## Test plan
- [x] `bazel test //subprocess:subprocess_test` — 6 cases covering round-trip stdout/stderr, EOF detection, non-zero-exit, `Kill`-before-`Wait`, custom `Dir`, PATH-lookup failure
- [x] `bazel build //...` — all 1083 targets pass
- [x] Cross-platform Windows fixture path handled via runfiles (rules_go `<target>_/<target>.exe` layout)
- [ ] Linux/macOS CI (would benefit from a non-Windows run before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)