### PR TITLE
fix(transformer): drop pure expressions when stripping void match returns

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,5 +1,13 @@
 load("//:gala.bzl", "gala_binary", "gala_go_test", "gala_library", "gala_test")
 
+# multifile_lib_regress holds a multi-file gala_library that is
+# explicitly declared further down in this BUILD. Gazelle, left to its
+# own devices, descends into the subdir and emits a BUILD.bazel for
+# its bare `events.go` — which then conflicts with the parent's label
+# references because Bazel sees the subdir as its own package. Tell
+# gazelle to leave it alone.
+# gazelle:exclude multifile_lib_regress
+
 filegroup(
     name = "single_file_gala_sources",
     srcs = glob(["*.gala"]),
@@ -28,6 +36,7 @@ filegroup(
         "match_method_chain/main.gala",
         "match_method_chain/types.gala",
         "match_return_iife.gala",
+        "match_void_block_trailing_literal.gala",
         "match_void_branches.gala",
         "mathlib/math.gala",
         "multi_file/greeter.gala",
@@ -1719,6 +1728,16 @@ gala_test(
     name = "match_void_branches",
     src = "match_void_branches.gala",
     expected = "match_void_branches.out",
+)
+
+# Regression: a void-context match whose case bodies are blocks ending
+# in a literal trailing expression (`true`, `42`, …) used to emit
+# `{ <literal>; return }` blocks — invalid Go, since the language only
+# accepts function calls (and channel ops) as expression statements.
+gala_test(
+    name = "match_void_block_trailing_literal",
+    src = "match_void_block_trailing_literal.gala",
+    expected = "match_void_block_trailing_literal.out",
 )
 
 # Verification: transitive Go import for return types (e.g., io/fs from os.Stat)

--- a/examples/match_void_block_trailing_literal.gala
+++ b/examples/match_void_block_trailing_literal.gala
@@ -1,0 +1,46 @@
+package main
+
+// Regression: a match used in void context (no result consumed) whose
+// case bodies are blocks ending in a literal trailing expression
+// (e.g. `true`, `42`, an identifier) generated invalid Go like
+// `{ true; return }` because `stripReturnStatement` blindly converted
+// `return true` to `<true>; return`. Go only permits function calls
+// (and a couple of channel ops) as bare expression statements; pure
+// values trigger "untyped bool constant is not used". The fix: drop
+// non-side-effecting expressions when stripping for void match.
+//
+// Source pattern lifted from gala_tui's layout.gala constraint walker.
+
+sealed type Constraint {
+    case Length(V int)
+    case Percent(P int)
+    case Fill(W int)
+}
+
+// classify returns 1/2/3 based on the variant. The match is used as a
+// statement (no value flows out); each arm ends in a bare literal
+// (`true`) which historically tripped the dangling-expression bug.
+func classify(c Constraint) int {
+    var kind = 0
+    c match {
+        case Length(_)  => {
+            kind = 1
+            true
+        }
+        case Percent(_) => {
+            kind = 2
+            true
+        }
+        case Fill(_)    => {
+            kind = 3
+            true
+        }
+    }
+    return kind
+}
+
+func main() {
+    Println(s"length=${classify(Length(V = 10))}")
+    Println(s"percent=${classify(Percent(P = 25))}")
+    Println(s"fill=${classify(Fill(W = 1))}")
+}

--- a/examples/match_void_block_trailing_literal.out
+++ b/examples/match_void_block_trailing_literal.out
@@ -1,0 +1,3 @@
+length=1
+percent=2
+fill=3

--- a/internal/transpiler/transformer/match_void_dispatch_test.go
+++ b/internal/transpiler/transformer/match_void_dispatch_test.go
@@ -119,6 +119,71 @@ func run(flag bool) {
 	}
 }
 
+// TestMatchVoidArm_TrailingLiteralExpressionIsDropped guards against a
+// regression where a void-context match whose case body is a block
+// ending in a literal value (`true`, `42`, an identifier, …) generated
+// invalid Go like `{ <literal>; return }`. Go only accepts function
+// calls (and channel ops) as expression-statements; a bare value
+// triggers "untyped bool constant is not used" and the package fails
+// to compile.
+//
+// The pattern is common in stream / dispatch code that hand-rolled a
+// `true` sentinel inside void match arms (e.g. gala_tui's layout
+// constraint walker). The fix lives in stripReturnStatement
+// (patterns.go) and elides side-effect-free expressions when stripping
+// the value off a return.
+func TestMatchVoidArm_TrailingLiteralExpressionIsDropped(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	input := `package main
+
+sealed type Constraint {
+    case Length(V int)
+    case Percent(P int)
+}
+
+func walk(c Constraint) {
+    var total = 0
+    c match {
+        case Length(v)  => {
+            total = total + v
+            true
+        }
+        case Percent(p) => {
+            total = total + p
+            true
+        }
+    }
+}
+`
+	got, err := trans.Transpile(input, "")
+	assert.NoError(t, err, "transpilation should succeed")
+	gen := stripGeneratedHeader(got)
+
+	// The literal trailing values must NOT appear as bare expression
+	// statements anywhere in the output (the previous bug emitted
+	// `{ true\n return }` blocks).
+	assertNoBareLiteralStmt(t, gen, "true")
+}
+
+// assertNoBareLiteralStmt asserts that `lit` does not appear on its own
+// line in `code`. This catches the dangling-literal-as-statement form
+// `{\n\tlit\n\treturn\n}` without false-positiving on legitimate uses
+// like `if x == true {`.
+func assertNoBareLiteralStmt(t *testing.T, code string, lit string) {
+	t.Helper()
+	for _, line := range strings.Split(code, "\n") {
+		if strings.TrimSpace(line) == lit {
+			t.Errorf("found bare literal %q as a Go expression-statement; this is invalid Go.\n--- generated ---\n%s", lit, code)
+			return
+		}
+	}
+}
+
 // TestMatchValueContextStillErrors sanity-checks that the fallback does not
 // silently turn a value-using match with all-nil arms into VoidType. When the
 // match IS used as a value and no branch has a concrete type, we still want

--- a/internal/transpiler/transformer/patterns.go
+++ b/internal/transpiler/transformer/patterns.go
@@ -1570,6 +1570,29 @@ func (t *galaASTTransformer) fixupReturnStatement(stmt ast.Stmt, resultType tran
 	}
 }
 
