### PR TITLE
fix(calls): lift bare T arg to Immutable[T] when expected param is val-declared

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2075,6 +2075,16 @@ gala_go_test(
     srcs = ["type_alias_lambda_inference.gala"],
 )
 
+# Eq(t, Immutable[V] actual, bare V literal) — when the call-site expected
+# type for an arg is Immutable[V] and the actual arg is a bare V literal,
+# the transpiler must lift the literal with NewImmutable[V]. Otherwise Go
+# rejects "cannot use \"notify\" (untyped string constant) as
+# std.Immutable[string] value".
+gala_go_test(
+    name = "fix009_eq_literal_immutable",
+    srcs = ["fix009_eq_literal_immutable.gala"],
+)
+
 # Option.When and Unless factory constructors
 gala_test(
     name = "option_when",

--- a/examples/fix009_eq_literal_immutable.gala
+++ b/examples/fix009_eq_literal_immutable.gala
@@ -1,0 +1,27 @@
+package main
+
+import (
+    . "martianoff/gala/std"
+    . "martianoff/gala/test"
+)
+
+// FIX-009 regression: when a function's call-site expected parameter
+// type is Immutable[T] and the actual arg is a bare T literal, the
+// transpiler must lift the literal with NewImmutable[T] — Go rejects
+// the bare literal as "cannot use \"notify\" (untyped string constant)
+// as std.Immutable[string] value in argument".
+//
+// Mirrors the gala-server team_config.PolicyConfig shape: a function
+// expecting Immutable[string] is called with a bare string literal at
+// one of its slots, and the literal must be auto-lifted to
+// Immutable[string] rather than emitted as `"notify"` directly.
+
+// EqStr expects both args as Immutable[string] (via the `val` keyword).
+// Calling EqStr(t, "notify", "notify") with bare literals must lift
+// each literal to Immutable[string]; no type parameter is involved so
+// the test isolates the literal-lift fix from generic inference.
+func EqStr(t T, val actual string, val expected string) T = Eq(t, actual, expected)
+
+func TestEqLiteralImmutable(t T) T {
+    return EqStr(t, "notify", "notify")
+}

--- a/examples/multifile_lib_regress/logic.gala
+++ b/examples/multifile_lib_regress/logic.gala
@@ -392,3 +392,13 @@ func DispatchByOutcome(outcome Try[string]) Tuple[DispatchModel, DispatchCmd[Dis
         }
     }
 }
+
+// --- Regression: bare T literal lift to Immutable[T] at val-param sites.
+// MatchPolicyName takes a `val expected string` parameter (so the Go
+// signature is `expected std.Immutable[string]`). Calling it with a bare
+// string literal must lift the literal to NewImmutable[string] — Go
+// rejects "cannot use \"notify\" (untyped string constant) as
+// std.Immutable[string] value" without that promotion.
+func MatchPolicyName(val expected string, val actual string) bool = expected == actual
+
+func PolicyMatches(name string) bool = MatchPolicyName("notify", name)

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -261,4 +261,12 @@ func main() {
     val r2 = multifile_lib_regress.DispatchByOutcome(errOutcome)
     Println(s"DispatchByOutcome ok counter=${r1.V1.Counter}")
     Println(s"DispatchByOutcome err counter=${r2.V1.Counter}")
+
+    // --- Regression: bare string literal at a val (Immutable[string]) param
+    // slot must auto-lift to NewImmutable[string]. PolicyMatches calls a
+    // helper declared `val expected string, val actual string`; passing the
+    // literal "notify" used to fail Go compile with "cannot use \"notify\"
+    // (untyped string constant) as std.Immutable[string]".
+    Println(multifile_lib_regress.PolicyMatches("notify"))
+    Println(multifile_lib_regress.PolicyMatches("retry"))
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -64,3 +64,5 @@ other
 [blue]    g bob
 DispatchByOutcome ok counter=2
 DispatchByOutcome err counter=1
+true
+false

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -1105,6 +1105,11 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 							} else {
 								funcMeta.ParamTypes = append(funcMeta.ParamTypes, transpiler.NilType{})
 							}
