### PR TITLE
fix: qualified named-arg ctor anchored to qualifier package

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -44,6 +44,7 @@ filegroup(
         "multi_file_types/model.gala",
         "multifile_lib_regress/proc_pkg/proc.gala",
         "multifile_lib_regress/proc_session.gala",
+        "multifile_lib_regress/shadow_func/shadow.gala",
         "multifile_lib_regress/team_lookup.gala",
         "multipackage_subpkg/main.gala",
         "multipackage_subpkg/state/state.gala",
@@ -2146,6 +2147,18 @@ gala_library(
     visibility = ["//visibility:public"],
 )
 
+# Sibling package that intentionally exports a top-level function whose name
+# shadows the `Snapshot` struct in multifile_lib_regress. Used by the
+# multifile_lib_regress_test consumer to verify that a qualified named-arg
+# constructor (`multifile_lib_regress.Snapshot(Field = ...)`) anchors lookup
+# to the qualifier rather than silently matching the dot-imported function.
+gala_library(
+    name = "multifile_lib_regress_shadow_func",
+    srcs = ["multifile_lib_regress/shadow_func/shadow.gala"],
+    importpath = "martianoff/gala/examples/multifile_lib_regress/shadow_func",
+    visibility = ["//visibility:public"],
+)
+
 gala_library(
     name = "multifile_lib_regress",
     srcs = [
@@ -2177,6 +2190,7 @@ gala_test(
     deps = [
         ":multifile_lib_regress",
         ":multifile_lib_regress_proc_pkg",
+        ":multifile_lib_regress_shadow_func",
         "//collection_immutable",
         "//examples/go_struct_bridge",
     ],

--- a/examples/multifile_lib_regress/shadow_func/shadow.gala
+++ b/examples/multifile_lib_regress/shadow_func/shadow.gala
@@ -1,0 +1,14 @@
+package shadow_func
+
+// Snapshot is intentionally a top-level function whose name shadows the
+// `Snapshot` struct in the sibling multifile_lib_regress package. Consumers
+// dot-import this package alongside the qualified import of
+// multifile_lib_regress; the qualified constructor call
+// `multifile_lib_regress.Snapshot(ProjectName = ...)` must resolve to the
+// struct, not to this function.
+func Snapshot(width int, height int) string = "tui-snap"
+
+// ShadowMarker is a non-clashing helper used by consumers that need to refer
+// to *something* exported from this package — keeps the dot-import live so
+// the consumer test file actually exercises the shadow scenario.
+func ShadowMarker() string = "shadow-marker"

--- a/examples/multifile_lib_regress/types.gala
+++ b/examples/multifile_lib_regress/types.gala
@@ -12,4 +12,12 @@ type UserInfo struct {
 
 func NewUser(name string, email string) UserInfo = UserInfo(Name = name, Email = email)
 
+// Snapshot exists ALSO as a function in the sibling shadow_func package below.
+// At call sites that import the shadow_func package via dot-import, the
+// qualified `multifile_lib_regress.Snapshot(Field = ...)` constructor must
+// resolve to this struct — not silently match the dot-imported function and
+// emit "unknown parameter" errors. Verifies the qualifier-anchored resolution
+// path.
+struct Snapshot(ProjectName string, SavedAt int64)
+
 // time.Parse is a Go function returning (time.Time, error)

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -3,6 +3,7 @@ package main
 import (
     "martianoff/gala/examples/multifile_lib_regress"
     "martianoff/gala/examples/multifile_lib_regress/proc_pkg"
+    . "martianoff/gala/examples/multifile_lib_regress/shadow_func"
     "martianoff/gala/examples/go_struct_bridge"
     . "martianoff/gala/collection_immutable"
     "time"
@@ -185,4 +186,20 @@ func main() {
     // (mirrors the original failing report). The lambda must still bind
     // v to V=Member.
     multifile_lib_regress.CloseAllMembers(mm2).ForEach((s) => Println(s))
+
+    // Qualified named-arg struct constructor must anchor the lookup to the
+    // explicit package qualifier even when a dot-imported sibling exports a
+    // function with the same identifier. Before the fix, the resolver would
+    // strip the qualifier and match the dot-imported `shadow_func.Snapshot`
+    // function — its (width, height) parameters did not match the struct's
+    // (ProjectName, SavedAt) field names and a misleading "unknown
+    // parameter" error fired at the call site.
+    val snap = multifile_lib_regress.Snapshot(
+        ProjectName = "demo",
+        SavedAt = int64(1234),
+    )
+    Println(s"snap: ${snap.ProjectName}=${snap.SavedAt}")
+    // Reference a non-clashing helper from the shadow package so the
+    // dot-import is actually exercised at compile time.
+    Println(ShadowMarker())
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -50,3 +50,5 @@ warn
 err: oops
 alice => Alice<a@x>
 bob => Bob<b@x>
+snap: demo=1234
+shadow-marker

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -80,6 +80,7 @@ go_test(
         "panic_audit_test.go",
         "phantom_reexport_funconly_test.go",
         "pointer_receiver_test.go",
+        "qualified_namedarg_shadow_test.go",
         "recursive_immutable_test.go",
         "sealed_string_func_field_test.go",
         "structs_test.go",

--- a/internal/transpiler/transformer/qualified_namedarg_shadow_test.go
+++ b/internal/transpiler/transformer/qualified_namedarg_shadow_test.go
@@ -1,0 +1,110 @@
+package transformer_test
+
+import (
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestQualifiedNamedArgConstructionShadowedByDotImport verifies that
+// `pkg.Struct(Field = ...)` resolves to the qualified package's struct even
+// when a dot-imported (or otherwise transitively in-scope) package exports a
+// function (or different struct) with the same name.
+//
+// Before the fix, `getFunction("session.Snapshot")` would not find a function
+// named "Snapshot" in the session package, then fall through to a simple-name
+// search across dot imports — which matched the dot-imported `gala_tui.Snapshot`
+// function. The named-args dispatcher then tried to use that function's
+// parameter names, producing:
+//
+//	"unknown parameter \"ProjectName\" in call to Snapshot"
+//
+// The qualifier `session.` should anchor the lookup to the session package.
+func TestQualifiedNamedArgConstructionShadowedByDotImport(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "qualified_namedarg_shadow_test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	err = os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte("module testmod\n\ngo 1.22\n"), 0644)
+	assert.NoError(t, err)
+
+	// Package `session` exposes a struct named Snapshot using GALA positional
+	// struct syntax — this is the form used in the original report.
+	sessionDir := filepath.Join(tempDir, "session")
+	err = os.MkdirAll(sessionDir, 0755)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(sessionDir, "session.gala"), []byte(`package session
+
+struct Snapshot(ProjectName string, SavedAt int64)
+`), 0644)
+	assert.NoError(t, err)
+
+	// Package `gala_tui` exposes a *function* named Snapshot. The signature
+	// references its own Widget struct so the analyzer registers the function
+	// with non-trivial parameter types.
+	tuiDir := filepath.Join(tempDir, "gala_tui")
+	err = os.MkdirAll(tuiDir, 0755)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tuiDir, "tui.gala"), []byte(`package gala_tui
+
+type Widget struct {
+    Name string
+}
+
+func Snapshot(w Widget, width int, height int) string = "tui-snap"
+`), 0644)
+	assert.NoError(t, err)
+
+	originalWd, err := os.Getwd()
+	assert.NoError(t, err)
+	defer os.Chdir(originalWd)
+	err = os.Chdir(tempDir)
+	assert.NoError(t, err)
+
+	p := transpiler.NewAntlrGalaParser()
+	// Pass nil search paths so the resolver derives the module root from the
+	// current working directory (the temp module created above). Otherwise
+	// the bazel runfiles' real gala.mod would shadow our temp module and the
+	// session/gala_tui packages would never be discovered.
+	a := analyzer.NewGalaAnalyzer(p, nil)
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	input := `package main
+
+import (
+    "testmod/session"
+    . "testmod/gala_tui"
+)
+
+func makeSnap() session.Snapshot {
+    return session.Snapshot(
+        ProjectName = "demo",
+        SavedAt     = int64(1234),
+    )
+}
+`
+
+	got, err := trans.Transpile(input, "")
+	assert.NoError(t, err,
+		"qualified named-arg struct construction should resolve to session.Snapshot,\nnot the shadowing dot-imported gala_tui.Snapshot function. got error:\n%v",
+		err)
+	if err != nil {
+		return
+	}
+	t.Logf("transpiled output:\n%s", got)
+
+	// Sanity: the output should contain a session.Snapshot composite literal
+	// with the field names (rather than a Snapshot(...) function call).
+	assert.Contains(t, got, "session.Snapshot",
+		"expected session-qualified Snapshot reference, got:\n%s", got)
+	assert.Contains(t, got, "ProjectName:",
+		"expected struct literal with ProjectName field, got:\n%s", got)
+}

--- a/internal/transpiler/transformer/transformer.go
+++ b/internal/transpiler/transformer/transformer.go
@@ -445,10 +445,14 @@ func (t *galaASTTransformer) resolveTypeName(typeName string, exists func(string
 		return typeName, true
 	}
 
-	// 2. If typeName has a package prefix (e.g., "pkg.Type"), extract the simple name
-	// and try resolving it — but ONLY if the package is a GALA package (has types
-	// registered from GALA analysis). Go packages (time, fmt, httpcore, go_struct_bridge)
-	// should NOT have their types resolved to same-named GALA types.
+	// 2. If typeName has a package prefix (e.g., "pkg.Type"), the qualifier is
+	// authoritative — the user explicitly anchored the lookup to that package.
+	// Resolve any alias on the qualifier and re-check; if still unresolved, do
+	// NOT fall through to a simple-name search across other packages. Falling
+	// back would let `session.Snapshot` (a struct in `session`) silently match
+	// a same-named symbol in a dot-imported sibling (`gala_tui.Snapshot`
+	// function), producing a misleading "unknown parameter" error at the call
+	// site.
 	if idx := strings.LastIndex(typeName, "."); idx != -1 {
 		pkgPrefix := typeName[:idx]
 		simpleName := typeName[idx+1:]
@@ -456,39 +460,20 @@ func (t *galaASTTransformer) resolveTypeName(typeName string, exists func(string
 		// Resolve import alias to actual package name (e.g., "libalias" -> "lib",
 		// "im" -> "collection_immutable") since types are registered under actual
 		// package names, not user-chosen aliases.
-		actualPkg := pkgPrefix
-		if resolved, ok := t.importManager.ResolveAlias(pkgPrefix); ok {
-			actualPkg = resolved
-		}
-
-		// Try exact match with the resolved package name first
-		// (e.g., "collection_immutable.HashMap" when alias was "im")
-		if actualPkg != pkgPrefix {
+		if actualPkg, ok := t.importManager.ResolveAlias(pkgPrefix); ok && actualPkg != pkgPrefix {
 			resolvedName := actualPkg + "." + simpleName
 			if exists(resolvedName) {
 				return resolvedName, true
 			}
 		}
 
-		// A package is a GALA package if any of its types exist in typeMetas
-		// (registered during GALA source analysis). Go packages won't have entries.
-		isGalaPackage := false
-		for key := range t.typeMetas {
-			if strings.HasPrefix(key, pkgPrefix+".") || strings.HasPrefix(key, actualPkg+".") {
-				isGalaPackage = true
-				break
-			}
-		}
-
-		// Only resolve the simple name to a GALA type if the qualifier is a GALA package
-		if isGalaPackage {
-			if resolved, found := t.tryResolveSimpleName(simpleName, exists); found {
-				return resolved, true
-			}
-		}
+		// Qualifier was provided but no match in that package. Stop here
+		// rather than allowing a cross-package shadow match.
+		return "", false
 	}
 
-	// 3. Try resolving the original typeName through all package prefixes
+	// 3. Unqualified name — try resolving through all package prefixes
+	// (current package, std, dot imports, named imports).
 	if resolved, found := t.tryResolveSimpleName(typeName, exists); found {
 		return resolved, true
 	}


### PR DESCRIPTION
## Summary

Fixes [issue #286](https://github.com/martianoff/gala/issues/286): calling a struct's named-arg constructor through a qualifier (`pkg.Struct(Field = ...)`) failed with "unknown parameter <Field> in call to <Struct>" when a different package transitively in scope (via `gala_deps` / sibling import) exported the same identifier as a function or different struct.

**Category**: TRANSPILER_BUG
**Priority**: P1

## Root Cause

`resolveTypeName` (in `internal/transpiler/transformer/transformer.go`) fell back to `tryResolveSimpleName(simpleName, ...)` when `pkg.X` did not resolve in `pkg`. That fallback iterated all imports — including dot imports — and accepted the first match. When a dot-imported sibling exposed a function with the same simple name as the qualified struct, the fallback silently picked the wrong symbol; the named-arg dispatcher then matched against the wrong `FunctionMetadata` and rejected every named arg with "unknown parameter".

## Changes

- `internal/transpiler/transformer/transformer.go` — `resolveTypeName` no longer cross-package-falls-back when a qualifier is supplied. The lookup is anchored to the qualifier's package (alias resolution still honored).
- `internal/transpiler/transformer/qualified_namedarg_shadow_test.go` — unit test for the resolver.
- `examples/multifile_lib_regress/types.gala` + `examples/multifile_lib_regress/shadow_func/shadow.gala` — cross-pkg regression where a sibling dot-imported package exports a same-named function.
- `examples/multifile_lib_regress_test.{gala,out}` + `examples/BUILD.bazel` + `internal/transpiler/transformer/BUILD.bazel`.

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (313/313)
- Regression test in `multifile_lib_regress` exercises the exact shadow shape from the report

## Repro (before fix)

\`\`\`gala
// pkg \`session\`: struct Snapshot(ProjectName string, SavedAt int64, ...)
// pkg \`gala_tui\`:  func Snapshot(w Widget, width int, height int) string { ... }

import (
    "github.com/example/session"
    . "github.com/example/gala_tui"
)

func makeSnap() session.Snapshot {
    return session.Snapshot(ProjectName = "demo", SavedAt = int64(1234), ...)
}
\`\`\`

\`\`\`
[SemanticError] unknown parameter "ProjectName" in call to Snapshot
\`\`\`

## Dependencies

None.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)