### PR TITLE
chore(errors): R3/R4 audit — coded errors for analyzer + infer

### DIFF
--- a/docs/errors/GALA-E0020.md
+++ b/docs/errors/GALA-E0020.md
@@ -1,0 +1,29 @@
+# GALA-E0020 — Package not found
+
+**When it fires.** The analyzer was asked to resolve a GALA package by
+its import path or relative path, but no matching directory exists on
+any of the configured search paths. Triggered both by explicit
+`import` statements and by directory-walk passes that follow them.
+
+**Error output.**
+
+```
+[SemanticError GALA-E0020] line 0:0 package not found: <path> (hint: check that the directory exists on a search path; for cross-module imports verify gala.mod has a `require` (and `replace` if local) for the module)
+```
+
+**Fix.** Three common causes:
+
+1. **Typo in the import path** — `import . "github.com/example/foo"` when the directory is `github.com/example/Foo` (case mismatch). GALA preserves case from the filesystem.
+2. **Missing search path** — when running outside Bazel, the standalone CLI needs `--search` to point at the workspace's module root. Bazel rules pass this automatically.
+3. **Cross-module dependency without `replace`** — `gala.mod` has `require github.com/example/foo v0.1.0` but no matching `replace ...` directive points at the local checkout. Add a replace, or run inside a workspace where `go mod download` has fetched the module.
+
+**Rationale.** Before this code existed, the failure surfaced as a
+generic `package not found: <path>` from the analyzer, with no stable
+identifier for tools or CI to grep. Promoting it to GALA-E0020 lets
+build tooling distinguish "user import is wrong" from other infrastructure
+failures (file-system errors, parser crashes, etc.).
+
+**Scope.** Only the analyzer's package-resolution failures, not Go-level
+import errors that surface from `go build` after transpilation. Those
+still appear as Go compiler messages (the GALA layer has already
+finished its work).

--- a/docs/errors/GALA-E0021.md
+++ b/docs/errors/GALA-E0021.md
@@ -1,0 +1,46 @@
+# GALA-E0021 — Type mismatch (unification failure)
+
+**When it fires.** Two types that the inference engine required to
+agree could not be unified. Covers every failure of the
+Hindley-Milner unification step, including (but not limited to):
+
+- A function argument's type does not match the parameter type.
+- The two arms of an `if` expression produce different types.
+- The condition of an `if` expression is not `bool`.
+- A constructor's positional argument does not match the declared
+  field type.
+
+The single code lets users grep for one identifier rather than a
+zoo of per-site identifiers; the message describes the specific
+mismatch.
+
+**Error output (representative).**
+
+```
+[SemanticError GALA-E0021] line 0:0 cannot unify Int and String (hint: the expression's type does not match what the surrounding context expects — annotate the binding or convert the value explicitly)
+
+[SemanticError GALA-E0021] line 0:0 if condition must be bool, got String (hint: the expression's type does not match what the surrounding context expects — annotate the binding or convert the value explicitly)
+
+[SemanticError GALA-E0021] line 0:0 if branches must have same type: Int and String (hint: the expression's type does not match what the surrounding context expects — annotate the binding or convert the value explicitly)
+```
+
+**Fix.** Usually one of three:
+
+1. **Convert one side** — e.g. `Int.toString(n)` to coerce an `Int`
+   to `String`.
+2. **Annotate the variable** — when the inference engine has too
+   little context, an explicit type forces it to commit and the
+   real mismatch surfaces against a fixed reference type.
+3. **Restructure the expression** — if both branches of an `if`
+   honestly produce different types, you usually want a sealed type
+   (`Either[A, B]`, `Option[A]`) instead of mixing the values.
+
+**Rationale.** Promoting these errors out of `fmt.Errorf` lets tools
+and CI surface them with a stable identifier. The shared code matches
+how the Go compiler reports its own mismatches under one bucket
+(`cannot use X as Y`) — users learn the code once and recognize it
+across every unification site.
+
+**Scope.** Inference failures from `internal/transpiler/infer/`. Type
+errors emitted by the transformer outside the inferer (e.g. specific
+sealed-variant arity checks) still use their own dedicated codes.

