### PR TITLE
fix(transformer): preserve enclosing return type for return-stmt lambda values

### DIFF
--- a/examples/multifile_lib_regress/logic.gala
+++ b/examples/multifile_lib_regress/logic.gala
@@ -312,3 +312,25 @@ func RuntimeFailure(seeds Array[string], cap int) Option[string] {
     })
     return failure
 }
+
+// --- Regression: nested sealed-case pattern inside Success(...) inside a
+// returned-lambda whose parameter type is implicit (driven by the enclosing
+// function's `func(Try[Msg]) string` return type). Without expected-param
+// propagation through the `return` statement, the lambda's `t` parameter
+// dropped to `any` and the match's matched type degraded to `Try[any]`.
+// Then `Success.Unapply(obj)` returned `any`, the inner `WireChunk.Unapply`
+// required `WireMsg`, and Go rejected with "need type assertion".
+sealed type WireMsg {
+    case WireChunk(Index int, Line string)
+    case WireSessionFailed(Index int, Err string)
+    case WireOther
+}
+
+func MakeWireHandler() func(Try[WireMsg]) string {
+    return (t) => t match {
+        case Failure(err) => s"fail: ${err.Error()}"
+        case Success(WireChunk(_, line)) => s"chunk: $line"
+        case Success(WireSessionFailed(_, e))   => s"sessfail: $e"
+        case _ => "other"
+    }
+}

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -1,6 +1,7 @@
 package main
 
 import (
+    "errors"
     "martianoff/gala/examples/multifile_lib_regress"
     "martianoff/gala/examples/multifile_lib_regress/proc_pkg"
     . "martianoff/gala/examples/multifile_lib_regress/shadow_func"
@@ -226,4 +227,16 @@ func main() {
         case Some(msg) => Println(s"runtime failure: $msg")
         case None()    => Println("runtime failure: <none>")
     }
+
+    // --- Regression: nested Success(InnerCase) match inside a returned
+    // lambda. The lambda parameter has no explicit type — it is driven by
+    // the enclosing function's `func(Try[WireMsg]) string` return type.
+    // Without expected-param propagation through the `return` statement,
+    // the matched type erased to `Try[any]`, and the inner sealed-case
+    // Unapply rejected with "need type assertion".
+    val handler = multifile_lib_regress.MakeWireHandler()
+    Println(handler(Failure[multifile_lib_regress.WireMsg](errors.New("boom"))))
+    Println(handler(Success[multifile_lib_regress.WireMsg](multifile_lib_regress.WireChunk(Index = 1, Line = "hi"))))
+    Println(handler(Success[multifile_lib_regress.WireMsg](multifile_lib_regress.WireSessionFailed(Index = 2, Err = "x"))))
+    Println(handler(Success[multifile_lib_regress.WireMsg](multifile_lib_regress.WireOther())))
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -56,3 +56,7 @@ chunk[topic]=first line
 end[topic] ok
 end[topic] err=boom
 runtime failure: runtime[1]: beta
+fail: boom
+chunk: hi
+sessfail: x
+other

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -77,6 +77,7 @@ go_test(
         "methods_test.go",
         "multi_file_some_none_test.go",
         "multi_var_test.go",
+        "nested_success_typearg_test.go",
         "option_test.go",
         "panic_audit_test.go",
         "phantom_reexport_funconly_test.go",

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -850,6 +850,19 @@ func (t *galaASTTransformer) resolveReturnTypeAsFuncType(typeExpr ast.Expr) *tra
 		return nil
 	}
 
+	return t.resolveTranspilerTypeAsFuncType(tp)
+}
+
+// resolveTranspilerTypeAsFuncType is the transpiler.Type-input variant of
+// resolveReturnTypeAsFuncType. Used at sites where the enclosing function's
+// return type is already a transpiler.Type (e.g. currentFuncReturnType) and
+// we want to thread expected lambda param/return types into a returned
+// lambda expression.
+func (t *galaASTTransformer) resolveTranspilerTypeAsFuncType(tp transpiler.Type) *transpiler.FuncType {
+	if tp == nil || tp.IsNil() {
+		return nil
+	}
+
 	// Check if it's already a FuncType
 	if ft, ok := tp.(transpiler.FuncType); ok {
 		return &ft

--- a/internal/transpiler/transformer/nested_success_typearg_test.go
+++ b/internal/transpiler/transformer/nested_success_typearg_test.go
@@ -1,0 +1,129 @@
+package transformer_test
+
+import (
+	"strings"
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNestedSuccessSealedTypeArg verifies that nested sealed-case patterns
+// inside Success(...) over Try[Msg] preserve the Msg type argument when the
+// match's scrutinee is a lambda parameter whose type is implicit (driven by
+// the enclosing function's `func(Try[Msg]) string` return type).
+//
+// Without expected-param propagation through the `return` statement, the
+// lambda's untyped parameter widened to any, the matched type degraded to
+// Try[any], the IIFE wrapper became `func(obj Try[any])`, and the inner
+// constructor's Unapply call (e.g., ChunkArrived{}.Unapply) ended up
+// receiving a value of type any instead of Msg — Go rejected with:
+//
+//	cannot use Try[Msg] as Try[any] value in argument to func(obj Try[any])
+//	cannot use _tmp_NN (variable of interface type any) as Msg value in
+//	argument to ChunkArrived{}.Unapply: need type assertion
+//
+// All three forms exercise nested Success(Case(...)) patterns; the
+// block-bodied function form (`func f() Lambda { return (t) => ... }`) is
+// the one that triggered the bug, while the expression-bodied form was
+// already working as a baseline check.
+func TestNestedSuccessSealedTypeArg(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "block-bodied function returning lambda with nested Success(Case)",
+			input: `package main
+
+sealed type Msg {
+    case ChunkArrived(Index int, Line string)
+    case SessionFailed(Index int, Err string)
+    case Other
+}
+
+func MakeHandler() func(Try[Msg]) string {
+    return (t) => t match {
+        case Failure(err) => s"fail: ${err.Error()}"
+        case Success(ChunkArrived(_, line)) => s"chunk: $line"
+        case Success(SessionFailed(_, e))   => s"sessfail: $e"
+        case _ => "other"
+    }
+}
+
+func main() {}
+`,
+		},
+		{
+			name: "expression-bodied function returning lambda with nested Success(Case)",
+			input: `package main
+
+sealed type Msg {
+    case ChunkArrived(Index int, Line string)
+    case SessionFailed(Index int, Err string)
+    case Other
+}
+
+func MakeHandler() func(Try[Msg]) string =
+    (t) => t match {
+        case Failure(err) => s"fail: ${err.Error()}"
+        case Success(ChunkArrived(_, line)) => s"chunk: $line"
+        case Success(SessionFailed(_, e))   => s"sessfail: $e"
+        case _ => "other"
+    }
+
+func main() {}
+`,
+		},
+		{
+			name: "direct match on Try[Msg] argument (baseline — was already working)",
+			input: `package main
+
+sealed type Msg {
+    case ChunkArrived(Index int, Line string)
+    case SessionFailed(Index int, Err string)
+    case Other
+}
+
+func DoMatch(t Try[Msg]) string {
+    return t match {
+        case Failure(err) => s"fail: ${err.Error()}"
+        case Success(ChunkArrived(_, line)) => s"chunk: $line"
+        case Success(SessionFailed(_, e))   => s"sessfail: $e"
+        case _ => "other"
+    }
+}
+
+func main() {}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := trans.Transpile(tt.input, "")
+			assert.NoError(t, err, "transpilation should succeed")
+			gen := stripGeneratedHeader(got)
+
+			// Match-IIFE param must use Try[Msg], never Try[any].
+			assert.False(t, strings.Contains(gen, "func(obj std.Try[any])") ||
+				strings.Contains(gen, "func(obj Try[any])"),
+				"match-IIFE parameter must NOT widen to Try[any]\n--- generated ---\n%s", gen)
+			// Lambda surfaced from `return (t) => ...` must spell its
+			// parameter as Try[Msg], not any.
+			assert.False(t, strings.Contains(gen, "func(t any)") ||
+				strings.Contains(gen, "func(t std.Try[any])"),
+				"lambda parameter must NOT erase to any\n--- generated ---\n%s", gen)
+		})
+	}
+}

--- a/internal/transpiler/transformer/statements.go
+++ b/internal/transpiler/transformer/statements.go
@@ -92,13 +92,34 @@ func (t *galaASTTransformer) transformStatement(ctx *grammar.StatementContext) (
 			// if-expression IIFE gets a concrete return type instead of falling back
 			// to `any` when HM type inference fails in multi-file batch mode.
 			ifExprCtx := t.findIfExpressionInExpression(retCtx.Expression())
-			if ifExprCtx != nil && t.currentFuncReturnType != nil && !t.currentFuncReturnType.IsNil() {
-				oldExpected := t.expectedIfExprType
-				t.expectedIfExprType = t.typeToExpr(t.currentFuncReturnType)
-				expr, err = t.transformIfExpression(ifExprCtx)
-				t.expectedIfExprType = oldExpected
-			} else {
-				expr, err = t.transformExpression(retCtx.Expression())
+			// If the return expression is a bare lambda and the enclosing
+			// function returns a function type, propagate the expected param
+			// and return types into the lambda. This mirrors what
+			// transformExpressionBodiedFunction does for `func f() T = lambda`,
+			// without which the lambda's untyped parameters fall through as
+			// `any` and downstream match expressions that scrutinize them
+			// erase their generic type arguments (e.g. `Try[Msg]` → `Try[any]`).
+			lambdaCtx := t.findLambdaInExpression(retCtx.Expression())
+			if lambdaCtx != nil && t.currentFuncReturnType != nil && !t.currentFuncReturnType.IsNil() {
+				if expectedFuncType := t.resolveTranspilerTypeAsFuncType(t.currentFuncReturnType); expectedFuncType != nil {
+					var expectedRetType ast.Expr
+					if len(expectedFuncType.Results) > 0 {
+						expectedRetType = t.typeToExpr(expectedFuncType.Results[0])
+					} else {
+						expectedRetType = ExpectedVoid
+					}
+					expr, err = t.transformLambdaWithExpectedType(lambdaCtx, expectedRetType, expectedFuncType.Params)
+				}
+			}
+			if expr == nil && err == nil {
+				if ifExprCtx != nil && t.currentFuncReturnType != nil && !t.currentFuncReturnType.IsNil() {
+					oldExpected := t.expectedIfExprType
+					t.expectedIfExprType = t.typeToExpr(t.currentFuncReturnType)
+					expr, err = t.transformIfExpression(ifExprCtx)
+					t.expectedIfExprType = oldExpected
+				} else {
+					expr, err = t.transformExpression(retCtx.Expression())
+				}
 			}
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Summary

Fixes **FIX-002** (gala_team 0.39.2 regression Bug 2): nested `Success(LocalCase(...))` patterns in a `Try[Msg]` match flattened the IIFE wrapper to `func(obj Try[any])`, causing `Success.Unapply` to return `any` and break the inner constructor's `.Unapply(Msg)` call.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1
**Found in**: `gala_team/app/headless/headless.gala`

## Root Cause

`transformStatement`'s return-statement path called bare `transformExpression` for lambda return values, dropping the expected param/return types. Only the if-expression case had been special-cased. When the scrutinee was a lambda parameter that lacked an explicit type annotation, the lambda's param type had to be inferred from the enclosing function's `func(Try[Msg]) string` return type — but that signal never arrived at the lambda body.

## Changes

- `internal/transpiler/transformer/statements.go` — when the return expression is a lambda and `currentFuncReturnType` resolves to a `FuncType`, route through `transformLambdaWithExpectedType` with the resolved params/result. Mirrors the lambda path already present in `transformExpressionBodiedFunction`.
- `internal/transpiler/transformer/declarations.go` — minor support adjustment.
- `internal/transpiler/transformer/nested_success_typearg_test.go` — three sub-cases covering block-bodied / expression-bodied / nested-pattern shapes.
- `examples/multifile_lib_regress/logic.gala::MakeWireHandler` — cross-package batch repro.

## Verification

- `bazel build //...` passes (1164 targets)
- `bazel test //...` passes (319 tests)

## Repro (before fix)

\`\`\`gala
sealed type Msg { case ChunkArrived(I Int, L String); case Other }

func makeHandler() func(Try[Msg]) String {
    return (t) => t match {
        case Failure(e) => s\"fail: \${e}\"
        case Success(ChunkArrived(_, line)) => s\"chunk: \${line}\"
        case _ => \"other\"
    }
}
\`\`\`

## Dependencies

None — independent fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)