### PR TITLE
fix(module): prefer search-path gala.mod over cwd in findGalaModRoot

### DIFF
--- a/internal/transpiler/module/resolver.go
+++ b/internal/transpiler/module/resolver.go
@@ -516,16 +516,25 @@ func (e *PackageNotFoundError) Error() string {
 	return "package not found: " + e.ImportPath
 }
 
-// findGalaModRoot searches for gala.mod starting from cwd, then falling back to search paths.
-// Returns the directory containing gala.mod, or empty string if not found.
+// findGalaModRoot searches for gala.mod, preferring the explicit search paths
+// over cwd. Returns the directory containing gala.mod, or empty string if not
+// found.
+//
+// When the caller passes search paths (gala_transpile prepends the consumer's
+// project directory; gala_bootstrap_transpile passes the staged module root
+// for the std files), those paths are the authoritative module roots for this
+// build. cwd is whatever the parent shell or build sandbox happens to be —
+// for a Bazel genrule it is the *consumer's* execroot, which under
+// `local_path_override` may itself contain a `gala.mod` belonging to an
+// unrelated module. Letting cwd win there hijacks `moduleRoot` for the
+// transpile of std (or any package whose source files live under the search
+// path), causing the analyzer to register the same .gala file under two
+// different `DefinedIn` strings and trip GALA-E0011 ("type X redefined").
+//
+// cwd is still consulted as a fallback for callers that pass no search paths
+// (legacy CLI invocations from inside a project directory).
 func findGalaModRoot(searchPaths []string) string {
-	// Try current working directory first
-	cwd, _ := os.Getwd()
-	if root := findGalaModFromDir(cwd); root != "" {
-		return root
-	}
-
-	// Fall back to search paths
+	// Prefer explicit search paths — these are authoritative when set.
 	for _, sp := range searchPaths {
 		absPath, err := filepath.Abs(sp)
 		if err != nil {
@@ -534,6 +543,13 @@ func findGalaModRoot(searchPaths []string) string {
 		if root := findGalaModFromDir(absPath); root != "" {
 			return root
 		}
+	}
+
+	// Fall back to cwd when no search paths were provided (or none yielded a
+	// gala.mod).
+	cwd, _ := os.Getwd()
+	if root := findGalaModFromDir(cwd); root != "" {
+		return root
 	}
 
 	return ""

--- a/internal/transpiler/module/resolver_test.go
+++ b/internal/transpiler/module/resolver_test.go
@@ -383,9 +383,12 @@ require example.com/dep v0.1.0
 	defer os.Chdir(originalWd)
 	require.NoError(t, os.Chdir(consumerDir))
 
-	// Search path points at the dep dir, mirroring what gala_transpile does
-	// from $(locations <dep>_gala_sources) inside the genrule sandbox.
-	resolver := NewResolver([]string{depDir})
+	// Search paths mirror what gala_transpile produces in real builds:
+	// the consumer's project root is the first entry (so its gala.mod wins
+	// the findGalaModRoot scan), with the dep dir appended after — see
+	// gala.bzl's _dep_search_shell_prelude and the --search assembly in
+	// gala_transpile / gala_transpile_package.
+	resolver := NewResolver([]string{consumerDir, depDir})
 	require.True(t, resolver.HasGalaMod(),
 		"consumer's gala.mod must be loaded for the require entry to be visible")
 	require.Equal(t, "example.com/consumer", resolver.ModuleName())
@@ -397,4 +400,67 @@ require example.com/dep v0.1.0
 	// `Case[T]()` conversions for sealed-case constructors.
 	assert.True(t, resolver.IsGalaPackage("example.com/dep"),
 		"GALA dep required without a cached version must still classify as GALA when reachable via a search path")
+}
+
+// TestResolver_PrefersSearchPathGalaModOverCwdGalaMod captures the
+// gala_bootstrap-from-downstream-execroot scenario. Reproduces the original
+// failure where transpiling std/*.gala from a downstream Bazel project
+// (consumer using local_path_override of @gala) hijacked moduleRoot via
+// cwd-walking and tripped GALA-E0011 "type ... redefined".
+//
+// Shape:
+//   - Search path points at the gala module's staged dir (e.g.,
+//     execroot/external/gala+/std/), which has gala.mod for the GALA module.
+//   - cwd is the consumer's execroot (e.g., execroot/_main/), which is
+//     incidentally inside a directory tree containing the consumer's own
+//     gala.mod for an unrelated module.
+//
+// The resolver MUST pick the search path's gala.mod (the actual module being
+// transpiled), not the cwd's gala.mod (the consumer that just happens to be
+// staged in the parent tree). Otherwise the std files end up registered with
+// two different DefinedIn strings (one through the --search resolution path,
+// one through cwd-walking) and the duplicate-type check in the analyzer
+// trips.
+func TestResolver_PrefersSearchPathGalaModOverCwdGalaMod(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "resolver_search_over_cwd_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// The GALA module being transpiled — has gala.mod plus a std-like package
+	// dir with a .gala source. Mirrors execroot/external/gala+/.
+	galaModuleDir := filepath.Join(tempDir, "gala_module")
+	require.NoError(t, os.MkdirAll(galaModuleDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(galaModuleDir, "gala.mod"),
+		[]byte("module martianoff/gala\n\ngala dev\n"), 0644))
+	stdDir := filepath.Join(galaModuleDir, "std")
+	require.NoError(t, os.MkdirAll(stdDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(stdDir, "option.gala"),
+		[]byte("package std\n"), 0644))
+
+	// Consumer's execroot — has its own gala.mod for an unrelated module.
+	// Mirrors what bazel stages at execroot/_main/ when the consumer module
+	// has a workspace-root gala.mod and uses local_path_override of @gala.
+	consumerExecroot := filepath.Join(tempDir, "consumer_execroot")
+	require.NoError(t, os.MkdirAll(consumerExecroot, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(consumerExecroot, "gala.mod"),
+		[]byte("module github.com/example/consumer\n\ngala dev\n"), 0644))
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalWd)
+	require.NoError(t, os.Chdir(consumerExecroot))
+
+	// Bootstrap-style invocation: --search points at the gala module's staged
+	// dir, cwd is the consumer's execroot. With the cwd-first lookup the
+	// resolver would pick consumerExecroot/gala.mod ("github.com/example/consumer")
+	// — wrong; the std files belong to martianoff/gala. With the fix the
+	// search path's gala.mod ("martianoff/gala") wins.
+	resolver := NewResolver([]string{galaModuleDir})
+
+	require.True(t, resolver.HasGalaMod(),
+		"resolver must load the gala module's gala.mod (reached via search path), not the consumer's stale one at cwd")
+	assert.Equal(t, "martianoff/gala", resolver.ModuleName(),
+		"moduleName must come from the search path's gala.mod (martianoff/gala), not cwd's gala.mod (github.com/example/consumer)")
+	assert.Equal(t, galaModuleDir, resolver.ModuleRoot(),
+		"moduleRoot must be the search path's gala.mod directory, not the consumer's execroot")
 }


### PR DESCRIPTION
## Summary

When \`gala_bootstrap\` (or \`gala transpile\`) is invoked from inside a downstream Bazel project's execroot via \`local_path_override\` of \`@gala\`, the consumer's own \`gala.mod\` is staged at \`execroot/_main/gala.mod\` and gets picked up by cwd-walking. The std transpile then runs with the consumer's module as \`moduleRoot\`, registering the same .gala source under two different \`DefinedIn\` strings and tripping \`GALA-E0011 \"type X redefined\"\`.

\`transpile.go::autoResolveSearchPaths\` and \`NewResolver\`'s own docstring both promise that explicit search paths win. \`findGalaModRoot\` was the lone holdout, walking cwd before the search paths — this PR aligns the implementation with the contract.

## Root Cause

\`internal/transpiler/module/resolver.go::findGalaModRoot\` looked at cwd first, then fell back to search paths. For a Bazel genrule, cwd is the *consumer's* execroot, not the module being transpiled — so a consumer with its own \`gala.mod\` hijacks \`moduleRoot\` for transpiles whose source files live under one of the search paths.

## Changes

- \`internal/transpiler/module/resolver.go\` — Reverse the lookup order in \`findGalaModRoot\`: scan explicit search paths first, fall back to cwd. Updated the function's docstring to describe the new contract and the bootstrap scenario the change unblocks.
- \`internal/transpiler/module/resolver_test.go\`
  - Updated \`TestResolver_IsGalaPackage_RequireWithoutCache_FallsThroughToSearchPath\` to use realistic search paths (consumer dir first, dep dir after), matching how \`gala.bzl::_dep_search_shell_prelude\` constructs them in real builds. The test's primary assertion (\`IsGalaPackage(\"example.com/dep\")\` succeeds via search-path scan) is preserved.
  - Added \`TestResolver_PrefersSearchPathGalaModOverCwdGalaMod\` — captures the bootstrap-from-downstream-execroot scenario from the bug report. Asserts that with a search path pointing at the GALA module's staged dir and cwd inside an unrelated consumer's tree, \`moduleRoot\` and \`moduleName\` come from the search path.

## Verification

- \`bazel build //...\` passes.
- \`bazel test //internal/transpiler/module:module_test\` passes (all 12 tests, including the new regression).
- \`bazel test //...\` passes 303/304 — the one failure (\`//examples:from_error\`) is a pre-existing Windows-environmental issue (test calls \`os.Mkdir(\"/tmp/...\")\` which fails on Windows) and is unrelated to this change. The diff touches only \`internal/transpiler/module/\`; \`examples/from_error.gala\` has not been modified since long before 0.37.0.

## Repro (before fix)

From a downstream \`gala_team\` workspace consuming \`@gala\` via \`local_path_override\`:

\`\`\`
bazel --output_base=C:/users/maxmr/_bazel_v3 build //app/ui:ui
\`\`\`

\`\`\`
Error: [SemanticError GALA-E0011] line N:0 type \"X\" in package \"std\" redefined
(first defined in C:\users\maxmr\_bazel_maxmr\nasc4bix\execroot\_main\external\gala+\std\X.gala)
\`\`\`

After this PR, the bootstrap genrules pick the GALA module's own staged \`gala.mod\` as \`moduleRoot\` (via the \`--search\` argument) regardless of what consumer \`gala.mod\` happens to be at the execroot.

## Dependencies

None — this PR is independent and can be reviewed and merged on its own.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)