--- a/docs/errors/GALA-E0022.md
+++ b/docs/errors/GALA-E0022.md
@@ -1,0 +1,39 @@
+# GALA-E0022 — Occurs check failure
+
+**When it fires.** During type unification, the inference engine
+attempted to substitute a type variable `T` with a type that
+*contains* `T`. Allowing such a substitution would produce an
+infinite type (e.g. `T = List[T]` with no way to bottom out), so
+Hindley-Milner rejects the unification.
+
+In practice this surfaces from:
+
+- A recursive value that has no fixed point (the function calls
+  itself with a value of the wrong shape, and the inferer cannot
+  pin a finite type).
+- A pattern that destructures the *whole* value into one of its
+  fields (e.g. matching a struct field against the entire struct).
+
+**Error output.**
+
+```
+[SemanticError GALA-E0022] line 0:0 occurs check failed: T in List[T] (hint: the inferred type would have to refer to itself; add an explicit type annotation or restructure the recursion)
+```
+
+**Fix.** Add an explicit type annotation at the recursion point so
+inference does not have to discover the fixpoint, or restructure the
+value so the recursion has a base case the inferer can see:
+
+```gala
+// Force the type at the recursion site:
+func length[T](xs List[T]) Int = ...
+```
+
+**Rationale.** Occurs check failures are extremely rare in
+straight-line GALA code; when they do fire, the inferer's diagnostic
+is opaque without knowing what "occurs check" means. The dedicated
+code lets the docs page link out to a primer instead of cramming
+type-theory into the error message.
+
+**Scope.** Hindley-Milner unification only. The transformer's own
+recursive-type guards (e.g. `Immutable[Immutable[T]]`) emit `GALA-E0001`.

--- a/docs/errors/GALA-E0023.md
+++ b/docs/errors/GALA-E0023.md
@@ -1,0 +1,29 @@
+# GALA-E0023 — Undefined variable
+
+**When it fires.** The inference engine encountered a name reference
+that has no binding in the current type environment. Common causes:
+
+- The name is misspelled.
+- The name is defined in another package that is not imported.
+- The name is bound by a pattern that did not actually match (e.g.
+  shadowed by an outer binding or referenced outside its arm).
+
+**Error output.**
+
+```
+[SemanticError GALA-E0023] line 0:0 undefined variable: foo (hint: check the spelling, ensure the import that introduces it is in scope, and verify the binding is reachable from the reference site)
+```
+
+**Fix.** Import the symbol, fix the typo, or move the reference
+inside the scope where it is bound. If the name is supposed to come
+from a dot-imported package, confirm the import has not been silently
+dropped (look for warnings about unused dot imports).
+
+**Rationale.** Undefined-variable errors are the single most common
+category of inference failure during early development; promoting
+them to a stable code lets editors and CI tools attach extra context
+(e.g. "did you mean…" suggestions sourced from the type environment).
+
+**Scope.** Inference engine only. The transformer's own scope-walker
+emits its own diagnostics for undefined identifiers in non-inference
+contexts.

--- a/docs/errors/GALA-E0024.md
+++ b/docs/errors/GALA-E0024.md
@@ -1,0 +1,26 @@
+# GALA-E0024 — Internal inference failure
+
+**When it fires.** The inference engine was asked to infer the type
+of an expression node it does not know how to handle. This is a
+transpiler bug — well-formed GALA source should always reach a
+recognized branch. If you see this code, please file an issue with
+the offending snippet so the missing case can be added.
+
+**Error output.**
+
+```
+[SemanticError GALA-E0024] line 0:0 unknown expression type: *infer.SomeNewNode (hint: please file an issue at https://github.com/martianoff/gala/issues with the source that triggered this failure)
+```
+
+**Fix (user).** None directly. As a workaround, simplify the
+surrounding expression and re-run; if a simpler form transpiles
+cleanly, the shape of the original is the trigger.
+
+**Fix (transpiler).** Add the missing case to the inferer's main
+`switch` and emit a coded diagnostic with a real source span if the
+new shape can fail.
+
+**Rationale.** Mirrors `GALA-E0017` (internal transformer panic) but
+for the inference layer. Wrapping these failures with a code gives
+maintainers a stable search target and end users a single hint
+about how to file the bug.

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -34,6 +34,11 @@ Each code has a dedicated documentation page in this directory explaining:
 | `GALA-E0017` | Internal transpiler panic | [GALA-E0017.md](GALA-E0017.md) |
 | `GALA-E0018` | Sealed variant type parameter cannot be inferred | [GALA-E0018.md](GALA-E0018.md) |
 | `GALA-E0019` | Empty parenthesized expression | [GALA-E0019.md](GALA-E0019.md) |
