### PR TITLE
fix(transformer): guard nil PrimaryContext cast for if-expr inside match arm body

### DIFF
--- a/internal/transpiler/transformer/expressions.go
+++ b/internal/transpiler/transformer/expressions.go
@@ -401,8 +401,15 @@ func (t *galaASTTransformer) getPrimaryFromExpression(ctx grammar.IExpressionCon
 	if primaryExpr == nil {
 		return nil
 	}
-	// primaryExpr -> primary
-	return primaryExpr.(*grammar.PrimaryExprContext).Primary().(*grammar.PrimaryContext)
+	// primaryExpr -> primary. The primaryExpr alternation also covers
+	// lambdaExpression, ifExpression, and partialFunctionLiteral; for those
+	// shapes Primary() returns a typed-nil interface and the cast below would
+	// panic. Callers all check for nil already, so just bail out.
+	primary := primaryExpr.(*grammar.PrimaryExprContext).Primary()
+	if primary == nil {
+		return nil
+	}
+	return primary.(*grammar.PrimaryContext)
 }
 
 // getCallPatternFromExpression checks if an expression is a call pattern like Left(n)

--- a/internal/transpiler/transformer/match_void_dispatch_test.go
+++ b/internal/transpiler/transformer/match_void_dispatch_test.go
@@ -157,3 +157,138 @@ func describe(s Shape) string {
 	_, err := trans.Transpile(input, "")
 	assert.NoError(t, err, "value-producing match with concrete branches must continue to work")
 }
+
+// TestIfExprFormInsideMatchArmBody guards against a panic that occurred when a
+// match-arm body contained the parenthesized if-expression form
+// `if (cond) callA() else callB()` (no braces, both branches calling void
+// functions). The transformer eagerly cast .Primary() to *grammar.PrimaryContext
+// without checking the result, but for the if-expression alternation
+// .Primary() returns a typed-nil interface, producing
+//
+//	interface conversion: grammar.IPrimaryContext is nil, not *grammar.PrimaryContext
+func TestIfExprFormInsideMatchArmBody(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	tests := []struct {
+		name     string
+		input    string
+		mustHave []string
+	}{
+		{
+			name: "parenthesized if-expr with void branches inside string-literal match arm",
+			input: `package main
+
+func voidA() {}
+func voidB() {}
+
+func dispatch(key string, flag bool) {
+    key match {
+        case "k" => {
+            if (flag) voidA()
+            else      voidB()
+        }
+        case _ => voidA()
+    }
+}
+`,
+			mustHave: []string{
+				`func dispatch(key string, flag bool) {`,
+				`voidA()`,
+				`voidB()`,
+			},
+		},
+		{
+			name: "parenthesized if-expr with void-call then-branch and assignment else-branch (faithful repro)",
+			input: `package main
+
+func voidA() {}
+
+func dispatch(key string, flag bool) {
+    var slot string
+    key match {
+        case "k" => {
+            if (flag) voidA()
+            else      slot = "x"
+        }
+        case _ => voidA()
+    }
+    Println(slot)
+}
+`,
+			mustHave: []string{
+				`func dispatch(key string, flag bool) {`,
+				`voidA()`,
+				`slot`,
+			},
+		},
+		{
+			name: "parenthesized if-expr inside match arm inside for loop (faithful field-decoder repro)",
+			input: `package main
+
+func voidA() {}
+
+func processAll(keys []string, flag bool) {
+    var slot string
+    for i := range keys {
+        keys[i] match {
+            case "k" => {
+                if (flag) voidA()
+                else      slot = "y"
+            }
+            case _ => voidA()
+        }
+    }
+    Println(slot)
+}
+`,
+			mustHave: []string{
+				`func processAll(`,
+				`voidA()`,
+			},
+		},
+		{
+			name: "parenthesized if-expr with void branches inside sealed-variant match arm",
+			input: `package main
+
+sealed type Tag {
+    case A()
+    case B()
+}
+
+func sideEffect() {}
+func other()      {}
+
+func dispatch(t Tag, flag bool) {
+    t match {
+        case A() => {
+            if (flag) sideEffect()
+            else      other()
+        }
+        case B() => sideEffect()
+    }
+}
+`,
+			mustHave: []string{
+				`func dispatch(t Tag, flag bool) {`,
+				`sideEffect()`,
+				`other()`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := trans.Transpile(tt.input, "")
+			assert.NoError(t, err, "transpilation must not panic on if-expr form inside match arm body")
+			gen := stripGeneratedHeader(got)
+			for _, frag := range tt.mustHave {
+				assert.True(t, strings.Contains(gen, frag),
+					"expected generated code to contain %q\n--- generated ---\n%s", frag, gen)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the unchecked type assertion in `getPrimaryFromExpression` (expressions.go:405) that crashed the transformer when a parenthesized if-expression of the form `if (cond) callA() else assign = rhs` appeared inside a match-arm body that was itself inside a `for` loop.

**Category**: TRANSPILER_BUG
**Priority**: P0 (compiler panic)

## Root Cause

`getPrimaryFromExpression` walks `expression -> ... -> primaryExpr` and then unconditionally casts `.Primary()` to `*grammar.PrimaryContext`. The `primaryExpr` alternation also covers `lambdaExpression`, `ifExpression`, and `partialFunctionLiteral`; for those shapes `.Primary()` returns a typed-nil interface and the cast panics with:

```
internal transpiler panic: interface conversion:
  grammar.IPrimaryContext is nil, not *grammar.PrimaryContext
```

Every caller already handles the nil return safely, so the function should bail out rather than panic.

## Changes

- `internal/transpiler/transformer/expressions.go` — guard the cast with a nil check on `.Primary()`.
- `internal/transpiler/transformer/match_void_dispatch_test.go` — add `TestIfExprFormInsideMatchArmBody` covering four shapes (string-literal match arm, sealed-variant arm, mixed call/assignment branches, for-loop wrapper). The for-loop case reliably panicked before the fix.

## Verification

- `bazel test //internal/transpiler/transformer:transformer_test` PASSES (was: panic before fix).
- `bazel build //...` PASSES.

## Repro (panicked before this fix)

```gala
package main

func voidA() {}

func processAll(keys []string, flag bool) {
    var slot string
    for i := range keys {
        keys[i] match {
            case "k" => {
                if (flag) voidA()
                else      slot = "y"
            }
            case _ => voidA()
        }
    }
}
```

## Dependencies

None — this PR can be reviewed and merged independently.

---
Generated with [Claude Code](https://claude.com/claude-code)