### PR TITLE
fix(release): bump gala.mod to 0.39.2

### DIFF
--- a/gala.mod
+++ b/gala.mod
@@ -1,3 +1,3 @@
 module martianoff/gala
 
-gala 0.39.1
+gala 0.39.2


### PR DESCRIPTION
Mechanical release-prep bump for 0.39.2. Tag follows.