### PR TITLE
fix(transformer): propagate LHS variable type into RHS for var reassignment

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2076,6 +2076,14 @@ gala_test(
     expected = "option_when.out",
 )
 
+# Reassignment of Some(...) to an Option[T] var must inherit the type-arg
+# from the LHS so the variant is emitted as Some[T]{}.Apply(...).
+gala_test(
+    name = "fix001_some_reassign",
+    src = "fix001_some_reassign.gala",
+    expected = "fix001_some_reassign.out",
+)
+
 # Go struct construction with GALA named-arg syntax
 gala_test(
     name = "go_struct_named_args",

--- a/examples/fix001_some_reassign.gala
+++ b/examples/fix001_some_reassign.gala
@@ -1,0 +1,37 @@
+package main
+
+import (
+    "errors"
+    . "martianoff/gala/std"
+)
+
+// FIX-001 regression: reassigning `Some(...)` to a `var` of inferred
+// `Option[string]` must inherit the LHS type so the variant is emitted
+// as `Some[string]{}.Apply(...)` (not `Some{}.Apply(...)` which Go
+// rejects as "generic type Some[T any] without instantiation").
+func describe(opt Option[string]) string = opt match {
+    case Some(s) => s
+    case None()  => "<none>"
+}
+
+func main() {
+    val onbErr Option[error] = Some[error](errors.New("init"))
+    var failure Option[string] = onbErr.Map((e) => s"onboarding: ${e.Error()}")  // Option[string]
+
+    // Reassignment must pick up Option[string] from the var's declared type.
+    // Use a literal whose type the call-site arg-inference cannot resolve
+    // (Get() on a fresh Option[string] returns string at runtime, but the
+    // transpiler resolves this through Immutable wrappers): the type-arg
+    // for Some must come from the LHS declared type.
+    val src Option[string] = Some[string]("plain")
+    failure = Some(src.Get())
+    Println(describe(failure))
+
+    // Mutate again to check the path is exercised at every site.
+    failure = None[string]()
+    Println(describe(failure))
+
+    // Direct string literal — already worked, kept as a sanity check.
+    failure = Some("recovered")
+    Println(describe(failure))
+}

--- a/examples/fix001_some_reassign.out
+++ b/examples/fix001_some_reassign.out
@@ -1,0 +1,3 @@
+plain
+<none>
+recovered

--- a/examples/multifile_lib_regress/logic.gala
+++ b/examples/multifile_lib_regress/logic.gala
@@ -289,3 +289,26 @@ func CloseAllMembers(members HashMap[string, Member]) Array[string] {
     })
     return failures.Sorted()
 }
