### PR TITLE
fix: drive method type-param inference from named-arg expected return type

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -986,6 +986,17 @@ gala_test(
     expected = "sealed_inference_arg_context.out",
 )
 
+# Regression: sealed-variant case constructor named-arg slot drives method
+# type-param inference for nested generic Map call whose lambda body is a
+# method call on a Go universe type (error.Error()). Without the fix, U=any
+# falls back, the lambda emits `func(error) any`, and Option_Map returns
+# Option[any] — incompatible with the Ended.ErrText: Option[string] slot.
+gala_test(
+    name = "sealed_option_map_method_body",
+    src = "sealed_option_map_method_body.gala",
+    expected = "sealed_option_map_method_body.out",
+)
+
 gala_test(
     name = "sealed_inference_container_context",
     src = "sealed_inference_container_context.gala",
@@ -2171,7 +2182,10 @@ gala_library(
 )
 gala_library(
     name = "multifile_lib_regress_proc_pkg",
-    srcs = ["multifile_lib_regress/proc_pkg/proc.gala"],
+    srcs = [
+        "multifile_lib_regress/proc_pkg/events.gala",
+        "multifile_lib_regress/proc_pkg/proc.gala",
+    ],
     importpath = "martianoff/gala/examples/multifile_lib_regress/proc_pkg",
     visibility = ["//visibility:public"],
 )
@@ -2191,6 +2205,7 @@ gala_library(
 gala_library(
     name = "multifile_lib_regress",
     srcs = [
+        "multifile_lib_regress/consult_end.gala",
         "multifile_lib_regress/events_pipe.gala",
         "multifile_lib_regress/go_interop.gala",
         "multifile_lib_regress/logic.gala",

--- a/examples/multifile_lib_regress/consult_end.gala
+++ b/examples/multifile_lib_regress/consult_end.gala
@@ -1,0 +1,40 @@
+package multifile_lib_regress
+
+import (
+    . "martianoff/gala/examples/multifile_lib_regress/proc_pkg"
+)
+
+// --- Regression: cross-package Option.Map lambda body returns method call.
+// ConsultEvent is sealed with cases ConsultChunk / ConsultEnd defined in
+// proc_pkg (a sibling GALA package). The ConsultEnd case carries an
+// Option[error] field. Pattern-matching on a ConsultEvent in this package
+// binds errOpt to that Option[error]; calling errOpt.Map((e) => e.Error())
+// must yield Option[string] — the lambda body's return type is a method
+// call on the bound element name, and the method's return type (`string`)
+// has to be propagated back through the .Map's result type even though
+// the receiver Option[error] is constructed in another package.
+//
+// Before the fix the generated Go was:
+//   Option_Map(errOpt, func(e error) any { return e.Error() })
+// which Go rejects because Option_Map's result Option[any] cannot satisfy
+// the surrounding Option[string] context.
+
+sealed type AppMsg {
+    case ChunkArrived(Name string, Line string)
+    case Ended(Name string, ErrText Option[string])
+}
+
+func ToAppMsg(ev ConsultEvent) AppMsg = ev match {
+    case ConsultChunk(name, line) =>
+        ChunkArrived(Name = name, Line = line)
+    case ConsultEnd(name, errOpt) =>
+        Ended(Name = name, ErrText = errOpt.Map((e) => e.Error()))
+}
+
+func DescribeAppMsg(m AppMsg) string = m match {
+    case ChunkArrived(name, line) => s"chunk[$name]=$line"
+    case Ended(name, errText)     => errText match {
+        case Some(msg) => s"end[$name] err=$msg"
+        case None()    => s"end[$name] ok"
+    }
+}

--- a/examples/multifile_lib_regress/proc_pkg/events.gala
+++ b/examples/multifile_lib_regress/proc_pkg/events.gala
@@ -1,0 +1,27 @@
+package proc_pkg
+
+import "errors"
+
+// Sealed type whose ConsultEnd case carries an Option[error] field. This
+// mirrors the original failing report (see issue #290): a sealed-type case
+// constructed in a sibling package that holds Option[T] / Try[T], so that
+// the pattern-bound name in a consumer file points at a generic value
+// whose receiver-package metadata is not local.
+
+sealed type ConsultEvent {
+    case ConsultChunk(Name string, Line string)
+    case ConsultEnd(Name string, Err Option[error])
+}
+
+// Constructors that build sample values from the cross-package side. The
+// consumer pattern-matches on these and chains .Map on the Option[error]
+// field — without the fix, the Map lambda's body type erases to `any`.
+
+func MakeChunk(name string, line string) ConsultEvent =
+    ConsultChunk(Name = name, Line = line)
+
+func MakeEndOk(name string) ConsultEvent =
+    ConsultEnd(Name = name, Err = None[error]())
+
+func MakeEndErr(name string, msg string) ConsultEvent =
+    ConsultEnd(Name = name, Err = Some(errors.New(msg)))

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -202,4 +202,18 @@ func main() {
     // Reference a non-clashing helper from the shadow package so the
     // dot-import is actually exercised at compile time.
     Println(ShadowMarker())
+
+    // --- Regression: cross-package Option.Map lambda whose body is a method
+    // call on the bound element name. ConsultEvent is sealed with cases
+    // defined in proc_pkg; ConsultEnd carries an Option[error]. The transform
+    // function pattern-matches on a ConsultEvent and chains
+    // errOpt.Map((e) => e.Error()) — the lambda body must keep its inferred
+    // string return type even though the receiver Option's metadata lives in
+    // another GALA package and the body is a method call (not an identifier).
+    val chunkEv = proc_pkg.MakeChunk("topic", "first line")
+    val endOkEv = proc_pkg.MakeEndOk("topic")
+    val endErrEv = proc_pkg.MakeEndErr("topic", "boom")
+    Println(multifile_lib_regress.DescribeAppMsg(multifile_lib_regress.ToAppMsg(chunkEv)))
+    Println(multifile_lib_regress.DescribeAppMsg(multifile_lib_regress.ToAppMsg(endOkEv)))
+    Println(multifile_lib_regress.DescribeAppMsg(multifile_lib_regress.ToAppMsg(endErrEv)))
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -52,3 +52,6 @@ alice => Alice<a@x>
 bob => Bob<b@x>
 snap: demo=1234
 shadow-marker
+chunk[topic]=first line
+end[topic] ok
+end[topic] err=boom

--- a/examples/sealed_option_map_method_body.gala
+++ b/examples/sealed_option_map_method_body.gala
@@ -1,0 +1,47 @@
+package main
+
+import "errors"
+
+// Regression: when a sealed-type case constructor named arg accepts an
+// Option[T], and the value at the call site is `errOpt.Map((e) => e.Error())`,
+// the lambda's body is a method call on a Go universe type (`error.Error()`)
+// whose method signature is not registered in goTypeInfo. Without driving the
+// `Map` method's type-arg U from the call-site expected type, U falls back to
+// `any` and the resulting `Option_Map` returns `Option[any]` — incompatible
+// with the target slot `Option[string]`.
+//
+// The fix: when the immediately-enclosing typed slot supplies a concrete
+// expected return type (here `Option[string]` from the Ended.ErrText field),
+// unify it against the method's declared return shape `Option[U]` to bind
+// U=string before transforming the lambda body. The lambda then sees a
+// concrete expected return and emits `func(error) string` instead of
+// `func(error) any`.
+
+sealed type AppMsg {
+    case Ended(Name string, ErrText Option[string])
+    case Started(Name string)
+}
+
+func describe(m AppMsg) string = m match {
+    case Started(name)        => s"started: $name"
+    case Ended(name, errText) => errText match {
+        case Some(s) => s"ended[$name] err=$s"
+        case None()  => s"ended[$name] ok"
+    }
+}
+
+// The transform that triggered the bug: the named arg ErrText receives an
+// Option.Map whose lambda body is a method call on an Option[error] element.
+func makeEnded(name string, errOpt Option[error]) AppMsg =
+    Ended(Name = name, ErrText = errOpt.Map((e) => e.Error()))
+
+func main() {
+    val ok = makeEnded("topic-a", None[error]())
+    Println(describe(ok))
+
+    val err = makeEnded("topic-b", Some(errors.New("oops")))
+    Println(describe(err))
+
+    val started = Started(Name = "topic-c")
+    Println(describe(started))
+}

--- a/examples/sealed_option_map_method_body.out
+++ b/examples/sealed_option_map_method_body.out
@@ -1,0 +1,3 @@
+ended[topic-a] ok
+ended[topic-b] err=oops
+started: topic-c

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -279,6 +279,7 @@ func (t *galaASTTransformer) tryTransformGenericMethodAsFunction(
 	typeArgs []ast.Expr,
 	recvType transpiler.Type,
 	lookupBaseName string,
+	pendingExpected transpiler.Type,
 ) (handled bool, result ast.Expr, err error) {
 	// Skip if the "receiver" is actually a package identifier — that is a
 	// package-qualified function call and belongs to a later section.
@@ -310,6 +311,38 @@ func (t *galaASTTransformer) tryTransformGenericMethodAsFunction(
 				typeSubst[tp] = t.exprToTypeString(typeArgs[i])
 			}
 			// Don't default to "any" — will try to infer from non-lambda args below.
+		}
+	}
+
+	// Drive method-level type-param inference from the call's expected return
+	// type (the immediately-enclosing typed slot — e.g. a named arg of a
+	// surrounding constructor or a typed val initializer). When the lambda
+	// body's own return type cannot be inferred locally — e.g. the body is a
+	// method call on a Go universe type like `error`, whose `Error()` is not
+	// resolvable through goTypeInfo — the lambda emits an `any` return, gap #9
+	// unification leaves U=any, and the method's result type erases to
+	// Option[any] / Try[any]. Unifying the method's declared return shape
+	// (with receiver substitutions applied) against the call-site expected
+	// type binds U directly from the surrounding context, making the lambda
+	// see a concrete expected return type and emit `func(T) U` with the
+	// correct U.
+	if methodMeta != nil && typeMeta != nil && len(methodMeta.TypeParams) > 0 &&
+		pendingExpected != nil && !pendingExpected.IsNil() && !pendingExpected.IsAny() &&
+		methodMeta.ReturnType != nil && !methodMeta.ReturnType.IsNil() {
+		recvTypeArgTypesForReturn := make([]transpiler.Type, 0, len(recvTypeArgStrings))
+		for _, a := range recvTypeArgStrings {
+			recvTypeArgTypesForReturn = append(recvTypeArgTypesForReturn, transpiler.ParseType(a))
+		}
+		substitutedReturn := t.substituteConcreteTypes(methodMeta.ReturnType, typeMeta.TypeParams, recvTypeArgTypesForReturn)
+		inferredFromExpected := make(map[string]transpiler.Type)
+		t.unifyForInference(substitutedReturn, pendingExpected, methodMeta.TypeParams, inferredFromExpected)
+		for tp, inferred := range inferredFromExpected {
+			if inferred == nil || inferred.IsNil() || inferred.IsAny() {
+				continue
+			}
+			if _, alreadySet := typeSubst[tp]; !alreadySet {
+				typeSubst[tp] = inferred.String()
+			}
 		}
 	}
 
@@ -1071,22 +1104,30 @@ func (t *galaASTTransformer) transformFunctionArgs(
 	return positional, named, hasSpread, nil
 }
 
-// resolveNamedArgExpectedFuncType looks up the expected FuncType for a named
-// argument so that lambda arguments can infer their parameter types. It tries
-// struct-field-type resolution first (with generic type-param substitution for
-// generic struct construction), then falls back to function metadata param
-// names. Returns NilType if no FuncType can be resolved. Extracted from
-// transformCallWithArgsCtx as part of A1 cont.
+// resolveNamedArgExpectedFuncType looks up the expected type for a named
+// argument so the value expression can be transformed with the right
+// expectation. For lambda arguments this is what gives them their parameter
+// types; for non-lambda arguments (e.g. nested generic method calls) the
+// expected type drives downstream type-param inference via the
+// expectedArgTypes stack — without it, a generic call like
+// `errOpt.Map((e) => e.Error())` whose lambda body's return type is locally
+// unresolvable falls back to U=any. Tries struct-field-type resolution first
+// (with generic type-param substitution for generic struct construction),
+// then falls back to function metadata param names. Returns NilType when no
+// expected type can be determined. Extracted from transformCallWithArgsCtx
+// as part of A1 cont.
 func (t *galaASTTransformer) resolveNamedArgExpectedFuncType(fun ast.Expr, argName string, callCtx functionCallContext) transpiler.Type {
-	// Step 1: struct-field lookup — handles lambdas passed as named struct args.
+	// Step 1: struct-field lookup — handles lambdas passed as named struct args
+	// AND non-lambda named args (so the call-site expected type can drive
+	// inference of nested generic method calls).
 	if callCtx.structFieldExpectedTypes != nil {
 		if funcName := t.extractFuncName(fun); funcName != "" {
 			typeMeta, resolvedTypeName := t.getTypeMetaResolved(funcName)
 			if resolvedTypeName != "" {
 				resolved := t.resolveStructTypeName(resolvedTypeName)
 				if fieldTypes, ok := t.structFieldTypes[resolved]; ok {
-					if ft, ok := fieldTypes[argName].(transpiler.FuncType); ok {
-						expected := transpiler.Type(ft)
+					if rawType, ok := fieldTypes[argName]; ok && rawType != nil && !rawType.IsNil() {
+						expected := rawType
 						// Apply generic type substitution for generic struct
 						// construction: e.g., Wrapper[U](compute = ...) maps T -> U.
 						if typeMeta != nil && len(typeMeta.TypeParams) > 0 {
@@ -1109,19 +1150,70 @@ func (t *galaASTTransformer) resolveNamedArgExpectedFuncType(fun ast.Expr, argNa
 	}
 
 	// Step 2: function metadata lookup — handles lambdas passed as named
-	// function-call args when the function has named parameters.
+	// function-call args when the function has named parameters. Returns the
+	// declared param type as-is (FuncType for lambda inference; non-FuncType
+	// values flow through the expectedArgTypes stack).
 	if callCtx.funcMeta != nil && len(callCtx.funcMeta.ParamNames) > 0 {
 		for i, paramName := range callCtx.funcMeta.ParamNames {
 			if paramName == argName && i < len(callCtx.funcMeta.ParamTypes) {
-				if ft, ok := callCtx.funcMeta.ParamTypes[i].(transpiler.FuncType); ok {
-					return ft
+				return callCtx.funcMeta.ParamTypes[i]
+			}
+		}
+	}
+
+	// Step 3: sealed-variant case constructor. Variants register an empty
+	// companion struct (so `t.structFields[VariantName]` is nil), but the
+	// per-field types live on the parent sealed type's SealedVariants. Look
+	// them up so a named arg whose value is a nested generic call (e.g.
+	// `Ended(ErrText = errOpt.Map((e) => e.Error()))`) gets the call-site's
+	// expected slot type pushed onto expectedArgTypes — without it, the
+	// nested .Map call cannot infer its result type-param from the enclosing
+	// context and falls back to U=any.
+	if typeName, _ := extractTypeNameFromExpr(fun); typeName != "" {
+		if sv := t.findSealedVariant(typeName); sv != nil {
+			for i, fieldName := range sv.FieldNames {
+				if fieldName == argName && i < len(sv.FieldTypes) {
+					expected := sv.FieldTypes[i]
+					if expected == nil || expected.IsNil() {
+						break
+					}
+					// Apply parent sealed type's type-param substitution when the
+					// call site supplied explicit type args (e.g. `Ended[int](...)`).
+					if parent := t.findSealedParentForVariant(typeName, ""); parent != nil && len(parent.TypeParams) > 0 {
+						if typeArgs := t.extractFuncCallTypeArgs(fun); len(typeArgs) > 0 {
+							typeSubst := make(map[string]string)
+							for j, tp := range parent.TypeParams {
+								if j < len(typeArgs) {
+									typeSubst[tp] = typeArgs[j]
+								}
+							}
+							expected = t.substituteTranspilerTypeParams(expected, typeSubst)
+						}
+					}
+					return expected
 				}
-				break
 			}
 		}
 	}
 
 	return transpiler.NilType{}
+}
+
+// findSealedVariant returns the SealedVariant metadata for a variant name by
+// searching all registered sealed parent types. Returns nil if the name is
+// not a known variant.
+func (t *galaASTTransformer) findSealedVariant(variantName string) *transpiler.SealedVariant {
+	for _, meta := range t.typeMetas {
+		if !meta.IsSealed {
+			continue
+		}
+		for i := range meta.SealedVariants {
+			if meta.SealedVariants[i].Name == variantName {
+				return &meta.SealedVariants[i]
+			}
+		}
+	}
+	return nil
 }
 
 // functionCallContext bundles the expected-type lookups used when
@@ -1381,7 +1473,7 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 
 	// --- Section 3: Generic method -> standalone function rewrite ---
 	if receiver != nil && isGenericMethod {
-		handled, expr, err := t.tryTransformGenericMethodAsFunction(argListCtx, receiver, method, typeArgs, recvType, lookupBaseName)
+		handled, expr, err := t.tryTransformGenericMethodAsFunction(argListCtx, receiver, method, typeArgs, recvType, lookupBaseName, pendingExpected)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

Fixes [issue #290](https://github.com/martianoff/gala/issues/290): when the Map / FlatMap callback's return type *should* be inferred from the receiver's element type but the lambda body is a method call on the bound name (e.g. `errOpt.Map((e) => e.Error())`), inference fell back to `any`, and the resulting Go failed compile (`Option[any]` not assignable to `Option[string]`).

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1

## Root Cause

The lambda body `e.Error()` returns `NilType` from `getExprTypeName` because Go's universe `error` type isn't registered in `goTypeInfo.Types`. Lambda-body inference therefore emitted `func(error) any`. The downstream method-call inference step committed `U=any` from this actual lambda type, causing `Option_Map(errOpt, ...)` to type as `Option[any]`. Surrounding context — the named-arg slot `ErrText: Option[string]` — was available but not used.

## Changes — `internal/transpiler/transformer/calls.go`

1. **`tryTransformGenericMethodAsFunction`** now consumes the call-site `pendingExpected` and unifies the method's declared return shape against it to bind unresolved method type-params *before* transforming the lambda arg. The lambda then receives a concrete `func(error) string` expected type and emits the correct return signature regardless of whether its body is locally resolvable.

2. **`resolveNamedArgExpectedFuncType`** now (a) propagates non-`FuncType` slot types onto the `expectedArgTypes` stack so nested generic calls can see them, and (b) consults parent sealed-type metadata for variant case-constructors. Variant companions register empty `structFields`, so the per-field type only lives on the parent's `SealedVariants` map.

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (314/314)
- `examples/sealed_option_map_method_body.gala` (single-file) and a new block in `examples/multifile_lib_regress` (cross-pkg) both exercise the failing pattern
- Generated Go now emits `std.Option_Map(errOpt, func(e error) string { return e.Error() })`

## Repro (before fix)

\`\`\`gala
case ConsultEnd(name, errOpt) => Ended(
    Name    = name,
    ErrText = errOpt.Map((e) => e.Error()),  // ← inference erased to any
)
\`\`\`

\`\`\`
cannot use Option_Map(errOpt, func(e error) any {…}) (value of struct type std.Option[any])
as std.Option[string] value
\`\`\`

## Dependencies

None.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)