### PR TITLE
test(transformer): cross-module qualified-import sealed-case + struct-ctor Apply lowering

### DIFF
--- a/bazel_test_fixtures/xmod_qualified/BUILD.bazel
+++ b/bazel_test_fixtures/xmod_qualified/BUILD.bazel
@@ -1,0 +1,46 @@
+"""Cross-module Bazel regression test for qualified-import Apply lowering.
+
+The sibling //bazel_test_fixtures/external_gala_consumer fixture covers the
+dot-import case (`import . "martianoff/external_gala_module/effects"`),
+which routes the call site through a bare-Ident shape such as
+`Halt[int](...)`. This fixture covers the qualified-import case
+(`import "martianoff/external_gala_module/effects"`) which routes the
+call site through a SelectorExpr shape such as `effects.Halt[int](...)`.
+
+Before the fix, the call dispatcher's Section-10 typeName extraction
+returned the bare leaf `Halt` for selector calls, missing the imported
+package's type metadata stored under the qualified key
+`effects.Halt`. The transformer fell through to the verbatim emit
+path, producing `effects.Halt[int]()` (a bare type conversion Go
+rejects as "missing argument in conversion") for zero-field sealed
+cases and `effects.Container[int]{Field: ..., Cb: ...}` (a raw struct
+literal where each field is std.Immutable[T]-wrapped at codegen) for
+named-arg struct constructors.
+"""
+
+load("@gala//:gala.bzl", "gala_transpile")
+load("@rules_go//go:def.bzl", "go_test")
+
+# Gazelle would otherwise auto-generate a duplicate go_test target.
+# gazelle:exclude qualified_lowering_test.go
+
+# Use gala_transpile (not gala_binary) so we exercise the same Bazel
+# wiring as the sibling xmod_consumer_galamod fixture: gala.mod with a
+# require directive routed through extra_srcs, no link step downstream.
+gala_transpile(
+    name = "transpile",
+    src = "main.gala",
+    out = "main.gen.go",
+    extra_srcs = ["gala.mod"],
+    gala_deps = ["@external_gala_module//effects"],
+)
+
+go_test(
+    name = "qualified_lowering_test",
+    srcs = ["qualified_lowering_test.go"],
+    data = [":transpile"],
+    deps = [
+        "@com_github_stretchr_testify//require",
+        "@rules_go//go/tools/bazel:go_default_library",
+    ],
+)

--- a/bazel_test_fixtures/xmod_qualified/gala.mod
+++ b/bazel_test_fixtures/xmod_qualified/gala.mod
@@ -1,0 +1,5 @@
+module example.com/xmod_qualified
+
+gala dev
+
+require martianoff/external_gala_module v0.0.0

--- a/bazel_test_fixtures/xmod_qualified/main.gala
+++ b/bazel_test_fixtures/xmod_qualified/main.gala
@@ -1,0 +1,57 @@
+package main
+
+import "martianoff/external_gala_module/effects"
+
+// Cross-module consumer that imports the external GALA module under a
+// qualified (non-dot) name. Sibling //bazel_test_fixtures/external_gala_consumer
+// covers the dot-import case (`Halt[int]()`); this fixture covers the
+// SelectorExpr call shape that arises from qualified import
+// (`effects.Halt[int]()`, etc.).
+//
+// All three call shapes must lower the same way as their dot-imported
+// counterparts:
+//
+//   - effects.Halt[int]()              -> effects.Halt[int]{}.Apply()
+//   - effects.Yield[int](Val = 42)     -> effects.Yield[int]{}.Apply(42)
+//   - effects.Container[int](
+//         Field = 7,
+//         Cb = (x) => x + 1,
+//     )                                 -> effects.Container[int]{
+//                                              Field: std.NewImmutable(7),
+//                                              Cb: std.NewImmutable(
+//                                                  func(x int) int { ... }),
+//                                          }
+//
+// The hazard the dispatcher must avoid: emitting a bare type conversion
+// `effects.Halt[int]()` (Go rejects: "missing argument in conversion to
+// effects.Halt[int]") or a raw struct literal whose fields would receive
+// raw values for std.Immutable[T]-wrapped fields (Go rejects:
+// "cannot use ... as std.Immutable[T] value in struct literal").
+//
+// Beyond the simple call sites the fixture also drives a function whose
+// return type embeds the imported sealed parent generic
+// (`effects.Effect[Msg]`) with a CONSUMER-defined type argument. This
+// exercises the "type-arg flows back into the imported sealed case"
+// path: the call-site `effects.Halt[Msg]()` must still lower to
+// `effects.Halt[Msg]{}.Apply()` even though Msg is defined in this
+// file, not in the imported module.
+sealed type Msg {
+    case Tick()
+    case Quit()
+}
+
+func step(m int, msg Msg) Tuple[int, effects.Effect[Msg]] = msg match {
+    case Tick() => (m + 1, effects.Halt[Msg]())
+    case Quit() => (m, effects.Yield[Msg](Val = Tick()))
+}
+
+func main() {
+    val h = effects.Halt[int]()
+    val y = effects.Yield[int](Val = 42)
+    val c = effects.Container[int](
+        Field = 7,
+        Cb = (x) => x + 1,
+    )
+    val (n, _) = step(0, Tick())
+    Println(s"h=${h.String()} y=${y.String()} c=${c.Field} n=$n")
+}

