### PR TITLE
test(examples): regression guard for multi-arg named-arg sealed-case widening

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2086,6 +2086,25 @@ gala_go_test(
     srcs = ["fix009_eq_literal_immutable.gala"],
 )
 
+# Multi-arg sealed-case constructor invoked with NAMED arguments must widen
+# to the parent sealed type at function-return position and call-arg
+# position. Single-arg named (`Failed(Reason = s)`) and positional multi-arg
+# (`Recovering(a, m)`) already widen; only the multi-arg + named-arg path
+# was failing.
+gala_library(
+    name = "fix013_named_arg_widen_lib",
+    srcs = ["fix013_named_arg_widen_lib/status.gala"],
+    importpath = "martianoff/gala/examples/fix013_named_arg_widen_lib",
+    visibility = ["//visibility:public"],
+)
+
+gala_test(
+    name = "fix013_named_arg_widen",
+    src = "fix013_named_arg_widen.gala",
+    expected = "fix013_named_arg_widen.out",
+    deps = [":fix013_named_arg_widen_lib"],
+)
+
 # Option.When and Unless factory constructors
 gala_test(
     name = "option_when",

--- a/examples/fix013_named_arg_widen.gala
+++ b/examples/fix013_named_arg_widen.gala
@@ -1,0 +1,40 @@
+package main
+
+// Multi-arg sealed-case constructor invoked with named arguments must widen
+// to the parent sealed type when used at function-return position and at
+// call-arg position. The single-arg named form and the positional multi-arg
+// form already widen; only the multi-arg + named-arg path was failing.
+
+import . "martianoff/gala/examples/fix013_named_arg_widen_lib"
+
+func makeRecovering(a int, m int) RecoveryStatus =
+    Recovering(Attempt = a, Max = m)
+
+func makeFailed(s string) RecoveryStatus =
+    Failed(Reason = s)
+
+func makeHelpWaiting(q string) RecoveryStatus =
+    HelpWaiting(Question = q)
+
+func describe(s RecoveryStatus) string = s match {
+    case Recovering(_, _) => "recovering"
+    case Failed(_)        => "failed"
+    case HelpWaiting(_)   => "help-waiting"
+    case Healthy          => "healthy"
+    case Idle             => "idle"
+    case Queued           => "queued"
+    case Working          => "working"
+    case Slow             => "slow"
+    case Stuck            => "stuck"
+}
+
+func recoveringDescription(a int, m int) string =
+    describe(Recovering(Attempt = a, Max = m))
+
+func main() {
+    Println(describe(makeRecovering(2, 5)))
+    Println(describe(makeFailed("boom")))
+    Println(describe(makeHelpWaiting("clarify?")))
+    Println(describe(Healthy()))
+    Println(recoveringDescription(3, 7))
+}

--- a/examples/fix013_named_arg_widen.out
+++ b/examples/fix013_named_arg_widen.out
@@ -1,0 +1,5 @@
+recovering
+failed
+help-waiting
+healthy
+recovering

--- a/examples/fix013_named_arg_widen_lib/status.gala
+++ b/examples/fix013_named_arg_widen_lib/status.gala
@@ -1,0 +1,18 @@
+package fix013_named_arg_widen_lib
+
+// Sealed type with multi-arg, single-arg, and zero-arg cases.
+// Mirrors a real-world Status enum with several no-paren cases, several
+// single-arg cases, and a multi-arg case. The multi-arg + named-arg
+// constructor at function-return position is the historically-failing
+// path this regression test guards.
+sealed type RecoveryStatus {
+    case Healthy
+    case Idle
+    case Queued
+    case Working
+    case Slow
+    case Stuck
+    case Recovering(Attempt int, Max int)
+    case HelpWaiting(Question string)
+    case Failed(Reason string)
+}


### PR DESCRIPTION
## Summary

Pins behavior for **FIX-013** (gala_team 0.39.2 regression Bug 13): multi-arg sealed-case constructed with **named** arguments at function-return position and call-arg position must widen to the parent sealed type. Single-arg named (\`Failed(Reason = s)\`) and positional multi-arg (\`Recovering(a, m)\`) already widened pre-fix; only the multi-arg + named-arg path was failing.

**Category**: TYPE_INFERENCE_BUG (regression guard only — bug already cleared)
**Priority**: P3 (guard)
**Found in**: \`gala_team/app/ui/update.gala::mkRecoveringStatus\` (data model has since been collapsed to single-arg as a workaround pivot, see comment block at line 913-921 of the original)

## Root Cause (per cluster diagnosis)

Same family as FIX-003/008/009-chained/010/011/012: a stale on-disk pkgAST cache at \`.gala/cache/v1-dev/\` produced by an older compiler revision was loaded by the newer analyzer with missing transitive type metadata, making sealed-case widening look broken at chained-accessor and named-arg sites. Closed by PR #306 (\`fix(analyzer): bust on-disk cache when gala binary content changes\`, merge SHA \`e7eea31\`).

## Verification

The synthetic regression mirrors the exact bug shape:
- Multi-arg sealed case in a separate package (\`examples/fix013_named_arg_widen_lib/status.gala\`)
- Dot-imported into the test driver
- Constructed with named args at function-return position: \`makeRecovering(a, m) RecoveryStatus = Recovering(Attempt = a, Max = m)\`
- Constructed with named args at call-arg position: \`describe(Recovering(Attempt = a, Max = m))\`
- Single-arg named (\`Failed(Reason = s)\`) and zero-arg cases also exercised

Tests pass on master post-#306. Without #306 (i.e., on a stale cache), the same test triggers \`cannot use Recovering as RecoveryStatus value\` style errors at the function-return and call-arg sites.

## Note on gala_team verification

gala_team has since pivoted the data model — \`case StRecovering(Note string)\` (single-arg) replaces the original \`StRecovering(Attempt int, Max int)\` (multi-arg). Reverting the data model in gala_team to re-test the exact original site would touch 5+ files (case decl + 4 match sites). This synthetic test in gala_simple stands as the canonical regression check going forward.

## Repro (before #306)

\`\`\`gala
sealed type RecoveryStatus {
    case Healthy
    case Recovering(Attempt int, Max int)
    case Failed(Reason string)
}

func makeRecovering(a int, m int) RecoveryStatus =
    Recovering(Attempt = a, Max = m)   // RED pre-#306: typed as Recovering, not RecoveryStatus

func recoveringDescription(a int, m int) string =
    describe(Recovering(Attempt = a, Max = m))   // RED pre-#306: same erasure at call-arg
\`\`\`

## Dependencies

None — independent regression-test-only branch.

## Battle Test Report Reference

Originally reported as Bug 13 in \`docs/private/GALA_TEAM_0_39_2_REGRESSIONS.md\` (workaround at \`gala_team/app/ui/update.gala\` lines 913-922).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)