### PR TITLE
test(examples): add try_chain_typeparam_repro multi-file regression

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2159,3 +2159,24 @@ gala_test(
     expected = "lambda_block_val_trailing.out",
     deps = ["//collection_immutable"],
 )
+
+# Regression: chained Try[T].FlatMap((_) => Try[U].Map((_) => V)) where the
+# receiver methods come from another GALA package. Generated Go must spell out
+# the outer closure return type as `Try[bool]` (not bare `Try`), otherwise it
+# fails with `cannot use generic type std.Try[T any] without instantiation`.
+gala_library(
+    name = "try_chain_typeparam_repro_lib",
+    srcs = [
+        "try_chain_typeparam_repro/proc.gala",
+        "try_chain_typeparam_repro/session.gala",
+    ],
+    importpath = "martianoff/gala/examples/try_chain_typeparam_repro",
+    visibility = ["//visibility:public"],
+)
+
+gala_test(
+    name = "try_chain_typeparam_repro",
+    src = "try_chain_typeparam_repro_main/main.gala",
+    expected = "try_chain_typeparam_repro_main/main.out",
+    deps = [":try_chain_typeparam_repro_lib"],
+)

--- a/examples/try_chain_typeparam_repro/proc.gala
+++ b/examples/try_chain_typeparam_repro/proc.gala
@@ -1,0 +1,11 @@
+package try_chain_typeparam_repro
+
+// Process.Kill() returns Try[bool] and Process.Wait() returns Try[int] — the
+// asymmetric element types let session.gala exercise a chained
+// FlatMap((_) => Map((_) => v)) whose synthesized closure return type must
+// preserve the [bool] type argument across both Try methods.
+
+struct Process(Pid int)
+
+func (p Process) Kill() Try[bool] = Success[bool](true)
+func (p Process) Wait() Try[int]  = Success[int](0)

--- a/examples/try_chain_typeparam_repro/session.gala
+++ b/examples/try_chain_typeparam_repro/session.gala
@@ -1,0 +1,21 @@
+package try_chain_typeparam_repro
+
+// Session wraps a Process and exercises the chained Try.FlatMap/Map pattern
+// in batch transpilation context. The FlatMap chain must propagate the inner
+// Try[bool] type argument through the synthesized closure return type so the
+// generated Go signature reads `func(_ bool) Try[bool]` and not bare `Try`.
+
+struct Session(Proc Process)
+
+// CloseSession exercises Try[bool].FlatMap((_) => Try[int].Map((_) => true)).
+// Generated Go must spell the outer closure return type as Try[bool].
+func CloseSession(s Session) Try[bool] =
+    s.Proc.Kill().FlatMap((_) => s.Proc.Wait().Map((_) => true))
+
+// CloseSessionMatch covers the same propagation through a match expression:
+// both arms must agree on Try[bool], so Wait().Map((_) => true) must be typed
+// as Try[bool] when the analyzer compares branch types.
+func CloseSessionMatch(s Session) Try[bool] = s.Proc.Kill() match {
+    case Success(_)   => s.Proc.Wait().Map((_) => true)
+    case Failure(err) => Failure[bool](err)
+}

--- a/examples/try_chain_typeparam_repro_main/main.gala
+++ b/examples/try_chain_typeparam_repro_main/main.gala
@@ -1,0 +1,22 @@
+package main
+
+// Driver for the cross-package chained Try.FlatMap repro. The actual
+// FlatMap/Map chain lives in the try_chain_typeparam_repro library so the
+// closure-signature synthesis runs in batch transpilation context.
+
+import (
+    "martianoff/gala/examples/try_chain_typeparam_repro"
+)
+
+func main() {
+    val s = try_chain_typeparam_repro.Session(
+        Proc = try_chain_typeparam_repro.Process(Pid = 1))
+    try_chain_typeparam_repro.CloseSession(s) match {
+        case Success(b) => Println(s"flatmap: $b")
+        case Failure(e) => Println(s"flatmap err: ${e.Error()}")
+    }
+    try_chain_typeparam_repro.CloseSessionMatch(s) match {
+        case Success(b) => Println(s"match: $b")
+        case Failure(e) => Println(s"match err: ${e.Error()}")
+    }
+}

--- a/examples/try_chain_typeparam_repro_main/main.out
+++ b/examples/try_chain_typeparam_repro_main/main.out
@@ -1,0 +1,2 @@
+flatmap: true
+match: true


### PR DESCRIPTION
## Summary

Adds a multi-file GALA library + driver under `examples/try_chain_typeparam_repro` that exercises the chained call shape:

```gala
func CloseSession(s Session) Try[bool] =
    s.Proc.Kill().FlatMap((_) => s.Proc.Wait().Map((_) => true))
```

A downstream project hit a transpiler bug where this shape emitted the outer closure return type as bare `std.Try` instead of `std.Try[bool]`, producing the Go compile error:

```
cannot use generic type std.Try[T any] without instantiation
```

The same shape also drove a sibling diagnostic where match arms disagreed (`std.Try` vs `std.Try[bool]`) when the value-bearing arm was `Wait().Map((_) => true)`.

**Category**: REGRESSION_TEST (the underlying transpiler bug appears to have been resolved by recent type-system work; this PR locks in the correct codegen).
**Priority**: P0 (the original symptom blocked downstream compilation).

## Root Cause Status

Reproduction attempted on current `master` (post-#272) with multiple variants — including the literal repro from the bug report and a more aggressive cross-package variant — all produced correct generated Go (`func(_ bool) std.Try[bool]`). Recent batch audit work (#266–#272) on the type system, sealed downward inference, and cross-module integration appears to have already addressed the propagation issue. This PR adds the regression guard so any future regression surfaces immediately under `bazel test`.

## Changes

- `examples/try_chain_typeparam_repro/proc.gala` — Process struct with asymmetric Kill/Wait Try return types.
- `examples/try_chain_typeparam_repro/session.gala` — both shapes from the original report: `CloseSession` (FlatMap chain) and `CloseSessionMatch` (cross-arm match).
- `examples/try_chain_typeparam_repro_main/main.gala` — driver that imports the library and exercises both shapes.
- `examples/BUILD.bazel` — `gala_library` and `gala_test` targets.

## Verification

- `bazel test //examples:try_chain_typeparam_repro` PASSES.
- `bazel build //...` PASSES.

## Dependencies

None — this PR can be reviewed and merged independently.

---
Generated with [Claude Code](https://claude.com/claude-code)