### PR TITLE
fix(match): widen sealed case to parent in tuple match-arm result

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -286,6 +286,12 @@ gala_test(
 )
 
 gala_test(
+    name = "fix007_sealed_tuple_widen",
+    src = "fix007_sealed_tuple_widen.gala",
+    expected = "fix007_sealed_tuple_widen.out",
+)
+
+gala_test(
     name = "either",
     src = "either.gala",
     expected = "either.out",

--- a/examples/fix007_sealed_tuple_widen.gala
+++ b/examples/fix007_sealed_tuple_widen.gala
@@ -1,0 +1,63 @@
+package main
+
+import "errors"
+
+// Repro for sealed-type case widening inside a tuple-typed match arm result.
+//
+// The function below has declared return type `Tuple[AppModel, Cmd[AppMsg]]`,
+// where `Cmd` is a sealed type with cases `NoCmd` and `MsgCmd`. When match
+// arms differ in whether the second tuple slot carries the sealed PARENT
+// (`Cmd[AppMsg]`) or the sealed CASE (`MsgCmd[AppMsg]`), match-arm
+// unification must widen the case to the parent. Without widening the
+// transpiler rejects the match with:
+//
+//   type mismatch in match expression:
+//     'case Failure(e)' returns 'Tuple[AppModel, MsgCmd[AppMsg]]'
+//     'case Success(s)' returns 'Tuple[AppModel, Cmd[AppMsg]]'
+//
+// even though every value of `MsgCmd[AppMsg]` is a value of `Cmd[AppMsg]`.
+
+sealed type AppMsg {
+    case Tick()
+    case ConsultFailed(Reason string)
+}
+
+sealed type Cmd[T any] {
+    case NoCmd()
+    case MsgCmd(Msg T)
+}
+
+struct AppModel(Counter int)
+
+// consultEventFutureCmd returns the sealed PARENT type Cmd[AppMsg].
+func consultEventFutureCmd(s string) Cmd[AppMsg] = NoCmd[AppMsg]()
+
+
+// DispatchConsult mirrors the original bug subject — a Try[T]-shaped match
+// where each arm produces a tuple with a Cmd[AppMsg] in slot 2.
+func DispatchConsult(n int) Try[string] =
+    if (n == 0) Failure[string](errors.New("boom")) else Success("ok")
+
+// dispatchOneConsult exercises the bug: arm 1's tuple slot 2 is bound to
+// the sealed CASE `MsgCmd[AppMsg]` via a val whose RHS is a sealed-case
+// constructor; arm 2's slot 2 is the sealed PARENT `Cmd[AppMsg]` from a
+// function returning the parent. Both arms must unify to the declared
+// return Tuple[AppModel, Cmd[AppMsg]].
+func dispatchOneConsult(n int) Tuple[AppModel, Cmd[AppMsg]] {
+    return DispatchConsult(n) match {
+        case Failure(e) => {
+            val cmd = MsgCmd[AppMsg](Msg = ConsultFailed(Reason = e.Error()))
+            return (AppModel(Counter = 1), cmd)
+        }
+        case Success(s) => {
+            return (AppModel(Counter = 2), consultEventFutureCmd(s))
+        }
+    }
+}
+
+func main() {
+    val r1 = dispatchOneConsult(0)
+    val r2 = dispatchOneConsult(7)
+    Println(s"r1.counter=${r1.V1.Counter}")
+    Println(s"r2.counter=${r2.V1.Counter}")
+}

--- a/examples/fix007_sealed_tuple_widen.out
+++ b/examples/fix007_sealed_tuple_widen.out
@@ -1,0 +1,2 @@
+r1.counter=1
+r2.counter=2

--- a/examples/multifile_lib_regress/logic.gala
+++ b/examples/multifile_lib_regress/logic.gala
@@ -353,3 +353,42 @@ func RenderRow(isCursor bool, glyph string, name string) string {
     val style = LabelStyle(Color = "blue")
     return TextStyled(label, style)
 }
+
+// --- Regression: sealed-case → sealed-parent widening inside a tuple-typed
+// match-arm result. When a function returns `Tuple[A, Cmd[T]]`, one match
+// arm produces `(a, MsgCmd[T](...))` (sealed CASE constructor in slot 2)
+// and another produces `(a, otherCmdReturningFunc())` (sealed PARENT). The
+// transpiler must widen the case to the parent so both arms agree on the
+// declared `Tuple[A, Cmd[T]]`. Without widening the transpiler rejected the
+// match with a "type mismatch" error even though every value of the case
+// type is a value of the parent type via the case's Apply method.
+sealed type DispatchMsg {
+    case TickMsg()
+    case FailMsg(Reason string)
+}
+
+sealed type DispatchCmd[T any] {
+    case NoDispatch()
+    case SendDispatch(Payload T)
+}
+
+struct DispatchModel(Counter int)
+
+// dispatchParent returns the sealed PARENT type DispatchCmd[DispatchMsg].
+func dispatchParent(seed string) DispatchCmd[DispatchMsg] = NoDispatch[DispatchMsg]()
+
+// dispatchByOutcome: arm 1's tuple slot 2 is bound to the sealed CASE via a
+// val whose RHS is a sealed-case constructor; arm 2's slot 2 is the sealed
+// PARENT from a function returning the parent. Both arms unify to the
+// declared return Tuple[DispatchModel, DispatchCmd[DispatchMsg]].
+func DispatchByOutcome(outcome Try[string]) Tuple[DispatchModel, DispatchCmd[DispatchMsg]] {
+    return outcome match {
+        case Failure(e) => {
+            val cmd = SendDispatch[DispatchMsg](Payload = FailMsg(Reason = e.Error()))
+            return (DispatchModel(Counter = 1), cmd)
+        }
+        case Success(s) => {
+            return (DispatchModel(Counter = 2), dispatchParent(s))
+        }
+    }
+}

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -247,4 +247,18 @@ func main() {
     // "cannot use ... as string".
     Println(multifile_lib_regress.RenderRow(true, "G", "alice"))
     Println(multifile_lib_regress.RenderRow(false, "g", "bob"))
+
+    // --- Regression: sealed-case → sealed-parent widening inside a
+    // tuple-typed match-arm result. The function's declared return is
+    // Tuple[DispatchModel, DispatchCmd[DispatchMsg]]; one arm produces the
+    // tuple with a sealed-CASE constructor (SendDispatch[DispatchMsg]) in
+    // slot 2 via a val binding, and the sibling arm produces the parent
+    // (DispatchCmd[DispatchMsg]) from a function returning the parent.
+    // Both arms must unify against the declared return.
+    val okOutcome = Success("hello")
+    val errOutcome = Failure[string](errors.New("nope"))
+    val r1 = multifile_lib_regress.DispatchByOutcome(okOutcome)
+    val r2 = multifile_lib_regress.DispatchByOutcome(errOutcome)
+    Println(s"DispatchByOutcome ok counter=${r1.V1.Counter}")
+    Println(s"DispatchByOutcome err counter=${r2.V1.Counter}")
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -62,3 +62,5 @@ sessfail: x
 other
 [blue] >> G alice
 [blue]    g bob
+DispatchByOutcome ok counter=2
+DispatchByOutcome err counter=1

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -85,6 +85,7 @@ go_test(
         "qualified_namedarg_shadow_test.go",
         "recursive_immutable_test.go",
         "sealed_string_func_field_test.go",
+        "sealed_tuple_widen_test.go",
         "structs_test.go",
         "test_helper.go",
         "tuple_arity_matrix_test.go",

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -966,17 +966,87 @@ func (t *galaASTTransformer) inferCommonResultType(types []transpiler.Type, patt
 			continue
 		}
 		// Note: NilType (from nil literal) is allowed and checked in typesCompatible
-		if !t.typesCompatible(refType, typ) {
-			msg := fmt.Sprintf("type mismatch in match expression: '%s' returns '%s' but '%s' returns '%s'. All branches must return the same type",
-				refPattern, refType.String(), patterns[i], typ.String())
-			if ctx != nil {
-				return nil, t.semanticErrorAt(ctx, msg)
-			}
-			return nil, galaerr.NewSemanticErrorAt(t.lastLine, t.lastCol, msg)
+		if t.typesCompatible(refType, typ) {
+			continue
 		}
+		// Sealed widening: when the only mismatch is a sealed-CASE in one arm
+		// vs. its sealed-PARENT in another (possibly nested in a tuple slot),
+		// widen both arms to the common parent type and continue. This lets a
+		// match arm produce a sealed CASE value (e.g. `MsgCmd[AppMsg]`) while
+		// a sibling arm produces the parent (`Cmd[AppMsg]`) without forcing
+		// the user to add `: Cmd[AppMsg]` annotations. The widened parent
+		// becomes the new reference type so subsequent arms unify against it.
+		if widened, ok := t.unifyWithSealedWidening(refType, typ); ok {
+			refType = widened
+			continue
+		}
+		msg := fmt.Sprintf("type mismatch in match expression: '%s' returns '%s' but '%s' returns '%s'. All branches must return the same type",
+			refPattern, refType.String(), patterns[i], typ.String())
+		if ctx != nil {
+			return nil, t.semanticErrorAt(ctx, msg)
+		}
+		return nil, galaerr.NewSemanticErrorAt(t.lastLine, t.lastCol, msg)
 	}
 
 	return refType, nil
+}
+
+// unifyWithSealedWidening attempts to unify two match arm result types by
+// widening sealed-variant CASE positions to their declared sealed PARENT
+// when the sibling arm carries the parent in the same position. Returns
+// (widenedType, true) on success and (nil, false) when no widening can
+// reconcile the two types.
+//
+// Handles three shapes:
+//
+//  1. Direct case ↔ parent: `MsgCmd[AppMsg]` and `Cmd[AppMsg]` widen to
+//     `Cmd[AppMsg]`.
+//  2. Generic container with mismatching params, where exactly one slot
+//     differs and that slot is a sealed-case-vs-parent: `Tuple[A, MsgCmd[X]]`
+//     and `Tuple[A, Cmd[X]]` widen to `Tuple[A, Cmd[X]]`.
+//  3. Recursive descent for nested generics (e.g. `Array[Tuple[A, Cmd[X]]]`)
+//     by reusing this helper on each parameter slot.
+//
+// The widening direction is fixed: when one operand is the case and the
+// other is the parent, the parent wins. This mirrors the value semantics —
+// every CASE value is a value of the PARENT type via the case's Apply
+// method — so widening never loses information at the Go-level.
+func (t *galaASTTransformer) unifyWithSealedWidening(a, b transpiler.Type) (transpiler.Type, bool) {
+	if a == nil || b == nil {
+		return nil, false
+	}
+	if t.typesCompatible(a, b) {
+		return a, true
+	}
+	// Direct sealed case → parent widening (in either direction).
+	if parent := t.sealedCaseParent(a); parent != nil && t.typesCompatible(parent, b) {
+		return b, true
+	}
+	if parent := t.sealedCaseParent(b); parent != nil && t.typesCompatible(parent, a) {
+		return a, true
+	}
+	// Same generic base, recurse into params. This covers the tuple-slot
+	// case from the bug report: Tuple[A, MsgCmd[X]] vs Tuple[A, Cmd[X]].
+	gen1, ok1 := a.(transpiler.GenericType)
+	gen2, ok2 := b.(transpiler.GenericType)
+	if !ok1 || !ok2 {
+		return nil, false
+	}
+	if gen1.Base.String() != gen2.Base.String() && !t.typesCompatible(gen1.Base, gen2.Base) {
+		return nil, false
+	}
+	if len(gen1.Params) != len(gen2.Params) {
+		return nil, false
+	}
+	mergedParams := make([]transpiler.Type, len(gen1.Params))
+	for i := range gen1.Params {
+		merged, ok := t.unifyWithSealedWidening(gen1.Params[i], gen2.Params[i])
+		if !ok {
+			return nil, false
+		}
+		mergedParams[i] = merged
+	}
+	return transpiler.GenericType{Base: gen1.Base, Params: mergedParams}, true
 }
 
 // typesCompatible checks if two types are compatible (same type, both any, or type parameter with any)

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -719,6 +719,21 @@ func (t *galaASTTransformer) transformTupleLiteralWithExpected(exprs []ast.Expr,
 				typeParams = append(typeParams, ast.NewIdent("any"))
 			}
 		} else {
+			// Sealed widening: when the element's static type is a sealed CASE
+			// (e.g. `MsgCmd[AppMsg]`) and the expected slot type is its sealed
+			// PARENT (`Cmd[AppMsg]`), emit the parent in the tuple's type
+			// arguments. This keeps a tuple-typed match-arm result aligned
+			// with the surrounding function's declared return type, where
+			// the parent type is the lowest common type for both arms.
+			if fallbackTypes != nil && i < len(fallbackTypes) {
+				expected := fallbackTypes[i]
+				if expected != nil && !expected.IsNil() && !expected.IsAny() && expected.String() != exprType.String() {
+					if parent := t.sealedCaseParent(exprType); parent != nil && parent.String() == expected.String() {
+						typeParams = append(typeParams, t.typeToExpr(expected))
+						continue
+					}
+				}
+			}
 			typeParams = append(typeParams, t.typeToExpr(exprType))
 		}
 	}