+							// Record val/var status so call-site argument transformation
+							// can lift bare T values (e.g. string literals) into the
+							// Immutable[T] wrapper that `val` parameters end up with in
+							// the generated Go signature.
+							funcMeta.ParamImmutFlags = append(funcMeta.ParamImmutFlags, paramCtx.VAL() != nil)
 							// Extract parameter name
 							if paramCtx.Identifier() != nil {
 								funcMeta.ParamNames = append(funcMeta.ParamNames, paramCtx.Identifier().GetText())
@@ -3160,6 +3165,11 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 								} else {
 									funcMeta.ParamTypes = append(funcMeta.ParamTypes, transpiler.NilType{})
 								}
+								// Record val/var status (mirrors the same field
+								// population in the multifile branch above) so the
+								// call-site arg transformer can lift bare T values
+								// to Immutable[T] when the param was declared val.
+								funcMeta.ParamImmutFlags = append(funcMeta.ParamImmutFlags, paramCtx.VAL() != nil)
 								if paramCtx.Identifier() != nil {
 									funcMeta.ParamNames = append(funcMeta.ParamNames, paramCtx.Identifier().GetText())
 								} else {

--- a/internal/transpiler/transformer/call_context.go
+++ b/internal/transpiler/transformer/call_context.go
@@ -181,6 +181,22 @@ func (t *galaASTTransformer) resolveExpectedFuncArgType(ctx callContext, argIdx 
 		}
 	}
 
+	// `val` parameters end up as `Immutable[T]` in the generated Go signature.
+	// When the callee declared this slot with `val`, surface the wrapped type
+	// to the argument transformer so it can lift bare T values (e.g. string
+	// literals) into `NewImmutable[T](…)`. Skip FuncType params: a function
+	// value parameter with `val` keeps its function type — wrapping it in
+	// Immutable would defeat the lambda inference paths.
+	if !expectedType.IsNil() && ctx.funcMeta != nil &&
+		argIdx < len(ctx.funcMeta.ParamImmutFlags) && ctx.funcMeta.ParamImmutFlags[argIdx] {
+		if _, isFunc := expectedType.(transpiler.FuncType); !isFunc {
+			expectedType = transpiler.GenericType{
+				Base:   transpiler.NamedType{Package: "std", Name: transpiler.TypeImmutable},
+				Params: []transpiler.Type{expectedType},
+			}
+		}
+	}
+
 	return expectedType
 }
 

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -2404,7 +2404,66 @@ func (t *galaASTTransformer) transformArgumentWithExpectedType(exprCtx grammar.I
 	}
 
 	// Not a lambda or partial function, transform normally
-	return t.transformExpression(exprCtx)
+	expr, err := t.transformExpression(exprCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Lift bare T value to Immutable[T] when the expected param type is
+	// Immutable[T] but the actual arg expression is a bare T (literal,
+	// arithmetic, etc.). Without this, Go rejects the bare value against
+	// the Immutable[T] parameter slot — the canonical case is calling
+	// `Eq[V](t, a, b)` where V resolves to `Immutable[string]` from one
+	// arg and the other arg is the bare string literal "notify".
+	if expectedType != nil && !expectedType.IsNil() && t.isImmutableType(expectedType) {
+		expr = t.liftToImmutableForArg(expr, expectedType)
+	}
+
+	return expr, nil
+}
+
+// liftToImmutableForArg wraps `expr` with `std.NewImmutable[T](expr)` when
+// the call-site expected param type is `Immutable[T]` and `expr` is a bare
+// `T` value (its inferred type does not already satisfy the Immutable
+// shape). Returns `expr` unchanged when no wrap is needed — including:
+//   - the expression already has type `Immutable[…]`,
+//   - `expr` is the `nil` literal (Immutable[T] has no nil shape — let the
+//     existing Some/None / Option diagnostics fire instead),
+//   - the inner type `T` can't be resolved (let the Go compiler surface a
+//     real mismatch rather than masking it).
+func (t *galaASTTransformer) liftToImmutableForArg(expr ast.Expr, expectedType transpiler.Type) ast.Expr {
+	if expr == nil {
+		return expr
+	}
+	// Skip nil literal — wrapping nil in NewImmutable is never desirable.
+	if id, ok := expr.(*ast.Ident); ok && id.Name == "nil" {
+		return expr
+	}
+	// If the expression is already Immutable[…], no wrap is needed.
+	exprType := t.getExprTypeName(expr)
+	if exprType != nil && !exprType.IsNil() && t.isImmutableType(exprType) {
+		return expr
+	}
+	// Resolve the inner type T from Immutable[T].
+	gen, ok := expectedType.(transpiler.GenericType)
+	if !ok || len(gen.Params) != 1 {
+		return expr
+	}
+	inner := gen.Params[0]
+	if inner == nil || inner.IsNil() {
+		return expr
+	}
+	innerExpr := t.typeToExpr(inner)
+	if innerExpr == nil {
+		return expr
+	}
+	return &ast.CallExpr{
+		Fun: &ast.IndexExpr{
+			X:     t.stdIdent("NewImmutable"),
+			Index: innerExpr,
+		},
+		Args: []ast.Expr{expr},
+	}
 }
 
 // transformLambdaArgWithExpectedType transforms a direct lambda argument.