+// exprIsLegalGoStmt reports whether `expr` is one of the limited
+// expression forms Go permits as a bare statement. Per the Go spec,
+// expression statements are legal only for function and method calls
+// and for channel receive operations; everything else (literals,
+// identifiers, binary ops, …) is rejected as "expression evaluated but
+// not used". Used by stripReturnStatement to decide whether the value
+// of `return <expr>` carries side effects worth preserving when the
+// surrounding match is in void context.
+func exprIsLegalGoStmt(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.CallExpr:
+		// `f(x)`, `obj.m()`, `T(x)` — calls always evaluate side effects.
+		// Type conversions (`int(x)`) are also CallExprs but Go treats
+		// them as legal expression statements too, so the broad rule is
+		// fine.
+		return true
+	case *ast.UnaryExpr:
+		// `<-ch` is a receive; Go permits it as a statement.
+		return e.Op == token.ARROW
+	}
+	return false
+}
+
 // stripReturnStatements converts return statements to expression statements + empty returns for void match.
 // This is used when a match is used purely for side effects (like fmt.Printf calls).
 // We keep empty returns to ensure early exit after each case branch.
@@ -1584,15 +1607,26 @@ func (t *galaASTTransformer) stripReturnStatements(stmts []ast.Stmt) []ast.Stmt 
 func (t *galaASTTransformer) stripReturnStatement(stmt ast.Stmt) ast.Stmt {
 	switch s := stmt.(type) {
 	case *ast.ReturnStmt:
-		// Convert "return expr" to "expr; return" (execute the expression, then return with no value)
+		// Convert "return expr" to a void early-exit. We keep the
+		// expression as a bare statement only when Go permits it as
+		// such — function calls and channel ops carry side effects
+		// the user expects to run. A pure expression (literal,
+		// identifier, binary op, …) is emitted by the user as a
+		// trailing arm value (`true`, `42`, `name`); the value is
+		// never observed in void context, and bare-evaluating it
+		// trips Go's "expression evaluated but not used" check.
 		if len(s.Results) > 0 {
-			// Create a block with the expression statement followed by an empty return
-			return &ast.BlockStmt{
-				List: []ast.Stmt{
-					&ast.ExprStmt{X: s.Results[0]},
-					&ast.ReturnStmt{}, // Empty return for early exit
-				},
+			res := s.Results[0]
+			if exprIsLegalGoStmt(res) {
+				return &ast.BlockStmt{
+					List: []ast.Stmt{
+						&ast.ExprStmt{X: res},
+						&ast.ReturnStmt{},
+					},
+				}
 			}
+			// Pure expression: drop the value, emit only the early exit.
+			return &ast.ReturnStmt{}
 		}
 		// Keep empty returns as-is
 		return s


### PR DESCRIPTION
## Summary
- Match arms with literal trailing values (`true`, `42`, …) inside void-context matches generated invalid Go: `{ true; return }`. Go only accepts function calls and channel ops as bare expression statements
- Gate the `return <expr>` → `<expr>; return` rewrite on whether the expression actually carries side effects; drop pure expressions and emit only the early-exit `return`
- Includes a `# gazelle:exclude` directive for `examples/multifile_lib_regress` so gazelle stops emitting a stray subpackage BUILD

## Repro
Building `gala_tui` against this transpiler reproduces:
```
gala_tui_21.gen.go:134:7: true (untyped bool constant) is not used
gala_tui_21.gen.go:152:8: true (untyped bool constant) is not used
…
```
The source is `gala_tui/layout.gala`'s constraint walker — `case Length(v) => { …; true }` style arms.

## What changed
- `internal/transpiler/transformer/patterns.go` — `exprIsLegalGoStmt` helper + gating in `stripReturnStatement`
- `internal/transpiler/transformer/match_void_dispatch_test.go` — `TestMatchVoidArm_TrailingLiteralExpressionIsDropped` unit
- `examples/match_void_block_trailing_literal.{gala,out}` — end-to-end repro example
- `examples/BUILD.bazel` — register the new gala_test + add `# gazelle:exclude multifile_lib_regress`

## Test plan
- [x] `bazel test //internal/transpiler/transformer:transformer_test` — full transformer suite green
- [x] `bazel test //internal/transpiler/analyzer:analyzer_test` — green
- [x] `bazel test //examples:match_void_block_trailing_literal` — repro passes
- [x] `bazel test` over the 19 unrelated `match_*` examples — no regressions
- [x] `bazel build @gala_tui//:gala_tui` (downstream) — now builds cleanly with this fix; previously failed with the dangling-`true` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)