### PR TITLE
fix(json): consume inter-element comma in StartObject and StartArray

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1837,6 +1837,19 @@ gala_test(
     ],
 )
 
+# Regression: Array[Foo] of structs round-trip through manual encoder + decoder.
+# Before the StartObject/StartArray fix, the decoder panicked on element 2+
+# because container openers did not consume the inter-element comma.
+gala_test(
+    name = "json_codec_nested_array",
+    src = "json_codec_nested_array.gala",
+    expected = "json_codec_nested_array.out",
+    deps = [
+        "//collection_immutable",
+        "//json",
+    ],
+)
+
 # Regex pattern matching usage
 gala_test(
     name = "regex_usage",

--- a/examples/json_codec_nested_array.gala
+++ b/examples/json_codec_nested_array.gala
@@ -1,0 +1,235 @@
+package main
+
+import (
+    . "martianoff/gala/std"
+    . "martianoff/gala/json"
+    . "martianoff/gala/collection_immutable"
+)
+
+// Round-trips composite shapes through the manual JSON encoder/decoder:
+//   1. Array[Foo] of structs              — StartObject inside StartArray
+//   2. HashMap[string, Foo]               — StartObject inside an object
+//   3a. HashMap[string, Array[int]]       — StartArray inside an object
+//   3.  Array[HashMap[string, int]]       — StartObject inside StartArray
+//                                           when the element is itself an object
+//
+// Before the StartObject/StartArray fix in json/codec.gala, cases (1) and (3)
+// panicked on element 2+ with `json at pos N: expected '{'` because the
+// inter-element comma was never consumed for container-element arrays.
+
+struct Line(Speaker string, Text string)
+
+// --- (1) Array[Line] of structs ---
+
+func encodeArray(convo Array[Line]) string {
+    val w = NewJsonEncoder()
+    w.WriteStartObject()
+    w.WriteKey("conversation")
+    w.WriteStartArray()
+    convo.ForEach((cl) => {
+        w.WriteStartObject()
+        w.WriteKey("speaker"); w.WriteString(cl.Speaker)
+        w.WriteKey("text");    w.WriteString(cl.Text)
+        w.WriteEndObject()
+    })
+    w.WriteEndArray()
+    w.WriteEndObject()
+    return w.String()
+}
+
+func decodeArray(payload string) Array[Line] {
+    var lines = EmptyArray[Line]()
+    val d = NewJsonDecoder(payload)
+    d.StartObject()
+    for d.HasMoreFields() {
+        if d.ReadKey() == "conversation" {
+            d.StartArray()
+            for d.HasMoreElements() {
+                var speaker = ""
+                var text    = ""
+                d.StartObject()
+                for d.HasMoreFields() {
+                    val k = d.ReadKey()
+                    if k == "speaker" { speaker = d.ReadString() }
+                    else if k == "text" { text = d.ReadString() }
+                    else { d.Skip() }
+                }
+                d.EndObject()
+                lines = lines.Append(Line(Speaker = speaker, Text = text))
+            }
+            d.EndArray()
+        } else {
+            d.Skip()
+        }
+    }
+    d.EndObject()
+    return lines
+}
+
+// --- (2) HashMap[string, Line] of struct values ---
+
+func encodeMap(m HashMap[string, Line]) string {
+    val w = NewJsonEncoder()
+    w.WriteStartObject()
+    // Iterate in sorted-key order so the output is deterministic.
+    val keys = m.Keys().ToArray().SortBy((k) => k)
+    keys.ForEach((k) => {
+        w.WriteKey(k)
+        val cl = m.Get(k).Get()
+        w.WriteStartObject()
+        w.WriteKey("speaker"); w.WriteString(cl.Speaker)
+        w.WriteKey("text");    w.WriteString(cl.Text)
+        w.WriteEndObject()
+    })
+    w.WriteEndObject()
+    return w.String()
+}
+
+func decodeMap(payload string) HashMap[string, Line] {
+    var out = EmptyHashMap[string, Line]()
+    val d = NewJsonDecoder(payload)
+    d.StartObject()
+    for d.HasMoreFields() {
+        val k = d.ReadKey()
+        var speaker = ""
+        var text    = ""
+        d.StartObject()
+        for d.HasMoreFields() {
+            val fk = d.ReadKey()
+            if fk == "speaker" { speaker = d.ReadString() }
+            else if fk == "text" { text = d.ReadString() }
+            else { d.Skip() }
+        }
+        d.EndObject()
+        out = out.Put(k, Line(Speaker = speaker, Text = text))
+    }
+    d.EndObject()
+    return out
+}
+
+// --- (3a) HashMap[string, Array[int]] — map of arrays ---
+
+func encodeMapOfArrays(m HashMap[string, Array[int]]) string {
+    val w = NewJsonEncoder()
+    w.WriteStartObject()
+    val keys = m.Keys().ToArray().SortBy((k) => k)
+    keys.ForEach((k) => {
+        w.WriteKey(k)
+        w.WriteStartArray()
+        m.Get(k).Get().ForEach((v) => w.WriteInt(v))
+        w.WriteEndArray()
+    })
+    w.WriteEndObject()
+    return w.String()
+}
+
+func decodeMapOfArrays(payload string) HashMap[string, Array[int]] {
+    var out = EmptyHashMap[string, Array[int]]()
+    val d = NewJsonDecoder(payload)
+    d.StartObject()
+    for d.HasMoreFields() {
+        val k = d.ReadKey()
+        var arr = EmptyArray[int]()
+        d.StartArray()
+        for d.HasMoreElements() {
+            arr = arr.Append(d.ReadInt())
+        }
+        d.EndArray()
+        out = out.Put(k, arr)
+    }
+    d.EndObject()
+    return out
+}
+
+// --- (3) Array[HashMap[string, int]] — array of maps ---
+
+func encodeArrayOfMaps(rows Array[HashMap[string, int]]) string {
+    val w = NewJsonEncoder()
+    w.WriteStartArray()
+    rows.ForEach((m) => {
+        val keys = m.Keys().ToArray().SortBy((k) => k)
+        w.WriteStartObject()
+        keys.ForEach((k) => {
+            w.WriteKey(k)
+            w.WriteInt(m.Get(k).Get())
+        })
+        w.WriteEndObject()
+    })
+    w.WriteEndArray()
+    return w.String()
+}
+
+func decodeArrayOfMaps(payload string) Array[HashMap[string, int]] {
+    var rows = EmptyArray[HashMap[string, int]]()
+    val d = NewJsonDecoder(payload)
+    d.StartArray()
+    for d.HasMoreElements() {
+        var m = EmptyHashMap[string, int]()
+        d.StartObject()
+        for d.HasMoreFields() {
+            val k = d.ReadKey()
+            m = m.Put(k, d.ReadInt())
+        }
+        d.EndObject()
+        rows = rows.Append(m)
+    }
+    d.EndArray()
+    return rows
+}
+
+func main() {
+    // (1) Array[Line]
+    val convo = ArrayOf(
+        Line(Speaker = "you",  Text = "a"),
+        Line(Speaker = "Iris", Text = "b"),
+        Line(Speaker = "you",  Text = "c"),
+    )
+    val arrayPayload = encodeArray(convo)
+    Println(arrayPayload)
+    val decodedArray = decodeArray(arrayPayload)
+    Println(s"array len=${decodedArray.Length()}")
+    decodedArray.ForEach((cl) => Println(s"${cl.Speaker}: ${cl.Text}"))
+
+    // (2) HashMap[string, Line]
+    val byId = EmptyHashMap[string, Line]()
+        .Put("u1", Line(Speaker = "you",  Text = "hi"))
+        .Put("u2", Line(Speaker = "Iris", Text = "hello"))
+        .Put("u3", Line(Speaker = "you",  Text = "ok"))
+    val mapPayload = encodeMap(byId)
+    Println(mapPayload)
+    val decodedMap = decodeMap(mapPayload)
+    Println(s"map size=${decodedMap.Size()}")
+    val mapKeys = decodedMap.Keys().ToArray().SortBy((k) => k)
+    mapKeys.ForEach((k) => {
+        val cl = decodedMap.Get(k).Get()
+        Println(s"$k -> ${cl.Speaker}: ${cl.Text}")
+    })
+
+    // (3a) HashMap[string, Array[int]]
+    val moa = EmptyHashMap[string, Array[int]]()
+        .Put("evens", ArrayOf(2, 4, 6))
+        .Put("odds",  ArrayOf(1, 3))
+    val moaPayload = encodeMapOfArrays(moa)
+    Println(moaPayload)
+    val decodedMoa = decodeMapOfArrays(moaPayload)
+    Println(s"moa size=${decodedMoa.Size()}")
+    val moaKeys = decodedMoa.Keys().ToArray().SortBy((k) => k)
+    moaKeys.ForEach((k) => {
+        val xs = decodedMoa.Get(k).Get()
+        val parts = xs.Map((v) => s"$v")
+        Println(s"$k -> [${parts.MkString(",")}]")
+    })
+
+    // (3) Array[HashMap[string, int]]
+    val row1 = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2)
+    val row2 = EmptyHashMap[string, int]().Put("c", 3)
+    val rows = ArrayOf(row1, row2)
+    val rowsPayload = encodeArrayOfMaps(rows)
+    Println(rowsPayload)
+    val decodedRows = decodeArrayOfMaps(rowsPayload)
+    Println(s"rows len=${decodedRows.Length()}")
+    decodedRows.ForEach((m) => {
+        val ks = m.Keys().ToArray().SortBy((k) => k)
+        ks.ForEach((k) => Println(s"  $k=${m.Get(k).Get()}"))
+    })
+}

