### PR TITLE
fix(module): prefer search-path go.mod over cwd in findModuleRootFromCwdOrPaths

### DIFF
--- a/internal/transpiler/module/resolver.go
+++ b/internal/transpiler/module/resolver.go
@@ -582,17 +582,23 @@ func findGalaModFromDir(startPath string) string {
 	return ""
 }
 
-// findModuleRootFromCwdOrPaths searches for go.mod starting from cwd,
-// then falling back to search paths.
+// findModuleRootFromCwdOrPaths searches for go.mod, preferring the explicit
+// search paths over cwd. Falls back to cwd only when no search paths were
+// provided (or none yielded a go.mod).
+//
+// Same rationale as findGalaModRoot: when the caller passes search paths,
+// those are authoritative for the module being transpiled. cwd may be a
+// downstream consumer's Bazel execroot whose go.mod belongs to an unrelated
+// module — picking it up there hijacks moduleRoot for transpiles whose
+// source files actually live under the search path. This bites the
+// gala_bootstrap path in particular: gala_simple ships only go.mod (no
+// gala.mod) at its repo root, so the bootstrap genrule for std/*.gala
+// reaches this fallback after findGalaModRoot returns empty, and a
+// consumer's go.mod staged at execroot/_main/go.mod takes over moduleRoot
+// — causing GALA-E0011 "type X redefined" once the std file is registered
+// under two different DefinedIn strings.
 func findModuleRootFromCwdOrPaths(searchPaths []string) (moduleRoot, moduleName string) {
-	// Try current working directory first
-	cwd, _ := os.Getwd()
-	moduleRoot, moduleName = FindModuleRoot(cwd)
-	if moduleRoot != "" {
-		return moduleRoot, moduleName
-	}
-
-	// Fall back to search paths
+	// Prefer explicit search paths — these are authoritative when set.
 	for _, sp := range searchPaths {
 		absPath, err := filepath.Abs(sp)
 		if err != nil {
@@ -602,6 +608,14 @@ func findModuleRootFromCwdOrPaths(searchPaths []string) (moduleRoot, moduleName 
 		if moduleRoot != "" {
 			return moduleRoot, moduleName
 		}
+	}
+
+	// Fall back to cwd when no search paths yielded a go.mod (legacy CLI
+	// invocations from inside a project directory).
+	cwd, _ := os.Getwd()
+	moduleRoot, moduleName = FindModuleRoot(cwd)
+	if moduleRoot != "" {
+		return moduleRoot, moduleName
 	}
 
 	return "", ""

--- a/internal/transpiler/module/resolver_test.go
+++ b/internal/transpiler/module/resolver_test.go
@@ -464,3 +464,58 @@ func TestResolver_PrefersSearchPathGalaModOverCwdGalaMod(t *testing.T) {
 	assert.Equal(t, galaModuleDir, resolver.ModuleRoot(),
 		"moduleRoot must be the search path's gala.mod directory, not the consumer's execroot")
 }
+
+// TestResolver_PrefersSearchPathGoModOverCwdGoMod is the go.mod-fallback
+// counterpart to TestResolver_PrefersSearchPathGalaModOverCwdGalaMod. It
+// captures the second half of the bootstrap-from-downstream-execroot bug:
+// when the GALA module being transpiled ships only `go.mod` at its repo
+// root (no `gala.mod` — the shape gala_simple itself uses), the resolver's
+// gala.mod scan returns empty and NewResolver falls through to
+// findModuleRootFromCwdOrPaths. That fallback must mirror the search-paths-
+// first ordering or the consumer's go.mod (staged at execroot/_main/go.mod
+// under local_path_override) hijacks moduleRoot for the std transpile and
+// trips GALA-E0011 "type X redefined".
+func TestResolver_PrefersSearchPathGoModOverCwdGoMod(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "resolver_search_over_cwd_gomod_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// The GALA module being transpiled — go.mod ONLY (no gala.mod), mirroring
+	// gala_simple's actual repo layout. Has a std-like package dir with a
+	// .gala source.
+	galaModuleDir := filepath.Join(tempDir, "gala_module")
+	require.NoError(t, os.MkdirAll(galaModuleDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(galaModuleDir, "go.mod"),
+		[]byte("module martianoff/gala\n\ngo 1.22\n"), 0644))
+	stdDir := filepath.Join(galaModuleDir, "std")
+	require.NoError(t, os.MkdirAll(stdDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(stdDir, "either.gala"),
+		[]byte("package std\n"), 0644))
+
+	// Consumer's execroot — has its own go.mod for an unrelated module.
+	// Mirrors what bazel stages at execroot/_main/go.mod when the consumer
+	// uses local_path_override of @gala. No gala.mod on either side, so the
+	// gala.mod scan returns empty and the resolver falls through to the
+	// go.mod path.
+	consumerExecroot := filepath.Join(tempDir, "consumer_execroot")
+	require.NoError(t, os.MkdirAll(consumerExecroot, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(consumerExecroot, "go.mod"),
+		[]byte("module github.com/example/consumer\n\ngo 1.22\n"), 0644))
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalWd)
+	require.NoError(t, os.Chdir(consumerExecroot))
+
+	// Bootstrap-style invocation: --search points at the gala module's staged
+	// dir, cwd is the consumer's execroot. With the cwd-first lookup the
+	// resolver would pick consumerExecroot/go.mod ("github.com/example/consumer")
+	// — wrong; the std files belong to martianoff/gala. With the fix the
+	// search path's go.mod ("martianoff/gala") wins.
+	resolver := NewResolver([]string{galaModuleDir})
+
+	assert.Equal(t, "martianoff/gala", resolver.ModuleName(),
+		"moduleName must come from the search path's go.mod (martianoff/gala), not cwd's go.mod (github.com/example/consumer)")
+	assert.Equal(t, galaModuleDir, resolver.ModuleRoot(),
+		"moduleRoot must be the search path's go.mod directory, not the consumer's execroot")
+}


### PR DESCRIPTION
## Summary

Second half of the cwd-first module discovery fix. PR #262 covered \`findGalaModRoot\` (gala.mod scan); this covers \`findModuleRootFromCwdOrPaths\` (go.mod fallback). Without it, downstream Bazel builds against \`@gala\` via \`local_path_override\` still hit \`GALA-E0011 \"type X redefined\"\` when \`gala_simple\` ships only \`go.mod\` at its repo root (its actual layout) — the resolver falls through to the go.mod path which still preferred cwd.

## Root Cause

In \`internal/transpiler/module/resolver.go\`, \`NewResolver\` calls \`findGalaModRoot\` first; if that returns empty (the GALA module has no \`gala.mod\`), it falls back to \`findModuleRootFromCwdOrPaths\`. PR #262 reversed the order in \`findGalaModRoot\` but left the go.mod variant unchanged. For Bazel genrules running from a consumer's execroot, that means a consumer \`go.mod\` staged at \`execroot/_main/go.mod\` still wins — so \`moduleRoot\` for the std transpile becomes the *consumer's* module, and the same \`.gala\` source is registered under two different \`DefinedIn\` strings (through \`--input\` vs through the reconstructed \`moduleRoot/std/<name>\` path), tripping the duplicate-type check.

The bug report (\`docs/private/TRANSPILER_BUG_FINDGALAMODROOT_CWD_PRIORITY.md\`) was updated after #262 merged with the new repro and proposed fix.

## Changes

- \`internal/transpiler/module/resolver.go\` — Reverse the lookup order in \`findModuleRootFromCwdOrPaths\`: scan explicit search paths first, fall back to cwd. Updated the function's docstring with the same rationale as #262 and the gala_simple-shaped scenario this unblocks.
- \`internal/transpiler/module/resolver_test.go\` — Added \`TestResolver_PrefersSearchPathGoModOverCwdGoMod\`: places \`go.mod\` only on both sides (no \`gala.mod\`), mirroring \`gala_simple\`'s actual repo layout. Asserts the search-path \`go.mod\` wins over cwd's. The existing gala.mod-on-both-sides regression test from #262 did not exercise this code path.

## Verification

- \`bazel build //...\` passes.
- \`bazel test //internal/transpiler/module:module_test\` passes.
- \`bazel test //...\` passes 303/304 — the one failure (\`//examples:from_error\`) is the same pre-existing Windows-environmental issue (test calls \`os.Mkdir(\"/tmp/...\")\` which fails on Windows) flagged in #262. The diff touches only \`internal/transpiler/module/\`; \`examples/from_error.gala\` is unmodified and unrelated to module resolution.

## Repro (before fix)

From the \`gala_team\` workspace consuming \`@gala\` via \`local_path_override\`:

\`\`\`
bazel --output_base=C:/users/maxmr/_bazel_v3 test //app/ui/...
\`\`\`

\`\`\`
Error: [SemanticError GALA-E0011] line 5:0 type \"Either\" in package \"std\"
redefined (first defined in
C:\users\maxmr\_bazel_maxmr\nasc4bix\execroot\_main\external\gala+\std\either.gala)
\`\`\`

After this PR, the bootstrap genrules pick the GALA module's own staged \`go.mod\` as \`moduleRoot\` (via the \`--search\` argument) regardless of the consumer \`go.mod\` at the execroot.

## Dependencies

Independent. PR #262 is already merged; this PR rebases off the latest \`master\` and can be reviewed and merged on its own.

## Bug Report Reference

\`docs/private/TRANSPILER_BUG_FINDGALAMODROOT_CWD_PRIORITY.md\` — \"Why #262 wasn't sufficient\" section.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)