### PR TITLE
fix(transpiler): lower match-as-statement with mixed value/void arms safely

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -961,6 +961,12 @@ gala_test(
 )
 
 gala_test(
+    name = "match_stmt_mixed_void",
+    src = "match_stmt_mixed_void.gala",
+    expected = "match_stmt_mixed_void.out",
+)
+
+gala_test(
     name = "match_void_pointer_arg",
     src = "match_void_pointer_arg.gala",
     expected = "match_void_pointer_arg.out",

--- a/examples/match_stmt_mixed_void.gala
+++ b/examples/match_stmt_mixed_void.gala
@@ -1,0 +1,45 @@
+package main
+
+// Regression: a `subject match { ... }` used as a *statement* (its value
+// discarded) where one arm calls a value-returning function and another
+// arm calls a void-returning function. Without the statement-position
+// fix, the IIFE inherited the value arm's return type, and the void arm
+// was emitted as `return d.Skip()` — which Go rejects with
+// "no value used as value".
+//
+// The fix lowers the IIFE as void when the match's value is discarded
+// (statement position), so void-returning arm calls are emitted as bare
+// expression statements, not return statements.
+
+func readValue() bool {
+    Println("read")
+    return true
+}
+
+func skip() {
+    Println("skipped")
+}
+
+func dispatch(key string) {
+    var unhandled = 0
+    // Statement-position match: value discarded.
+    // - "value" arm calls a function returning bool (typed value).
+    // - "skip" arm calls a function returning nothing (void).
+    // - default arm (assignment) returns void via simple statement.
+    // Result type would otherwise widen to bool, forcing the void
+    // arms into `return <voidCall>` which fails Go compilation.
+    key match {
+        case "value" => readValue()
+        case "skip"  => skip()
+        case _       => unhandled = unhandled + 1
+    }
+    if unhandled > 0 {
+        Println(s"unhandled: $unhandled")
+    }
+}
+
+func main() {
+    dispatch("value")
+    dispatch("skip")
+    dispatch("other")
+}

--- a/examples/match_stmt_mixed_void.out
+++ b/examples/match_stmt_mixed_void.out
@@ -1,0 +1,3 @@
+read
+skipped
+unhandled: 1

--- a/examples/multifile_lib_regress/logic.gala
+++ b/examples/multifile_lib_regress/logic.gala
@@ -155,3 +155,36 @@ func selectEffect(n int) Effect[int] = n match {
     case 1 => Halt()
     case _ => Yield(n)
 }
+
+// --- Regression: statement-position match with mixed value/void arms ---
+// Lint suggested rewriting an explicit `if/else if/else` chain as a
+// `match { ... }` used as a *statement* (its value discarded). When one
+// arm called a function returning a typed value (e.g. bool from a Go
+// method) and another arm called a void-returning function, the
+// generated IIFE inherited the typed return type and the void arm was
+// emitted as `return d.Skip()` — Go rejects that with "no value used as
+// value". The fix lowers the IIFE as void in statement position so the
+// void arms are emitted as bare expression statements.
+
+func emitInfo() bool {
+    Println("info")
+    return true
+}
+
+func emitWarn() {
+    Println("warn")
+}
+
+// EmitLevel uses match as a statement with mixed value/void arms.
+// `info` arm calls a value-returning function; `warn` arm calls a void
+// function; default arm is an assignment (statement). The match value
+// is discarded — only the side effects matter.
+func EmitLevel(level string) int {
+    var unhandled = 0
+    level match {
+        case "info" => emitInfo()
+        case "warn" => emitWarn()
+        case _      => unhandled = unhandled + 1
+    }
+    return unhandled
+}

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -126,4 +126,13 @@ func main() {
 
     val tr = multifile_lib_regress.MakeTriple(7, "label", 1.5)
     Println(tr.V1, tr.V2, tr.V3)
+
+    // Statement-position match with mixed value/void arms (regression).
+    // EmitLevel runs `level match { ... }` as a statement; one arm calls
+    // a value-returning function, another calls a void function, and
+    // the default is a bare assignment. Without the fix the transpiler
+    // wrapped the void arm in `return <voidCall>`, breaking Go compile.
+    Println(multifile_lib_regress.EmitLevel("info"))
+    Println(multifile_lib_regress.EmitLevel("warn"))
+    Println(multifile_lib_regress.EmitLevel("other"))
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -37,3 +37,8 @@ true
 401
 true ready
 7 label 1.5
+info
+0
+warn
+0
+1

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -711,6 +711,14 @@ func (t *galaASTTransformer) transformFunctionDeclaration(ctx *grammar.FunctionD
 
 	var body *ast.BlockStmt
 	if ctx.Block() != nil {
+		// When the function has a non-void return type, the block's last
+		// expression is promoted to the implicit return below — signal that
+		// to transformBlock so a trailing bare `match` is NOT marked as
+		// statement-position (which would force the IIFE to void and break
+		// the implicit-return promotion).
+		if funcType.Results != nil && len(funcType.Results.List) > 0 {
+			t.blockLastStmtIsValue = true
+		}
 		b, err := t.transformBlock(ctx.Block().(*grammar.BlockContext))
 		if err != nil {
 			return nil, err

--- a/internal/transpiler/transformer/expressions.go
+++ b/internal/transpiler/transformer/expressions.go
@@ -664,6 +664,67 @@ func (t *galaASTTransformer) transformIfExpression(ctx *grammar.IfExpressionCont
 	}, nil
 }
 
+// expressionIsBareMatch reports whether the expression context is a bare
+// `subject match { ... }` form whose value is the entire expression (i.e.
+// not nested inside arithmetic, calls, or other operators). When such a
+// match appears in statement position, its value is discarded — see
+// transformBlock, which uses this to mark the match as statement-position
+// so void-returning arm calls do not get wrapped in `return ...`.
+func (t *galaASTTransformer) expressionIsBareMatch(exprCtx grammar.IExpressionContext) bool {
+	if exprCtx == nil {
+		return false
+	}
+	orExpr := exprCtx.OrExpr()
+	if orExpr == nil {
+		return false
+	}
+	orCtx := orExpr.(*grammar.OrExprContext)
+	if len(orCtx.AllAndExpr()) != 1 {
+		return false
+	}
+	andCtx := orCtx.AndExpr(0).(*grammar.AndExprContext)
+	if len(andCtx.AllEqualityExpr()) != 1 {
+		return false
+	}
+	eqCtx := andCtx.EqualityExpr(0).(*grammar.EqualityExprContext)
+	if len(eqCtx.AllRelationalExpr()) != 1 {
+		return false
+	}
+	relCtx := eqCtx.RelationalExpr(0).(*grammar.RelationalExprContext)
+	if len(relCtx.AllAdditiveExpr()) != 1 {
+		return false
+	}
+	addCtx := relCtx.AdditiveExpr(0).(*grammar.AdditiveExprContext)
+	if len(addCtx.AllMultiplicativeExpr()) != 1 {
+		return false
+	}
+	mulCtx := addCtx.MultiplicativeExpr(0).(*grammar.MultiplicativeExprContext)
+	if len(mulCtx.AllUnaryExpr()) != 1 {
+		return false
+	}
+	unaryCtx := mulCtx.UnaryExpr(0).(*grammar.UnaryExprContext)
+	postfixExpr := unaryCtx.PostfixExpr()
+	if postfixExpr == nil {
+		return false
+	}
+	postfixCtx := postfixExpr.(*grammar.PostfixExprContext)
+	// transformPostfixExpr detects match by scanning children for a node whose
+	// text is the keyword `match`. Mirror that here.
+	if postfixCtx.GetChildCount() <= 1 {
+		return false
+	}
+	for i := 0; i < postfixCtx.GetChildCount(); i++ {
+		child := postfixCtx.GetChild(i)
+		if child == nil {
+			continue
+		}
+		if pt, ok := child.(antlr.ParseTree); ok && pt.GetText() == "match" {
+			return true
+		}
+	}
+	return false
+}
+
 // findIfExpressionInExpression traverses the expression tree to find an if-expression
 // if the expression is simply an if-expression (not part of a larger expression).
 // Follows the same traversal pattern as findLambdaInExpression in lambdas.go.

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -179,6 +179,13 @@ func (t *galaASTTransformer) transformLambdaWithExpectedType(ctx *grammar.Lambda
 // or when the lambda is void. Extracted from transformLambdaWithExpectedType
 // as part of A6.
 func (t *galaASTTransformer) transformBlockLambdaBody(ctx *grammar.LambdaExpressionContext, isVoidExpected, isConcreteExpectedType, expectsReturnValue bool) (*ast.BlockStmt, ast.Expr, error) {
+	// Signal to transformBlock that the lambda body's last expression is
+	// promoted to the implicit return when this lambda is value-returning.
+	// Without this, a trailing bare `match` whose value becomes the lambda's
+	// return would be marked statement-position and forced to void.
+	if !isVoidExpected {
+		t.blockLastStmtIsValue = true
+	}
 	b, err := t.transformBlock(ctx.Block().(*grammar.BlockContext))
 	if err != nil {
 		return nil, nil, err
@@ -1203,6 +1210,9 @@ func (t *galaASTTransformer) transformPartialCaseClause(ctx *grammar.CaseClauseC
 	var resultType transpiler.Type
 
 	if ctx.GetBodyBlock() != nil {
+		// Partial function arm body: the trailing expression is wrapped in
+		// Some(...) below, so it is value-consumed.
+		t.blockLastStmtIsValue = true
 		b, err := t.transformBlock(ctx.GetBodyBlock().(*grammar.BlockContext))
 		if err != nil {
 			return nil, nil, err

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -30,9 +30,23 @@ func (t *galaASTTransformer) transformMatchExpression(ctx grammar.IExpressionCon
 	t.currentMatchSubjectType = matchedType
 	defer func() { t.currentMatchSubjectType = prevMatchSubjectType }()
 
+	// Consume the statement-position marker set by transformBlock so arm
+	// bodies see matchInStatementPos = false (a NESTED match used as the
+	// arm's value must remain value-producing).
+	stmtPosition := t.matchInStatementPos
+	t.matchInStatementPos = false
+	defer func() { t.matchInStatementPos = stmtPosition }()
+
 	clauses, defaultBody, resultType, err := t.transformMatchClauses(ctx, paramName, matchedType)
 	if err != nil {
 		return nil, err
+	}
+
+	// Statement-position matches discard their value; force the IIFE to be
+	// void so void-returning arm calls do not appear as `return d.Skip()`
+	// (which Go rejects as "no value used as value").
+	if stmtPosition {
+		resultType = transpiler.VoidType{}
 	}
 
 	t.needsStdImport = true
@@ -522,6 +536,9 @@ func (t *galaASTTransformer) transformMatchClauses(ctx grammar.IExpressionContex
 			}
 
 			if ccCtx.GetBodyBlock() != nil {
+				// The default arm's block-body last expression becomes the
+				// arm's value (when not void), so it is value-consumed.
+				t.blockLastStmtIsValue = true
 				b, err := t.transformBlock(ccCtx.GetBodyBlock().(*grammar.BlockContext))
 				if err != nil {
 					return nil, nil, nil, err
@@ -1160,6 +1177,9 @@ func (t *galaASTTransformer) transformCaseClauseWithType(ctx *grammar.CaseClause
 	var resultType transpiler.Type
 
 	if ctx.GetBodyBlock() != nil {
+		// The case body's block last expression becomes the arm's value, so
+		// it is value-consumed (not statement-position).
+		t.blockLastStmtIsValue = true
 		b, err := t.transformBlock(ctx.GetBodyBlock().(*grammar.BlockContext))
 		if err != nil {
 			return nil, nil, err

--- a/internal/transpiler/transformer/patterns.go
+++ b/internal/transpiler/transformer/patterns.go
@@ -418,6 +418,9 @@ func (t *galaASTTransformer) transformCaseClause(ctx *grammar.CaseClauseContext,
 	bodyBlockCtx := ctx.GetBodyBlock()
 	bodyStmtCtx := ctx.GetBodyStmt()
 	if bodyBlockCtx != nil {
+		// The case body's block last expression becomes the arm's value, so
+		// it is value-consumed.
+		t.blockLastStmtIsValue = true
 		b, err := t.transformBlock(bodyBlockCtx.(*grammar.BlockContext))
 		if err != nil {
 			return nil, err

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -442,6 +442,13 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 	t.currentMatchSubjectType = matchedType
 	defer func() { t.currentMatchSubjectType = prevMatchSubjectType }()
 
+	// Consume the statement-position marker set by transformBlock. Arm bodies
+	// must see matchInStatementPos = false so a NESTED match used as the arm's
+	// value is not also forced to void.
+	stmtPosition := t.matchInStatementPos
+	t.matchInStatementPos = false
+	defer func() { t.matchInStatementPos = stmtPosition }()
+
 	// Downward inference for match-arm sealed-variant constructors (context 5):
 	// when the match expression's value flows into a slot with a known
 	// concrete type (val with explicit type, function return, function arg),
@@ -506,6 +513,9 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 			}
 
 			if ccCtx.GetBodyBlock() != nil {
+				// The default arm's block-body last expression becomes the
+				// arm's value, so it is value-consumed.
+				t.blockLastStmtIsValue = true
 				b, err := t.transformBlock(ccCtx.GetBodyBlock().(*grammar.BlockContext))
 				if err != nil {
 					return nil, err
@@ -552,6 +562,14 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 	resultType, err := t.inferCommonResultType(resultTypes, casePatterns, ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	// Statement-position matches discard their value; force the IIFE to be
+	// void so that arms with mixed value/void payloads — e.g. one arm calling
+	// a Go method returning bool, another calling a void Go method — do not
+	// emit `return <voidCall>` (rejected by Go as "no value used as value").
+	if stmtPosition {
+		resultType = transpiler.VoidType{}
 	}
 
 	// Reject bare `return` inside a value-producing match (the IIFE would need

--- a/internal/transpiler/transformer/statements.go
+++ b/internal/transpiler/transformer/statements.go
@@ -250,15 +250,73 @@ func (t *galaASTTransformer) transformShortVarDeclWithMutability(ctx *grammar.Sh
 func (t *galaASTTransformer) transformBlock(ctx *grammar.BlockContext) (*ast.BlockStmt, error) {
 	t.pushScope()
 	defer t.popScope()
+	// Capture and reset the block-last-stmt-is-value flag once: it applies
+	// only to *this* block's last statement, not to any nested blocks.
+	lastStmtIsValue := t.blockLastStmtIsValue
+	t.blockLastStmtIsValue = false
+	defer func() { t.blockLastStmtIsValue = lastStmtIsValue }()
+
 	block := &ast.BlockStmt{}
-	for _, stmtCtx := range ctx.AllStatement() {
+	allStmts := ctx.AllStatement()
+	lastIdx := len(allStmts) - 1
+	for i, stmtCtx := range allStmts {
+		// A bare `subject match { ... }` whose value is discarded by the
+		// surrounding ExprStmt must be lowered as a void IIFE; otherwise
+		// arms calling void Go functions (e.g. `d.Skip()`) get wrapped in
+		// `return d.Skip()` because at least one other arm produced a typed
+		// value, and Go rejects "return d.Skip()" as "no value used as
+		// value". A non-trailing statement is unconditionally
+		// statement-position; the trailing statement is statement-position
+		// only when the caller did NOT signal that the block's last
+		// expression is consumed (via blockLastStmtIsValue) — function
+		// bodies with a return type, lambda bodies, and match arm bodies
+		// all set that flag, since their trailing expression becomes the
+		// block's value.
+		prev := t.matchInStatementPos
+		isTrailing := i == lastIdx
+		discardsValue := !isTrailing || !lastStmtIsValue
+		if discardsValue && stmtIsBareMatchExpression(stmtCtx.(*grammar.StatementContext), t) {
+			t.matchInStatementPos = true
+		}
 		stmt, err := t.transformStatement(stmtCtx.(*grammar.StatementContext))
+		t.matchInStatementPos = prev
 		if err != nil {
 			return nil, err
 		}
 		block.List = append(block.List, stmt)
 	}
 	return block, nil
+}
+
+// stmtIsBareMatchExpression reports whether a statement is just a bare
+// `subject match { ... }` expression. It descends through statement →
+// declaration / simpleStatement → expression to reach the match check.
+// The transformer is passed for access to expressionIsBareMatch.
+func stmtIsBareMatchExpression(ctx *grammar.StatementContext, t *galaASTTransformer) bool {
+	if ctx == nil {
+		return false
+	}
+	declCtx := ctx.Declaration()
+	if declCtx == nil {
+		return false
+	}
+	dc, ok := declCtx.(*grammar.DeclarationContext)
+	if !ok {
+		return false
+	}
+	simpleCtx := dc.SimpleStatement()
+	if simpleCtx == nil {
+		return false
+	}
+	sc, ok := simpleCtx.(*grammar.SimpleStatementContext)
+	if !ok {
+		return false
+	}
+	exprCtx := sc.Expression()
+	if exprCtx == nil {
+		return false
+	}
+	return t.expressionIsBareMatch(exprCtx)
 }
 
 func (t *galaASTTransformer) transformForStatement(ctx *grammar.ForStatementContext) (ast.Stmt, error) {

--- a/internal/transpiler/transformer/transformer.go
+++ b/internal/transpiler/transformer/transformer.go
@@ -62,6 +62,8 @@ type galaASTTransformer struct {
 	instanceInterfaceNames map[string]string            // type name -> actual generated interface name (for collision avoidance)
 	expectedIfExprType     ast.Expr                     // expected return type for if-expression IIFE (set by expression-bodied function handler)
 	expectedArgTypes       expectedArgTypeStack         // (B1) LIFO stack of expected-type hints for downward inference; replaces a single-field side-channel. See expected_arg_stack.go for the contract.
+	matchInStatementPos    bool                         // set when transforming a `subject match { ... }` whose value is discarded (statement-position match); causes the IIFE to be lowered as void so void-returning arm calls do not appear as `return d.Skip()`
+	blockLastStmtIsValue   bool                         // set by callers of transformBlock that consume the block's last expression (function body with return type, lambda body, match arm body, partial-function body); without this, transformBlock treats the trailing statement as discarded — same as the trailing statement of for/if bodies — and marks any trailing bare `match` as statement-position
 	lspVarTypes            map[string]transpiler.Type   // LSP: collects all resolved var types during transformation
 	lspCurrentFunc         string                       // LSP: name of the function currently being transformed (for scoping)
 	lspLambdaParamHints    []transpiler.LambdaParamHint // LSP: positions of lambda params with inferred types


### PR DESCRIPTION
## Summary

When a bare `subject match { ... }` is used in statement position (its value discarded by the surrounding `ExprStmt`) and one arm produces a typed value (e.g. `d.ReadBool()` returning `bool`) while another arm calls a void Go function (e.g. `d.Skip()`), the transpiler used to emit the void arm as `return d.Skip()` — which Go rejects:

```
config_0.gen.go:177:12: d.Skip() (no value) used as value
```

**Category**: CODEGEN_BUG
**Priority**: P0 (compiler error — blocks compilation for the lint-recommended match-as-statement form).

## Root Cause

`inferCommonResultType` picked up the typed return from the value-bearing arm and forced every arm — including the void ones — through `lowerMatchArmTailExpr`'s value path. The existing void-dispatch fallback only fired when **all** arms were void/nil; mixed value/void arms in statement position were not covered.

## Changes

- `internal/transpiler/transformer/transformer.go` — added `matchInStatementPos` and `blockLastStmtIsValue` flags.
- `internal/transpiler/transformer/expressions.go` — added `expressionIsBareMatch` helper.
- `internal/transpiler/transformer/statements.go` — `transformBlock` now marks bare-match expression statements as statement-position when their value is discarded.
- `internal/transpiler/transformer/match.go` — `transformMatchExpression` consumes the flag and forces `resultType = VoidType{}`; arm `transformBlock` opts in via `blockLastStmtIsValue`.
- `internal/transpiler/transformer/postfix.go` — same pattern in `buildMatchExpressionFromClauses`.
- `internal/transpiler/transformer/declarations.go` — function body block opts in when the function has a return type.
- `internal/transpiler/transformer/lambdas.go` — block lambda body opts in when not void; partial function arm opts in.
- `internal/transpiler/transformer/patterns.go` — partial-function pattern body opts in.
- `examples/match_stmt_mixed_void.gala` + `.out` — single-file repro.
- `examples/multifile_lib_regress/logic.gala::EmitLevel` + driver/expected updates — multi-file batch regression.

## Verification

- `bazel build //...` PASSES.
- `bazel test //...` PASSES (305/305).

## Repro (failed before this fix)

```gala
for d.HasMoreFields() {
    d.ReadKey() match {
        case "qa_required"        => qa = d.ReadBool()
        case "parallel_engineers" => parallel = d.ReadBool()
        case _                    => d.Skip()
    }
}
```

## Dependencies

None — this PR can be reviewed and merged independently.

---
Generated with [Claude Code](https://claude.com/claude-code)