### PR TITLE
fix(interpolation): tag s/f-string CallExpr with string return type

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2256,6 +2256,17 @@ gala_test(
     deps = ["//collection_immutable"],
 )
 
+# FIX-004: if-expression with both arms producing s-string interpolations
+# must lower to `func() string { ... }()`, not `func() any { ... }()`.
+# Otherwise downstream callers expecting a concrete string (e.g. a
+# `string`-typed val initialiser) fail to compile in the generated Go.
+gala_test(
+    name = "fix004_if_string_iife",
+    src = "fix004_if_string_iife.gala",
+    expected = "fix004_if_string_iife.out",
+    deps = ["//collection_immutable"],
+)
+
 # Gap #10 regression: tuple literal passed to Append on Array[Tuple[A,B]]
 # infers A,B from the receiver, not falling back to any.
 gala_test(

--- a/examples/fix004_if_string_iife.gala
+++ b/examples/fix004_if_string_iife.gala
@@ -1,0 +1,49 @@
+package main
+
+import (
+    . "martianoff/gala/collection_immutable"
+)
+
+// Repro for FIX-004: `if (cond) sStr1 else sStr2` previously produced a
+// `func() any { ... }()` IIFE instead of `func() string { ... }()`, because
+// the lowered `fmt.Sprintf` CallExpr was not tagged with its return type.
+// When the if-expression appears in a `var` initialiser or argument position
+// (rather than a return statement), the IIFE return type was widened to
+// `any` and downstream callers expecting a concrete `string` failed to
+// compile in the generated Go (e.g. `NewImmutable[string](...)` rejected
+// the `any` value with "need type assertion").
+//
+// The original failing shape interpolates a value whose static type is
+// `Immutable[T]` (auto-unwrapped to `.Get()` by the s-string lowering).
+// HM type inference cannot reliably reach inside the lowered fmt.Sprintf
+// call to recover its `string` return type, so the if-expression's
+// per-branch fallback must rely on the AST-node type tag we attach in
+// `buildSprintfCall`.
+
+struct Style(Color string)
+
+func TextStyled(label string, style Style) string =
+    s"[${style.Color}] $label"
+
+// glyph is `Immutable[string]` (val-bindings are wrapped). The s-string
+// lowering inserts `glyph.Get()`, but the CallExpr's return type still
+// needs to be tagged as string for the if-expression IIFE.
+func render(isCursor bool, name string) string {
+    val glyph = if (isCursor) ">>" else "--"
+    val label = if (isCursor) s"$glyph cursor: $name" else s"$glyph: $name"
+    val style = Style(Color = "blue")
+    return TextStyled(label, style)
+}
+
+// f-string variant: same lowering, same expected type tagging.
+func formatNum(n int) string {
+    val s = if (n >= 0) f"+$n%d" else f"$n%d"
+    return s
+}
+
+func main() {
+    Println(render(true, "alice"))
+    Println(render(false, "bob"))
+    Println(formatNum(3))
+    Println(formatNum(-1))
+}

--- a/examples/fix004_if_string_iife.out
+++ b/examples/fix004_if_string_iife.out
@@ -1,0 +1,4 @@
+[blue] >> cursor: alice
+[blue] --: bob
++3
+-1

--- a/examples/multifile_lib_regress/logic.gala
+++ b/examples/multifile_lib_regress/logic.gala
@@ -334,3 +334,22 @@ func MakeWireHandler() func(Try[WireMsg]) string {
         case _ => "other"
     }
 }
+
+// --- Regression: if-expression with both arms producing s-string
+// interpolations must lower to `func() string { ... }()`, not
+// `func() any { ... }()`. The if-expression sits in `var` initialiser
+// position (not a return), which exercises the IIFE-typing fallback
+// path. The lowered `fmt.Sprintf` CallExpr's return type was not
+// recognised as `string` by the per-branch type oracle, so the IIFE
+// widened to `func() any` and the consumer of `label` (here
+// TextStyled, which expects a concrete `string`) failed to compile.
+struct LabelStyle(Color string)
+
+func TextStyled(label string, style LabelStyle) string =
+    s"[${style.Color}] $label"
+
+func RenderRow(isCursor bool, glyph string, name string) string {
+    val label = if (isCursor) s">> $glyph $name" else s"   $glyph $name"
+    val style = LabelStyle(Color = "blue")
+    return TextStyled(label, style)
+}

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -239,4 +239,12 @@ func main() {
     Println(handler(Success[multifile_lib_regress.WireMsg](multifile_lib_regress.WireChunk(Index = 1, Line = "hi"))))
     Println(handler(Success[multifile_lib_regress.WireMsg](multifile_lib_regress.WireSessionFailed(Index = 2, Err = "x"))))
     Println(handler(Success[multifile_lib_regress.WireMsg](multifile_lib_regress.WireOther())))
+
+    // --- Regression: if-expression in var-initialiser whose arms are both
+    // s-string interpolations must lower to `func() string`, not
+    // `func() any`. Otherwise the call to TextStyled (which takes a
+    // concrete `string` first param) rejects the `any` value with
+    // "cannot use ... as string".
+    Println(multifile_lib_regress.RenderRow(true, "G", "alice"))
+    Println(multifile_lib_regress.RenderRow(false, "g", "bob"))
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -60,3 +60,5 @@ fail: boom
 chunk: hi
 sessfail: x
 other
+[blue] >> G alice
+[blue]    g bob

--- a/internal/transpiler/transformer/coverage_regression_test.go
+++ b/internal/transpiler/transformer/coverage_regression_test.go
@@ -163,6 +163,44 @@ func main() {
 		"expected tuple access to auto-unwrap the Immutable val binding via .Get() before projecting V1")
 }
 
