### PR TITLE
docs: A6 — branch-naming convention

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -180,7 +180,8 @@ bazel run //:gazelle       # if files were added or removed
 
 ## Submitting a Pull Request
 
-1. Create a feature branch from `master`:
+1. Create a feature branch from `master`. Pick a descriptive slug — see
+   [Branch naming](#branch-naming) for the convention:
 
    ```bash
    git checkout -b feature/my-feature master
@@ -209,6 +210,40 @@ bazel run //:gazelle       # if files were added or removed
    - What the change does and why
    - Example GALA code demonstrating the feature (if applicable)
    - Which documentation files were updated
+
+## Branch naming
+
+Use a `<type>/<slug>` shape — type prefix matches the commit prefix from
+the previous section, slug is a short kebab-case description. Examples:
+
+```
+feat/yaml-codec
+fix/copy-chained-field-access
+fix/cross-module-apply-lowering
+refactor/audit-systemic-correctness
+test/hex-literal-parser-regression
+docs/gala-deps-vs-deps
+```
+
+When the work corresponds to a tracked issue or PR, prefer including the
+ID in the slug so the branch is grep-able later:
+
+```
+fix/PR260-panic-as-match-arm
+fix/issue142-windows-path-normalization
+```
+
+**Avoid sequence-number-only slugs** like `fix/FIX-001-...`,
+`fix/FIX-005-...`, etc. The audit of the first ~50 PRs found four
+such IDs (`FIX-001`, `FIX-005`, `FIX-006`, `FIX-007`) each picked up by
+two unrelated bugs because the sequence was reset per-author or
+per-batch — making it impossible to disambiguate the branches in
+`git log` or PR titles. If you do not have an issue/PR number to anchor
+against, write a slug that is descriptive enough to identify the bug on
+its own (`fix/null-pointer-in-immutable-unwrap`, not `fix/FIX-001`).
+
+This is a recommendation, not enforced by tooling. Pick what reads best
+to a future reviewer searching `git log` for the change.
 
 ## Reporting Bugs
 


### PR DESCRIPTION
## Summary

Documents a branch-naming convention in CONTRIBUTING.MD and motivates it with audit evidence.

## The problem

The audit of the first ~50 PRs found four FIX-### IDs each picked up by two unrelated bugs:

| ID | First use | Second use |
|---|---|---|
| \`FIX-001\` | PR #214 (void method match panic) | PR #260 (panic-as-match-arm) |
| \`FIX-005\` | PR #218 (octal-literal-0o) | PR #251 (if-expr-lambda-return-type) |
| \`FIX-006\` | PR #205 (generic-struct-shorthand) | PR #225 (struct-field-name-collision) |
| \`FIX-007\` | PR #207 (gala-build-subpackage-recursion) | PR #226 (chained-call-generic-erasure-v2) |

The duplication confused \`git log\` searches, made PR titles ambiguous, and required cross-referencing commit messages to disambiguate which bug was which.

## The convention

Adds a "Branch naming" section to CONTRIBUTING.MD with:

- The recommended \`<type>/<slug>\` shape and concrete examples drawn from recent merged branches (\`feat/yaml-codec\`, \`fix/cross-module-apply-lowering\`, etc.).
- A note on anchoring tracked work to issue/PR numbers (\`fix/PR260-panic-as-match-arm\`) so the branch is grep-able later.
- Explicit guidance to avoid sequence-number-only slugs like \`fix/FIX-001-...\`, with the audit data as motivation.
- A statement that the convention is a recommendation, not enforced by tooling — "pick what reads best to a future reviewer".

Cross-link from the existing "Submitting a Pull Request" step 1 so the convention is discoverable from the PR-flow narrative.

## Quality gates

No code changes; docs only.

## Test plan

- [ ] Markdown renders correctly on GitHub
- [ ] The cross-link from "Submitting a Pull Request" step 1 lands on the new "Branch naming" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)