### PR TITLE
fix(module): refuse multi-segment import path fallback to single-segment base-name match

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -50,6 +50,8 @@ filegroup(
         "multipackage_subpkg/main.gala",
         "multipackage_subpkg/state/state.gala",
         "newimmutable_nil.gala",
+        "sealed_done_state_pkg/state/helpers.gala",
+        "sealed_done_state_pkg/state/state.gala",
         "slice_unwrap/main.gala",
         "slice_unwrap/model.gala",
         "struct_field_unwrap/main.gala",
@@ -1324,6 +1326,28 @@ gala_test(
     src = "use_sealed_dot_import.gala",
     expected = "use_sealed_dot_import.out",
     deps = [":sealed_dot_import_lib"],
+)
+
+# Regression: a dot-imported sealed type whose first case is named `Done`
+# (with at least one field) must not be shadowed by an entry whose simple
+# name happens to be the sub-package name (`state`). Pattern
+# `case Done(body) =>` must resolve to the dot-imported sealed case
+# companion.
+gala_library(
+    name = "sealed_done_state_pkg",
+    srcs = [
+        "sealed_done_state_pkg/state/helpers.gala",
+        "sealed_done_state_pkg/state/state.gala",
+    ],
+    importpath = "martianoff/gala/examples/sealed_done_state_pkg/state",
+    visibility = ["//visibility:public"],
+)
+
+gala_test(
+    name = "use_sealed_done_state",
+    src = "use_sealed_done_state.gala",
+    expected = "use_sealed_done_state.out",
+    deps = [":sealed_done_state_pkg"],
 )
 
 # Multi-file Option test: Some/None in multi-file mode

--- a/examples/sealed_done_state_pkg/state/helpers.gala
+++ b/examples/sealed_done_state_pkg/state/helpers.gala
@@ -1,0 +1,10 @@
+package state
+
+// Sibling file forces a multi-file batch transpile, matching the original
+// reproduction shape.
+func DescribeStatus(s Status) string = s match {
+    case Done(body) => s"done($body)"
+    case Help()     => "help"
+    case Blocked()  => "blocked"
+    case Finished() => "finished"
+}

--- a/examples/sealed_done_state_pkg/state/state.gala
+++ b/examples/sealed_done_state_pkg/state/state.gala
@@ -1,0 +1,20 @@
+package state
+
+// Regression: a sealed type whose first non-trivial case is named
+// `Done(Body string)` lives in a sub-package literally named `state`
+// (i.e. the import path is `<...>/state` with `state` as the last segment).
+// A consumer that dot-imports this package and writes
+// `case Done(body) => ...` must resolve `Done` to this case companion,
+// not be silently routed to an unrelated namesake package elsewhere
+// in the workspace.
+sealed type Status {
+    case Done(Body string)
+    case Help
+    case Blocked
+    case Finished
+}
+
+func MakeDone(body string) Status = Done(body)
+func MakeHelp() Status            = Help()
+func MakeBlocked() Status         = Blocked()
+func MakeFinished() Status        = Finished()

--- a/examples/use_sealed_done_state.gala
+++ b/examples/use_sealed_done_state.gala
@@ -1,0 +1,26 @@
+package main
+
+// Regression: a sealed case named `Done(Body string)` lives in a
+// dot-imported sub-package whose final path segment is `state`. Pattern
+// matching on bare `case Done(body) =>` must resolve the case companion
+// from the package the consumer actually imported, not from any unrelated
+// sibling package elsewhere in the workspace that happens to share the
+// name `state`.
+
+import . "martianoff/gala/examples/sealed_done_state_pkg/state"
+
+func describe(s Status) string = s match {
+    case Done(body) => s"done($body)"
+    case Help()     => "help"
+    case Blocked()  => "blocked"
+    case Finished() => "finished"
+}
+
+func main() {
+    Println(describe(MakeDone("hello")))
+    Println(describe(MakeHelp()))
+    Println(describe(MakeBlocked()))
+    Println(describe(MakeFinished()))
+    // Also exercise the sibling-file match arm via DescribeStatus.
+    Println(DescribeStatus(MakeDone("again")))
+}

--- a/examples/use_sealed_done_state.out
+++ b/examples/use_sealed_done_state.out
@@ -1,0 +1,5 @@
+done(hello)
+help
+blocked
+finished
+done(again)

--- a/internal/transpiler/module/resolver.go
+++ b/internal/transpiler/module/resolver.go
@@ -201,16 +201,34 @@ func (r *Resolver) ResolvePackagePath(importPath string) (string, error) {
 	// Strategy 6: Recursive directory search — when the import path's directory name
 	// doesn't match the filesystem layout (e.g., importpath "martianoff/gala/crossfile"
 	// maps to "crossfile" but the actual directory is "examples/.../crossfile/").
-	// Search the module root and search paths for a directory whose name matches
-	// the last segment of the import path and contains .gala files.
-	pkgName := filepath.Base(importPath)
+	// Search the module root and search paths for a directory whose path matches
+	// the longest possible suffix of the import path and contains .gala files.
+	//
+	// Matching by longest suffix (rather than just the last segment) prevents a
+	// distinct package from accidentally claiming the lookup when two unrelated
+	// directories happen to share the same base name. For example,
+	// `examples/sealed_done_state_pkg/state` and `examples/multipackage_subpkg/state`
+	// both have base name `state`; matching only the base name picks whichever
+	// directory the walk visits first, surfacing as a confusing
+	// "extractor must define an Unapply method" error when the consumer tries
+	// to pattern-match a sealed case from the package it actually imported.
+	//
+	// For module-prefixed import paths, the relative-to-module-root portion is
+	// used as the suffix to match (the module name itself is not part of any
+	// real on-disk path). Other paths use the full import path as the suffix.
+	suffixPath := importPath
+	if r.moduleName != "" {
+		if rel, ok := hasModulePrefix(importPath, r.moduleName); ok {
+			suffixPath = rel
+		}
+	}
 	searchRoots := make([]string, 0, 1+len(r.searchPaths))
 	if r.moduleRoot != "" {
 		searchRoots = append(searchRoots, r.moduleRoot)
 	}
 	searchRoots = append(searchRoots, r.searchPaths...)
 	for _, root := range searchRoots {
-		if found := findPackageDirByName(root, pkgName); found != "" {
+		if found := findPackageDirByLongestSuffix(root, suffixPath); found != "" {
 			return found, nil
 		}
 	}
@@ -709,6 +727,110 @@ func findGalaModuleRoot(startPath string) (moduleRoot, moduleName string) {
 func isValidPackageDir(dirPath string) bool {
 	info, err := os.Stat(dirPath)
 	return err == nil && info.IsDir()
+}
+
+// findPackageDirByLongestSuffix walks root searching for a directory whose
+// trailing path segments match the longest possible suffix of importPath and
+// that contains at least one .gala file. Trying suffixes in decreasing length
+// disambiguates two directories that share a base name: an importpath of
+// "user/foo/bar" prefers a directory ending in "foo/bar" over a directory
+// ending in just "bar" elsewhere in the tree.
+//
+// When the import path has more than one segment, the search refuses to fall
+// back to matching only the final segment. A multi-segment path where every
+// multi-segment suffix is missing is almost certainly pointing at an entirely
+// different package than any unrelated namesake elsewhere in the tree, and
+// returning the namesake silently picks the wrong sources — which surfaces
+// downstream as a confusing
+// "extractor 'X' must define an Unapply method" error when the consumer tries
+// to pattern-match a sealed case that lives in the package they actually
+// imported.
+func findPackageDirByLongestSuffix(root, importPath string) string {
+	parts := splitImportPath(importPath)
+	// Stop one short of the single-segment fallback when the import path has
+	// more than one segment — see comment above.
+	stop := len(parts)
+	if len(parts) > 1 {
+		stop = len(parts) - 1
+	}
+	for i := 0; i < stop; i++ {
+		suffix := parts[i:]
+		if found := findPackageDirByPathSuffix(root, suffix); found != "" {
+			return found
+		}
+	}
+	return ""
+}
+
+// splitImportPath splits an import path into segments using forward slashes.
+func splitImportPath(importPath string) []string {
+	if importPath == "" {
+		return nil
+	}
+	return strings.Split(importPath, "/")
+}
+
+// findPackageDirByPathSuffix recursively searches under root for a directory
+// whose trailing path segments equal `suffix` and that contains at least one
+// .gala file. Returns the first match found, or empty string if none found.
+func findPackageDirByPathSuffix(root string, suffix []string) string {
+	if len(suffix) == 0 {
+		return ""
+	}
+	pkgName := suffix[len(suffix)-1]
+
+	skipDirs := map[string]bool{
+		"bazel-out": true, "bazel-bin": true, "bazel-testlogs": true,
+		".git": true, ".idea": true, ".ijwb": true, ".bazelbsp": true,
+		"node_modules": true, "external": true,
+	}
+
+	matchesSuffix := func(path string) bool {
+		// Walk up `path`'s components and verify the last len(suffix) segments
+		// equal suffix.
+		segs := strings.Split(filepath.ToSlash(path), "/")
+		if len(segs) < len(suffix) {
+			return false
+		}
+		for i := range suffix {
+			if segs[len(segs)-len(suffix)+i] != suffix[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	var walk func(dir string) string
+	walk = func(dir string) string {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return ""
+		}
+		for _, e := range entries {
+			path := filepath.Join(dir, e.Name())
+
+			isDir := e.IsDir()
+			if !isDir {
+				if info, err := os.Stat(path); err == nil {
+					isDir = info.IsDir()
+				}
+			}
+			if !isDir {
+				continue
+			}
+			if skipDirs[e.Name()] {
+				continue
+			}
+			if e.Name() == pkgName && matchesSuffix(path) && hasGalaFiles(path) {
+				return path
+			}
+			if found := walk(path); found != "" {
+				return found
+			}
+		}
+		return ""
+	}
+	return walk(root)
 }
 
 // findPackageDirByName recursively searches under root for a directory whose base name

--- a/internal/transpiler/module/resolver_test.go
+++ b/internal/transpiler/module/resolver_test.go
@@ -519,3 +519,57 @@ func TestResolver_PrefersSearchPathGoModOverCwdGoMod(t *testing.T) {
 	assert.Equal(t, galaModuleDir, resolver.ModuleRoot(),
 		"moduleRoot must be the search path's go.mod directory, not the consumer's execroot")
 }
+
+// TestResolver_ResolvePackagePath_MultiSegmentDoesNotCollapseToSingleSegment
+// pins the regression where two distinct multi-segment import paths shared the
+// same final directory name. The recursive fallback in Strategy 6 used to match
+// only the last segment, so a request for `mod/foo/state` could be answered with
+// `mod/bar/state` whenever the actual `mod/foo/state` directory was missing
+// from the test sandbox. The consumer then loaded the namesake's metadata and
+// any unrelated sealed cases (e.g. `Done(Body string)`) would surface as
+// `extractor 'Done' must define an Unapply method` because the right package's
+// types were never registered.
+func TestResolver_ResolvePackagePath_MultiSegmentDoesNotCollapseToSingleSegment(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "resolver_multi_segment_test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	goModContent := "module martianoff/gala\n\ngo 1.22\n"
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "go.mod"), []byte(goModContent), 0644))
+
+	// Create a NAMESAKE package at examples/other/state/state.gala — the
+	// directory whose base name matches the import path's last segment but
+	// is at the wrong location.
+	otherDir := filepath.Join(tempDir, "examples", "other", "state")
+	require.NoError(t, os.MkdirAll(otherDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(otherDir, "state.gala"), []byte("package state\n"), 0644))
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(originalWd)
+	require.NoError(t, os.Chdir(tempDir))
+
+	resolver := NewResolver([]string{tempDir})
+
+	// The requested package `examples/wanted/state` is not on disk. The
+	// resolver MUST NOT degrade to matching just `state` and silently return
+	// the namesake under `examples/other/state`.
+	_, resolveErr := resolver.ResolvePackagePath("martianoff/gala/examples/wanted/state")
+	assert.Error(t, resolveErr,
+		"resolver must refuse to fall back to a single-segment match when the multi-segment import path has no actual directory at the expected location")
+
+	// Sanity: a SINGLE-segment import path that has no exact match still uses
+	// the recursive fallback (this is the bazel-importpath shape that Strategy 6
+	// is intended for).
+	pathOnly, err := resolver.ResolvePackagePath("state")
+	require.NoError(t, err)
+	assert.Equal(t, otherDir, pathOnly,
+		"single-segment import path should still use the recursive name match")
+
+	// Sanity: a multi-segment import path whose suffix matches a real on-disk
+	// path of two or more segments resolves correctly.
+	pathTwoSeg, err := resolver.ResolvePackagePath("martianoff/gala/examples/other/state")
+	require.NoError(t, err)
+	assert.Equal(t, otherDir, pathTwoSeg,
+		"multi-segment import path with a real two-segment suffix match should resolve to that directory")
+}


### PR DESCRIPTION
## Summary

Closes **FIX-014**: pattern \`case Done(body) => ...\` failed with \`[GALA-E0005] extractor 'Done' must define an Unapply method\` even when \`Done\` was correctly declared as a sealed case in the user's package. Other one-word case names (\`Help\`, \`Blocked\`, \`Finished\`, \`Summary\`, \`Dispatch\`) worked fine — only \`Done\` collided.

**Category**: TRANSPILER_BUG (module / package-path resolver)
**Priority**: P1 — silent misresolution produces misleading error against user code
**Found in**: \`gala_team/app/directive/parser.gala\` (worked-around by renaming \`Done\` → \`Finished\`)

## Root Cause

Not a \`Done\` name collision in any internal resolver entry — and not specific to \`Done\` at all. It just happened that \`gala_team\`'s \`app/directive\` package was the trigger because of how its directory layout interacted with \`ResolvePackagePath\`'s recursive fallback.

\`internal/transpiler/module/resolver.go\` Strategy 6 (recursive directory search) walked the workspace looking for any directory whose base name matched the **last segment** of the requested import path. When two \`package state\` packages existed at different paths in the workspace, a request for \`martianoff/gala/examples/sealed_done_state_pkg/state\` whose primary Strategy 1 location was absent (partial test sandbox) was silently answered with \`examples/multipackage_subpkg/state\` (a different namesake). The consumer loaded the wrong package's types — none of which contained the sealed \`Done\` case — so the case-pattern lookup failed with \`extractor 'Done' must define an Unapply method\` even though the case was correctly declared in the user's actual \`state\` package.

## Fix

When the import path has more than one segment, the recursive fallback in \`ResolvePackagePath\` no longer degrades to a single-segment base-name match. Suffixes are tried in decreasing length, but the loop stops one step short of the bare last segment.

Single-segment import paths (bare type/package names like \`std\`, \`time_utils\`) still use the base-name fallback — that's the original case Strategy 6 was written for (bazel-importpath-vs-filesystem-layout mismatches).

## Changes

- \`internal/transpiler/module/resolver.go\` — Strategy 6 fallback now refuses to collapse multi-segment paths to single-segment base-name matches.
- \`internal/transpiler/module/resolver_test.go\` — new unit test \`TestResolver_ResolvePackagePath_MultiSegmentDoesNotCollapseToSingleSegment\`.
- \`examples/sealed_done_state_pkg/state/\` — new sealed type with \`Done(Body string)\` consumed by \`examples/use_sealed_done_state.gala\`. Picked up by \`TestCompilationGate\` (single-file analyzer harness) which is where the bug originally surfaced.

## Verification

- \`bazel build //...\` clean
- \`bazel test //...\` 323/323 pass (the new regression example is part of the suite)
- New \`TestResolver_ResolvePackagePath_MultiSegmentDoesNotCollapseToSingleSegment\` covers the resolver path directly.

## Repro (before fix)

\`\`\`gala
// In a package that's referenced by a multi-segment import path
sealed type Status {
    case Done(Body string)
    case Help
    case Blocked
}

// Consumer dot-imports the above; another \`state\` package exists elsewhere in the workspace.
import . "martianoff/gala/examples/sealed_done_state_pkg/state"

match d {
    case Done(body) => ...   // FAILS: \`extractor 'Done' must define an Unapply method\`
    case Help       => ...   // (not reached)
}
\`\`\`

The error is misleading — it points at \`Done\`, but the actual problem is that the resolver loaded the wrong \`state\` package (one without \`Done\`).

## Dependencies

None — independent fix on top of master.

## Battle Test Report Reference

Originally reported as Bug 14 in \`docs/private/GALA_TEAM_0_39_2_REGRESSIONS.md\`. Note: the report's framing ("\`Done\` collides with internal \`state.Done\` resolver entry") was a reasonable hypothesis based on the symptom — the actual cause was the resolver picking up an unrelated workspace-side \`state\` package because of the base-name fallback collapse.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)