+
+// --- Regression: reassigning `Some(...)` to an Option[T] var must propagate
+// the LHS variable's declared type-arg into the RHS sealed-variant
+// constructor so the variant is emitted as `Some[T]{}.Apply(...)` (not the
+// uninstantiated `Some{}.Apply(...)` which Go rejects).
+//
+// Mirrors the gala-server runtime-error fallback shape: an Option[string]
+// var is initialised from a cross-package mapping and later reassigned
+// inside a loop. Without LHS-type propagation, the per-iteration `Some(...)`
+// erases to Some[any] and downstream uses of `failure` (passed to a function
+// expecting Option[string]) fail Go compile.
+func RuntimeFailure(seeds Array[string], cap int) Option[string] {
+    val onbErr Option[error] = Some[error](errors.New("seed missing"))
+    var failure = onbErr.Map((e) => s"onboarding: ${e.Error()}")
+    var i = 0
+    seeds.ForEach((s) => {
+        if i < cap {
+            failure = Some(s"runtime[$i]: $s")
+        }
+        i = i + 1
+    })
+    return failure
+}

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -216,4 +216,14 @@ func main() {
     Println(multifile_lib_regress.DescribeAppMsg(multifile_lib_regress.ToAppMsg(chunkEv)))
     Println(multifile_lib_regress.DescribeAppMsg(multifile_lib_regress.ToAppMsg(endOkEv)))
     Println(multifile_lib_regress.DescribeAppMsg(multifile_lib_regress.ToAppMsg(endErrEv)))
+
+    // --- Regression: `failure = Some(...)` reassignment to an Option[T] var
+    // must inherit the LHS type-arg so the variant is emitted as
+    // `Some[T]{}.Apply(...)`. Exercises the cross-package shape with the
+    // helper defined in multifile_lib_regress/logic.gala.
+    val seeds = ArrayOf("alpha", "beta", "gamma")
+    multifile_lib_regress.RuntimeFailure(seeds, 2) match {
+        case Some(msg) => Println(s"runtime failure: $msg")
+        case None()    => Println("runtime failure: <none>")
+    }
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -55,3 +55,4 @@ shadow-marker
 chunk[topic]=first line
 end[topic] ok
 end[topic] err=boom
+runtime failure: runtime[1]: beta

--- a/internal/transpiler/transformer/statements.go
+++ b/internal/transpiler/transformer/statements.go
@@ -155,7 +155,23 @@ func (t *galaASTTransformer) transformAssignment(ctx *grammar.AssignmentContext)
 	if err != nil {
 		return nil, err
 	}
-	rhsExprs, err := t.transformExpressionList(ctx.GetChild(2).(*grammar.ExpressionListContext))
+
+	// Downward type-inference for sealed-variant constructors on the RHS:
+	// when the LHS is a single bare variable (`failure = Some(...)`) and that
+	// variable's declared type carries concrete type arguments
+	// (e.g. `Option[string]`), push the LHS type onto the expected-type stack
+	// so the RHS call dispatcher can pick up the parent sealed type's type
+	// arguments and emit `Some[string]{}.Apply(...)` instead of an
+	// uninstantiated `Some{}.Apply(...)`. Mirrors the same hint pushed by val
+	// declarations with explicit type annotations (declarations.go).
+	rhsListCtx := ctx.GetChild(2).(*grammar.ExpressionListContext)
+	if lhsName, lhsOk := t.singleAssignmentLHSName(lhsCtx); lhsOk {
+		if lhsType := t.getValType(lhsName); !lhsType.IsNil() {
+			release := t.expectedArgTypes.push(lhsType)
+			defer release()
+		}
+	}
+	rhsExprs, err := t.transformExpressionList(rhsListCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -514,6 +530,29 @@ func (t *galaASTTransformer) isConstPtrDerefAssignment(ctx grammar.IExpressionCo
 		}
 	}
 	return false
+}
+
+// singleAssignmentLHSName returns the bare variable name on the LHS of a
+// single-target assignment (`x = ...`). Returns ("", false) for tuple-style
+// assignments (`a, b = ...`), field/index targets (`v.f = ...`, `v[i] = ...`),
+// and any other expression that is not a plain identifier.
+//
+// Used by transformAssignment to look up the variable's declared type so
+// downward inference can drive sealed-variant constructors on the RHS.
+func (t *galaASTTransformer) singleAssignmentLHSName(lhsCtx *grammar.ExpressionListContext) (string, bool) {
+	exprs := lhsCtx.AllExpression()
+	if len(exprs) != 1 {
+		return "", false
+	}
+	exprCtx := exprs[0]
+	if !t.isDirectVariableExpression(exprCtx) {
+		return "", false
+	}
+	pc := t.getPrimaryFromExpression(exprCtx)
+	if pc == nil || pc.Identifier() == nil {
+		return "", false
+	}
+	return pc.Identifier().GetText(), true
 }
 
 // isDirectVariableExpression checks whether the expression is a bare identifier


### PR DESCRIPTION
## Summary

Fixes **FIX-001** (gala_team 0.39.2 regression Bug 1): `Some(...)` reassignment to a `var` of declared type `Option[T]` lost its type-arg, emitting `Some{}.Apply(...)` (i.e., `Some[any]`). Generated Go then failed with `cannot use generic type std.Some[T any] without instantiation`.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1
**Found in**: `gala_team/app/headless/headless.gala`, `gala_team/app/ui/update.gala`

## Root Cause

`transformAssignment` did not push the LHS variable's declared type onto the `expectedArgTypes` stack while transforming the RHS. So sealed-variant downward-inference in `tryTransformCompanionApplyOrStructCtor` had no fallback context to infer `Some[string]` from the LHS's `Option[string]`. The val-declaration path already pushed the LHS hint via `declarations.go`; assignment did not.

## Changes

- `internal/transpiler/transformer/statements.go` — when LHS is a single bare variable, look up its declared type via `getValType(name)` and push it via `t.expectedArgTypes.push(lhsType)` for the duration of RHS transformation. Mirrors the existing val/var declaration hint.

## Verification

- `examples/fix001_some_reassign.gala` (single-file)
- `examples/multifile_lib_regress/logic.gala::RuntimeFailure` (cross-package batch)
- `bazel build //...` passes
- `bazel test //...` passes (319 tests)

## Repro (before fix)

\`\`\`gala
var failure = onbErr.Map((e) => s\"onboarding: \${e}\")  // Option[string]
failure = Some(s\"runtime: \${err.Error()}\")           // erased to Some[any] without fix
\`\`\`

## Dependencies

None — independent fix, can be merged on its own.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)