### PR TITLE
fix(transformer): emit panic(...) match arms as bare statements

### DIFF
--- a/docs/DEPENDENCY_MANAGEMENT.MD
+++ b/docs/DEPENDENCY_MANAGEMENT.MD
@@ -544,7 +544,21 @@ The `gala.from_file()` extension is only needed when your project has external G
 
 ### BUILD Files
 
-Reference dependencies in the standard `deps` attribute:
+`gala_library` / `gala_binary` accept two related dep attributes:
+
+- **`gala_deps`** — GALA library labels whose **source files** must be
+  visible to the transpiler during this target's transpile step.
+  Required whenever your code calls into the dep's **sealed-type case
+  constructors** (`NoCmd[Msg]()`), **named-arg struct constructors**
+  (`Program[Model, Msg](Initial = ..., …)`), or other forms where the
+  analyzer needs the dep's GALA-side metadata to lower correctly.
+- **`deps`** — plain Bazel labels (Go libraries / GALA libraries used
+  only via fully-typed function calls). Sufficient when the call site
+  doesn't trigger any GALA-side lowering.
+
+When in doubt, **prefer `gala_deps` for any GALA library you import**.
+The cost is only at transpile time (Bazel re-reads the source files);
+the runtime artifact is identical.
 
 ```python
 load("//:gala.bzl", "gala_library", "gala_binary")
@@ -553,15 +567,25 @@ gala_library(
     name = "mylib",
     src = "mylib.gala",
     importpath = "github.com/user/project/mylib",
-    deps = ["@com_github_example_utils//:utils"],
+    gala_deps = ["@com_github_example_utils//:utils"],  # GALA library — analyzer needs source
+    deps = ["@com_github_other_go_lib//:lib"],          # plain Go library
 )
 
 gala_binary(
     name = "myapp",
     src = "main.gala",
-    deps = ["@com_github_example_utils//:utils"],
+    gala_deps = ["@com_github_example_utils//:utils"],
 )
 ```
