### PR TITLE
fix(analyzer): bust on-disk cache when gala binary content changes

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//:gala.bzl", "gala_binary", "gala_go_test", "gala_library", "gala_test")
-load("@rules_go//go:def.bzl", "go_library")
 
 filegroup(
     name = "single_file_gala_sources",
@@ -42,6 +41,8 @@ filegroup(
         "multi_file_option/main.gala",
         "multi_file_types/main.gala",
         "multi_file_types/model.gala",
+        "multifile_lib_regress/directive_chain.gala",
+        "multifile_lib_regress/directive_pkg/directive.gala",
         "multifile_lib_regress/proc_pkg/proc.gala",
         "multifile_lib_regress/proc_session.gala",
         "multifile_lib_regress/shadow_func/shadow.gala",
@@ -2204,6 +2205,7 @@ gala_library(
     importpath = "martianoff/gala/examples/multifile_lib_regress/team_pkg",
     visibility = ["//visibility:public"],
 )
+
 gala_library(
     name = "multifile_lib_regress_proc_pkg",
     srcs = [
@@ -2212,6 +2214,25 @@ gala_library(
     ],
     importpath = "martianoff/gala/examples/multifile_lib_regress/proc_pkg",
     visibility = ["//visibility:public"],
+)
+
+# Sub-library exercising the chained-accessor regression: a sealed
+# Directive type plus a Parse(string) Array[Directive] function whose
+# return type comes from collection_immutable. The consumer (in the
+# test driver) dot-imports this package and exercises:
+#   - dirs.Get(N) match  — sealed-type match through Array.Get
+#   - cfg.Members.Get(N).Model match  — Option[T] match through 2-deep chain
+#   - cfg.Members.Get(N).Model.IsDefined() / .GetOrElse(...)  — method
+#     dispatch through Immutable[Option[T]]
+#   - cfg.Hooks.Get(0).Args.Size()  — method dispatch through
+#     Immutable[Array[T]]
+#   - cfgs.Get(N).Lead.Name  — 3-deep field chain
+gala_library(
+    name = "multifile_lib_regress_directive_pkg",
+    srcs = ["multifile_lib_regress/directive_pkg/directive.gala"],
+    importpath = "martianoff/gala/examples/multifile_lib_regress/directive_pkg",
+    visibility = ["//visibility:public"],
+    deps = ["//collection_immutable"],
 )
 
 # Sibling package that intentionally exports a top-level function whose name
@@ -2230,6 +2251,7 @@ gala_library(
     name = "multifile_lib_regress",
     srcs = [
         "multifile_lib_regress/consult_end.gala",
+        "multifile_lib_regress/directive_chain.gala",
         "multifile_lib_regress/events_pipe.gala",
         "multifile_lib_regress/go_interop.gala",
         "multifile_lib_regress/logic.gala",
@@ -2244,8 +2266,9 @@ gala_library(
     importpath = "martianoff/gala/examples/multifile_lib_regress",
     visibility = ["//visibility:public"],
     deps = [
-        ":multifile_lib_regress_team_pkg",
+        ":multifile_lib_regress_directive_pkg",
         ":multifile_lib_regress_proc_pkg",
+        ":multifile_lib_regress_team_pkg",
         "//collection_immutable",
         "//examples/go_struct_bridge",
     ],
@@ -2257,6 +2280,7 @@ gala_test(
     expected = "multifile_lib_regress_test.out",
     deps = [
         ":multifile_lib_regress",
+        ":multifile_lib_regress_directive_pkg",
         ":multifile_lib_regress_proc_pkg",
         ":multifile_lib_regress_shadow_func",
         "//collection_immutable",

--- a/examples/multifile_lib_regress/directive_chain.gala
+++ b/examples/multifile_lib_regress/directive_chain.gala
@@ -1,0 +1,43 @@
+package multifile_lib_regress
+
+import (
+    "martianoff/gala/examples/multifile_lib_regress/directive_pkg"
+    . "martianoff/gala/collection_immutable"
+)
+
+// --- Regression: chained accessor through Immutable wrapper ---
+//
+// These helpers re-export directive_pkg fixtures so the test driver
+// can exercise them through dot-imports. The pre-existing failure
+// mode: when the consumer's on-disk pkgAST cache predates the
+// transitive-type-merge in scanImports, `collection_immutable.Array`
+// is missing from the consumer's typeMetas. Then `dirs.Get(0)` (where
+// `dirs` was a val storing `Array[Directive]`) inferred its type via
+// `inferGetMethodType` → `getTypeMeta("collection_immutable.Array")`
+// → nil → fall through to `return xType` (the Array receiver itself,
+// not the .Get(0) return type).
+//
+// Downstream:
+//   - `val firstD = dirs.Get(0)` stored `firstD` as `Array[Directive]`
+//     instead of `Directive`.
+//   - `firstD match { case Dispatch(...) => ... }` typed the IIFE
+//     param as `Array[Directive]` and `Dispatch{}.Unapply(obj)` was
+//     rejected because Unapply expects `Directive`, not the array.
+//
+// The fix invalidates that stale cache by mixing the gala compiler
+// binary's content hash into the cache directory key.
+
+// ParseDirectives returns Array[Directive] for the consumer to chain
+// .Get(N) and match against. Routes through directive_pkg so the
+// match site sits across a package boundary.
+func ParseDirectives(msg string) Array[directive_pkg.Directive] =
+    directive_pkg.Parse(msg)
+
+// LoadCfg is the cross-package container access helper.
+func LoadCfg() directive_pkg.Cfg = directive_pkg.SampleCfg()
+
+// LoadCfgs is the 3-deep chain test helper. The driver does
+// `cfgs.Get(N).Lead.Name` which traverses
+//   `Array[Cfg] → Cfg → Member → string`
+// where each hop is wrapped/unwrapped through Immutable.
+func LoadCfgs() Array[directive_pkg.Cfg] = directive_pkg.SampleCfgs()

--- a/examples/multifile_lib_regress/directive_pkg/directive.gala
+++ b/examples/multifile_lib_regress/directive_pkg/directive.gala
@@ -1,0 +1,86 @@
+package directive_pkg
+
+import (
+    . "martianoff/gala/collection_immutable"
+)
+
+// directive_pkg mirrors the real-world shape that hit the chained
+// auto-unwrap regressions in production: a sealed type plus a
+// `Parse(string) Array[Sealed]` function that returns an Array from a
+// transitively-imported library (collection_immutable). The consumer
+// dot-imports this package and exercises:
+//
+//   - `dirs.Get(N) match { case Foo(...) => ... }` — match-IIFE over a
+//     chained-accessor result whose type comes from Array[T].Get → T,
+//     where T is a sealed type defined here.
+//   - `cfg.Items.Get(N).Field match { ... }` — match over a deep chain
+//     ending at an `Immutable[Option[T]]` field.
+//   - `Eq(t, x.Get(N).Field, "lit")` — literal lift through chained
+//     accessors that return `Immutable[string]`.
+//   - `.Size()` / `.IsDefined()` / `.GetOrElse(...)` on chained
+//     accessors that return `Immutable[Array[T]]` / `Immutable[Option[T]]`.
+//
+// All of these failed when the on-disk analyzer cache was poisoned
+// with a pre-merge pkgAST for this package — the consumer would load
+// only the local types and miss `collection_immutable.Array`'s method
+// metadata, falling back to the receiver type for `dirs.Get(0)` and
+// then typing match subjects as `Array[Directive]` instead of
+// `Directive`. The fix invalidates that cache when the gala compiler
+// binary itself changes.
+
+sealed type Directive {
+    case Dispatch(Target string, Body string)
+    case Summary(Body string)
+}
+
+// Parse synthesises a fixed sequence of directives. The two-Dispatch
+// shape exercises Array.Get(0) / Array.Get(1) returning `Directive`,
+// the consumer's match arms then bind `target` and `body`.
+func Parse(msg string) Array[Directive] = ArrayOf(
+    Dispatch(Target = "first",  Body = msg),
+    Dispatch(Target = "second", Body = msg),
+)
+
+// Member is a struct whose Model field is `Option[string]`. The
+// consumer reaches it via `cfg.Members.Get(N).Model.IsDefined()` —
+// a 3-deep chain (Cfg → Array[Member] → Member → Option[string]).
+struct Member(
+    Name  string,
+    Model Option[string],
+)
+
+// Hook holds an Array[string]. The consumer reaches `.Args.Size()`
+// via `cfg.Hooks.Get(0).Args.Size()` to exercise method dispatch on
+// `Immutable[Array[string]]`.
+struct Hook(
+    Name string,
+    Cmd  string,
+    Args Array[string],
+)
+
+// Cfg is the top-level container the consumer pulls everything from.
+// Members → Array[Member]; Hooks → Array[Hook]; Lead → Member (3-deep
+// chain via Cfg → Array[Cfg] → Cfg → Member → field).
+struct Cfg(
+    Members Array[Member],
+    Hooks   Array[Hook],
+    Lead    Member,
+)
+
+// SampleCfg builds a fixture Cfg with mixed `None` / `Some` members
+// and a hook with no args. The consumer test driver matches against
+// this exact shape.
+func SampleCfg() Cfg = Cfg(
+    Members = ArrayOf(
+        Member(Name = "Iris",  Model = None[string]()),
+        Member(Name = "Felix", Model = Some("opus-4")),
+    ),
+    Hooks = ArrayOf(
+        Hook(Name = "lint", Cmd = "go", Args = EmptyArray[string]()),
+    ),
+    Lead = Member(Name = "Theo", Model = Some("sonnet-4")),
+)
+
+// SampleCfgs returns an Array[Cfg] so the consumer can exercise the
+// 3-deep chain `cfgs.Get(N).Lead.Name` (returns `Immutable[string]`).
+func SampleCfgs() Array[Cfg] = ArrayOf(SampleCfg(), SampleCfg())

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -4,6 +4,7 @@ import (
     "errors"
     "martianoff/gala/examples/multifile_lib_regress"
     "martianoff/gala/examples/multifile_lib_regress/proc_pkg"
+    . "martianoff/gala/examples/multifile_lib_regress/directive_pkg"
     . "martianoff/gala/examples/multifile_lib_regress/shadow_func"
     "martianoff/gala/examples/go_struct_bridge"
     . "martianoff/gala/collection_immutable"
@@ -269,4 +270,67 @@ func main() {
     // (untyped string constant) as std.Immutable[string]".
     Println(multifile_lib_regress.PolicyMatches("notify"))
     Println(multifile_lib_regress.PolicyMatches("retry"))
+
+    // --- Regression: chained accessor `dirs.Get(N) match` over a
+    // cross-package sealed type + Array indirection.
+    //
+    // `Parse(msg)` returns `Array[Directive]` from the dot-imported
+    // directive_pkg. The val `dirs` therefore stores `Array[Directive]`.
+    // `dirs.Get(N)` should yield `Directive`. The match arms then bind
+    // case fields. Before the cache-invalidation fix this regressed
+    // when a stale on-disk pkgAST for directive_pkg was reused — the
+    // collection_immutable.Array typeMeta was missing from the
+    // consumer's lookup table, so `inferGetMethodType` fell through to
+    // returning the receiver type, and `firstD` was stored as
+    // `Array[Directive]` instead of `Directive`. The match-IIFE then
+    // typed `obj` as `Array[Directive]` and Go rejected the
+    // `Dispatch{}.Unapply` call.
+    val dirs = multifile_lib_regress.ParseDirectives("payload")
+    val firstD  = dirs.Get(0)
+    val secondD = dirs.Get(1)
+    Println(firstD match {
+        case Dispatch(target, _) => s"first dispatch -> $target"
+        case Summary(body)       => s"first summary  -> $body"
+    })
+    Println(secondD match {
+        case Dispatch(target, _) => s"second dispatch -> $target"
+        case Summary(body)       => s"second summary  -> $body"
+    })
+
+    // --- Regression: chained accessor `cfg.Members.Get(N).Model match`
+    // (FIX-008 + FIX-010 shape). Cfg.Members is `Array[Member]`,
+    // .Get(N) returns `Member`, .Model is `Option[string]`. The match
+    // subject must be typed as `Option[string]` — not `Option[any]`,
+    // and the match-IIFE param must accept the Immutable wrapper unwrap.
+    val cfg = multifile_lib_regress.LoadCfg()
+    Println(cfg.Members.Get(0).Model match {
+        case None()  => "member 0: no model (expected)"
+        case Some(m) => s"member 0: $m"
+    })
+    Println(cfg.Members.Get(1).Model match {
+        case Some(m) => s"member 1: $m"
+        case None()  => "member 1: no model"
+    })
+
+    // --- Regression: `.IsDefined()` / `.GetOrElse(...)` on
+    // `Immutable[Option[T]]` reached through a chained accessor
+    // (FIX-010 shape). The auto-unwrap codegen must dispatch through
+    // the Immutable wrapper before the method lookup.
+    Println(s"hasModel(0)=${cfg.Members.Get(0).Model.IsDefined()}")
+    Println(s"hasModel(1)=${cfg.Members.Get(1).Model.IsDefined()}")
+    Println(s"modelOr(0)=${cfg.Members.Get(0).Model.GetOrElse(\"<none>\")}")
+
+    // --- Regression: `.Size()` on `Immutable[Array[T]]` reached
+    // through a chained accessor (FIX-011 shape). cfg.Hooks.Get(0)
+    // returns `Immutable[Hook]`, .Args returns `Immutable[Array[string]]`,
+    // .Size() must auto-unwrap before dispatching the method.
+    Println(s"hook0.args.size=${cfg.Hooks.Get(0).Args.Size()}")
+
+    // --- Regression: 3-deep chain `cfgs.Get(N).Lead.Name` (FIX-012
+    // shape). The chain goes Cfg → Array[Cfg] → Cfg → Member → string,
+    // each traversed through Immutable wrappers. .Name on
+    // `Immutable[Member]` must resolve to the field's `Immutable[string]`
+    // and Go must accept a bare string literal at the Eq site.
+    val cfgs = multifile_lib_regress.LoadCfgs()
+    Println(s"cfgs(1).Lead=${cfgs.Get(1).Lead.Name}")
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -66,3 +66,12 @@ DispatchByOutcome ok counter=2
 DispatchByOutcome err counter=1
 true
 false
+first dispatch -> first
+second dispatch -> second
+member 0: no model (expected)
+member 1: opus-4
+hasModel(0)=false
+hasModel(1)=true
+modelOr(0)=<none>
+hook0.args.size=0
+cfgs(1).Lead=Theo

--- a/internal/transpiler/analyzer/cache.go
+++ b/internal/transpiler/analyzer/cache.go
@@ -41,6 +41,32 @@ const CacheVersion = "v1"
 // If empty, only CacheVersion is used (backward compatible).
 var CompilerVersion string
 
+// binarySelfHash returns a short content hash of the running gala binary.
+// It is used to invalidate the on-disk analysis cache automatically when the
+// compiler binary changes — critical for unstamped "dev" builds (Version="dev",
+// GitCommit="unknown") where CompilerVersion alone cannot distinguish between
+// compiler revisions. Without this, recompiling the transpiler does not bust
+// the cache, and cached metadata produced by an older analyzer can poison new
+// builds (e.g., a per-package pkgAST that was serialized before transitive
+// type-merge was introduced will still be loaded by a newer analyzer that
+// expects the merged form, producing "no typeMeta for collection_immutable.Array"
+// failures at the consumer side).
+//
+// Returns an empty string on any I/O failure; the caller treats the empty case
+// as "no extra invalidation key", which preserves the previous behaviour.
+var binarySelfHash = func() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	data, err := ioutil.ReadFile(exe)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])[:12]
+}()
+
 // CachedRichAST is the serializable subset of RichAST (no antlr.Tree).
 type CachedRichAST struct {
 	PackageName      string
@@ -98,6 +124,19 @@ type analysisCache struct {
 
 // newAnalysisCache creates a cache rooted at the given project directory.
 // Returns a disabled cache if the directory can't be created.
+//
+// The cache directory path embeds:
+//   - CacheVersion: bump on serialization-format changes.
+//   - CompilerVersion: when stamping is active (Version + "-" + GitCommit).
+//   - binarySelfHash: short hash of the gala binary itself, so unstamped "dev"
+//     builds also invalidate when the binary changes. Without this, the
+//     analyzer's serialized pkgAST from an older revision (e.g. before
+//     transitive-type-merge in scanImports) could outlive the binary upgrade
+//     and silently feed stale metadata to a newer transformer expecting the
+//     merged shape — producing failures like
+//     `firstD = NewImmutable(dirs.Get().Get(0))` typed as `Array[T]` instead
+//     of `T` because `collection_immutable.Array` had been pruned from the
+//     cached `directive` package's metadata.
 func newAnalysisCache(projectRoot string) *analysisCache {
 	if projectRoot == "" {
 		return &analysisCache{enabled: false}
@@ -105,6 +144,9 @@ func newAnalysisCache(projectRoot string) *analysisCache {
 	cacheDir := CacheVersion
 	if CompilerVersion != "" {
 		cacheDir = CacheVersion + "-" + CompilerVersion
+	}
+	if binarySelfHash != "" {
+		cacheDir = cacheDir + "-" + binarySelfHash
 	}
 	dir := filepath.Join(projectRoot, ".gala", "cache", cacheDir)
 	if err := os.MkdirAll(dir, 0755); err != nil {


### PR DESCRIPTION
## Summary

Closes a class of \"type metadata mysteriously missing\" failures in consumer projects: chained-accessor match subjects typed as \`Array[T]\` instead of \`T\`, \`.IsDefined()\` / \`.GetOrElse(...)\` undefined on \`Immutable[Option[T]]\`, \`.Size()\` undefined on \`Immutable[Array[T]]\`, and \`.Name\` undefined on \`Immutable[StructFromOtherPkg]\` reached through 2+ hops of \`.Get(N)\` / field access.

**Originally reported as**: gala_team 0.39.2 regressions FIX-003, FIX-008, FIX-009 (chained-accessor case), FIX-010, FIX-011, FIX-012.

**Category**: TRANSPILER_BUG (cache invalidation; not a logic bug)
**Priority**: P0 — silently produces wrong type metadata for consumer projects

## Root Cause

The analyzer's serialized per-package pkgAST is keyed by \`v1-{Version}\` where \`Version=\"dev\"\` for unstamped builds. Two compiler revisions sharing that key — one before transitive type merge in \`scanImports\` was added, one after — happily share the same \`v1-dev\` cache directory. A pkgAST that was originally serialized with only the package's own types (e.g. \`directive.Directive\` and its variants but not \`collection_immutable.Array\`) gets loaded as-is by the newer analyzer, which then expects to find \`Array.Get\` metadata when type-inferring \`dirs.Get(N)\` and silently falls through to returning the receiver type. Downstream this poisons val-decl type inference, match-IIFE subject typing, and all chained accessor auto-unwrap codegen — producing the six distinct symptoms reported.

## Fix

Extend the cache directory key with a 12-char SHA-256 prefix of the running gala binary's own bytes. Any rebuild of the transpiler produces a new key, so stale serializations from a prior revision are no longer visible to the new binary. The hash is computed once at package init via \`os.Executable()\` + \`sha256.Sum256\`; on I/O failure the function returns \"\" and the previous behaviour is preserved.

## Changes

- \`internal/transpiler/analyzer/cache.go\` — add \`binarySelfHash\` and incorporate into the cache directory key when non-empty.
- \`examples/multifile_lib_regress/directive_pkg/directive.gala\` (NEW) — sealed type + \`Parse(string) Array[Directive]\` mirroring gala_team's structural shape (cross-package generic receiver holding a sealed type from a dot-imported local package).
- \`examples/multifile_lib_regress/directive_chain.gala\` (NEW) — re-export helpers for the chained-accessor patterns.
- \`examples/multifile_lib_regress_test.gala\` / \`.out\` — exercise all six failing shapes (sealed match through Array.Get, Option[T] match through 2-deep chain, .IsDefined()/.GetOrElse() through Immutable[Option[T]], .Size() through Immutable[Array[T]], 3-deep field chain).
- \`examples/BUILD.bazel\` — register \`multifile_lib_regress_directive_pkg\`.

## Verification

- gala_team's \`parser_test.gala\` and \`team_config_test.gala\` compile cleanly without any of the typed-val workarounds reported in the verification report (sites at parser_test.gala:51-52, 159-160, 175, 210-211; team_config_test.gala:131-132, 245, 274, 281, 367, 374-375). The match-IIFE for \`dirs.Get(N) match { … }\` now spells its parameter \`func(obj directive.Directive) T\` instead of \`func(obj collection_immutable.Array[directive.Directive]) T\`.
- \`bazel build //...\` passes
- \`bazel test //...\` passes (322/322)

## Repro (before fix)

\`\`\`gala
// In a package that dot-imports another package's sealed type
val dirs = Parse(msg)        // Array[Directive] from collection_immutable + dot-imported Directive
dirs.Get(0) match {
    case Dispatch(name, _) => ...   // FAILS: Dispatch.Unapply expects Directive, gets Array[Directive]
    case _                  => ...
}

// And the cluster's other shapes
members.Get(0).Model.IsDefined()              // FAILS: undefined on Immutable[Option[string]]
pol.PreMerge.Get(0).Args.Size()               // FAILS: undefined on Immutable[Array[string]]
cfg.Teams.Get(1).Lead.Name                    // FAILS: undefined on Immutable[Member] (3-deep)
Eq(t, pol.PreMerge.Get(0).Name, \"notify\")     // FAILS: untyped string vs Immutable[string]
\`\`\`

All six fail because of the same underlying cache poisoning.

## Dependencies

None — independent fix on top of master.

## Battle Test Report Reference

Originally reported as Bugs 3, 8, 9 (chained-accessor case), and the three NEW \"Immutable doesn't auto-unwrap on chained access\" regressions documented in \`docs/private/GALA_TEAM_0_39_2_REGRESSIONS.md\` §3, §8, §9, §10, §11, §12.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)