--- a/internal/transpiler/transpiler.go
+++ b/internal/transpiler/transpiler.go
@@ -265,15 +265,21 @@ type MethodMetadata struct {
 }
 
 type FunctionMetadata struct {
-	Name          string
-	Package       string
-	Pos           SourcePos // Position of the function name identifier in DefinedIn
-	ParamTypes    []Type
-	ParamNames    []string         // Parameter names (for named argument matching and default injection)
-	ReturnType    Type
-	TypeParams    []string
-	DefaultExprs  map[int]string   // Param index -> default expression source text (nil = required)
-	DefinedIn     string           // Source file where this function was defined
+	Name       string
+	Package    string
+	Pos        SourcePos // Position of the function name identifier in DefinedIn
+	ParamTypes []Type
+	ParamNames []string // Parameter names (for named argument matching and default injection)
+	// ParamImmutFlags[i] is true when parameter i was declared with the
+	// `val` keyword. The corresponding Go parameter is `std.Immutable[T]`
+	// rather than the bare `T` recorded in ParamTypes — call-site argument
+	// transformation needs this flag to lift bare T values (e.g. string
+	// literals) into the Immutable wrapper expected by the callee.
+	ParamImmutFlags []bool
+	ReturnType      Type
+	TypeParams      []string
+	DefaultExprs    map[int]string // Param index -> default expression source text (nil = required)
+	DefinedIn       string         // Source file where this function was defined
 }
 
 // CompanionObjectMetadata stores information about companion objects that can be used


### PR DESCRIPTION
## Summary

Fixes **FIX-009** (gala_team 0.39.2 regression Bug 9): `Eq(t, struct.Field, \"notify\")` failed with `cannot use \"notify\" (untyped string constant) as std.Immutable[string] value in argument to Eq` even though `Eq[T]` takes `Immutable[T]` and \"notify\" should have been wrapped.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1
**Found in**: `gala_team/app/config/team_config_test.gala`

## Root Cause

`FunctionMetadata.ParamTypes` recorded the user-declared GALA parameter type (e.g. `string`) but no flag indicated `val`-declared parameters become `Immutable[T]` in the generated Go signature. `resolveExpectedFuncArgType` therefore returned bare `string` and the argument transformer skipped the `NewImmutable` wrap on a bare-string-literal arg.

## Changes

1. `internal/transpiler/transpiler.go` — added `ParamImmutFlags` field on `FunctionMetadata`.
2. `internal/transpiler/analyzer/analyzer.go` — populates `ParamImmutFlags` from `val` keyword presence per parameter, in two analyzer paths (function decl + cross-package metadata sync).
3. `internal/transpiler/transformer/call_context.go` — `resolveExpectedFuncArgType` wraps the declared param type in `Immutable[T]` when the flag is set (excluding `FuncType` params — function-typed params are not Immutable-wrapped).
4. `internal/transpiler/transformer/calls.go` — new `liftToImmutableForArg` helper called from `transformArgumentWithExpectedType` lifts bare `T` expressions to `NewImmutable[T](…)` when the expected type is `Immutable[T]` and the actual expression is not already Immutable-shaped (with `nil` literal excluded).

## Verification

- `examples/fix009_eq_literal_immutable.gala` (single-file)
- `examples/multifile_lib_regress/logic.gala::MatchPolicyName` + `PolicyMatches` (cross-package batch)
- `bazel build //...` passes
- `bazel test //...` passes (319 tests)

## Repro (before fix)

\`\`\`gala
return Eq(t3, pol.PostMerge.Get(0).Name, \"notify\")
// before: cannot use \"notify\" (untyped string constant) as Immutable[string]
\`\`\`

## Dependencies

None — independent fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)