### PR TITLE
feat(inference): downward inference for generic sealed-type case constructors

### DIFF
--- a/docs/TYPE_INFERENCE.MD
+++ b/docs/TYPE_INFERENCE.MD
@@ -365,6 +365,50 @@ val joined = list.FoldLeft("", (acc, x) => acc + x)     // acc inferred as strin
 
 ---
 
+## Downward Inference for Generic Sealed-Type Case Constructors
+
+A generic sealed type's case constructors (e.g. `NoCmd()` for `sealed type Cmd[T any]`) carry a vestigial type parameter that cannot be inferred from the constructor's own arguments — a zero-field variant has no value of type `T` to pin against. To avoid forcing users to write `NoCmd[Msg]()` everywhere, the transpiler propagates an **expected type** downward from the surrounding context and rewrites the bare reference into an explicit instantiation (`NoCmd[Msg]{}.Apply()`).
+
+Five contexts feed the expected type:
+
+| # | Context | Example |
+|---|---------|---------|
+| 1 | `val`/`var` with explicit type | `val c Cmd[int] = NoCmd()` |
+| 2 | Function return type | `func make() Cmd[Msg] = NoCmd()` |
+| 3 | Function argument expected type | `runCmd(NoCmd())` where `runCmd(c Cmd[Msg])` |
+| 4 | Container element type | `ArrayOf[Cmd[Msg]](NoCmd(), QuitCmd())` |
+| 5 | Match arm with externally-pinned result | `val c Cmd[Msg] = m match { case Tick() => NoCmd() … }` |
+
+### Propagation mechanism
+
+- A single transformer field, `pendingExpectedArgType`, threads the expected slot type from a setter context (val decl, argument transform, tuple element) into the call dispatcher. The dispatcher consumes-and-clears it on entry, so deeper sub-expressions don't accidentally see a stale value.
+- For the **zero-arg call** path (`NoCmd()` with empty parens), `applyCallSuffix` consults `pendingExpectedArgType` after `inferZeroArgTypeParams` (which already covered the match-subject and enclosing-return fallbacks for `None()` / `Some()`), and rewrites the receiver via `injectSealedVariantTypeArgs`.
+- For the **non-zero-arg call** path, `transformCallWithArgsCtx` already invoked the same rewrite at the top of the dispatcher.
+- For **function arguments** (context 3), `resolveExpectedFuncArgType` was extended to return the declared param type verbatim for non-FuncType params of non-generic GALA functions, so the existing argument-transform path can stash it in `pendingExpectedArgType`.
+- For **tuple elements** (context 2 with tuple return), `transformPrimary` inspects the enclosing `currentFuncReturnType` for a Tuple-shaped expected type and threads each per-slot type into the corresponding element transform.
+- For **match arms** (context 5), `buildMatchExpressionFromClauses` promotes a pending expected slot type to `currentFuncReturnType` for the IIFE's body, so each arm's expression — not just the first — picks it up via the existing companion-of-sealed lookup.
+
+If none of the contexts supply a concrete type and the constructor is genuinely ambiguous, the existing "cannot infer type for case constructor" error fires; downward inference does not silently fall back to `any`.
+
+### Limitations
+
+- The match-arm path (5) currently propagates a single type only when the match expression is itself the immediate value of one of the contexts above. Arms inside a match used purely as a side-effect dispatch still rely on per-arm inference.
+- The propagation field is a single value, not a stack of expected types per nesting depth. Re-entrancy is handled with `defer` saves; cleanup is reliable but observers should not assume the value persists past one dispatcher entry.
+
+### Pointers
+
+| File | Role |
+|------|------|
+| `transformer/calls.go::injectSealedVariantTypeArgs` | Rewrites `Variant(...)` → `Variant[Args]` when expected is the sealed parent |
+| `transformer/calls.go::applyCallSuffix` (zero-arg branch) | Consumes `pendingExpectedArgType` for `Variant()` |
+| `transformer/calls.go::transformCallWithArgsCtx` | Consumes `pendingExpectedArgType` for `Variant(arg, …)` |
+| `transformer/call_context.go::resolveExpectedFuncArgType` | Surfaces non-FuncType param types from non-generic functions |
+| `transformer/constructors.go::transformPrimary` (paren/tuple case) | Threads per-element expected type for tuple literals |
+| `transformer/declarations.go::transformValDeclaration` / `transformVarDeclaration` | Stashes the explicit declared type before transforming RHS |
+| `transformer/postfix.go::buildMatchExpressionFromClauses` | Promotes a pending slot type to `currentFuncReturnType` for arm bodies |
+
+---
+
 ## Go Type Inference
 
 When the Go SDK is available (via `GOROOT` or `PATH`), the transpiler can infer types from Go standard library and third-party packages:

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -918,6 +918,37 @@ gala_test(
 )
 
 gala_test(
+    name = "sealed_inference_val_explicit_type",
+    src = "sealed_inference_val_explicit_type.gala",
+    expected = "sealed_inference_val_explicit_type.out",
+)
+
+gala_test(
+    name = "sealed_inference_return_type",
+    src = "sealed_inference_return_type.gala",
+    expected = "sealed_inference_return_type.out",
+)
+
+gala_test(
+    name = "sealed_inference_arg_context",
+    src = "sealed_inference_arg_context.gala",
+    expected = "sealed_inference_arg_context.out",
+)
+
+gala_test(
+    name = "sealed_inference_container_context",
+    src = "sealed_inference_container_context.gala",
+    expected = "sealed_inference_container_context.out",
+    deps = ["//collection_immutable"],
+)
+
+gala_test(
+    name = "sealed_inference_match_arm",
+    src = "sealed_inference_match_arm.gala",
+    expected = "sealed_inference_match_arm.out",
+)
+
+gala_test(
     name = "match_void_dispatch",
     src = "match_void_dispatch.gala",
     expected = "match_void_dispatch.out",

--- a/examples/multifile_lib_regress/logic.gala
+++ b/examples/multifile_lib_regress/logic.gala
@@ -116,3 +116,42 @@ func DispatchStates[T any](items Array[State[T]]) Array[State[T]] {
 func IfMapEcho[T any](items Array[T], pred func(T) bool, advance func(T) T) Array[T] {
     return items.Map((it) => if (pred(it)) advance(it) else it)
 }
+
+// --- Regression: downward inference of generic sealed-type case constructors.
+// `NoCmd()` and `QuitCmd()` should resolve their type parameter from the
+// enclosing context (val with explicit type, function return type, function
+// argument expected type, container element type, match arm result type).
+// Without inference these constructors emit uninstantiated `NoCmd{}.Apply()`
+// literals which Go rejects with "cannot use generic type without
+// instantiation".
+sealed type Effect[T any] {
+    case NoEffect()
+    case Halt()
+    case Yield(Value T)
+}
+
+// Context (1): val with explicit type drives downward inference.
+val effectOne Effect[int] = NoEffect()
+
+// Context (2): function return type drives downward inference.
+func makeHalt() Effect[string] = Halt()
+
+// Context (3): argument expected type drives downward inference.
+func runEffect(e Effect[int]) string = e match {
+    case NoEffect() => "noop"
+    case Halt() => "halt"
+    case Yield(_) => "yield"
+}
+
+func runDefaultNoEffect() string = runEffect(NoEffect())
+
+// Context (4): container element type drives downward inference.
+func defaultEffects() Array[Effect[int]] =
+    ArrayOf[Effect[int]](NoEffect(), Halt(), Yield(7))
+
+// Context (5): match arm result drives downward inference.
+func selectEffect(n int) Effect[int] = n match {
+    case 0 => NoEffect()
+    case 1 => Halt()
+    case _ => Yield(n)
+}

--- a/examples/sealed_inference_arg_context.gala
+++ b/examples/sealed_inference_arg_context.gala
@@ -1,0 +1,27 @@
+package main
+
+// Context (3): function argument expected-type drives downward inference.
+// `runCmd(NoCmd())` should infer `Cmd[Msg]` from `runCmd`'s parameter type.
+
+sealed type Msg {
+    case Tick()
+    case Quit()
+}
+
+sealed type Cmd[T any] {
+    case NoCmd()
+    case QuitCmd()
+    case MsgCmd(M T)
+}
+
+func runCmd(c Cmd[Msg]) string = c match {
+    case NoCmd() => "no"
+    case QuitCmd() => "quit"
+    case MsgCmd(_) => "msg"
+}
+
+func main() {
+    Println(runCmd(NoCmd()))
+    Println(runCmd(QuitCmd()))
+    Println(runCmd(MsgCmd(Tick())))
+}

--- a/examples/sealed_inference_arg_context.out
+++ b/examples/sealed_inference_arg_context.out
@@ -1,0 +1,3 @@
+no
+quit
+msg

--- a/examples/sealed_inference_container_context.gala
+++ b/examples/sealed_inference_container_context.gala
@@ -1,0 +1,28 @@
+package main
+
+import . "martianoff/gala/collection_immutable"
+
+// Context (4): elements of a container with a concrete element type
+// (Array[Cmd[Msg]]) drive downward inference for unannotated case
+// constructors. Bare `NoCmd()` etc. should infer T from the slot's type.
+
+sealed type Msg {
+    case Tick()
+    case Quit()
+}
+
+sealed type Cmd[T any] {
+    case NoCmd()
+    case QuitCmd()
+    case MsgCmd(M T)
+}
+
+func main() {
+    val cmds = ArrayOf[Cmd[Msg]](
+        NoCmd(),
+        QuitCmd(),
+        MsgCmd(Tick()),
+    )
+    Println(s"length=${cmds.Length()}")
+    cmds.ForEach((c) => Println(c))
+}

--- a/examples/sealed_inference_container_context.out
+++ b/examples/sealed_inference_container_context.out
@@ -1,0 +1,4 @@
+length=3
+NoCmd()
+QuitCmd()
+MsgCmd(Tick())

--- a/examples/sealed_inference_match_arm.gala
+++ b/examples/sealed_inference_match_arm.gala
@@ -1,0 +1,33 @@
+package main
+
+// Context (5): match-arm inference. When a match expression's result type
+// is constrained externally (e.g. assigned to a typed val or returned from
+// a typed function), each arm's expression should resolve unannotated
+// case constructors against that expected type.
+
+sealed type Msg {
+    case Tick()
+    case Quit()
+}
+
+sealed type Cmd[T any] {
+    case NoCmd()
+    case QuitCmd()
+    case MsgCmd(M T)
+}
+
+func updateMsg(m Msg) Cmd[Msg] = m match {
+    case Tick() => NoCmd()
+    case Quit() => QuitCmd()
+}
+
+func main() {
+    val a Cmd[Msg] = Tick() match {
+        case Tick() => NoCmd()
+        case Quit() => QuitCmd()
+    }
+    Println(a)
+
+    Println(updateMsg(Tick()))
+    Println(updateMsg(Quit()))
+}

--- a/examples/sealed_inference_match_arm.out
+++ b/examples/sealed_inference_match_arm.out
@@ -1,0 +1,3 @@
+NoCmd()
+NoCmd()
+QuitCmd()

--- a/examples/sealed_inference_return_type.gala
+++ b/examples/sealed_inference_return_type.gala
@@ -1,0 +1,33 @@
+package main
+
+// Context (2): function return-type drives downward inference.
+// When a function declares `Cmd[MegaMsg]` as return, a tail-position
+// `NoCmd()` (or `(model, NoCmd())`) should infer `[MegaMsg]` without
+// explicit type-args on the variant.
+
+sealed type Msg {
+    case Tick()
+    case Quit()
+}
+
+sealed type Cmd[T any] {
+    case NoCmd()
+    case QuitCmd()
+    case MsgCmd(M T)
+}
+
+func makeNoCmd() Cmd[Msg] = NoCmd()
+
+func makeQuitCmd() Cmd[Msg] = QuitCmd()
+
+func updateBlock(n int) Tuple[int, Cmd[Msg]] {
+    val next = n + 1
+    return (next, NoCmd())
+}
+
+func main() {
+    Println(makeNoCmd())
+    Println(makeQuitCmd())
+    val (n, c) = updateBlock(0)
+    Println(s"n=$n cmd=$c")
+}

--- a/examples/sealed_inference_return_type.out
+++ b/examples/sealed_inference_return_type.out
@@ -1,0 +1,3 @@
+NoCmd()
+QuitCmd()
+n=1 cmd=NoCmd()

--- a/examples/sealed_inference_val_explicit_type.gala
+++ b/examples/sealed_inference_val_explicit_type.gala
@@ -1,0 +1,21 @@
+package main
+
+// Context (1): direct val assignment with an explicit type.
+// `val c Cmd[int] = NoCmd()` should resolve T -> int from the
+// declared variable type rather than requiring `NoCmd[int]()`.
+sealed type Cmd[T any] {
+    case NoCmd()
+    case QuitCmd()
+    case MsgCmd(M T)
+}
+
+func main() {
+    val c1 Cmd[int] = NoCmd()
+    Println(c1)
+
+    val c2 Cmd[string] = QuitCmd()
+    Println(c2)
+
+    val c3 Cmd[int] = MsgCmd(42)
+    Println(c3)
+}

--- a/examples/sealed_inference_val_explicit_type.out
+++ b/examples/sealed_inference_val_explicit_type.out
@@ -1,0 +1,3 @@
+NoCmd()
+QuitCmd()
+MsgCmd(42)

--- a/internal/transpiler/transformer/call_context.go
+++ b/internal/transpiler/transformer/call_context.go
@@ -152,6 +152,21 @@ func (t *galaASTTransformer) resolveExpectedFuncArgType(ctx callContext, argIdx 
 		}
 	}
 
+	// Non-FuncType param of a non-generic GALA function: pass the declared
+	// param type through verbatim so sealed-variant downward inference (the
+	// pendingExpectedArgType propagation in transformArgumentWithExpectedType)
+	// can resolve a zero-arg case constructor like `NoCmd()` against the
+	// callee's declared parameter type (e.g. `Cmd[Msg]`). Skipping FuncType
+	// is intentional: those have a dedicated path above with masking logic.
+	if expectedType.IsNil() && ctx.funcMeta != nil && len(ctx.funcMeta.TypeParams) == 0 && argIdx < len(ctx.funcMeta.ParamTypes) {
+		paramType := ctx.funcMeta.ParamTypes[argIdx]
+		if !paramType.IsNil() {
+			if _, isFunc := paramType.(transpiler.FuncType); !isFunc {
+				expectedType = paramType
+			}
+		}
+	}
+
 	// Fall back to Go type info for lambda expected types
 	if expectedType.IsNil() && ctx.goParamTypes != nil && argIdx < len(ctx.goParamTypes) {
 		if ft, ok := ctx.goParamTypes[argIdx].(transpiler.FuncType); ok {

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -77,6 +77,22 @@ func (t *galaASTTransformer) applyCallSuffix(base ast.Expr, suffix *grammar.Post
 									receiverType = inferredBase
 								}
 							}
+							// Downward inference: a sealed-variant zero-arg constructor
+							// (e.g. `NoCmd()`) inside a context that expects the parent
+							// sealed type (`Cmd[int]`) needs explicit type args injected
+							// onto the variant — without them Go cannot pin the
+							// vestigial type parameter from an empty composite literal.
+							// Consume the pendingExpectedArgType set by enclosing val
+							// declarations / argument transforms.
+							if receiverType == base {
+								pending := t.pendingExpectedArgType
+								if pending != nil && !pending.IsNil() {
+									if rewritten, ok := t.injectSealedVariantTypeArgs(base, pending); ok {
+										receiverType = rewritten
+										t.pendingExpectedArgType = nil
+									}
+								}
+							}
 							receiver := &ast.CompositeLit{Type: receiverType}
 							return &ast.CallExpr{
 								Fun: &ast.SelectorExpr{

--- a/internal/transpiler/transformer/constructors.go
+++ b/internal/transpiler/transformer/constructors.go
@@ -57,18 +57,92 @@ func (t *galaASTTransformer) transformPrimary(ctx *grammar.PrimaryContext) (ast.
 	}
 	for i := 0; i < ctx.GetChildCount(); i++ {
 		if exprListCtx, ok := ctx.GetChild(i).(grammar.IExpressionListContext); ok {
-			exprs, err := t.transformExpressionList(exprListCtx.(*grammar.ExpressionListContext))
+			el := exprListCtx.(*grammar.ExpressionListContext)
+			// When a tuple literal flows into a Tuple-shaped enclosing context
+			// (e.g., the return position of a function declared to return
+			// `Tuple[int, Cmd[Msg]]`), thread each element's expected type so
+			// that nested sealed-variant constructors like `NoCmd()` infer their
+			// type parameters from the tuple's slot.
+			elemExprs := el.AllExpression()
+			if len(elemExprs) > 1 {
+				perElemExpected := t.tupleElementExpectedTypes(len(elemExprs))
+				exprs, err := t.transformTupleElementExpressions(elemExprs, perElemExpected)
+				if err != nil {
+					return nil, err
+				}
+				return t.transformTupleLiteral(exprs, ctx.GetStart().GetLine(), ctx.GetStart().GetColumn())
+			}
+			exprs, err := t.transformExpressionList(el)
 			if err != nil {
 				return nil, err
 			}
 			if len(exprs) == 1 {
 				return &ast.ParenExpr{X: exprs[0]}, nil
 			}
-			// Multiple expressions in parentheses -> tuple literal syntax
 			return t.transformTupleLiteral(exprs, ctx.GetStart().GetLine(), ctx.GetStart().GetColumn())
 		}
 	}
 	return nil, nil
+}
+
+// tupleElementExpectedTypes returns the per-element expected types for a
+// tuple literal of the given arity, computed from the most-specific available
+// outer context. Currently checks `currentFuncReturnType` for the
+// enclosing-return case (context 2 of downward sealed-variant inference).
+// Returns nil if no Tuple-shaped expected type is available.
+func (t *galaASTTransformer) tupleElementExpectedTypes(arity int) []transpiler.Type {
+	candidates := []transpiler.Type{t.currentFuncReturnType}
+	for _, cand := range candidates {
+		if cand == nil || cand.IsNil() {
+			continue
+		}
+		gen, ok := cand.(transpiler.GenericType)
+		if !ok {
+			continue
+		}
+		if !t.isTupleTypeName(gen.Base.String()) {
+			continue
+		}
+		if len(gen.Params) != arity {
+			continue
+		}
+		return gen.Params
+	}
+	return nil
+}
+
+// transformTupleElementExpressions transforms each element of a tuple literal
+// with its corresponding expected type stashed in pendingExpectedArgType, so
+// that sealed-variant constructors nested directly inside an element can
+// resolve their type arguments from the surrounding tuple slot.
+func (t *galaASTTransformer) transformTupleElementExpressions(
+	elemExprs []grammar.IExpressionContext,
+	perElemExpected []transpiler.Type,
+) ([]ast.Expr, error) {
+	out := make([]ast.Expr, 0, len(elemExprs))
+	for i, eCtx := range elemExprs {
+		var expected transpiler.Type
+		if i < len(perElemExpected) {
+			expected = perElemExpected[i]
+		}
+		if expected != nil && !expected.IsNil() {
+			prev := t.pendingExpectedArgType
+			t.pendingExpectedArgType = expected
+			expr, err := t.transformExpression(eCtx)
+			t.pendingExpectedArgType = prev
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, expr)
+			continue
+		}
+		expr, err := t.transformExpression(eCtx)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, expr)
+	}
+	return out, nil
 }
 
 func (t *galaASTTransformer) transformCompositeLiteral(ctx *grammar.CompositeLiteralContext) (ast.Expr, error) {

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -198,6 +198,26 @@ func (t *galaASTTransformer) transformValDeclaration(ctx *grammar.ValDeclaration
 	}
 
 	namesCtx := ctx.IdentifierList().(*grammar.IdentifierListContext).AllIdentifier()
+
+	// Downward type-inference for sealed-variant constructors (context 1):
+	// when the val carries an explicit type annotation (`val c Cmd[int] = NoCmd()`),
+	// stash the declared type as the expected type so the RHS call dispatcher
+	// can pick up the parent sealed type's type arguments and emit
+	// `NoCmd[int]{}.Apply()` instead of an uninstantiated `NoCmd{}.Apply()`.
+	// transformCallWithArgsCtx consumes-and-clears pendingExpectedArgType on
+	// entry so this only affects the immediately-enclosing call.
+	if ctx.Type_() != nil && len(namesCtx) == 1 {
+		typeExpr, terr := t.transformType(ctx.Type_())
+		if terr == nil {
+			declaredType := t.astTypeToTranspilerType(typeExpr)
+			if declaredType != nil && !declaredType.IsNil() {
+				prev := t.pendingExpectedArgType
+				t.pendingExpectedArgType = declaredType
+				defer func() { t.pendingExpectedArgType = prev }()
+			}
+		}
+	}
+
 	rhsExprs, err := t.transformExpressionList(ctx.ExpressionList().(*grammar.ExpressionListContext))
 	if err != nil {
 		return nil, err
@@ -454,6 +474,22 @@ func (t *galaASTTransformer) transformValTuplePattern(ctx *grammar.ValDeclaratio
 
 func (t *galaASTTransformer) transformVarDeclaration(ctx *grammar.VarDeclarationContext) (ast.Decl, error) {
 	namesCtx := ctx.IdentifierList().(*grammar.IdentifierListContext).AllIdentifier()
+
+	// Mirror transformValDeclaration: thread an explicit declared type as
+	// pendingExpectedArgType so RHS sealed-variant constructors can pick up
+	// the parent's concrete type args.
+	if ctx.Type_() != nil && len(namesCtx) == 1 {
+		typeExpr, terr := t.transformType(ctx.Type_())
+		if terr == nil {
+			declaredType := t.astTypeToTranspilerType(typeExpr)
+			if declaredType != nil && !declaredType.IsNil() {
+				prev := t.pendingExpectedArgType
+				t.pendingExpectedArgType = declaredType
+				defer func() { t.pendingExpectedArgType = prev }()
+			}
+		}
+	}
+
 	rhsExprs := make([]ast.Expr, 0)
 	if ctx.ExpressionList() != nil {
 		var err error

--- a/internal/transpiler/transformer/match_test.go
+++ b/internal/transpiler/transformer/match_test.go
@@ -168,7 +168,7 @@ val res = x match {
 
 import "martianoff/gala/std"
 
-var x std.Immutable[std.Option[any]] = std.NewImmutable[std.Option[any]](std.Some[string]{}.Apply("test"))
+var x std.Immutable[std.Option[any]] = std.NewImmutable[std.Option[any]](std.Some[any]{}.Apply("test"))
 var res = std.NewImmutable(func(obj std.Option[any]) string {
 	{
 		_tmp_1 := std.Some[any]{}.Unapply(obj)

--- a/internal/transpiler/transformer/option_test.go
+++ b/internal/transpiler/transformer/option_test.go
@@ -35,7 +35,7 @@ val y Option[int] = None()`,
 import "martianoff/gala/std"
 
 var x = std.NewImmutable(std.Some[int]{}.Apply(10))
-var y std.Immutable[std.Option[int]] = std.NewImmutable[std.Option[int]](std.None{}.Apply())
+var y std.Immutable[std.Option[int]] = std.NewImmutable[std.Option[int]](std.None[int]{}.Apply())
 `,
 		},
 		{
@@ -105,7 +105,7 @@ func update() {
 
 import "martianoff/gala/std"
 
-var o std.Option[int] = std.None{}.Apply()
+var o std.Option[int] = std.None[int]{}.Apply()
 
 func update() {
 	o = std.Some[int]{}.Apply(42)

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -446,6 +446,22 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 	t.currentMatchSubjectType = matchedType
 	defer func() { t.currentMatchSubjectType = prevMatchSubjectType }()
 
+	// Downward inference for match-arm sealed-variant constructors (context 5):
+	// when the match expression's value flows into a slot with a known
+	// concrete type (val with explicit type, function return, function arg),
+	// promote that expected type to the IIFE's enclosing return type so each
+	// arm's expression can resolve unannotated case constructors against it.
+	// pendingExpectedArgType captures the slot type set by the val-decl /
+	// argument transformers; consume it (so subsequent unrelated calls don't
+	// see it) and stash on currentFuncReturnType for the duration of arm
+	// processing.
+	if pending := t.pendingExpectedArgType; pending != nil && !pending.IsNil() {
+		prevReturn := t.currentFuncReturnType
+		t.currentFuncReturnType = pending
+		t.pendingExpectedArgType = nil
+		defer func() { t.currentFuncReturnType = prevReturn }()
+	}
+
 	var clauses []ast.Stmt
 	var defaultBody []ast.Stmt
 	foundDefault := false


### PR DESCRIPTION
## Summary

Generic sealed types like `sealed type Cmd[T any] { case NoCmd() … }` previously forced users to write `NoCmd[Msg]()` everywhere because a zero-field variant has no value to pin its vestigial `T` against. This PR threads the expected type **downward** from five surrounding contexts so unannotated `NoCmd()` infers `[Msg]` automatically.

### Contexts covered (all 5)

| # | Context | Example |
|---|---------|---------|
| 1 | `val`/`var` with explicit type | `val c Cmd[int] = NoCmd()` |
| 2 | function return type | `func make() Cmd[Msg] = NoCmd()` |
| 3 | function argument expected type | `runCmd(NoCmd())` |
| 4 | container element type | `ArrayOf[Cmd[Msg]](NoCmd(), QuitCmd())` |
| 5 | match arm with pinned outer slot | `val c Cmd[Msg] = m match { case Tick() => NoCmd() … }` |

No contexts are deferred.

### Before / After

```gala
// before — annotation noise on every variant
val c Cmd[Msg] = NoCmd[Msg]()
val cmds = ArrayOf[Cmd[Msg]](
    NoCmd[Msg](),
    QuitCmd[Msg](),
    MsgCmd[Msg](Tick()),
)
func update(m Msg) Cmd[Msg] = m match {
    case Tick() => NoCmd[Msg]()
    case Quit() => QuitCmd[Msg]()
}

// after — type parameter is inferred from the slot
val c Cmd[Msg] = NoCmd()
val cmds = ArrayOf[Cmd[Msg]](NoCmd(), QuitCmd(), MsgCmd(Tick()))
func update(m Msg) Cmd[Msg] = m match {
    case Tick() => NoCmd()
    case Quit() => QuitCmd()
}
```

### Mechanism

A single `pendingExpectedArgType` field threads the slot type into the call dispatcher, which consumes-and-clears it on entry. Per-context plumbing:

- **(1)** val/var declarations stash the declared type before transforming the RHS
- **(2)** existing `tryTransformCompanionApplyOrStructCtor` already used `currentFuncReturnType`; tuple-return case extended via `transformPrimary` per-element threading
- **(3)** `resolveExpectedFuncArgType` now surfaces non-FuncType param types from non-generic GALA functions
- **(4)** unchanged — already worked through the generic-arg substitution path
- **(5)** `buildMatchExpressionFromClauses` promotes a pending slot type to `currentFuncReturnType` for the IIFE body so every arm picks it up

The std `None()` / `Some()` match-subject pinning continues to work via the pre-existing `inferZeroArgTypeParams` path; new propagation fires only when that primary path is exhausted.

### Regression tests

- `examples/sealed_inference_val_explicit_type` — context (1)
- `examples/sealed_inference_return_type` — context (2), incl. tuple-element case
- `examples/sealed_inference_arg_context` — context (3)
- `examples/sealed_inference_container_context` — context (4)
- `examples/sealed_inference_match_arm` — context (5)
- `examples/multifile_lib_regress/logic.gala` — `Effect[T]` exercise covering all five contexts in batch (multi-file) transpilation

### Tests

- All 302 tests in `bazel test //...` pass.
- Two unit-test expectations updated (`option_test.go`, `match_test.go`) to reflect the corrected, instantiated output (`None[int]{}.Apply()` instead of bare `None{}.Apply()`); the previous expectations would have produced un-typeable Go in real assignments.

Design rationale is described separately in `docs/private/GENERIC_SEALED_TYPE_INFERENCE.md`. New behavior documented in `docs/TYPE_INFERENCE.MD`.

## Test plan

- [x] `bazel build //...` passes
- [x] `bazel test //...` passes (302/302)
- [x] Each context has a dedicated example test
- [x] Multifile (batch transpile) regression covers all five contexts
- [x] `docs/TYPE_INFERENCE.MD` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)