### PR TITLE
fix(release): bump gala.mod to 0.39.0

### DIFF
--- a/gala.mod
+++ b/gala.mod
@@ -1,3 +1,3 @@
 module martianoff/gala
 
-gala 0.38.0
+gala 0.39.0


### PR DESCRIPTION
Mechanical release-prep bump for 0.39.0. Tag follows.