### PR TITLE
fix(type-inference): tuple literal element types use call-site expected type

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -250,6 +250,13 @@ gala_test(
 )
 
 gala_test(
+    name = "fix007_repro",
+    src = "fix007_repro.gala",
+    expected = "fix007_repro.out",
+    deps = ["//collection_immutable"],
+)
+
+gala_test(
     name = "either",
     src = "either.gala",
     expected = "either.out",

--- a/examples/fix007_repro.gala
+++ b/examples/fix007_repro.gala
@@ -1,0 +1,21 @@
+package main
+
+import (
+    "errors"
+    . "martianoff/gala/collection_immutable"
+)
+
+// FIX-007 reproducer: tuple literal as call argument should infer concrete element types
+// from the call-site expected parameter type, not collapse to `Tuple[any, error]`.
+func collectFailures() Array[Tuple[string, error]] {
+    var failures = EmptyArray[Tuple[string, error]]()
+    val name = "session-1"
+    val err = errors.New("boom")
+    failures = failures.Append((name, err))
+    return failures
+}
+
+func main() {
+    val out = collectFailures()
+    out.ForEach((p) => Println(s"${p.V1}=${p.V2.Error()}"))
+}

--- a/examples/fix007_repro.out
+++ b/examples/fix007_repro.out
@@ -1,0 +1,1 @@
+session-1=boom

--- a/examples/multifile_lib_regress/logic.gala
+++ b/examples/multifile_lib_regress/logic.gala
@@ -93,6 +93,21 @@ func MakeFlagPair(flag bool, label string) Tuple[bool, string] = Tuple(flag, lab
 func MakeTriple(n int, label string, ratio float64) Tuple3[int, string, float64] =
     Tuple(n, label, ratio)
 
+// --- Regression: tuple literal as call argument inherits element types from
+// the call-site's expected parameter type (bidirectional inference).
+// Without this the `(name, err)` literal had its first element collapse to
+// `any` because `getExprTypeName` of the val-bound `name` did not resolve
+// to a concrete `string` from the call-site context, and Append was rejected
+// with `cannot use Tuple[any, error] as Tuple[string, error]`.
+func CollectFailures(names Array[string]) Array[Tuple[string, error]] {
+    var failures = EmptyArray[Tuple[string, error]]()
+    names.ForEach((name) => {
+        val err = NoSuchElement(s"failed-$name")
+        failures = failures.Append((name, err))
+    })
+    return failures
+}
+
 // --- Regression: expression-bodied if-expression inside Map lambda whose
 // arms reference methods on a user-defined generic type. HM type inference
 // can't model methods on generics (env only carries top-level functions

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -127,6 +127,13 @@ func main() {
     val tr = multifile_lib_regress.MakeTriple(7, "label", 1.5)
     Println(tr.V1, tr.V2, tr.V3)
 
+    // Tuple literal in call-argument position inherits element types from
+    // the call-site's expected parameter type (bidirectional inference).
+    // Without this the `(name, err)` literal was emitted as
+    // Tuple[any, error] and Array.Append rejected the mismatch.
+    val fails = multifile_lib_regress.CollectFailures(ArrayOf("alpha", "beta"))
+    fails.ForEach((p) => Println(s"${p.V1}=${p.V2.Error()}"))
+
     // Statement-position match with mixed value/void arms (regression).
     // EmitLevel runs `level match { ... }` as a statement; one arm calls
     // a value-returning function, another calls a void function, and

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -37,6 +37,8 @@ true
 401
 true ready
 7 label 1.5
+alpha=failed-alpha
+beta=failed-beta
 info
 0
 warn

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -85,6 +85,7 @@ go_test(
         "test_helper.go",
         "tuple_arity_matrix_test.go",
         "tuple_call_unwrap_test.go",
+        "tuple_callsite_inference_test.go",
         "tuple_either_test.go",
         "tuple_field_unwrap_repro_test.go",
         "tuple_return_arity_test.go",

--- a/internal/transpiler/transformer/constructors.go
+++ b/internal/transpiler/transformer/constructors.go
@@ -86,9 +86,13 @@ func (t *galaASTTransformer) transformPrimary(ctx *grammar.PrimaryContext) (ast.
 			el := exprListCtx.(*grammar.ExpressionListContext)
 			// When a tuple literal flows into a Tuple-shaped enclosing context
 			// (e.g., the return position of a function declared to return
-			// `Tuple[int, Cmd[Msg]]`), thread each element's expected type so
-			// that nested sealed-variant constructors like `NoCmd()` infer their
-			// type parameters from the tuple's slot.
+			// `Tuple[int, Cmd[Msg]]`, or a call argument expecting
+			// `Tuple[string, error]`), thread each element's expected type so
+			// that nested sealed-variant constructors like `NoCmd()` infer
+			// their type parameters from the tuple's slot, and so the
+			// synthesized composite literal carries concrete element types
+			// rather than collapsing to `any` when an element's standalone
+			// type happens to resolve to nil/any.
 			elemExprs := el.AllExpression()
 			if len(elemExprs) > 1 {
 				perElemExpected := t.tupleElementExpectedTypes(len(elemExprs))
@@ -96,7 +100,7 @@ func (t *galaASTTransformer) transformPrimary(ctx *grammar.PrimaryContext) (ast.
 				if err != nil {
 					return nil, err
 				}
-				return t.transformTupleLiteral(exprs, ctx.GetStart().GetLine(), ctx.GetStart().GetColumn())
+				return t.transformTupleLiteralWithExpected(exprs, perElemExpected, ctx.GetStart().GetLine(), ctx.GetStart().GetColumn())
 			}
 			exprs, err := t.transformExpressionList(el)
 			if err != nil {
@@ -125,10 +129,26 @@ func (t *galaASTTransformer) transformPrimary(ctx *grammar.PrimaryContext) (ast.
 
 // tupleElementExpectedTypes returns the per-element expected types for a
 // tuple literal of the given arity, computed from the most-specific available
-// outer context. Currently checks `currentFuncReturnType` for the
-// enclosing-return case (context 2 of downward sealed-variant inference).
-// Returns nil if no Tuple-shaped expected type is available.
+// outer context. Checks two sources, most-specific first:
+//
+//  1. The top of `expectedArgTypes` — the slot type at the immediately
+//     enclosing call argument / val-decl / tuple-element position. This
+//     drives bidirectional inference for the call-site case
+//     (`f((a, b))` where `f`'s parameter is `Tuple[T1, T2]`).
+//  2. `currentFuncReturnType` — the enclosing function's declared return
+//     type, used when the tuple literal is the value at a function return.
+//
+// Returns nil if no Tuple-shaped expected type is available. When (1)
+// matches, the entry is consumed off the stack so that nested expressions
+// inside this tuple do not pick it up again (B1 contract).
 func (t *galaASTTransformer) tupleElementExpectedTypes(arity int) []transpiler.Type {
+	if pending := t.expectedArgTypes.peek(); pending != nil && !pending.IsNil() {
+		if gen, ok := pending.(transpiler.GenericType); ok &&
+			t.isTupleTypeName(gen.Base.String()) && len(gen.Params) == arity {
+			t.expectedArgTypes.consume()
+			return gen.Params
+		}
+	}
 	candidates := []transpiler.Type{t.currentFuncReturnType}
 	for _, cand := range candidates {
 		if cand == nil || cand.IsNil() {

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -670,6 +670,19 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 }
 
 func (t *galaASTTransformer) transformTupleLiteral(exprs []ast.Expr, line ...int) (ast.Expr, error) {
+	return t.transformTupleLiteralWithExpected(exprs, nil, line...)
+}
+
+// transformTupleLiteralWithExpected lowers a tuple literal `(a, b, ...)` to
+// `std.TupleN[T1, T2, ...]{V1: NewImmutable(a), V2: NewImmutable(b), ...}`.
+// `perElemExpected`, when non-nil, supplies a higher-priority per-element
+// fallback for type-parameter synthesis (used for the call-site bidirectional
+// inference path). The previous fallback —
+// `currentFuncReturnType` — is still consulted when the per-element hint is
+// absent or itself uninformative, preserving the enclosing-return-type case.
+// When neither hint resolves a concrete element type, the parameter
+// degrades to `any` (matching the historical behavior).
+func (t *galaASTTransformer) transformTupleLiteralWithExpected(exprs []ast.Expr, perElemExpected []transpiler.Type, line ...int) (ast.Expr, error) {
 	n := len(exprs)
 	if n < 2 || n > 10 {
 		errLine, errCol := t.lastLine, t.lastCol
@@ -682,13 +695,18 @@ func (t *galaASTTransformer) transformTupleLiteral(exprs []ast.Expr, line ...int
 	// Determine tuple type name based on arity (B2 — single source of truth).
 	typeName, _ := tupleArityName(n)
 
-	// Infer type parameters from expression types.
-	// When inference fails for an element, fall back to the enclosing function's
-	// return type if it is a Tuple with matching arity (prevents type widening to any).
+	// Build the per-element fallback ladder. The most-specific source —
+	// the explicit per-element expected types passed in by the caller —
+	// wins over the enclosing function's return type.
 	var fallbackTypes []transpiler.Type
-	if retType, ok := t.currentFuncReturnType.(transpiler.GenericType); ok &&
-		t.isTupleTypeName(retType.Base.String()) && len(retType.Params) == n {
-		fallbackTypes = retType.Params
+	if perElemExpected != nil && len(perElemExpected) == n {
+		fallbackTypes = perElemExpected
+	}
+	if fallbackTypes == nil {
+		if retType, ok := t.currentFuncReturnType.(transpiler.GenericType); ok &&
+			t.isTupleTypeName(retType.Base.String()) && len(retType.Params) == n {
+			fallbackTypes = retType.Params
+		}
 	}
 
 	var typeParams []ast.Expr

--- a/internal/transpiler/transformer/tuple_callsite_inference_test.go
+++ b/internal/transpiler/transformer/tuple_callsite_inference_test.go
@@ -1,0 +1,123 @@
+package transformer_test
+
+import (
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTupleLiteralCallSiteInference verifies bidirectional type inference for
+// tuple literals used as call arguments. The tuple element types must be
+// derived from the call site's expected parameter type, not collapse to
+// `Tuple[any, ...]` when individual element-expression types alone would
+// resolve correctly.
+//
+// Regression: previously `arr.Append((name, err))` where the call expects
+// `Tuple[string, error]` emitted `std.Tuple[any, error]{...}`, which Go
+// rejected with "cannot use Tuple[any, error] as Tuple[string, error]".
+func TestTupleLiteralCallSiteInference(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    []string
+		notExpected []string
+	}{
+		{
+			// Direct repro: a function with parameter type Tuple[string, error]
+			// receives a tuple literal whose first element is a typed string
+			// and whose second element is a typed error. Without bidirectional
+			// inference the tuple literal collapses to Tuple[any, error].
+			name: "tuple literal as call arg uses expected param type",
+			input: `package main
+
+import "errors"
+
+func consume(p Tuple[string, error]) string = p.V1
+
+func main() {
+    val name = "x"
+    val err = errors.New("boom")
+    val s = consume((name, err))
+}`,
+			expected: []string{
+				"std.Tuple[string, error]",
+			},
+			notExpected: []string{
+				"std.Tuple[any, error]",
+				"std.Tuple[any, any]",
+			},
+		},
+		{
+			// Method-call shape mirroring the bug exactly: an Array.Append
+			// call where the array's element type is Tuple[string, error]
+			// and the literal supplies the pair.
+			name: "Array.Append((name, err)) keeps Tuple[string, error]",
+			input: `package main
+
+import (
+    "errors"
+    . "martianoff/gala/collection_immutable"
+)
+
+func collect() Array[Tuple[string, error]] {
+    var arr = EmptyArray[Tuple[string, error]]()
+    val name = "x"
+    val err = errors.New("boom")
+    arr = arr.Append((name, err))
+    return arr
+}`,
+			expected: []string{
+				"std.Tuple[string, error]",
+			},
+			notExpected: []string{
+				"std.Tuple[any, error]",
+			},
+		},
+		{
+			// Negative — make sure the no-call-context path still infers from
+			// element expression types. A bare val-binding has no expected
+			// type so the existing element-by-element inference must remain
+			// the source of truth.
+			name: "val-bound tuple literal still infers from element types",
+			input: `package main
+
+import "errors"
+
+func main() {
+    val name = "x"
+    val err = errors.New("boom")
+    val pair = (name, err)
+}`,
+			expected: []string{
+				"std.Tuple[string, error]",
+			},
+			notExpected: []string{
+				"std.Tuple[any, error]",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := trans.Transpile(tt.input, "")
+			assert.NoError(t, err)
+			for _, exp := range tt.expected {
+				assert.True(t, strings.Contains(got, exp), "Output missing %q\nGot:\n%s", exp, got)
+			}
+			for _, ne := range tt.notExpected {
+				assert.False(t, strings.Contains(got, ne), "Output should NOT contain %q\nGot:\n%s", ne, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **FIX-007**: `(name, err)` tuple literal in argument position to a call expecting `Tuple[string, error]` was inferred as `Tuple[any, error]`, causing `cannot use Tuple[any, error] ... as std.Tuple[string, error] value`.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1
**Found in**: `gala_team/app/runtime/runtime_glue.gala::CloseAllSessions` (Issue B in `docs/private/TRANSPILER_BUGS_HASHMAP_FOREACH_TUPLE.md`)

## Root Cause

Tuple-literal lowering ignored the `expectedArgTypes` stack (call-site hint) — it only consulted `currentFuncReturnType` as a fallback when element types collapsed. When a tuple literal sat in an argument position (e.g., `arr.Append((name, err))`), the analyzer had a perfectly good expected type at hand (`Tuple[string, error]` from `Append`'s parameter signature) but never read it, falling back to widening element types to `any`.

This is bidirectional inference for tuples — the same pattern already used for `None()`, `Some(x)`, and sealed-type constructors.

## Changes

- `internal/transpiler/transformer/constructors.go`: extended `tupleElementExpectedTypes` to peek at the top of `expectedArgTypes` (the call-arg slot) before falling back to `currentFuncReturnType`. On a Tuple-shaped match the entry is consumed off the stack so nested expressions inside the tuple don't pick it up again (preserving B1 contract).
- `internal/transpiler/transformer/postfix.go`: split `transformTupleLiteral` into a thin wrapper around a new `transformTupleLiteralWithExpected(exprs, perElemExpected, line...)` helper. The helper uses `perElemExpected` as a higher-priority fallback for type-param synthesis ahead of `currentFuncReturnType`. The `val t = (a, b)` (no call context) path is unchanged because it still arrives via the original entry point with no expected types.

## Verification

- `examples/fix007_repro.gala` (single-file direct repro)
- Regression case in `examples/multifile_lib_regress/logic.gala` exercising `Array.Append((name, err))` inside a `ForEach` lambda
- `internal/transpiler/transformer/tuple_callsite_inference_test.go` — three table-driven cases (direct call, Array.Append, val-bound negative)
- `bazel build //...` passes
- `bazel test //...` passes (308/308)
- All existing tuple tests still pass: `tuple_positional_ctor_test`, `tuple_arity_matrix_test`, `tuple_either_test`, `tuple_call_unwrap_test`, `tuple_field_unwrap_repro_test`, `tuple_return_arity_test`

## Repro (before fix)

```gala
var failures = EmptyArray[Tuple[string, error]]()
val name = \"alice\"
val err = NewError(\"timeout\")
failures = failures.Append((name, err))     // ← typed as Tuple[any, error], rejected
```

Generated Go (broken):
```go
failures = failures.Append(std.Tuple[any, error]{V1: name, V2: err})
//   cannot use Tuple[any, error]{...} as std.Tuple[string, error] value
```

## Negative regression check

`val t = (a, b)` (tuple literal in non-call context) still infers concrete element types from `a` and `b` — covered by the val-bound negative case in `tuple_callsite_inference_test.go` and by all pre-existing tuple tests.

## Dependencies

None — this PR can be reviewed and merged independently.

## Battle Test Report Reference

Originally reported as Issue B in `docs/private/TRANSPILER_BUGS_HASHMAP_FOREACH_TUPLE.md`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)