--- a/internal/transpiler/transformer/sealed.go
+++ b/internal/transpiler/transformer/sealed.go
@@ -843,3 +843,93 @@ func isSelfReferentialSealedField(fieldTypeText, parentName string) bool {
 	}
 	return false
 }
+
+// sealedCaseParent returns the sealed parent type for a sealed-case type, or
+// nil if `caseType` is not a known sealed-variant case. The parent type
+// preserves the case type's type-argument bindings — e.g. given a case
+// `MsgCmd[AppMsg]` of sealed type `Cmd[T]`, the result is `Cmd[AppMsg]`.
+//
+// Used by match arm result-type unification to widen a sealed-case arm to
+// its parent when a sibling arm produced the parent type. Without this,
+// `Tuple[A, MsgCmd[X]]` and `Tuple[A, Cmd[X]]` are treated as incompatible
+// match-arm result types even though `MsgCmd[X]` is a value of `Cmd[X]`.
+func (t *galaASTTransformer) sealedCaseParent(caseType transpiler.Type) transpiler.Type {
+	if caseType == nil || caseType.IsNil() {
+		return nil
+	}
+	// Extract the case's bare base name and any type arguments.
+	caseBase := stripPackagePrefix(caseType.BaseName())
+	var caseArgs []transpiler.Type
+	if gen, ok := caseType.(transpiler.GenericType); ok {
+		caseArgs = gen.Params
+	}
+
+	// A sealed case must be registered as a companion object whose target is
+	// the parent sealed type. lookupCompanion handles std-prefix and
+	// package-qualified lookup.
+	companion := t.lookupCompanion(caseBase)
+	if companion == nil {
+		return nil
+	}
+	parentBase := stripPackagePrefix(companion.TargetType)
+	if parentBase == "" || parentBase == caseBase {
+		return nil
+	}
+
+	// Confirm the parent is registered as a sealed type AND lists this case
+	// as one of its variants. Without this guard a non-sealed companion
+	// (e.g. a plain extractor type) could masquerade as a sealed case.
+	parentMeta := t.getTypeMeta(parentBase)
+	if parentMeta == nil && companion.Package != "" {
+		parentMeta = t.getTypeMeta(companion.Package + "." + parentBase)
+	}
+	if parentMeta == nil || !parentMeta.IsSealed {
+		return nil
+	}
+	variantMatches := false
+	for _, v := range parentMeta.SealedVariants {
+		if v.Name == caseBase {
+			variantMatches = true
+			break
+		}
+	}
+	if !variantMatches {
+		return nil
+	}
+
+	// Reconstruct the parent type with the case's bound type arguments.
+	// The companion's TargetType may include a package prefix; preserve it
+	// so the resulting GenericType prints with the same qualification as
+	// other references to the parent type produce in the same scope.
+	//
+	// Special case: when the companion's package is the current package (or
+	// the convenience markers "main"/"test" the analyzer applies to local
+	// declarations), other inferred references print the type WITHOUT a
+	// package prefix. Mirror that here so the widened parent stringifies
+	// identically — otherwise the expected-type comparison at the call site
+	// (`expected.String() == parent.String()`) would mismatch on package
+	// qualification alone.
+	var parentBaseType transpiler.Type
+	pkg := companion.Package
+	if pkg == "main" || pkg == "test" || pkg == t.packageName {
+		pkg = ""
+	}
+	if pkg != "" {
+		typeName := companion.TargetType
+		if strings.HasPrefix(typeName, pkg+".") {
+			typeName = typeName[len(pkg)+1:]
+		}
+		parentBaseType = transpiler.NamedType{Package: pkg, Name: typeName}
+	} else {
+		parentBaseType = transpiler.BasicType{Name: parentBase}
+	}
+	if len(caseArgs) > 0 && len(caseArgs) == len(parentMeta.TypeParams) {
+		return transpiler.GenericType{Base: parentBaseType, Params: caseArgs}
+	}
+	if len(parentMeta.TypeParams) == 0 {
+		return parentBaseType
+	}
+	// Generic parent but case had no/mismatched type args — surface the parent
+	// without args; downstream substitution handles the mismatch.
+	return parentBaseType
+}

