### PR TITLE
fix: allow trailing comma in tuple literal so multi-line match arms parse

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -197,7 +197,7 @@ struct Cookie(
 )
 ```
 
-Trailing commas are optional — single-line parameter lists work with or without them. This also applies to sealed type case fields.
+Trailing commas are optional — single-line parameter lists work with or without them. This also applies to sealed type case fields, function call arguments, and tuple literals (e.g. `(model, cmd,)`), so a multi-line tuple body in a `match` arm parses cleanly.
 
 ### Named Arguments
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -254,6 +254,14 @@ gala_test(
     expected = "fix_006_three_tuple_return.out",
 )
 
+# Verifies that multi-line tuple literals with trailing commas parse when used
+# as match arm bodies (Elm-style update functions returning (model, cmd)).
+gala_test(
+    name = "fix004_repro",
+    src = "fix004_repro.gala",
+    expected = "fix004_repro.out",
+)
+
 gala_test(
     name = "fix007_repro",
     src = "fix007_repro.gala",

--- a/examples/fix004_repro.gala
+++ b/examples/fix004_repro.gala
@@ -1,0 +1,30 @@
+package main
+
+import . "martianoff/gala/std"
+
+sealed type Msg {
+    case Boom(reason string)
+    case Ok(name string)
+}
+
+// Multi-line tuple literals as match arm bodies, with trailing commas, mirror
+// the Elm-style update-function pattern that returns (model, cmd). Make sure
+// the parser accepts this layout — it used to choke on the trailing comma.
+func dispatch(model string, msg Msg) Tuple[string, string] = msg match {
+    case Boom(reason) => (
+        model,
+        reason,
+    )
+    case Ok(name) => (
+        model,
+        name,
+    )
+}
+
+func main() {
+    val (m1, c1) = dispatch("M", Boom("bang"))
+    Println(s"$m1 / $c1")
+
+    val (m2, c2) = dispatch("M", Ok("hello"))
+    Println(s"$m2 / $c2")
+}

--- a/examples/fix004_repro.out
+++ b/examples/fix004_repro.out
@@ -1,0 +1,2 @@
+M / bang
+M / hello

--- a/internal/parser/grammar/gala.g4
+++ b/internal/parser/grammar/gala.g4
@@ -173,9 +173,16 @@ argument: (identifier '=')? (lambdaExpression | pattern);
 primary
     : identifier
     | literal
-    | '(' expressionList? ')'
+    | '(' tupleExpressionList? ')'
     | compositeLiteral
     ;
+
+// Parenthesized tuple/grouping expressions allow an optional trailing comma so
+// multi-line tuple literals (Elm-style `(model, cmd,)`) parse cleanly. Kept
+// separate from `expressionList`, which is used in statement positions
+// (assignments, short var decls, val declarations) where a trailing comma
+// would be a syntax error in the surrounding production.
+tupleExpressionList: expression (',' expression)* ','?;
 
 compositeLiteral: type ('{' (elementList ','?)? '}');
 elementList: keyedElement (',' keyedElement)*;

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -162,6 +162,49 @@ val x = 0X1f`,
 val x = 0xFF + 0x01`,
 			wantErr: false,
 		},
+		{
+			name: "Single-line tuple as match arm body",
+			input: `package main
+
+func dispatch(m string, n int) Tuple[string, int] = n match {
+	case 0 => (m, n)
+	case _ => (m, n)
+}`,
+			wantErr: false,
+		},
+		{
+			name: "Multi-line tuple as match arm body without trailing comma",
+			input: `package main
+
+func dispatch(m string, n int) Tuple[string, int] = n match {
+	case 0 => (
+		m,
+		n
+	)
+	case _ => (m, n)
+}`,
+			wantErr: false,
+		},
+		{
+			name: "Multi-line tuple as match arm body with trailing comma",
+			input: `package main
+
+func dispatch(m string, n int) Tuple[string, int] = n match {
+	case 0 => (
+		m,
+		n,
+	)
+	case _ => (m, n)
+}`,
+			wantErr: false,
+		},
+		{
+			name: "Tuple literal with trailing comma",
+			input: `package main
+
+val t = (1, 2,)`,
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/transpiler/transformer/constructors.go
+++ b/internal/transpiler/transformer/constructors.go
@@ -81,36 +81,38 @@ func (t *galaASTTransformer) transformPrimary(ctx *grammar.PrimaryContext) (ast.
 	if ctx.CompositeLiteral() != nil {
 		return t.transformCompositeLiteral(ctx.CompositeLiteral().(*grammar.CompositeLiteralContext))
 	}
-	for i := 0; i < ctx.GetChildCount(); i++ {
-		if exprListCtx, ok := ctx.GetChild(i).(grammar.IExpressionListContext); ok {
-			el := exprListCtx.(*grammar.ExpressionListContext)
-			// When a tuple literal flows into a Tuple-shaped enclosing context
-			// (e.g., the return position of a function declared to return
-			// `Tuple[int, Cmd[Msg]]`, or a call argument expecting
-			// `Tuple[string, error]`), thread each element's expected type so
-			// that nested sealed-variant constructors like `NoCmd()` infer
-			// their type parameters from the tuple's slot, and so the
-			// synthesized composite literal carries concrete element types
-			// rather than collapsing to `any` when an element's standalone
-			// type happens to resolve to nil/any.
-			elemExprs := el.AllExpression()
-			if len(elemExprs) > 1 {
-				perElemExpected := t.tupleElementExpectedTypes(len(elemExprs))
-				exprs, err := t.transformTupleElementExpressions(elemExprs, perElemExpected)
-				if err != nil {
-					return nil, err
-				}
-				return t.transformTupleLiteralWithExpected(exprs, perElemExpected, ctx.GetStart().GetLine(), ctx.GetStart().GetColumn())
-			}
-			exprs, err := t.transformExpressionList(el)
+	if tupleListCtx := ctx.TupleExpressionList(); tupleListCtx != nil {
+		el := tupleListCtx.(*grammar.TupleExpressionListContext)
+		// When a tuple literal flows into a Tuple-shaped enclosing context
+		// (e.g., the return position of a function declared to return
+		// `Tuple[int, Cmd[Msg]]`, or a call argument expecting
+		// `Tuple[string, error]`), thread each element's expected type so
+		// that nested sealed-variant constructors like `NoCmd()` infer
+		// their type parameters from the tuple's slot, and so the
+		// synthesized composite literal carries concrete element types
+		// rather than collapsing to `any` when an element's standalone
+		// type happens to resolve to nil/any.
+		elemExprs := el.AllExpression()
+		if len(elemExprs) > 1 {
+			perElemExpected := t.tupleElementExpectedTypes(len(elemExprs))
+			exprs, err := t.transformTupleElementExpressions(elemExprs, perElemExpected)
 			if err != nil {
 				return nil, err
 			}
-			if len(exprs) == 1 {
-				return &ast.ParenExpr{X: exprs[0]}, nil
-			}
-			return t.transformTupleLiteral(exprs, ctx.GetStart().GetLine(), ctx.GetStart().GetColumn())
+			return t.transformTupleLiteralWithExpected(exprs, perElemExpected, ctx.GetStart().GetLine(), ctx.GetStart().GetColumn())
 		}
+		exprs := make([]ast.Expr, 0, len(elemExprs))
+		for _, eCtx := range elemExprs {
+			expr, err := t.transformExpression(eCtx)
+			if err != nil {
+				return nil, err
+			}
+			exprs = append(exprs, expr)
+		}
+		if len(exprs) == 1 {
+			return &ast.ParenExpr{X: exprs[0]}, nil
+		}
+		return t.transformTupleLiteral(exprs, ctx.GetStart().GetLine(), ctx.GetStart().GetColumn())
 	}
 	// Empty parenthesized expression `()` — the grammar admits it because
 	// `'(' expressionList? ')'` makes the inner list optional, but GALA

--- a/internal/transpiler/transformer/patterns.go
+++ b/internal/transpiler/transformer/patterns.go
@@ -63,8 +63,8 @@ func (t *galaASTTransformer) transformExpressionPatternWithType(patExprCtx gramm
 
 	// Tuple pattern with parentheses syntax: (a, b, c) => Tuple3(a, b, c)
 	if p := t.getPrimaryFromExpression(patExprCtx); p != nil {
-		if exprList := p.ExpressionList(); exprList != nil {
-			if el, ok := exprList.(*grammar.ExpressionListContext); ok {
+		if exprList := p.TupleExpressionList(); exprList != nil {
+			if el, ok := exprList.(*grammar.TupleExpressionListContext); ok {
 				exprs := el.AllExpression()
 				if len(exprs) >= 2 {
 					// This is a tuple pattern (a, b, c) - transform to TupleN pattern


### PR DESCRIPTION
## Summary

Fixes [issue #288](https://github.com/martianoff/gala/issues/288): a match arm whose body is a multi-line tuple literal — common in Elm-style update functions returning `(model, cmd)` — failed to parse with cascading "no viable alternative" errors when the tuple had a trailing comma after a multi-line layout.

**Category**: PARSER_BUG (grammar)
**Priority**: P1

## Root Cause

The grammar's `primary` rule lowered parenthesized tuple literals via `expressionList`, which does not accept a trailing comma:

\`\`\`
expressionList: expression (',' expression)*;
\`\`\`

By contrast, `argumentList` does accept it (`','?`). Multi-line formatters naturally emit a trailing comma after the last element, so the multi-line tuple form was rejected even though the single-line form (no trailing comma) parsed fine. Newlines were never the root cause — only the trailing comma was.

## Changes

- `internal/parser/grammar/gala.g4` — new dedicated rule `tupleExpressionList: expression (',' expression)* ','?;` referenced from the parenthesized alternative of `primary`. Kept separate from `expressionList` so that statement-position lists (`assignment`, `shortVarDecl`, `valDeclaration`, `varDeclaration`, postfix `[…]` indexing) still reject trailing commas.
- `internal/transpiler/transformer/constructors.go` — `transformPrimary` tuple-literal branch reads `ctx.TupleExpressionList()` instead of walking `IExpressionListContext`.
- `internal/transpiler/transformer/patterns.go` — tuple-pattern detection in match arms reads `p.TupleExpressionList()`.
- `internal/parser/parser_test.go` — 4 new parser unit tests covering trailing comma, multi-line layout, mixed forms.
- `examples/fix004_repro.gala` (+ `.out`), `examples/BUILD.bazel` — end-to-end verification example.
- `docs/GALA.MD` — documents the trailing-comma allowance.

ANTLR-generated `.go` files are produced into `bazel-bin` on every build (`//internal/parser/grammar:gala_grammar_go` genrule); no checked-in `.go` files were hand-edited.

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (314/314)

## Repro (before fix)

\`\`\`gala
case Failure(e) => (
    m,
    MsgCmd[AppMsg](Msg = SomeFailure(ErrText = e.Error())),
)
\`\`\`

\`\`\`
[SyntaxError] line 2:8 no viable alternative at input '('
\`\`\`

## Dependencies

None.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)