### PR TITLE
fix(transformer): qualify cross-package function calls when not dot-imported

### DIFF
--- a/bazel_test_fixtures/external_gala_consumer/consumer_lowering_test.go
+++ b/bazel_test_fixtures/external_gala_consumer/consumer_lowering_test.go
@@ -59,6 +59,18 @@ func TestCrossModuleApplyLoweringForExternalRepoDep(t *testing.T) {
 		"lambda parameter must not collapse to func(any) any, got:\n%s", got)
 	require.True(t, strings.Contains(got, "func(x int) int"),
 		"expected concrete-typed lambda func(x int) int in generated Go, got:\n%s", got)
+
+	// Top-level cross-module function call: the analyzer must load the
+	// imported package's function metadata so the lambda's first parameter
+	// gets the declared `int` type and the result type stays string. If the
+	// signature is dropped, the lambda regresses to `func(i any) any` and
+	// the body's string-interpolation produces the wrong return type.
+	require.False(t, strings.Contains(got, "func(i any) any"),
+		"top-level cross-module lambda must not collapse to func(i any) any, got:\n%s", got)
+	require.False(t, strings.Contains(got, "func(i any) string"),
+		"top-level cross-module lambda parameter must not be typed any, got:\n%s", got)
+	require.True(t, strings.Contains(got, "func(i int) string"),
+		"expected concrete-typed lambda func(i int) string for TabulateInts call, got:\n%s", got)
 }
 
 // containsBareConversion reports whether the source text contains a bare

--- a/bazel_test_fixtures/external_gala_consumer/main.gala
+++ b/bazel_test_fixtures/external_gala_consumer/main.gala
@@ -25,5 +25,10 @@ func main() {
         Field = 7,
         Cb = (x) => x + 1,
     )
-    Println(s"h=${h.String()} y=${y.String()} c=${c.Field}")
+    // Top-level function call: lambda's `i` parameter must lower to
+    // `func(i int) string`, not `func(i any) string`. The signature
+    // for TabulateInts lives in the external Bazel module's package
+    // and must be loaded by the analyzer when transpiling this file.
+    val s = TabulateInts(3, (i) => s"n=$i")
+    Println(s"h=${h.String()} y=${y.String()} c=${c.Field} s=$s")
 }

--- a/bazel_test_fixtures/external_gala_module/effects/BUILD.bazel
+++ b/bazel_test_fixtures/external_gala_module/effects/BUILD.bazel
@@ -1,8 +1,18 @@
 load("@gala//:gala.bzl", "gala_library")
 
+# Note: ArrayTabulate / Array (used by BuildLabels in effects.gala) are
+# auto-imported from std's collection_immutable. They do not appear in
+# gala_deps because stdlib types are reached via the gala.bzl --search
+# argument that points at the gala module root (the dep's go.mod
+# directory), not via explicit gala_deps. This mirrors how downstream
+# external GALA modules reach stdlib types in production.
 gala_library(
     name = "effects",
-    srcs = ["effects.gala"],
+    srcs = [
+        "effects.gala",
+        "widget.gala",
+    ],
     importpath = "martianoff/external_gala_module/effects",
     visibility = ["//visibility:public"],
+    deps = ["@gala//collection_immutable"],
 )

--- a/bazel_test_fixtures/external_gala_module/effects/effects.gala
+++ b/bazel_test_fixtures/external_gala_module/effects/effects.gala
@@ -17,3 +17,18 @@ struct Container[T any](
     Field T,
     Cb func(T) T,
 )
+
+// Top-level generic function whose lambda parameter is typed `int` (not
+// a type-parameter). Mirrors the shape of std's ArrayTabulate. A
+// consumer importing this across Bazel modules must propagate the
+// `func(int) T` signature into the lambda transformer so that the
+// generated Go reads `func(i int) string`, not `func(i any) string`.
+func TabulateInts[T any](n int, f func(int) T) T = f(n)
+
+// Call ArrayTabulate (from std's collection_immutable) inside the
+// external module's own source. When the module is transpiled inside
+// a downstream consumer's Bazel sandbox, the analyzer must still
+// resolve `ArrayTabulate`'s `func(int) T` signature so the lambda's
+// `i` parameter lowers to `int`, not `any`. Reproduces the gala_tui
+// cross-module ArrayTabulate regression.
+func BuildLabels(n int) Array[string] = ArrayTabulate(n, (i) => s"row=$i")