+
+**Symptom of the wrong split** (GALA dep listed under `deps` instead of
+`gala_deps`): Go-side compile errors at the call site, e.g.
+`missing argument in conversion to pkg.NoCmd[Msg]` or
+`cannot use Model{…} as std.Immutable[Model] value in struct literal`.
+The transpiled `.gen.go` emits a raw type conversion / raw struct
+literal because the analyzer couldn't see that `NoCmd` is a sealed-case
+constructor or that `Program`'s fields are auto-wrapped in
+`std.Immutable`.
 
 ### Repository Naming Convention
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -226,6 +226,12 @@ gala_test(
 )
 
 gala_test(
+    name = "match_arm_panic",
+    src = "match_arm_panic.gala",
+    expected = "match_arm_panic.out",
+)
+
+gala_test(
     name = "tuple",
     src = "tuple.gala",
     expected = "tuple.out",

--- a/examples/match_arm_panic.gala
+++ b/examples/match_arm_panic.gala
@@ -1,0 +1,50 @@
+package main
+
+import "fmt"
+
+func roleFromName(name string) Option[string] {
+    return name match {
+        case "admin" => Some("Administrator")
+        case "user"  => Some("Regular User")
+        case _       => None[string]()
+    }
+}
+
+// Simple-statement panic arm: `case None() => panic(...)`.
+// Pre-fix this emitted invalid `return panic(...)` Go.
+func resolveRole(name string) string {
+    return roleFromName(name) match {
+        case Some(r) => r
+        case None()  => panic(s"unknown role '$name'")
+    }
+}
+
+// Default-case panic arm: `case _ => panic(...)`. The default branch
+// also went through the buggy `return <expr>` lowering before the fix.
+func describeCode(code int) string {
+    return code match {
+        case 0 => "ok"
+        case 1 => "warn"
+        case _ => panic(s"invalid code $code")
+    }
+}
+
+// Block-body panic arm with a side-effect statement before the panic.
+// Exercises the multi-statement block lowering path.
+func mustParseRole(name string) string {
+    return roleFromName(name) match {
+        case Some(r) => r
+        case None() => {
+            Println(s"role lookup failed for '$name'")
+            panic(s"missing role '$name'")
+        }
+    }
+}
+
+func main() {
+    fmt.Println(resolveRole("admin"))
+    fmt.Println(resolveRole("user"))
+    fmt.Println(describeCode(0))
+    fmt.Println(describeCode(1))
+    fmt.Println(mustParseRole("user"))
+}

--- a/examples/match_arm_panic.out
+++ b/examples/match_arm_panic.out
@@ -1,0 +1,5 @@
+Administrator
+Regular User
+ok
+warn
+Regular User

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -160,6 +160,24 @@ func (t *galaASTTransformer) isSealedExhaustive(matchedType transpiler.Type, pat
 	return true, len(missing) == 0, missing
 }
 
+// isNoReturnCallExpr reports whether expr is a call to a Go builtin/function
+// that does not return a value (e.g., `panic(...)`). Such a call cannot be
+// wrapped in a `return <expr>` statement — Go rejects `return panic(...)` as
+// "no value used as value". When such a call appears at the tail of a match
+// arm, the transformer must emit it as a bare statement and rely on Go's
+// terminating-statement analysis (panic does not fall through) so the
+// surrounding IIFE still type-checks.
+func isNoReturnCallExpr(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	if ident, ok := call.Fun.(*ast.Ident); ok {
+		return ident.Name == "panic"
+	}
+	return false
+}
+
 // containsBareReturn reports whether any statement in stmts (recursively) is a
 // `return` with no results. It is used to detect "bare return" inside a branch
 // of a match-as-value expression, which would generate invalid Go because the
@@ -497,9 +515,16 @@ func (t *galaASTTransformer) transformMatchClauses(ctx grammar.IExpressionContex
 						resultTypes = append(resultTypes, t.inferResultType(ret.Results[0]))
 						casePatterns = append(casePatterns, "case _")
 					} else if exprStmt, ok := lastStmt.(*ast.ExprStmt); ok {
-						defaultBody[len(defaultBody)-1] = &ast.ReturnStmt{Results: []ast.Expr{exprStmt.X}}
-						resultTypes = append(resultTypes, t.inferResultType(exprStmt.X))
-						casePatterns = append(casePatterns, "case _")
+						if isNoReturnCallExpr(exprStmt.X) {
+							// Leave bare `panic(...)` as ExprStmt; NilType
+							// keeps this arm out of common-type inference.
+							resultTypes = append(resultTypes, transpiler.NilType{})
+							casePatterns = append(casePatterns, "case _")
+						} else {
+							defaultBody[len(defaultBody)-1] = &ast.ReturnStmt{Results: []ast.Expr{exprStmt.X}}
+							resultTypes = append(resultTypes, t.inferResultType(exprStmt.X))
+							casePatterns = append(casePatterns, "case _")
+						}
 					}
 				}
 			} else if ccCtx.GetBodyStmt() != nil {
@@ -1098,8 +1123,14 @@ func (t *galaASTTransformer) transformCaseClauseWithType(ctx *grammar.CaseClause
 			lastStmt := body[len(body)-1]
 			if lastStmt != nil {
 				if exprStmt, ok := lastStmt.(*ast.ExprStmt); ok {
-					body[len(body)-1] = &ast.ReturnStmt{Results: []ast.Expr{exprStmt.X}}
-					resultType = t.inferResultType(exprStmt.X)
+					if isNoReturnCallExpr(exprStmt.X) {
+						// Leave bare `panic(...)` as an ExprStmt; reporting
+						// NilType keeps this arm out of common-type inference.
+						resultType = transpiler.NilType{}
+					} else {
+						body[len(body)-1] = &ast.ReturnStmt{Results: []ast.Expr{exprStmt.X}}
+						resultType = t.inferResultType(exprStmt.X)
+					}
 				} else if ret, ok := lastStmt.(*ast.ReturnStmt); ok && len(ret.Results) > 0 {
 					resultType = t.inferResultType(ret.Results[0])
 				}
@@ -1168,6 +1199,13 @@ func (t *galaASTTransformer) transformCaseBodyStmt(ctx grammar.ISimpleStatementC
 		expr, err := t.transformExpression(exprCtx)
 		if err != nil {
 			return nil, nil, err
+		}
+		// Calls that do not return (e.g., `panic(...)`) cannot be wrapped in
+		// `return <expr>`. Emit as a bare statement and report NilType so the
+		// arm is skipped during common-result-type inference; the IIFE still
+		// type-checks because Go recognizes panic as a terminating statement.
+		if isNoReturnCallExpr(expr) {
+			return []ast.Stmt{&ast.ExprStmt{X: expr}}, transpiler.NilType{}, nil
 		}
 		resultType := t.inferResultType(expr)
 		return []ast.Stmt{&ast.ReturnStmt{Results: []ast.Expr{expr}}}, resultType, nil

--- a/internal/transpiler/transformer/match_test.go
+++ b/internal/transpiler/transformer/match_test.go
@@ -630,6 +630,76 @@ func unwrap(h Holder) int {
 	}(h.Cell.Get().Get())
 }`,
 		},
+		{
+			// Regression: panic(...) as a value-producing match arm used to
+			// emit invalid `return panic(...)` Go ("no value used as value").
+			// The arm must be lowered to a bare panic statement so the IIFE
+			// type-checks via Go's terminating-statement analysis.
+			name: "Panic as match arm emits bare statement (not return)",
+			input: `package main
+
+func resolve(opt Option[int]) int {
+	return opt match {
+		case Some(n) => n
+		case None()  => panic("missing")
+	}
+}`,
+			expected: `package main
+
+import "martianoff/gala/std"
+
+func resolve(opt std.Option[int]) int {
+	return func(obj std.Option[int]) int {
+		{
+			_tmp_1 := std.Some[int]{}.Unapply(obj)
+			_tmp_2 := _tmp_1.IsDefined()
+			var _tmp_3 int
+			if _tmp_2 {
+				_tmp_3 = _tmp_1.Get()
+			}
+			_ = _tmp_3
+			n := _tmp_3
+			if _tmp_2 {
+				return n
+			} else {
+				_tmp_4 := std.None[int]{}.Unapply(obj)
+				if _tmp_4 {
+					panic("missing")
+				} else {
+					panic("unreachable")
+				}
+			}
+		}
+	}(opt)
+}`,
+		},
+		{
+			// Regression: panic on the default `case _` arm. Exercises the
+			// distinct default-case lowering path in transformMatchClauses.
+			name: "Panic as default match arm emits bare statement",
+			input: `package main
+
+func describe(code int) string {
+	return code match {
+		case 0 => "ok"
+		case 1 => "warn"
+		case _ => panic("invalid")
+	}
+}`,
+			expected: `package main
+
+func describe(code int) string {
+	return func(obj int) string {
+		if obj == 0 {
+			return "ok"
+		} else if obj == 1 {
+			return "warn"
+		} else {
+			panic("invalid")
+		}
+	}(code)
+}`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

`val r = opt match { case Some(x) => x; case None() => panic("...") }` previously generated invalid `return panic(...)` Go (`panic(...) (no value) used as value`). The match-arm IIFE unconditionally wrapped tail expressions in `return <expr>`, but `panic` returns nothing.

## Root cause

`match.go` had three sites that all wrapped a match arm's tail in `&ast.ReturnStmt{Results: []ast.Expr{<expr>}}` regardless of whether `<expr>` was a value-producing call: `transformCaseBodyStmt` (single-statement form), the block-form last-stmt fixup in `transformCaseClauseWithType`, and the default-case block fixup in `transformMatchClauses`.

## Fix

- New helper `isNoReturnCallExpr` detects bare `panic(...)` calls.
- All three lowering sites now emit such arms as a bare `*ast.ExprStmt` and report `transpiler.NilType{}` so they are skipped during common-result-type inference.
- The IIFE still type-checks because Go recognizes `panic` as a terminating statement.

## Verification

- `bazel build //...`
- `bazel test //...` (298/298 pass)
- New `examples/match_arm_panic.gala` exercises the simple-statement, default-case, and block-body forms.
- Two new `TestMatch` cases in `internal/transpiler/transformer/match_test.go` lock in the lowering shape.

## Repro (before fix)

```gala
val role = roleFromName("admin") match {
    case Some(r) => r
    case None()  => panic("unknown role 'admin'")
}
```

Generated Go before the fix:

```go
return panic("unknown role 'admin'")  // ← Go: "no value used as value"
```

After the fix:

```go
panic("unknown role 'admin'")  // bare statement; IIFE type-checks
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)