### PR TITLE
refactor(types): L3 + L1 — IsVoid() predicate + TYPE_INFERENCE.MD update

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -556,6 +556,15 @@ val success = Ok[int](42)
 val failure = Err[int](fmt.Errorf("oops"))
 ```
 
+When a generic sealed variant takes no fields that mention the parent's
+type parameter (e.g. `case None()` of `Option[T]`, or `case NoCmd()` of
+`Cmd[T]`), the parameter is pinned by downward inference from the
+surrounding context — match subject, `val`/`var` annotation, or
+function return. If no signal is available, the transpiler rejects the
+call with [`GALA-E0018`](errors/GALA-E0018.md). The full set of
+contexts and the propagation mechanism are described in
+[Downward Inference for Generic Sealed-Type Case Constructors](TYPE_INFERENCE.MD#downward-inference-for-generic-sealed-type-case-constructors).
+
 #### Wildcard Catch-All in Sealed Match
 When you only care about a subset of variants, use `case _ =>` as a catch-all instead of listing every variant. This is valid for exhaustive matching:
 

--- a/docs/TYPE_INFERENCE.MD
+++ b/docs/TYPE_INFERENCE.MD
@@ -381,30 +381,61 @@ Five contexts feed the expected type:
 
 ### Propagation mechanism
 
-- A single transformer field, `pendingExpectedArgType`, threads the expected slot type from a setter context (val decl, argument transform, tuple element) into the call dispatcher. The dispatcher consumes-and-clears it on entry, so deeper sub-expressions don't accidentally see a stale value.
-- For the **zero-arg call** path (`NoCmd()` with empty parens), `applyCallSuffix` consults `pendingExpectedArgType` after `inferZeroArgTypeParams` (which already covered the match-subject and enclosing-return fallbacks for `None()` / `Some()`), and rewrites the receiver via `injectSealedVariantTypeArgs`.
-- For the **non-zero-arg call** path, `transformCallWithArgsCtx` already invoked the same rewrite at the top of the dispatcher.
-- For **function arguments** (context 3), `resolveExpectedFuncArgType` was extended to return the declared param type verbatim for non-FuncType params of non-generic GALA functions, so the existing argument-transform path can stash it in `pendingExpectedArgType`.
-- For **tuple elements** (context 2 with tuple return), `transformPrimary` inspects the enclosing `currentFuncReturnType` for a Tuple-shaped expected type and threads each per-slot type into the corresponding element transform.
-- For **match arms** (context 5), `buildMatchExpressionFromClauses` promotes a pending expected slot type to `currentFuncReturnType` for the IIFE's body, so each arm's expression — not just the first — picks it up via the existing companion-of-sealed lookup.
+- A LIFO stack on the transformer, `expectedArgTypes` (see
+  `transformer/expected_arg_stack.go`), threads expected slot types
+  from setter contexts (val decl, argument transform, tuple element)
+  into the call dispatcher. Each `push` returns an idempotent unwind
+  function — if a downstream `consume` removes the hint first, the
+  unwind is a no-op. This replaced an earlier single-field channel
+  whose mismatched save/restore bookkeeping silently leaked state
+  across siblings.
+- For the **zero-arg call** path (`NoCmd()` with empty parens),
+  `applyCallSuffix` peeks the top hint after `inferZeroArgTypeParams`
+  (which already covered the match-subject and enclosing-return
+  fallbacks for `None()` / `Some()`), and rewrites the receiver via
+  `injectSealedVariantTypeArgs`. On a successful rewrite it consumes
+  the hint so deeper sub-expressions cannot pick it up.
+- For the **non-zero-arg call** path, `transformCallWithArgsCtx`
+  consumes the top hint at dispatcher entry and invokes the same
+  rewrite.
+- For **function arguments** (context 3),
+  `resolveExpectedFuncArgType` returns the declared param type
+  verbatim for non-FuncType params of non-generic GALA functions, so
+  the argument-transform path can push it onto the stack.
+- For **tuple elements** (context 4 / context 2 with tuple return),
+  `transformPrimary` inspects the enclosing `currentFuncReturnType`
+  for a Tuple-shaped expected type and pushes each per-slot type
+  onto the stack for the duration of that element's transform.
+- For **match arms** (context 5), `buildMatchExpressionFromClauses`
+  promotes a pending expected slot type to `currentFuncReturnType`
+  for the IIFE's body, so each arm's expression — not just the first
+  — picks it up via the existing companion-of-sealed lookup.
 
-If none of the contexts supply a concrete type and the constructor is genuinely ambiguous, the existing "cannot infer type for case constructor" error fires; downward inference does not silently fall back to `any`.
+If none of the contexts supplies a concrete type and the constructor
+is a sealed variant of a generic parent, the transpiler fails fast
+with [`GALA-E0018`](errors/GALA-E0018.md) at the offending call — it
+does **not** silently emit an untyped `Variant{}` literal that Go
+would later reject with an obscure deduction error far from the
+source.
 
 ### Limitations
 
-- The match-arm path (5) currently propagates a single type only when the match expression is itself the immediate value of one of the contexts above. Arms inside a match used purely as a side-effect dispatch still rely on per-arm inference.
-- The propagation field is a single value, not a stack of expected types per nesting depth. Re-entrancy is handled with `defer` saves; cleanup is reliable but observers should not assume the value persists past one dispatcher entry.
+The match-arm path (context 5) currently propagates a single type
+only when the match expression is itself the immediate value of one
+of the surrounding contexts. Arms inside a match used purely as a
+side-effect dispatch still rely on per-arm inference.
 
 ### Pointers
 
 | File | Role |
 |------|------|
+| `transformer/expected_arg_stack.go` | Push/peek/consume primitives + the idempotent-unwind contract |
 | `transformer/calls.go::injectSealedVariantTypeArgs` | Rewrites `Variant(...)` → `Variant[Args]` when expected is the sealed parent |
-| `transformer/calls.go::applyCallSuffix` (zero-arg branch) | Consumes `pendingExpectedArgType` for `Variant()` |
-| `transformer/calls.go::transformCallWithArgsCtx` | Consumes `pendingExpectedArgType` for `Variant(arg, …)` |
+| `transformer/calls.go::applyCallSuffix` (zero-arg branch) | Peeks/consumes the top hint for `Variant()`; emits `GALA-E0018` when no signal pins the parameter |
+| `transformer/calls.go::transformCallWithArgsCtx` | Consumes the top hint for `Variant(arg, …)` |
 | `transformer/call_context.go::resolveExpectedFuncArgType` | Surfaces non-FuncType param types from non-generic functions |
-| `transformer/constructors.go::transformPrimary` (paren/tuple case) | Threads per-element expected type for tuple literals |
-| `transformer/declarations.go::transformValDeclaration` / `transformVarDeclaration` | Stashes the explicit declared type before transforming RHS |
+| `transformer/constructors.go::transformPrimary` (paren/tuple case) | Pushes per-element expected type for tuple literals |
+| `transformer/declarations.go::transformValDeclaration` / `transformVarDeclaration` | Pushes the explicit declared type before transforming RHS |
 | `transformer/postfix.go::buildMatchExpressionFromClauses` | Promotes a pending slot type to `currentFuncReturnType` for arm bodies |
 
 ---

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -255,7 +255,7 @@ func (t *galaASTTransformer) validateNoBareReturnsInValueMatch(
 	if resultType == nil || resultType.IsNil() {
 		return nil
 	}
-	if _, isVoid := resultType.(transpiler.VoidType); isVoid {
+	if resultType != nil && resultType.IsVoid() {
 		return nil
 	}
 	offender := false
@@ -671,7 +671,7 @@ func (t *galaASTTransformer) buildMatchBody(clauses []ast.Stmt, defaultBody []as
 		body = defaultBody
 	}
 
-	_, isVoid := resultType.(transpiler.VoidType)
+	isVoid := resultType != nil && resultType.IsVoid()
 	if isVoid {
 		body = t.stripReturnStatements(body)
 	} else if resultType != nil && !resultType.IsNil() && !resultType.IsAny() {
@@ -689,7 +689,7 @@ func (t *galaASTTransformer) generateMatchIIFE(expr ast.Expr, paramName string, 
 	}
 
 	var resultsField *ast.FieldList
-	if _, isVoid := resultType.(transpiler.VoidType); !isVoid {
+	if resultType == nil || !resultType.IsVoid() {
 		resultTypeExpr := t.typeToExpr(resultType)
 		if resultTypeExpr == nil {
 			return nil, galaerr.NewSemanticErrorAt(matchLine, matchCol, "cannot infer result type of match expression. Please ensure all branches return the same type")
@@ -811,7 +811,7 @@ func (t *galaASTTransformer) inferCommonResultType(types []transpiler.Type, patt
 	// Check if all branches are void (side-effect only, like fmt.Printf calls)
 	allVoid := true
 	for _, typ := range types {
-		if _, isVoid := typ.(transpiler.VoidType); !isVoid {
+		if !typ.IsVoid() {
 			allVoid = false
 			break
 		}
@@ -831,7 +831,7 @@ func (t *galaASTTransformer) inferCommonResultType(types []transpiler.Type, patt
 				continue
 			}
 			// Skip void types when looking for reference
-			if _, isVoid := typ.(transpiler.VoidType); isVoid {
+			if typ.IsVoid() {
 				continue
 			}
 			refType = typ
@@ -846,7 +846,7 @@ func (t *galaASTTransformer) inferCommonResultType(types []transpiler.Type, patt
 		allNilOrVoid := true
 		for _, typ := range types {
 			if typ != nil && !typ.IsNil() {
-				if _, isVoid := typ.(transpiler.VoidType); !isVoid {
+				if !typ.IsVoid() {
 					allNilOrVoid = false
 					if t.isTypeParameter(typ.String()) {
 						hasTypeParam = true
@@ -901,7 +901,7 @@ func (t *galaASTTransformer) inferCommonResultType(types []transpiler.Type, patt
 			if typ == nil || typ.IsNil() {
 				continue
 			}
-			if _, isVoid := typ.(transpiler.VoidType); isVoid {
+			if typ.IsVoid() {
 				continue
 			}
 			name := typ.String()
@@ -939,7 +939,7 @@ func (t *galaASTTransformer) inferCommonResultType(types []transpiler.Type, patt
 			return nil, galaerr.NewSemanticErrorAt(line, col, fmt.Sprintf("cannot infer result type for '%s'. Please add explicit type annotation", patterns[i]))
 		}
 		// VoidType is compatible with any type (for mixed match where some branches are void)
-		if _, isVoid := typ.(transpiler.VoidType); isVoid {
+		if typ.IsVoid() {
 			continue
 		}
 		// NilType means inference failed for this branch — treat as compatible

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -632,7 +632,7 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 	stmts := t.buildMatchBody(clauses, defaultBody, resultType)
 
 	// Check if result type is void (for side-effect only match statements)
-	_, isVoid := resultType.(transpiler.VoidType)
+	isVoid := resultType != nil && resultType.IsVoid()
 
 	// Build IIFE with or without return type depending on void
 	var resultsField *ast.FieldList

--- a/internal/transpiler/types.go
+++ b/internal/transpiler/types.go
@@ -5,10 +5,17 @@ import (
 )
 
 // Type represents a structured type in GALA/Go.
+//
+// Predicates (IsNil, IsAny, IsVoid) are exposed as interface methods
+// rather than ad-hoc type assertions so callers can check kind without
+// importing the concrete type definitions and without hard-coded
+// string comparisons. Each implementation returns the obvious answer
+// for its kind; only the matching variant returns true.
 type Type interface {
 	String() string
 	IsNil() bool
 	IsAny() bool
+	IsVoid() bool
 	BaseName() string
 	GetPackage() string // Returns the package of the type, or "" if none
 }
@@ -21,6 +28,7 @@ type BasicType struct {
 func (t BasicType) String() string     { return t.Name }
 func (t BasicType) IsNil() bool        { return false }
 func (t BasicType) IsAny() bool        { return t.Name == "any" }
+func (t BasicType) IsVoid() bool       { return false }
 func (t BasicType) BaseName() string   { return t.Name }
 func (t BasicType) GetPackage() string { return "" }
 
@@ -39,6 +47,7 @@ func (t NamedType) String() string {
 }
 func (t NamedType) IsNil() bool        { return false }
 func (t NamedType) IsAny() bool        { return false }
+func (t NamedType) IsVoid() bool       { return false }
 func (t NamedType) BaseName() string   { return t.String() }
 func (t NamedType) GetPackage() string { return t.Package }
 
@@ -65,6 +74,7 @@ func (t GenericType) String() string {
 }
 func (t GenericType) IsNil() bool        { return false }
 func (t GenericType) IsAny() bool        { return false }
+func (t GenericType) IsVoid() bool       { return false }
 func (t GenericType) BaseName() string   { return t.Base.BaseName() }
 func (t GenericType) GetPackage() string { return t.Base.GetPackage() }
 
@@ -81,6 +91,7 @@ func (t ArrayType) String() string {
 }
 func (t ArrayType) IsNil() bool        { return false }
 func (t ArrayType) IsAny() bool        { return false }
+func (t ArrayType) IsVoid() bool       { return false }
 func (t ArrayType) BaseName() string   { return "[]" + t.Elem.BaseName() }
 func (t ArrayType) GetPackage() string { return "" }
 
@@ -95,6 +106,7 @@ func (t MapType) String() string {
 }
 func (t MapType) IsNil() bool        { return false }
 func (t MapType) IsAny() bool        { return false }
+func (t MapType) IsVoid() bool       { return false }
 func (t MapType) BaseName() string   { return "map" }
 func (t MapType) GetPackage() string { return "" }
 
@@ -108,6 +120,7 @@ func (t PointerType) String() string {
 }
 func (t PointerType) IsNil() bool        { return false }
 func (t PointerType) IsAny() bool        { return false }
+func (t PointerType) IsVoid() bool       { return false }
 func (t PointerType) BaseName() string   { return "*" + t.Elem.BaseName() }
 func (t PointerType) GetPackage() string { return "" }
 
@@ -144,6 +157,7 @@ func (t FuncType) String() string {
 }
 func (t FuncType) IsNil() bool        { return false }
 func (t FuncType) IsAny() bool        { return false }
+func (t FuncType) IsVoid() bool       { return false }
 func (t FuncType) BaseName() string   { return "func" }
 func (t FuncType) GetPackage() string { return "" }
 
@@ -153,6 +167,7 @@ type NilType struct{}
 func (t NilType) String() string     { return "" }
 func (t NilType) IsNil() bool        { return true }
 func (t NilType) IsAny() bool        { return false }
+func (t NilType) IsVoid() bool       { return false }
 func (t NilType) BaseName() string   { return "" }
 func (t NilType) GetPackage() string { return "" }
 
@@ -164,6 +179,7 @@ type VoidType struct{}
 func (t VoidType) String() string     { return "void" }
 func (t VoidType) IsNil() bool        { return false }
 func (t VoidType) IsAny() bool        { return false }
+func (t VoidType) IsVoid() bool       { return true }
 func (t VoidType) BaseName() string   { return "void" }
 func (t VoidType) GetPackage() string { return "" }
 


### PR DESCRIPTION
## Summary

Closes two of the audit's smaller follow-up items in one batch and documents one item as a verified false positive.

### L3 — \`IsVoid()\` on the \`Type\` interface

Adds \`IsVoid() bool\` to \`transpiler.Type\` alongside the existing \`IsNil()\` and \`IsAny()\` predicates. Migrates the 9 ad-hoc type-assertion sites in \`match.go\` and \`postfix.go\` from \`_, isVoid := typ.(transpiler.VoidType)\` to \`typ.IsVoid()\`. Mechanical and behaviour-preserving.

**Out of scope (per L3's verification-before-acting rule):**
- \`IsTypeParam()\` — context-dependent (\`activeTypeParams\`); promoting it would lose context.
- \`IsImmutable()\` — intertwined with a side effect (raises a coded error on recursive wrapping); splitting would create two ways to ask the same question.

### L1 — Downward-inference rule documentation

Refreshes \`docs/TYPE_INFERENCE.MD\`'s existing \"Downward Inference for Generic Sealed-Type Case Constructors\" section to match the post-#261 reality:

- The \`pendingExpectedArgType\` single field has been replaced by an \`expectedArgTypes\` LIFO stack with idempotent unwinds (B1) — the doc now describes the stack contract instead of the older "single value, defer-restore" pattern.
- The "If none of the contexts supply a concrete type ... the existing 'cannot infer ...' error fires" sentence is updated to point at \`GALA-E0018\` (B6), with a docs link.
- The \"Limitations\" section drops the obsolete \"single value, not a stack\" entry; only the match-arm propagation limitation remains.
- The \"Pointers\" table adds the new \`expected_arg_stack.go\` file and notes that the zero-arg branch now emits \`GALA-E0018\`.

\`docs/GALA.MD\`'s sealed-types section gets a one-paragraph cross-reference to TYPE_INFERENCE.MD instead of duplicating the rule (per CLAUDE.md: GALA.MD = language reference, TYPE_INFERENCE.MD = inference rules).

### A4 — verified false positive

On closer reading, the audit's A4 (\"dedup Apply-path inference between \`calls.go\` and \`type_inference_calls.go\`\") does not represent actual duplicated logic:

- \`calls.go::inferTypeArgsFromApply\` infers **type args** for an Apply call by walking \`ParamTypes\` and matching argument types.
- \`type_inference_calls.go:350-365\` infers the **result type** for specific std \`_Apply\` constructors (\`Some_Apply\` / \`Left_Apply\` / \`Right_Apply\`) via hard-coded shape-matching.

Different concerns; no shared logic to hoist. Documented per the audit's \"retire false positives in writing\" rule.

## Quality gates

- \`bazel build //...\` clean
- \`bazel test //...\` — **304/304**

## Test plan

- [ ] CI: \`bazel test //...\` 304/304
- [ ] Verify all 9 \`IsVoid()\` migration sites in match.go + postfix.go behave identically (covered by existing match tests)
- [ ] Verify the TYPE_INFERENCE.MD anchor (\`#downward-inference-for-generic-sealed-type-case-constructors\`) renders correctly from the GALA.MD cross-reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)