### PR TITLE
fix: pre-existing bugs surfaced by audit infrastructure

### DIFF
--- a/docs/errors/GALA-E0019.md
+++ b/docs/errors/GALA-E0019.md
@@ -1,0 +1,51 @@
+# GALA-E0019 — Empty parenthesized expression
+
+**When it fires.** The source contains an empty parenthesized expression,
+`()`, in a position where an expression is required (e.g. as a match-arm
+body, an argument, or the right-hand side of a declaration). The grammar
+admits the form because the inner `expressionList` is optional, but GALA
+has no unit/void literal the transpiler can lower to a Go expression — so
+attempting to emit `()` would produce a nil AST node that crashes Go's
+printer downstream.
+
+The most common offender is a void-arm shorthand:
+
+```gala
+func handle(code Int) Unit = code match {
+    case 0 => Println("zero")
+    case _ => ()                  // ← GALA-E0019: not allowed
+}
+```
+
+**Error output.**
+
+```
+[SemanticError GALA-E0019] file.gala:5:16 empty parenthesized expression "()" cannot be used as a value (hint: use a real statement (e.g. `Println("…")`) or remove the arm if it cannot occur)
+```
+
+**Fix.** Replace `()` with whatever the arm actually does:
+
+```gala
+case _ => Println("other")        // an actual side-effecting call
+case _ => { /* no-op block */ }   // an explicit empty block, when allowed
+```
+
+If the arm represents an unreachable case, prefer panic with a coded
+message so a future bug surfaces loudly:
+
+```gala
+case _ => panic("unreachable: handler received unexpected code")
+```
+
+**Rationale.** GALA's grammar reuses `expressionList?` inside `'(' … ')'`
+so that paired and 1-arity cases share a rule. The nil-list branch was
+previously unhandled in the transformer; before this code existed, the
+emit path produced a nil `ast.Expr` that crashed Go's printer with a
+generic `ast.Walk: unexpected node type <nil>` (now wrapped as
+`GALA-E0017`). Surfacing the failure at its real site — the GALA source —
+gives users an actionable hint instead of a transpiler stack trace.
+
+**Scope.** Only the literal expression `()`. Calls written as `f()` are
+unaffected (the empty argument list is a different grammar production).
+A future language change that introduces an explicit unit value would
+remove this error.

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -33,6 +33,7 @@ Each code has a dedicated documentation page in this directory explaining:
 | `GALA-E0016` | Struct field name collides with type name | [GALA-E0016.md](GALA-E0016.md) |
 | `GALA-E0017` | Internal transpiler panic | [GALA-E0017.md](GALA-E0017.md) |
 | `GALA-E0018` | Sealed variant type parameter cannot be inferred | [GALA-E0018.md](GALA-E0018.md) |
+| `GALA-E0019` | Empty parenthesized expression | [GALA-E0019.md](GALA-E0019.md) |
 
 ## Adding a new code
 

--- a/examples/from_error.gala
+++ b/examples/from_error.gala
@@ -4,26 +4,35 @@ import (
     "fmt"
     . "martianoff/gala/std"
     "os"
+    "path/filepath"
 )
 
 // Verify FromError converts Go error returns to Try[Void],
 // and that Void type works correctly.
+//
+// The example uses os.TempDir() instead of a hardcoded "/tmp" path so
+// the test passes in Bazel sandboxes on every platform (the previous
+// "/tmp/gala-test-from-error" path failed under Windows Bazel because
+// the sandbox does not expose the MSYS /tmp mapping).
 
 func main() {
+    val testDir = filepath.Join(os.TempDir(), "gala-test-from-error")
+    val nonexistentDir = filepath.Join(os.TempDir(), "gala-nonexistent-dir-12345")
+
     // FromError with a successful operation
-    val result = FromError(os.Mkdir("/tmp/gala-test-from-error", 0755))
+    val result = FromError(os.Mkdir(testDir, 0755))
     fmt.Println(result.IsSuccess())
 
     // Clean up — also via FromError
-    val cleanup = FromError(os.Remove("/tmp/gala-test-from-error"))
+    val cleanup = FromError(os.Remove(testDir))
     fmt.Println(cleanup.IsSuccess())
 
     // FromError with an error (remove non-existent dir)
-    val fail = FromError(os.Remove("/tmp/gala-nonexistent-dir-12345"))
+    val fail = FromError(os.Remove(nonexistentDir))
     fmt.Println(fail.IsFailure())
 
     // Chain with OnFailure — just check it fires
-    FromError(os.Remove("/tmp/gala-nonexistent-dir-12345"))
+    FromError(os.Remove(nonexistentDir))
         .OnFailure((err) => fmt.Println("error handled"))
 
     // Void type

--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -153,6 +153,13 @@ const (
 	// pins it. Without that signal the transpiler can only emit an
 	// untyped `Variant{}` literal that Go cannot instantiate.
 	CodeSealedVariantUninferred ErrorCode = "GALA-E0018"
+
+	// E0019: empty parenthesized expression `()` in expression position.
+	// The grammar permits the form, but GALA has no unit/void value the
+	// transpiler can emit for it. Common offender: a void match arm
+	// written as `case _ => ()` — replace with a real statement (e.g.
+	// `case _ => Println("…")`) or remove the arm if it cannot occur.
+	CodeEmptyParenExpression ErrorCode = "GALA-E0019"
 )
 
 // MultiError collects multiple GALA errors.

--- a/internal/transpiler/transformer/constructors.go
+++ b/internal/transpiler/transformer/constructors.go
@@ -108,7 +108,19 @@ func (t *galaASTTransformer) transformPrimary(ctx *grammar.PrimaryContext) (ast.
 			return t.transformTupleLiteral(exprs, ctx.GetStart().GetLine(), ctx.GetStart().GetColumn())
 		}
 	}
