### PR TITLE
fix(module): add gala.mod at repo root

### DIFF
--- a/gala.mod
+++ b/gala.mod
@@ -1,0 +1,3 @@
+module martianoff/gala
+
+gala 0.38.0


### PR DESCRIPTION
## Summary
- Adds `gala.mod` at the gala_simple repo root declaring `module martianoff/gala`, `gala 0.38.0`.
- Fixes downstream `local_path_override` builds where the std transpile would hijack the consumer's `gala.mod` as `moduleRoot`.

## Why

PR #262 (`findGalaModRoot` cwd→search) and PR #264 (`findModuleRootFromCwdOrPaths` cwd→search) both reorder discovery preference but neither prevents `findGalaModFromDir` from escaping above the search path when gala_simple itself declares no module — the upward walk just keeps going until it lands on a foreign `gala.mod`.

Concretely, building gala_team via `local_path_override` of `@gala`:

```
bazel --output_base=C:/users/maxmr/_bazel_v3 test //app/ui/...   # in gala_team
```

failed at the std bootstrap genrule with:

```
[SemanticError GALA-E0012] line 14:0 method "Deref" on type "ConstPtr" in package "std" redefined
(first defined in C:\users\maxmr\_bazel_maxmr\nasc4bix\execroot\_main\external\gala+\std\constptr.gala)
```

Trace:
- `--search external/gala+` → `findGalaModFromDir(_bazel_v3/execroot/_main/external/gala+)`
- gala_simple has no `gala.mod`, so the loop walks up
- finds `_bazel_v3/execroot/_main/gala.mod` — the **consumer's** (gala_team) gala.mod, staged into the execroot by Bazel
- `moduleRoot` is set to the consumer's execroot, the std transpile re-resolves its own files via that wrong root, registers the same source under two `DefinedIn` strings, and trips `GALA-E0011`/`GALA-E0012`.

Adding a `gala.mod` at the repo root makes `findGalaModFromDir` succeed on the first iteration at the search path itself, which is the correct identity for std bootstrap transpiles.

## Test plan
- [ ] CI green on this repo.
- [ ] Build a downstream consumer (gala_team) via `local_path_override` of `@gala` from a fresh output_base — std bootstrap genrules should succeed without `GALA-E0011`/`GALA-E0012`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)