--- a/examples/json_codec_nested_array.out
+++ b/examples/json_codec_nested_array.out
@@ -1,0 +1,19 @@
+{"conversation":[{"speaker":"you","text":"a"},{"speaker":"Iris","text":"b"},{"speaker":"you","text":"c"}]}
+array len=3
+you: a
+Iris: b
+you: c
+{"u1":{"speaker":"you","text":"hi"},"u2":{"speaker":"Iris","text":"hello"},"u3":{"speaker":"you","text":"ok"}}
+map size=3
+u1 -> you: hi
+u2 -> Iris: hello
+u3 -> you: ok
+{"evens":[2,4,6],"odds":[1,3]}
+moa size=2
+evens -> [2,4,6]
+odds -> [1,3]
+[{"a":1,"b":2},{"c":3}]
+rows len=2
+  a=1
+  b=2
+  c=3

--- a/json/codec.gala
+++ b/json/codec.gala
@@ -157,6 +157,11 @@ type JsonDecoderImpl struct {
 func NewJsonDecoder(s string) *JsonDecoderImpl = &JsonDecoderImpl{data: toBytes(s), pos: 0}
 
 func (d *JsonDecoderImpl) StartObject() {
+    // Container openers must consume the inter-element comma when the
+    // enclosing context is an array — otherwise Array[Foo] of structs
+    // panics on the leading ',' of element 2+. The primitive Read* paths
+    // already do this; objects/arrays were missing the same hook.
+    d.consumeElemComma()
     d.skipWs()
     if d.pos >= len(d.data) || d.data[d.pos] != '{' {
         panic(fmt.Sprintf("json at pos %d: expected '{'", d.pos))
@@ -177,6 +182,9 @@ func (d *JsonDecoderImpl) EndObject() {
 }
 
 func (d *JsonDecoderImpl) StartArray() {
+    // See StartObject — the enclosing array context's leading ',' must be
+    // consumed before we can recognise the '[' of a nested array element.
+    d.consumeElemComma()
     d.skipWs()
     if d.pos >= len(d.data) || d.data[d.pos] != '[' {
         panic(fmt.Sprintf("json at pos %d: expected '['", d.pos))


### PR DESCRIPTION
## Summary

The JSON decoder's primitive readers (`ReadString`, `ReadInt`, ...) all call `consumeElemComma()` so that arrays of primitives parse correctly across the leading `,` between elements. The container openers `StartObject` and `StartArray` did not, which made any **nested-container** array — `Array[Foo]` of structs, `Array[HashMap[K, V]]`, etc. — panic on the second element with:

```
panic: json at pos N: expected '{'
```

even though the encoder produced perfectly valid JSON.

**Category**: USABILITY (stdlib bug)
**Priority**: P1
**Found in**: `gala_team/app/session` (session-snapshot persistence)

## Root Cause

`consumeElemComma()` is the helper that consumes the inter-element `,` when the enclosing context is an array. Every primitive `Read*` calls it. `StartObject` / `StartArray` didn't, so once you nested any container inside an array, element 2+ saw a `,` instead of `{` or `[` and panicked.

## Changes

- `json/codec.gala` — `StartObject` and `StartArray` now call `consumeElemComma()` before the leading-byte check. The helper is a no-op outside of array context, so primitive-element arrays and top-level / object-value containers are unaffected.
- `examples/json_codec_nested_array.gala` + `.out` — round-trips four shapes:
  1. `Array[Foo]` (struct elements)
  2. `HashMap[string, Foo]` (struct values)
  3. `HashMap[string, Array[int]]` (array values inside an object)
  4. `Array[HashMap[string, int]]` (object elements inside an array)
- `examples/BUILD.bazel` — wires the new `gala_test` target.

## Verification

- `bazel test examples:json_codec_nested_array` PASSES.
- Confirmed regression on master: stashing only the `codec.gala` fix and re-running the example reproduces `panic: json at pos 45: expected '{'`.
- `bazel test //...` PASSES (307/307).

## Repro (panicked before this fix)

```gala
struct Line(Speaker string, Text string)

val convo = ArrayOf(
    Line(Speaker = "you",  Text = "a"),
    Line(Speaker = "Iris", Text = "b"),
)
val payload = encode(convo)   // valid JSON
val decoded = decode(payload) // panic on element 2
```

## Follow-up (out of scope here)

`genCollectionWrite` carries a "primitives only" gate that bails to `WriteNull` for non-primitive element types. With this fix in place, that gate can be dropped so `Codec[T]` (the typed codegen path) supports `Array[Foo]` natively too. Tracked separately.

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported in `docs/private/JSON_CODEC_NESTED_ARRAY_GAP.md` (gala_team session-snapshot work, 2026-04-27).

---
Generated with [Claude Code](https://claude.com/claude-code)