--- a/bazel_test_fixtures/xmod_qualified/qualified_lowering_test.go
+++ b/bazel_test_fixtures/xmod_qualified/qualified_lowering_test.go
@@ -1,0 +1,98 @@
+package qualified_lowering_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/stretchr/testify/require"
+)
+
+// TestQualifiedCrossModuleApplyLowering verifies that gala_transpile lowers
+// sealed-case constructors and named-arg struct constructors correctly when
+// the dep is imported under a qualified (non-dot) name. The sibling
+// external_gala_consumer fixture asserts the dot-import shape; this fixture
+// asserts the SelectorExpr shape that arises from
+// `import "martianoff/external_gala_module/effects"` (no dot).
+//
+// The hazards locked in by this test:
+//
+//  1. Zero-field sealed case must lower to {}.Apply(), never to a bare
+//     type conversion `effects.Halt[int]()` that Go rejects on a struct
+//     with no fields.
+//  2. Fielded sealed case must lower to {}.Apply(arg), never to a raw
+//     struct literal `effects.Yield[int]{Val: 42}` that bypasses the
+//     variant invariants.
+//  3. Named-arg struct constructor must lower to a struct literal whose
+//     std.Immutable[T] fields are wrapped via std.NewImmutable, with a
+//     concrete-typed lambda parameter (`func(x int) int`, not
+//     `func(x any) any`).
+//  4. The consumer's own sealed type used as a type argument to the
+//     imported case (`effects.Halt[Msg]`) must propagate through the
+//     dispatcher's type-arg inference even though `Msg` is defined in
+//     this file, not in the imported module.
+func TestQualifiedCrossModuleApplyLowering(t *testing.T) {
+	genFile, err := bazel.Runfile("bazel_test_fixtures/xmod_qualified/main.gen.go")
+	require.NoError(t, err, "main.gen.go must be present in runfiles")
+
+	data, err := os.ReadFile(genFile)
+	require.NoError(t, err)
+	got := string(data)
+	t.Logf("generated main.gen.go:\n%s", got)
+
+	// (1) Zero-field sealed case across qualified import.
+	require.True(t, strings.Contains(got, "effects.Halt[int]{}.Apply()"),
+		"expected effects.Halt[int]{}.Apply() in generated Go, got:\n%s", got)
+	require.False(t, containsBareConversion(got, "effects.Halt[int]"),
+		"unexpected bare conversion effects.Halt[int]() in generated Go, got:\n%s", got)
+
+	// (2) Fielded sealed case across qualified import.
+	require.True(t, strings.Contains(got, "effects.Yield[int]{}.Apply("),
+		"expected effects.Yield[int]{}.Apply(...) in generated Go, got:\n%s", got)
+	require.False(t, strings.Contains(got, "effects.Yield[int]{Val:"),
+		"unexpected raw struct literal effects.Yield[int]{Val: ...} in generated Go, got:\n%s", got)
+
+	// (3) Named-arg struct constructor across qualified import.
+	require.True(t, strings.Contains(got, "effects.Container[int]{"),
+		"expected effects.Container[int]{...} in generated Go, got:\n%s", got)
+	require.False(t, strings.Contains(got, "func(x any) any"),
+		"lambda parameter must not collapse to func(any) any, got:\n%s", got)
+	require.True(t, strings.Contains(got, "func(x int) int"),
+		"expected concrete-typed lambda func(x int) int in generated Go, got:\n%s", got)
+	require.True(t, strings.Contains(got, "Field: std.NewImmutable("),
+		"expected Field: std.NewImmutable(...) wrapping in generated Go, got:\n%s", got)
+	require.True(t, strings.Contains(got, "Cb: std.NewImmutable("),
+		"expected Cb: std.NewImmutable(...) wrapping in generated Go, got:\n%s", got)
+
+	// (4) Consumer-defined sealed type flowing into imported sealed-case
+	// type arg. The match arm must lower `effects.Halt[Msg]()` to
+	// `effects.Halt[Msg]{}.Apply()` (and likewise for the fielded variant).
+	require.True(t, strings.Contains(got, "effects.Halt[Msg]{}.Apply()"),
+		"expected effects.Halt[Msg]{}.Apply() in generated Go, got:\n%s", got)
+	require.False(t, containsBareConversion(got, "effects.Halt[Msg]"),
+		"unexpected bare conversion effects.Halt[Msg]() in generated Go, got:\n%s", got)
+	require.True(t, strings.Contains(got, "effects.Yield[Msg]{}.Apply("),
+		"expected effects.Yield[Msg]{}.Apply(...) in generated Go, got:\n%s", got)
+}
+
+// containsBareConversion reports whether the source text contains a bare
+// type-conversion call of the form `<typeExpr>()` (zero arguments) that
+// would silently bypass the sealed-case Apply lowering. The check
+// excludes the `<typeExpr>{}.Apply()` form, which is the correct
+// lowering and shares a textual prefix with the broken shape.
+func containsBareConversion(source, typeExpr string) bool {
+	needle := typeExpr + "("
+	idx := 0
+	for {
+		offset := strings.Index(source[idx:], needle)
+		if offset < 0 {
+			return false
+		}
+		hitEnd := idx + offset + len(needle)
+		if hitEnd <= len(source) && source[hitEnd-1] == '(' && hitEnd < len(source) && source[hitEnd] == ')' {
+			return true
+		}
+		idx = idx + offset + len(needle)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `bazel_test_fixtures/xmod_qualified/` regression coverage for the **qualified (non-dot) import** variant of cross-module `.Apply()` lowering. The existing fixtures (`external_gala_consumer/`, `xmod_consumer_galamod/`) both use dot-import; the SelectorExpr call path went uncovered.
- Locks in the lowerings:
  - `effects.Halt[int]()` → `effects.Halt[int]{}.Apply()` (zero-field sealed case)
  - `effects.Yield[int](Val = 42)` → `effects.Yield[int]{}.Apply(42)` (fielded sealed case)
  - `effects.Container[int](Field = 7, Cb = (x) => x + 1)` → `effects.Container[int]{Field: std.NewImmutable(7), Cb: std.NewImmutable(func(x int) int { ... })}` (named-arg struct ctor)
- Also locks in the type-arg-flow-back-into-imported-case shape: consumer defines `sealed type Msg` and writes `effects.Halt[Msg]()` from a `match` arm.

## Root cause (already fixed; this PR adds regression coverage)

Issue 2 (cross-module zero-field sealed case) and Issue 3 (cross-module named-arg struct ctor) were originally fixed by the resolver/analyzer work in `ee89223 fix(resolver): prefer gala.mod over walked-up go.mod and recognise replace deps`, `76c2d38 fix(analyzer): emit {}.Apply() lowering for sealed cases imported from external GALA packages`, and `404508a fix(transformer): allow named args for generic Go-style structs via dot-import`. Existing tests covered the dot-import shape only.

The qualified-import path is a different transformer entry: zero-arg sealed-case calls `effects.Halt[T]()` with empty parens take the `argList == nil` branch in `applyCallSuffix` (because the GALA grammar produces no `argumentList` for `()`). That branch has its own SelectorExpr `isType` check at `internal/transpiler/transformer/calls.go:60-67`. Removing that branch (verification step before this PR) immediately regresses the consumer's match arm with `type mismatch ... 'effects.Halt' vs 'effects.Effect[Msg]'`, proving the test catches the regression.

Named-arg struct ctor `effects.Container[int](Field = ..., Cb = ...)` flows through `handleNamedArgsCall` → `buildStructLiteralWithNamedArgs` where `extractTypeNameFromExpr` already returns `effects.Container` for the qualified shape, and the analyzer's qualified-key metadata lookup wraps each `std.Immutable[T]` field via `NewImmutable`.

## Test plan
- [x] `bazel build //...` passes
- [x] `bazel test //bazel_test_fixtures/...` passes (3 tests, including the new one)
- [x] `bazel test //internal/transpiler/transformer/... //internal/build/...` passes
- [x] Regression check: with `applyCallSuffix:60-67` SelectorExpr branch removed, the new fixture immediately fails to build (semantic error in the match arm), confirming the test is faithful

🤖 Generated with [Claude Code](https://claude.com/claude-code)