+// TestIfExpressionStringInterpolationIIFEReturnType pins the regression
+// where an if-expression whose arms were s-string interpolations lowered
+// to `func() any { ... }()` instead of `func() string { ... }()`.
+//
+// The bug: the per-branch type oracle used by transformIfExpression's
+// IIFE-typing fallback could not always reach inside the lowered
+// `fmt.Sprintf(...)` CallExpr to recover its `string` return type
+// (e.g. when the Go SDK was unavailable for type info, falling back
+// to the universal `any` widening). The fix tags every Sprintf call
+// produced by buildSprintfCall with type `string` so the per-branch
+// oracle resolves it without re-deriving the return type from `fmt`.
+//
+// Verifies the IIFE wrapper for an if-expression whose arms are s-string
+// interpolations is `func() string`, not `func() any`.
+func TestIfExpressionStringInterpolationIIFEReturnType(t *testing.T) {
+	trans := newTranspiler()
+	input := `package main
+
+func makeLabel(use bool, name string) string {
+    val label = if (use) s">> $name" else s"-- $name"
+    return label
+}
+
+func main() {
+    _ = makeLabel(true, "alice")
+}`
+	out, err := trans.Transpile(input, "")
+	require.NoError(t, err)
+	// The if-expression IIFE wrapper must be typed as `func() string`,
+	// not `func() any` — otherwise downstream consumers expecting a
+	// concrete `string` (e.g. `NewImmutable[string]`) would reject the
+	// `any` value with "need type assertion".
+	assert.Contains(t, out, "func() string {",
+		"expected if-expression IIFE wrapper to be func() string for s-string interpolation arms")
+	assert.NotContains(t, out, "func() any {",
+		"if-expression IIFE wrapper must not widen to func() any when both arms are string-interpolation s-strings")
+}
+
 // firstSprintf returns the first fmt.Sprintf(...) call from generated
 // Go, or the full string if none found. Used by T5 to narrow the
 // assertion window to the interpolation-generated call site.

--- a/internal/transpiler/transformer/interpolation.go
+++ b/internal/transpiler/transformer/interpolation.go
@@ -130,13 +130,21 @@ func (t *galaASTTransformer) buildSprintfCall(parts []interpolationPart, isForma
 	})
 	allArgs = append(allArgs, args...)
 
-	return &ast.CallExpr{
+	call := &ast.CallExpr{
 		Fun: &ast.SelectorExpr{
 			X:   ast.NewIdent("fmt"),
 			Sel: ast.NewIdent("Sprintf"),
 		},
 		Args: allArgs,
-	}, nil
+	}
+	// Tag the resulting CallExpr with type `string` so downstream type
+	// inference (getExprTypeNameManual / getExprTypeName) recognises it
+	// without re-deriving the return type from `fmt.Sprintf`. Without this,
+	// when the Go SDK is unavailable for type info, an if-expression whose
+	// arms are s-string interpolations would widen its IIFE return type to
+	// `func() any` and break callers that expect a concrete `string`.
+	t.exprTypeCache[call] = transpiler.BasicType{Name: "string"}
+	return call, nil
 }
 
 // parseAndTransformExpr parses a GALA expression string and transforms it to Go AST.


### PR DESCRIPTION
## Summary

Fixes **FIX-004** (gala_team 0.39.2 regression Bug 4): `if (cond) s\"...\" else s\"...\"` produced a `func() any { ... }` IIFE instead of `func() string`. Generated Go failed with `cannot use func() any {…}() (interface) as string value in argument to NewImmutable[string]`.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P0
**Found in**: `gala_team/app/view/team_panel.gala::renderSidebarRow`

## Root Cause

`transformIfExpression` calls HM-based `inferIfType` first; if that returns `NilType`, it falls back to per-branch `getExprTypeName`. For s/f-string interpolation, the lowered `fmt.Sprintf` `*ast.CallExpr` was never pre-tagged with its `string` return type. The per-branch oracle then went through `inferCallSelectorType`, which only special-cases `fmt.Println`/`fmt.Print` as `Void`. For `fmt.Sprintf` it relied on `goTypeInfo.GetFuncReturnType(...)` — when the Go SDK is not reachable (sandboxed builds), that returns `NilType`, so both arms collapsed to `any` and the IIFE widened to `func() any`.

## Changes

- `internal/transpiler/transformer/interpolation.go` — `buildSprintfCall` pre-populates `exprTypeCache[call] = BasicType{string}` so `getExprTypeNameManual`'s cache hit short-circuits regardless of `goTypeInfo` reachability. Also benefits `bridge.go::toInferExpr` (queries the same cache before reaching HM).
- `internal/transpiler/transformer/coverage_regression_test.go` — adds `TestIfExpressionStringInterpolationIIFEReturnType`.
- `examples/fix004_if_string_iife.gala` + `RenderRow` addition to `multifile_lib_regress`.

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (319 tests)

## Repro (before fix)

\`\`\`gala
val label = if (isCursor) s\"▶ \${glyph} \${name}\" else s\"  \${glyph} \${name}\"
TextStyled(label, style)  // fails: NewImmutable[string](func()any{}()) — needs assertion
\`\`\`

## Dependencies

None — independent fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)