--- a/bazel_test_fixtures/external_gala_module/effects/widget.gala
+++ b/bazel_test_fixtures/external_gala_module/effects/widget.gala
@@ -1,0 +1,16 @@
+package effects
+
+// Sibling file in the same external module. It explicitly imports
+// collection_immutable. In the in-repo (single-module) build the
+// analyzer's sibling-import scan picks up this dependency so that
+// effects.gala's bare `ArrayTabulate` reference is resolved to the
+// imported package and the lambda parameter is typed `int`.
+//
+// Cross-module — when this package is transpiled inside a downstream
+// consumer's Bazel sandbox — must behave the same way: the lambda
+// parameter must NOT regress to `any` just because the source files
+// are reached via @<module>+/effects/* instead of //effects/*.
+import . "martianoff/gala/collection_immutable"
+
+// Use the imported package somewhere so the import isn't dead code.
+func WidgetSize(n int) Array[int] = ArrayTabulate(n, (i) => i + 1)

--- a/internal/transpiler/transformer/constructors.go
+++ b/internal/transpiler/transformer/constructors.go
@@ -42,6 +42,32 @@ func (t *galaASTTransformer) transformPrimary(ctx *grammar.PrimaryContext) (ast.
 		if resolvedFunc != nil && resolvedFunc.Package == registry.StdPackageName {
 			return t.stdIdent(name), nil
 		}
+		// Function from another GALA package (e.g., ArrayTabulate from
+		// collection_immutable). Either keep the bare name (when the package
+		// is dot-imported in this file) and mark the dot-import as used, or
+		// qualify as `pkg.Name` and add a transitive import. Without this,
+		// a sibling file's dot-import propagates the function's metadata into
+		// our richAST so the lambda's parameter type is inferred correctly,
+		// but the call site emits an unqualified `Name(...)` that the Go
+		// compiler rejects with `undefined: Name`.
+		if resolvedFunc != nil && resolvedFunc.Package != "" && resolvedFunc.Package != t.packageName {
+			pkg := resolvedFunc.Package
+			if t.importManager.IsDotImported(pkg) {
+				t.markDotImportUsed(pkg)
+				return ident, nil
+			}
+			alias := pkg
+			if a, ok := t.importManager.GetAlias(pkg); ok {
+				alias = a
+			}
+			if path, ok := t.importManager.GetPath(pkg); ok {
+				t.importManager.AddTransitive(path, alias)
+			}
+			return &ast.SelectorExpr{
+				X:   ast.NewIdent(alias),
+				Sel: ast.NewIdent(name),
+			}, nil
+		}
 		// Check if it's a known std exported function (defined in Go, not GALA)
 		if registry.IsStdFunction(name) {
 			return t.stdIdent(name), nil


### PR DESCRIPTION
## Summary

When a sibling file dot-imports a GALA package, the analyzer correctly populates that package's function metadata into `richAST.Functions` so the current file can infer lambda parameter types from the imported function's signature. However, `transformPrimary` was returning the bare identifier for any non-`std` resolved function, ignoring the importManager's view of how the package is reachable in the current file. The result was a non-dot `collection_immutable` import alongside an unqualified `ArrayTabulate(...)` call, which Go rejects with `undefined: ArrayTabulate`.

## Root cause

`internal/transpiler/transformer/constructors.go` `transformPrimary` only handled the `std` package case when resolving a bare identifier to a `FunctionMetadata`. For any function in another GALA package (e.g., `collection_immutable.ArrayTabulate`), it emitted the bare ident regardless of whether that package was dot-imported in the current file.

## Fix

Consult `importManager` for the resolved function's package:
- If dot-imported in this file → mark the dot-import as used, keep bare name.
- Otherwise → emit `pkg.Name` (using any registered alias) and record a transitive import so the generated import section matches the call shape.

## Cross-module regression coverage

Extended the existing fixture under `bazel_test_fixtures/external_gala_module/effects/` to drive both shapes:

- `effects.gala` calls `ArrayTabulate` without its own dot-import → must qualify as `collection_immutable.ArrayTabulate`.
- New sibling `widget.gala` dot-imports `collection_immutable` → keeps the bare-name form for its own `ArrayTabulate` call.
- Consumer (`external_gala_consumer/main.gala`) gains a `TabulateInts(3, (i) => …)` call against the external module's own top-level generic function. The `consumer_lowering_test.go` asserts `func(i int) string` and rejects `func(i any) any` / `func(i any) string`.

This locks in:
1. Cross-module top-level function lambda parameter typing (the gala_tui regression flavor).
2. The codegen-side qualification fix landed in this PR.

## Test plan

- [x] `bazel build //...` passes
- [x] `bazel test //...` passes (297/297)
- [x] `bazel test bazel_test_fixtures/...` — both consumer fixtures pass
- [ ] Re-verify against gala_tui consumed via `local_path_override`

🤖 Generated with [Claude Code](https://claude.com/claude-code)