-	return nil, nil
+	// Empty parenthesized expression `()` — the grammar admits it because
+	// `'(' expressionList? ')'` makes the inner list optional, but GALA
+	// has no unit/void literal we can lower to a Go expression. Surface
+	// as GALA-E0019 with a hint pointing at the common offender (void
+	// match-arm shorthand). Without this guard the call returned nil, nil
+	// and downstream code crashed Go's printer with `ast.Walk: unexpected
+	// node type <nil>` far from the source span.
+	return nil, galaerr.NewCodedSemanticError(
+		galaerr.CodeEmptyParenExpression,
+		ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+		"empty parenthesized expression \"()\" cannot be used as a value",
+		"use a real statement (e.g. `Println(\"…\")`) or remove the arm if it cannot occur",
+	)
 }
 
 // tupleElementExpectedTypes returns the per-element expected types for a

--- a/internal/transpiler/transformer/error_codes_test.go
+++ b/internal/transpiler/transformer/error_codes_test.go
@@ -229,6 +229,25 @@ func main() {
 			expectCode:     galaerr.CodeSealedVariantUninferred,
 			expectContains: "cannot infer type parameter",
 		},
+		{
+			// Empty parenthesized expression `()` (the unit-shorthand the
+			// grammar admits but the transpiler has no Go lowering for)
+			// must surface as GALA-E0019 with a real source span instead
+			// of crashing Go's printer downstream.
+			name: "GALA-E0019 empty parens in match arm",
+			input: `package main
+
+func handle(code Int) Unit = code match {
+    case 0 => Println("zero")
+    case _ => ()
+}
+
+func main() {
+    handle(0)
+}`,
+			expectCode:     galaerr.CodeEmptyParenExpression,
+			expectContains: "empty parenthesized expression",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Two unrelated pre-existing failures, both surfaced by the audit work landed in #261 / #263, both fixed here. Independent of any A/R/L follow-up batch.

### (1) `GALA-E0019` — empty parenthesized expression `()`

The grammar admits `'(' expressionList? ')'` with the inner list optional, but the transformer's primary handler returned `nil, nil` when the list was absent. The nil expression crashed Go's printer with `ast.Walk: unexpected node type <nil>` — surfaced as `GALA-E0017` thanks to the B4 wrap landed in #261, but with no actionable hint pointing at the source.

**Surface example:**

\`\`\`gala
func handle(code Int) Unit = code match {
    case 0 => Println("zero")
    case _ => ()                  // ← was: ast.Walk panic, now: GALA-E0019
}
\`\`\`

**This PR:**
- Adds `CodeEmptyParenExpression = "GALA-E0019"` (append-only).
- Replaces silent \`nil, nil\` return with a coded error + hint naming the common cause (void match-arm shorthand).
- Adds \`docs/errors/GALA-E0019.md\` and a README index entry.
- Adds an \`error_codes_test.go\` case.

This bug was discovered by T4 in #263: the B4 wrap caught a real pre-existing panic that would otherwise have shipped as a generic stack trace.

### (2) \`examples:from_error\` — Windows Bazel sandbox failure

The example used hardcoded \`/tmp/...\` paths. On Windows under Bazel, the sandbox does not expose the MSYS \`/tmp\` mapping; \`os.Mkdir\` failed and the first two \`IsSuccess()\` returned \`false\`.

**Fix:** replaced literal paths with \`filepath.Join(os.TempDir(), …)\` so the example runs hermetically on every platform. A comment documents the Windows-sandbox gotcha so the next contributor doesn't re-introduce a \`/tmp\` reference.

## Quality gate

- \`bazel build //...\` clean
- \`bazel test //...\` — **304/304**, fully green for the first time since the audit work began (the lone pre-existing failure is now closed).

## Test plan

- [ ] CI: \`bazel test //...\` 304/304
- [ ] \`TestErrorPathAssertions/GALA-E0019_empty_parens_in_match_arm\` passes
- [ ] \`examples:from_error\` passes on Windows + Linux CI
- [ ] \`docs/errors/GALA-E0019.md\` rendered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)