+| `GALA-E0020` | Package not found | [GALA-E0020.md](GALA-E0020.md) |
+| `GALA-E0021` | Type mismatch (unification failure) | [GALA-E0021.md](GALA-E0021.md) |
+| `GALA-E0022` | Occurs check failure | [GALA-E0022.md](GALA-E0022.md) |
+| `GALA-E0023` | Undefined variable | [GALA-E0023.md](GALA-E0023.md) |
+| `GALA-E0024` | Internal inference failure | [GALA-E0024.md](GALA-E0024.md) |
 
 ## Adding a new code
 

--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -160,6 +160,36 @@ const (
 	// written as `case _ => ()` — replace with a real statement (e.g.
 	// `case _ => Println("…")`) or remove the arm if it cannot occur.
 	CodeEmptyParenExpression ErrorCode = "GALA-E0019"
+
+	// E0020: an `import` statement (or directory walk) references a GALA
+	// package the analyzer cannot locate on its search paths. Distinct
+	// from a malformed import (parser error) — the path is well-formed
+	// but no matching directory exists in the workspace.
+	CodePackageNotFound ErrorCode = "GALA-E0020"
+
+	// E0021: type unification failure during inference. Two types that
+	// must agree (call argument vs. parameter, both arms of an if, etc.)
+	// could not be reconciled. Covers the inference engine's general
+	// "cannot unify" diagnostics so users see one stable code regardless
+	// of which specific unification site fired.
+	CodeTypeMismatch ErrorCode = "GALA-E0021"
+
+	// E0022: occurs check failure during type unification. A type
+	// variable would have to expand into a type that contains itself
+	// (e.g. `T = List[T]` with no constructor) — Hindley-Milner rejects
+	// these to keep types finite.
+	CodeOccursCheck ErrorCode = "GALA-E0022"
+
+	// E0023: a variable referenced in an expression has no binding in
+	// the type-inference environment. Usually means the name is mis-
+	// spelled, the import is missing, or the variable is shadowed by a
+	// pattern that did not actually fire.
+	CodeUndefinedVariable ErrorCode = "GALA-E0023"
+
+	// E0024: the inference engine encountered an expression node it does
+	// not know how to handle. Indicates a transpiler bug rather than user
+	// error; the user is asked to file an issue with the snippet.
+	CodeInternalInferenceFailure ErrorCode = "GALA-E0024"
 )
 
 // MultiError collects multiple GALA errors.

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -2022,7 +2022,12 @@ func (a *galaAnalyzer) analyzePackage(relPath string) (*transpiler.RichAST, erro
 	// Use the resolver to find the package directory
 	dirPath, err := a.resolver.ResolvePackagePath(relPath)
 	if err != nil {
-		return nil, fmt.Errorf("package not found: %s", relPath)
+		return nil, galaerr.NewCodedSemanticError(
+			galaerr.CodePackageNotFound,
+			0, 0,
+			fmt.Sprintf("package not found: %s", relPath),
+			"check that the directory exists on a search path; for cross-module imports verify gala.mod has a `require` (and `replace` if local) for the module",
+		)
 	}
 
 	// Check disk cache before doing expensive analysis.
@@ -2069,7 +2074,17 @@ func (a *galaAnalyzer) analyzePackage(relPath string) (*transpiler.RichAST, erro
 				if pkgAST.PackageName == "" {
 					pkgAST.PackageName = res.PackageName
 				} else if pkgAST.PackageName != res.PackageName {
-					return nil, fmt.Errorf("multiple package names in directory %s: %s and %s", dirPath, pkgAST.PackageName, res.PackageName)
+					// Mirror the explicit --package-files path (line ~308) which
+					// already raises CodeDuplicatePackageName for the same
+					// condition. The auto-discovery walk had been emitting an
+					// uncoded fmt.Errorf; both paths now produce the same code
+					// so tools and CI can match on a single identifier.
+					return nil, galaerr.NewCodedSemanticError(
+						galaerr.CodeDuplicatePackageName,
+						0, 0,
+						fmt.Sprintf("multiple package names in directory %s: %s and %s", dirPath, pkgAST.PackageName, res.PackageName),
+						"use the same package name across all sibling .gala files, or move the file to a different directory",
+					)
 				}
 				// Canonicalize filePath once — isSameFile resolves symlinks and
 				// runs os.Stat, which is too expensive to call per type.

--- a/internal/transpiler/infer/BUILD.bazel
+++ b/internal/transpiler/infer/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     ],
     importpath = "martianoff/gala/internal/transpiler/infer",
     visibility = ["//:__subpackages__"],
+    deps = ["//galaerr"],
 )
 
 go_test(

--- a/internal/transpiler/infer/infer.go
+++ b/internal/transpiler/infer/infer.go
@@ -2,7 +2,20 @@ package infer
 
 import (
 	"fmt"
+
+	"martianoff/gala/galaerr"
 )
+
+// codedInferError builds a SemanticError with no source span. The infer
+// package operates on its own AST that does not carry GALA source
+// positions; downstream callers wrap the error with a real span via
+// `galaerr.NewSemanticErrorAt` when they have one. The code makes the
+// failure family stable for tools and CI.
+func codedInferError(code galaerr.ErrorCode, msg, hint string) error {
+	return galaerr.NewCodedSemanticError(code, 0, 0, msg, hint)
+}
+
+const typeMismatchHint = "the expression's type does not match what the surrounding context expects — annotate the binding or convert the value explicitly"
 
 // TypeEnv is a mapping from variable names to type schemes.
 type TypeEnv map[string]*Scheme
@@ -74,7 +87,8 @@ func (inf *Inferer) unify(t1, t2 Type) (Substitution, error) {
 	if a, ok := t1.(*TypeApp); ok {
 		if b, ok := t2.(*TypeApp); ok {
 			if a.Name != b.Name || len(a.Args) != len(b.Args) {
-				return nil, fmt.Errorf("cannot unify %s and %s", a, b)
+				return nil, codedInferError(galaerr.CodeTypeMismatch,
+					fmt.Sprintf("cannot unify %s and %s", a, b), typeMismatchHint)
 			}
 			s := make(Substitution)
 			for i := 0; i < len(a.Args); i++ {
@@ -96,7 +110,8 @@ func (inf *Inferer) unify(t1, t2 Type) (Substitution, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("cannot unify %s and %s", t1, t2)
+	return nil, codedInferError(galaerr.CodeTypeMismatch,
+		fmt.Sprintf("cannot unify %s and %s", t1, t2), typeMismatchHint)
 }
 
 func (inf *Inferer) bind(v *TypeVariable, t Type) (Substitution, error) {
@@ -104,7 +119,9 @@ func (inf *Inferer) bind(v *TypeVariable, t Type) (Substitution, error) {
 		return make(Substitution), nil
 	}
 	if t.FreeTypeVars()[v] {
-		return nil, fmt.Errorf("occurs check failed: %s in %s", v, t)
+		return nil, codedInferError(galaerr.CodeOccursCheck,
+			fmt.Sprintf("occurs check failed: %s in %s", v, t),
+			"the inferred type would have to refer to itself; add an explicit type annotation or restructure the recursion")
 	}
 	return Substitution{v: t}, nil
 }
@@ -123,7 +140,9 @@ func (inf *Inferer) infer(env TypeEnv, e Expr) (Type, Substitution, error) {
 		if s, ok := env[expr.Name]; ok {
 			return inf.instantiate(s), make(Substitution), nil
 		}
-		return nil, nil, fmt.Errorf("undefined variable: %s", expr.Name)
+		return nil, nil, codedInferError(galaerr.CodeUndefinedVariable,
+			fmt.Sprintf("undefined variable: %s", expr.Name),
+			"check the spelling, ensure the import that introduces it is in scope, and verify the binding is reachable from the reference site")
 
 	case *Abs:
 		tv := inf.NewTypeVar()
@@ -174,7 +193,8 @@ func (inf *Inferer) infer(env TypeEnv, e Expr) (Type, Substitution, error) {
 		}
 		s2, err := inf.unify(tCond, &TypeConst{Name: "bool"})
 		if err != nil {
-			return nil, nil, fmt.Errorf("if condition must be bool, got %s", tCond)
+			return nil, nil, codedInferError(galaerr.CodeTypeMismatch,
+				fmt.Sprintf("if condition must be bool, got %s", tCond), typeMismatchHint)
 		}
 		newEnv := env.Apply(s2).Apply(s1)
 		tThen, s3, err := inf.infer(newEnv, expr.Then)
@@ -187,10 +207,13 @@ func (inf *Inferer) infer(env TypeEnv, e Expr) (Type, Substitution, error) {
 		}
 		s5, err := inf.unify(tThen.Apply(s4), tElse)
 		if err != nil {
-			return nil, nil, fmt.Errorf("if branches must have same type: %s and %s", tThen.Apply(s4), tElse)
+			return nil, nil, codedInferError(galaerr.CodeTypeMismatch,
+				fmt.Sprintf("if branches must have same type: %s and %s", tThen.Apply(s4), tElse), typeMismatchHint)
 		}
 		return tThen.Apply(s4).Apply(s5), s5.Compose(s4).Compose(s3).Compose(s2).Compose(s1), nil
 	}
 
-	return nil, nil, fmt.Errorf("unknown expression type: %T", e)
+	return nil, nil, codedInferError(galaerr.CodeInternalInferenceFailure,
+		fmt.Sprintf("unknown expression type: %T", e),
+		"please file an issue at https://github.com/martianoff/gala/issues with the source that triggered this failure")
 }


### PR DESCRIPTION
## Summary

Migrates user-visible semantic errors from \`analyzer/analyzer.go\` and \`infer/infer.go\` from raw \`fmt.Errorf\` to \`galaerr.NewCodedSemanticError\`. After this PR every error category that surfaces from the type-system or package-resolution layers carries a stable \`GALA-Exxxx\` code that tools, tests, and CI can match on.

## New codes

| Code | Title | Sites |
|---|---|---|
| \`GALA-E0020\` | Package not found | analyzer.go (1 site) |
| \`GALA-E0021\` | Type mismatch (unification failure) | infer.go (4 sites — single code keeps the family searchable) |
| \`GALA-E0022\` | Occurs check failure | infer.go (1 site) |
| \`GALA-E0023\` | Undefined variable | infer.go (1 site) |
| \`GALA-E0024\` | Internal inference failure | infer.go (1 site — mirrors the transformer's E0017) |

\`GALA-E0019\` is reserved by the pre-existing-bugs PR (#265) for the empty-paren case; this PR continues at E0020 to keep codes append-only without conflicts.

## Migrated sites

**analyzer.go (2 sites):**
- Line 2025 — \`package not found\` → E0020
- Line 2072 — \`multiple package names in directory\` → reuses E0010 (the explicit \`--package-files\` path at line 308 already emits E0010 for the same condition; auto-discovery now matches)

**infer.go (6 sites):**
- Lines 77, 99 — \`cannot unify\` → E0021
- Line 177 — \`if condition must be bool\` → E0021
- Line 190 — \`if branches must have same type\` → E0021
- Line 107 — \`occurs check\` → E0022
- Line 126 — \`undefined variable\` → E0023
- Line 195 — \`unknown expression type\` → E0024

The infer package now imports \`galaerr\` (added to its BUILD.bazel deps).

## Out of scope (intentionally left as \`fmt.Errorf\`)

- \`analyzer.go:280\` — defensive \`expected SourceFileContext\` (internal invariant, not user-authored)
- \`analyzer.go:1198\` — validation summary (already aggregates coded errors)
- \`analyzer.go:2476-2521\` — I/O wrappers (read/parse/transform/generate/write file failures); these wrap lower-level errors with \`%w\` and represent infrastructure failures rather than user-authored mistakes

## Docs

Each new code has a dedicated page (\`docs/errors/GALA-E00xx.md\`) following the established template: when it fires, representative output, canonical fix, rationale, scope. README index updated.

## Quality gates

- \`bazel build //...\` clean
- \`bazel test //...\` — 303/304, unchanged from master baseline. The lone \`examples:from_error\` failure is the pre-existing /tmp-path issue closed by PR #265; independent of this branch.

## Test plan

- [ ] CI: \`bazel build //...\` and \`bazel test //...\`
- [ ] Verify analyzer's \`package not found\` and \`multiple package names\` errors carry the new codes (existing analyzer tests cover both paths)
- [ ] Verify infer tests (\`infer_test\`) still pass — the test file does not match on error message text, so the migration is transparent

🤖 Generated with [Claude Code](https://claude.com/claude-code)