--- a/internal/transpiler/transformer/sealed_tuple_widen_test.go
+++ b/internal/transpiler/transformer/sealed_tuple_widen_test.go
@@ -1,0 +1,110 @@
+package transformer_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+)
+
+// TestSealedTupleArmWidening verifies that match arm result type unification
+// widens a sealed-variant CASE to its declared sealed PARENT when a sibling
+// arm produces the parent type — including when the case appears inside a
+// tuple slot. This mirrors the original failure shape:
+//
+//	func dispatch(...) Tuple[A, Cmd[T]] = ... match {
+//	    case Failure(e) => (a, MsgCmd[T](Msg = ...))   // case in slot 2
+//	    case Success(s) => (a, otherFnReturningCmd())  // parent in slot 2
+//	}
+//
+// Before the fix, match arm unification rejected this with "type mismatch
+// in match expression: case Failure returns Tuple[A, MsgCmd[T]] but case
+// Success returns Tuple[A, Cmd[T]]" even though every value of MsgCmd[T]
+// is a value of Cmd[T] (its sealed parent).
+func TestSealedTupleArmWidening(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    []string
+		notExpected []string
+	}{
+		{
+			// Direct case ↔ parent in a tuple slot. The Failure arm's tuple
+			// slot 2 is bound to a value typed as the case (via a function
+			// declared to return the case); the Success arm's slot 2 is the
+			// parent. The function's declared return is the parent, so both
+			// arms must widen against it.
+			name: "tuple slot with case-vs-parent widens to parent",
+			input: `package main
+
+import "errors"
+
+sealed type AppMsg {
+    case Tick()
+    case Fail(Reason string)
+}
+
+sealed type Cmd[T any] {
+    case NoCmd()
+    case MsgCmd(Msg T)
+}
+
+struct AppModel(Counter int)
+
+func parentCmd(s string) Cmd[AppMsg] = NoCmd[AppMsg]()
+
+func dispatch(n int) Tuple[AppModel, Cmd[AppMsg]] {
+    return (if (n == 0) Failure[string](errors.New("boom")) else Success("ok")) match {
+        case Failure(e) => {
+            val cmd = MsgCmd[AppMsg](Msg = Fail(Reason = e.Error()))
+            return (AppModel(Counter = 1), cmd)
+        }
+        case Success(s) => {
+            return (AppModel(Counter = 2), parentCmd(s))
+        }
+    }
+}
+
+func main() {
+    val r = dispatch(0)
+    Println(r.V1.Counter)
+}`,
+			expected: []string{
+				// IIFE return type widens to the parent
+				"std.Tuple[AppModel, Cmd[AppMsg]]",
+			},
+			notExpected: []string{
+				// Without widening the failure arm tuple type would carry the
+				// case in slot 2. The fix must produce Cmd[AppMsg] in every
+				// tuple-slot 2 site so the Go literal types agree.
+				"std.Tuple[AppModel, MsgCmd[AppMsg]]{",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := transpiler.NewAntlrGalaParser()
+			a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+			tr := transformer.NewGalaASTTransformer()
+			g := generator.NewGoCodeGenerator()
+			trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+			got, err := trans.Transpile(tt.input, "")
+			assert.NoError(t, err)
+			for _, exp := range tt.expected {
+				assert.True(t, strings.Contains(got, exp),
+					"Output missing %q\nGot:\n%s", exp, got)
+			}
+			for _, ne := range tt.notExpected {
+				assert.False(t, strings.Contains(got, ne),
+					"Output should NOT contain %q\nGot:\n%s", ne, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **FIX-007** (gala_team 0.39.2 regression Bug 7): match-arm result-type unification rejected `Tuple[A, MsgCmd[T]]` vs `Tuple[A, Cmd[T]]` even though `MsgCmd[T]` is a case of sealed `Cmd[T]`. Compiler error: `'case Failure(e)' returns 'Tuple[A, MsgCmd[T]]' but 'case Success(s)' returns 'Tuple[A, Cmd[T]]'. All branches must return the same type`.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1
**Found in**: `gala_team/app/ui/update.gala::dispatchOneConsult`

## Root Cause

`inferCommonResultType` called `typesCompatible` by structural identity only. A sealed-CASE in a tuple slot did not unify with the sealed-PARENT carrying the same type arguments — even though every CASE value is a value of the PARENT via Apply. The widening machinery existed for direct-arg positions but not tuple-element positions.

## Changes

- `internal/transpiler/transformer/sealed.go` — new `sealedCaseParent` helper resolves case→parent via `companionObjects` metadata, package-aware. Reconstructs the parent's type with the case's type-args. Mirrors bare-name vs package-qualified printing convention.
- `internal/transpiler/transformer/match.go` — new `unifyWithSealedWidening` recursively descends into generic params, widening sealed case→parent when a sibling arm has the parent in the same slot. The widening becomes the new reference type so subsequent arms unify against the parent. Called from `inferCommonResultType` only when `typesCompatible` fails.
- `internal/transpiler/transformer/postfix.go` — `transformTupleLiteralWithExpected` widens an emitted tuple slot type from sealed CASE to PARENT when the expected slot type is the parent. Keeps generated Go literal types aligned with the IIFE's parent return type.
- `internal/transpiler/transformer/sealed_tuple_widen_test.go` — unit test covering the IIFE widens to parent and the failure-arm tuple does not carry the case type in slot 2.
- `examples/multifile_lib_regress/logic.gala::DispatchByOutcome` + test driver + .out — cross-package batch repro.
- `examples/fix007_sealed_tuple_widen.gala` (+ .out + BUILD.bazel entry).

Widening is **scoped**: only fires (a) when both operands are otherwise structurally identical except for a sealed-case-vs-parent slot, and (b) at tuple-slot positions when the surrounding expected type is the parent. No global change to widening rules.

## Verification

- `bazel build //...` passes
- `bazel test //...` passes (319 tests)

## Repro (before fix)

\`\`\`gala
sealed type Cmd[T] { case MsgCmd(Msg T); case FutureCmd(...) }

func dispatchOneConsult(...) Tuple[AppModel, Cmd[AppMsg]] {
    return DispatchConsult(...) match {
        case Failure(e) => (model, MsgCmd[AppMsg](Msg = ConsultFailed(e)))
        case Success(s) => (model, consultEventFutureCmd(s))   // returns Cmd[AppMsg]
    }
}
\`\`\`

## Dependencies

None — independent fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)