### PR TITLE
fix(transpiler): support Array/List/HashMap of structs in Codec[T]

### DIFF
--- a/docs/EXAMPLES.MD
+++ b/docs/EXAMPLES.MD
@@ -591,31 +591,74 @@ hello
 ```gala
 package main
 
-import . "martianoff/gala/std"
+import (
+    . "martianoff/gala/std"
+    . "martianoff/gala/json"
+    . "martianoff/gala/collection_immutable"
+)
 
-type Person struct {
-    var Name string
-    var Age  int
-}
+struct Tag(Key string, Color string)
+struct User(Name string, Tags Array[Tag])
 
 func main() {
-    val person = Person{Name: "Alice", Age: 30}
-    val jsonStr = JsonStringify(person).Get()
+    val codec = Codec[User](SnakeCase())
+
+    val tags = EmptyArray[Tag]().Append(Tag("urgent", "red"))
+    val user = User("alice", tags)
+
+    val jsonStr = codec.Encode(user).Get()
     Println(jsonStr)
 
-    // Pattern matching with Json extractor
-    val result = jsonStr match {
-        case Json[Person](p) => s"Matched: ${p.Name}, age ${p.Age}"
-        case _ => "no match"
+    // Pattern matching extractor: case fails (no panic) if decode fails.
+    val msg = jsonStr match {
+        case codec(u) => s"Matched: ${u.Name}, ${u.Tags.Get(0).Key}"
+        case _        => "no match"
     }
-    Println(result)
+    Println(msg)
 }
 ```
 
 Output:
 ```
-{"Name":"Alice","Age":30}
-Matched: Alice, age 30
+{"name":"alice","tags":[{"key":"urgent","color":"red"}]}
+Matched: alice, urgent
+```
+
+## YAML Serialization
+
+```gala
+package main
+
+import (
+    . "martianoff/gala/std"
+    . "martianoff/gala/yaml"
+    . "martianoff/gala/collection_immutable"
+)
+
+struct Tag(Key string, Color string)
+struct User(Name string, Tags Array[Tag])
+
+func main() {
+    val codec = Codec[User](SnakeCase())
+
+    val tags = EmptyArray[Tag]().Append(Tag("urgent", "red"))
+    val user = User("alice", tags)
+
+    val yamlStr = codec.Encode(user).Get()
+    Println(yamlStr)
+
+    val decoded = codec.Decode(yamlStr).Get()
+    Println(s"first tag: ${decoded.Tags.Get(0).Key}/${decoded.Tags.Get(0).Color}")
+}
+```
+
+Output:
+```
+name: alice
+tags:
+  - key: urgent
+    color: red
+first tag: urgent/red
 ```
 
 ## Regex Pattern Matching

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -30,6 +30,7 @@ GALA (Go Alternative LAnguage) is a modern programming language that transpiles 
    - [Try Monad](#try-monad)
    - [Future Monad](#future-monad)
    - [Json](#json)
+   - [Yaml](#yaml)
    - [Regex](#regex)
    - [IO Effect](#io-effect)
    - [Slices](#slices)
@@ -1586,6 +1587,57 @@ val codec = json.Codec[Person](json.SnakeCase())
 | `.Decode(s)` | `string → Try[T]` | Deserialize from JSON |
 | `.Unapply(s)` | `string → Option[T]` | Pattern matching extractor |
 
+#### Nested Structures and Unknown Fields
+
+`Codec[T]` handles nested struct fields including `Array[Struct]`, `List[Struct]`, `HashMap[string, Struct]`, and combinations such as `Array[Array[Struct]]`. The transpiler discovers reachable structs transitively (including across packages), and the naming strategy propagates into nested fields automatically.
+
+```gala
+struct Tag(Key string, Color string)
+struct User(Name string, Tags Array[Tag])
+
+val codec = Codec[User](SnakeCase())
+val tags = EmptyArray[Tag]().Append(Tag("urgent", "red"))
+val user = User("alice", tags)
+codec.Encode(user).Get()
+// => {"name":"alice","tags":[{"key":"urgent","color":"red"}]}
+```
+
+The decoder silently drops fields that are not declared on the target struct — there is no strict mode. See the website [Json docs](https://martianov.dev/docs/json/) for the long-form treatment.
+
+### Yaml
+
+The `yaml` package mirrors `json` exactly: same builder API, same auto-injected `StructMeta[T]`, same `Encode` / `Decode` / `Unapply` surface. The only difference is the emitted format — block-style YAML instead of JSON. Located in the `yaml` package.
+
+```gala
+import . "martianoff/gala/yaml"
+
+struct Person(FirstName string, LastName string, Age int)
+
+val codec = Codec[Person](SnakeCase())
+
+val yamlStr = codec.Encode(Person("Alice", "Smith", 30)).Get()
+// =>
+// first_name: Alice
+// last_name: Smith
+// age: 30
+
+val decoded = codec.Decode(yamlStr)  // Try[Person]
+
+// Pattern matching extractor
+val msg = yamlStr match {
+    case codec(p) => s"Hello ${p.FirstName}"
+    case _ => "invalid"
+}
+```
+
+Builder methods (`Naming`, `Omit`, `Rename`, `OmitEmpty`), naming strategies (`AsIs`, `CamelCase`, `SnakeCase`, `KebabCase`), nested struct collections, and the silent-drop behaviour for unknown fields all match the JSON codec — see the [Json](#json) section for details. There is no `EncodePretty` for YAML; block-style output is already readable.
+
+#### Supported YAML Subset
+
+The codec covers a focused subset: block-style mappings, block-style sequences, scalars (`string`, `int`, `float`, `bool`, `null`), literal block scalars (`|`), comments, and nested structures. Out of scope: anchors, aliases, flow style, custom tags.
+
+See the website [Yaml docs](https://martianov.dev/docs/yaml/) for the long-form treatment.
+
 ### StructMeta — Compile-Time Struct Introspection
 
 `StructMeta[T]` is a compiler intrinsic that provides zero-reflection, type-safe access to struct fields. It is the foundation for building codecs and any code that needs to inspect struct layout at compile time.
@@ -1602,7 +1654,7 @@ The transpiler generates a specialised struct (`_StructMeta_Person`) that satisf
 
 #### Auto-Injection
 
-When a generic type's `Apply` method declares its first parameter as `StructMeta[T]` (the typed interface in `std/meta.gala`), the transpiler auto-generates and injects the appropriate `_StructMeta_T{}` value. This is how `Codec[Person](SnakeCase())` works — the user never needs to write `StructMeta[Person]()` explicitly. `Codec[T]` itself is implemented as a pure GALA library (`std/json/codec.gala`) built on top of the neutral `FieldEncoder` / `FieldDecoder` interfaces from `std/meta.gala`; the transpiler carries no JSON-specific knowledge.
+When a generic type's `Apply` method declares its first parameter as `StructMeta[T]` (the typed interface in `std/meta.gala`), the transpiler auto-generates and injects the appropriate `_StructMeta_T{}` value. This is how `Codec[Person](SnakeCase())` works — the user never needs to write `StructMeta[Person]()` explicitly. `Codec[T]` itself is implemented as a pure GALA library (`json/json.gala`, with the `yaml` package as its YAML twin) built on top of the neutral `FieldEncoder` / `FieldDecoder` interfaces from `std/meta.gala`; the transpiler carries no format-specific knowledge.
 
 #### Building Custom Codecs
 
@@ -1633,8 +1685,8 @@ Then create a codec type with an `Apply(meta StructMeta[T], ...)` method — the
 |--------|-----------|-------------|
 | `NumFields` | `() int` | Number of fields in the struct |
 | `FieldName` | `(i int) string` | Name of field at index i |
-| `EncodeFields` | `(w FieldEncoder, t T, nameFn func(int) string, omitFn func(int) bool)` | Typed serialise of a T via the writer interface |
-| `DecodeFields` | `(r FieldDecoder, lookup func(string) int) T` | Typed construct of a T via the reader interface |
+| `EncodeFields` | `(w FieldEncoder, t T, nameFn func(int) string, omitFn func(int) bool, naming func(string) string)` | Typed serialise of a T via the writer interface; `naming` propagates into nested struct dispatch |
+| `DecodeFields` | `(r FieldDecoder, lookup func(string) int, naming func(string) string) T` | Typed construct of a T via the reader interface; `naming` propagates into nested struct dispatch |
 
 ### Regex
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -633,6 +633,57 @@ gala_test(
     ],
 )
 
+gala_test(
+    name = "json_codec_array_of_structs",
+    src = "json_codec_array_of_structs.gala",
+    expected = "json_codec_array_of_structs.out",
+    deps = [
+        "//collection_immutable",
+        "//json",
+    ],
+)
+
+gala_test(
+    name = "yaml_codec_array_of_structs",
+    src = "yaml_codec_array_of_structs.gala",
+    expected = "yaml_codec_array_of_structs.out",
+    deps = [
+        "//collection_immutable",
+        "//yaml",
+    ],
+)
+
+gala_test(
+    name = "yaml_codec_collections",
+    src = "yaml_codec_collections.gala",
+    expected = "yaml_codec_collections.out",
+    deps = [
+        "//collection_immutable",
+        "//yaml",
+    ],
+)
+
+# Cross-package nested struct codec: parent in main, inner struct in a
+# sibling package — exercises the recursive _StructMeta_X{} lookup
+# across module boundaries.
+gala_library(
+    name = "json_codec_cross_pkg_inner",
+    srcs = ["json_codec_cross_pkg/inner/inner.gala"],
+    importpath = "martianoff/gala/examples/json_codec_cross_pkg/inner",
+    visibility = ["//visibility:public"],
+)
+
+gala_test(
+    name = "json_codec_cross_pkg",
+    src = "json_codec_cross_pkg/main.gala",
+    expected = "json_codec_cross_pkg/main.out",
+    deps = [
+        "//collection_immutable",
+        "//json",
+    ],
+    gala_deps = [":json_codec_cross_pkg_inner"],
+)
+
 # Temporarily enabled for debugging
 gala_test(
     name = "try_recovery",

--- a/examples/json_codec_array_of_structs.gala
+++ b/examples/json_codec_array_of_structs.gala
@@ -1,0 +1,25 @@
+package main
+
+import (
+    . "martianoff/gala/std"
+    . "martianoff/gala/json"
+    . "martianoff/gala/collection_immutable"
+)
+
+// Repro for Codec[T]: Array[Struct] / List[Struct] / HashMap[string, Struct].
+// Mirrors the claude stream-json shape: assistant message wraps a list of
+// content parts.  Before the fix, the Array[Part] field was silently
+// skipped on decode and the array always ended up empty.
+
+struct Part(Type string, Text string)
+struct Msg(Content Array[Part])
+struct Wrap(Type string, Message Msg)
+
+func main() {
+    val codec = Codec[Wrap](SnakeCase())
+    val raw = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}"
+    val decoded = codec.Decode(raw).Get()
+    Println(s"type=${decoded.Type}")
+    Println(s"content size=${decoded.Message.Content.Size()}")
+    Println(s"first text=${decoded.Message.Content.Get(0).Text}")
+}

--- a/examples/json_codec_array_of_structs.out
+++ b/examples/json_codec_array_of_structs.out
@@ -1,0 +1,3 @@
+type=assistant
+content size=1
+first text=hello

--- a/examples/json_codec_collections.out
+++ b/examples/json_codec_collections.out
@@ -1,1 +1,13 @@
 {"name":"alice","tags":["go","gala"],"labels":{"role":"admin"}}
+{"title":"Demo","score":42,"tags":[{"key":"urgent","color":"red"},{"key":"draft","color":"yellow"}],"meta":{"hot":{"key":"urgent","color":"red"}}}
+item.title=Demo score=42
+item.tags.size=2 first=urgent/red
+item.meta[hot]=urgent/red
+item round-trip equal=true
+{"name":"Bread","steps":[{"order":1,"note":"mix"},{"order":2,"note":"bake"}]}
+recipe.steps.size=2
+recipe round-trip equal=true
+{"rows":[[{"value":1,"tag":"a"},{"value":2,"tag":"b"}],[{"value":3,"tag":"c"}]]}
+grid.rows.size=2
+grid.rows[0].size=2 first=1/a
+grid round-trip equal=true

--- a/examples/json_codec_cross_pkg/inner/inner.gala
+++ b/examples/json_codec_cross_pkg/inner/inner.gala
@@ -1,0 +1,3 @@
+package inner
+
+struct Part(Type string, Text string)

--- a/examples/json_codec_cross_pkg/main.gala
+++ b/examples/json_codec_cross_pkg/main.gala
@@ -1,0 +1,24 @@
+package main
+
+import (
+    . "martianoff/gala/std"
+    . "martianoff/gala/json"
+    . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/examples/json_codec_cross_pkg/inner"
+)
+
+// Cross-package nested struct codec: parent (Wrap) is in main, inner
+// (Part) is in a sibling package.  Acceptance criterion #6 from
+// FIX-025 — codec recursion works across module boundaries.
+
+struct Msg(Content Array[Part])
+struct Wrap(Type string, Message Msg)
+
+func main() {
+    val codec = Codec[Wrap](SnakeCase())
+    val raw = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}"
+    val decoded = codec.Decode(raw).Get()
+    Println(s"type=${decoded.Type}")
+    Println(s"content size=${decoded.Message.Content.Size()}")
+    Println(s"first text=${decoded.Message.Content.Get(0).Text}")
+}

--- a/examples/json_codec_cross_pkg/main.out
+++ b/examples/json_codec_cross_pkg/main.out
@@ -1,0 +1,3 @@
+type=assistant
+content size=1
+first text=hello

--- a/examples/json_codec_new.gala
+++ b/examples/json_codec_new.gala
@@ -26,7 +26,8 @@ func main() {
     val w = NewJsonEncoder()
     val nameFn = (i int) => meta.FieldName(i)
     val omitFn = (i int) => false
-    meta.EncodeFields(w, p, nameFn, omitFn)
+    val naming = (n string) => n
+    meta.EncodeFields(w, p, nameFn, omitFn, naming)
     Println(w.String())
 
     // Decode via the new typed path: reverse-lookup from field name → index.
@@ -43,7 +44,7 @@ func main() {
         }
         return -1
     }
-    val decoded = meta.DecodeFields(r, lookup)
+    val decoded = meta.DecodeFields(r, lookup, naming)
     // Fields default to Immutable[T]; .Get() unwraps to the raw value.
     Println(s"decoded: X=${decoded.X.Get()} Y=${decoded.Y.Get()} Label=${decoded.Label.Get()}")
 }

--- a/examples/json_codec_option.gala
+++ b/examples/json_codec_option.gala
@@ -16,11 +16,12 @@ func main() {
     val meta = StructMeta[User]()
     val nameFn = (i int) => meta.FieldName(i)
     val omitFn = (i int) => false
+    val naming = (n string) => n
 
     // --- case 1: Some fields round-trip ---
     val u1 = User("alice", Some("ally"), Some(30))
     val w1 = NewJsonEncoder()
-    meta.EncodeFields(w1, u1, nameFn, omitFn)
+    meta.EncodeFields(w1, u1, nameFn, omitFn, naming)
     Println(w1.String())
 
     val r1 = NewJsonDecoder(w1.String())
@@ -36,18 +37,18 @@ func main() {
         }
         return -1
     }
-    val d1 = meta.DecodeFields(r1, lookup)
+    val d1 = meta.DecodeFields(r1, lookup, naming)
     Println(s"d1.Nickname.IsDefined=${d1.Nickname.Get().IsDefined()} value=${d1.Nickname.Get().GetOrElse("")}")
     Println(s"d1.Age.IsDefined=${d1.Age.Get().IsDefined()} value=${d1.Age.Get().GetOrElse(0)}")
 
     // --- case 2: None fields round-trip ---
     val u2 = User("bob", None[string](), None[int]())
     val w2 = NewJsonEncoder()
-    meta.EncodeFields(w2, u2, nameFn, omitFn)
+    meta.EncodeFields(w2, u2, nameFn, omitFn, naming)
     Println(w2.String())
 
     val r2 = NewJsonDecoder(w2.String())
-    val d2 = meta.DecodeFields(r2, lookup)
+    val d2 = meta.DecodeFields(r2, lookup, naming)
     Println(s"d2.Nickname.IsDefined=${d2.Nickname.Get().IsDefined()}")
     Println(s"d2.Age.IsDefined=${d2.Age.Get().IsDefined()}")
 }

--- a/examples/yaml_codec_array_of_structs.gala
+++ b/examples/yaml_codec_array_of_structs.gala
@@ -1,0 +1,33 @@
+package main
+
+import (
+    . "martianoff/gala/std"
+    . "martianoff/gala/yaml"
+    . "martianoff/gala/collection_immutable"
+)
+
+// YAML twin of json_codec_array_of_structs.gala — same shape (Wrap → Msg →
+// Array[Part]) round-tripped through the YAML codec.  The fix to
+// genTypedRead / genCollectionWrite / genHashMapWrite in
+// codec_typed.go is shared between formats via the std.FieldEncoder /
+// std.FieldDecoder interface, so a single transpiler change lights up
+// both JSON and YAML codecs.
+
+struct Part(Type string, Text string)
+struct Msg(Content Array[Part])
+struct Wrap(Type string, Message Msg)
+
+func main() {
+    val codec = Codec[Wrap](SnakeCase())
+    val part = Part("text", "hello")
+    val parts = EmptyArray[Part]().Append(part)
+    val msg = Msg(parts)
+    val w = Wrap("assistant", msg)
+    val encoded = codec.Encode(w).Get()
+    Println(encoded)
+    val decoded = codec.Decode(encoded).Get()
+    Println(s"type=${decoded.Type}")
+    Println(s"content size=${decoded.Message.Content.Size()}")
+    Println(s"first text=${decoded.Message.Content.Get(0).Text}")
+    Println(s"round-trip equal=${w.Equal(decoded)}")
+}

--- a/examples/yaml_codec_array_of_structs.out
+++ b/examples/yaml_codec_array_of_structs.out
@@ -1,0 +1,9 @@
+type: assistant
+message:
+  content:
+    - type: text
+      text: hello
+type=assistant
+content size=1
+first text=hello
+round-trip equal=true

--- a/examples/yaml_codec_collections.gala
+++ b/examples/yaml_codec_collections.gala
@@ -2,27 +2,18 @@ package main
 
 import (
     . "martianoff/gala/std"
-    . "martianoff/gala/json"
+    . "martianoff/gala/yaml"
     . "martianoff/gala/collection_immutable"
 )
 
-// Extended Codec[T] coverage: struct fields of Array / HashMap shapes,
-// including Array[Struct], List[Struct], HashMap[string, Struct], and
-// Array[Array[Struct]] (double nesting).  Round-trip property: for every
-// value v, Codec[T].Decode(Codec[T].Encode(v).Get()).Get() == v (the
-// generated Equal method handles immutable-wrapped fields).
-//
-// Naming config (SnakeCase) propagates into the inner struct's
-// field-name resolution: nested fields are also serialised in
-// snake_case and looked up by the same convention on decode.
+// YAML twin of json_codec_collections.gala — same shapes (Array[Struct],
+// List[Struct], HashMap[string, Struct], Array[Array[Struct]], mixed
+// primitive + struct fields), same round-trip property, exercised
+// through the YAML codec.  The transpiler's codegen is format-agnostic
+// (writes through std.FieldEncoder / std.FieldDecoder), so the JSON
+// fix lights up YAML at the same time — this file is the explicit
+// proof.
 
-struct Profile(
-    Name string,
-    Tags Array[string],
-    Labels HashMap[string, string],
-)
-
-// Array[Struct] / HashMap[string, Struct] / mixed-primitives parent.
 struct Tag(Key string, Color string)
 struct Item(
     Title string,
@@ -31,23 +22,14 @@ struct Item(
     Meta HashMap[string, Tag],
 )
 
-// List[Struct] case (List uses the same FromSlice constructor under the hood).
 struct Step(Order int, Note string)
 struct Recipe(Name string, Steps List[Step])
 
-// Double-nested: Array[Array[Struct]].
 struct Cell(Value int, Tag string)
 struct Grid(Rows Array[Array[Cell]])
 
 func main() {
-    // --- 1) Primitive collections (legacy, still works) ---
-    val codec = Codec[Profile](SnakeCase())
-    val tags = EmptyArray[string]().Append("go").Append("gala")
-    val labels = EmptyHashMap[string, string]().Put("role", "admin")
-    val p = Profile("alice", tags, labels)
-    Println(codec.Encode(p).Get())
-
-    // --- 2) Array[Struct] + HashMap[string, Struct] + mixed primitives ---
+    // --- 1) Array[Struct] + HashMap[string, Struct] + mixed primitives ---
     val itemCodec = Codec[Item](SnakeCase())
     val tag1 = Tag("urgent", "red")
     val tag2 = Tag("draft", "yellow")
@@ -63,7 +45,7 @@ func main() {
     Println(s"item.meta[hot]=${hot.Key}/${hot.Color}")
     Println(s"item round-trip equal=${item.Equal(itemDecoded)}")
 
-    // --- 3) List[Struct] ---
+    // --- 2) List[Struct] ---
     val recipeCodec = Codec[Recipe](SnakeCase())
     val steps = EmptyList[Step]().Append(Step(1, "mix")).Append(Step(2, "bake"))
     val recipe = Recipe("Bread", steps)
@@ -73,7 +55,7 @@ func main() {
     Println(s"recipe.steps.size=${recipeDecoded.Steps.Length()}")
     Println(s"recipe round-trip equal=${recipe.Equal(recipeDecoded)}")
 
-    // --- 4) Array[Array[Struct]] (double nesting) ---
+    // --- 3) Array[Array[Struct]] (double nesting) ---
     val gridCodec = Codec[Grid](SnakeCase())
     val row0 = EmptyArray[Cell]().Append(Cell(1, "a")).Append(Cell(2, "b"))
     val row1 = EmptyArray[Cell]().Append(Cell(3, "c"))

--- a/examples/yaml_codec_collections.out
+++ b/examples/yaml_codec_collections.out
@@ -1,0 +1,35 @@
+title: Demo
+score: 42
+tags:
+  - key: urgent
+    color: red
+  - key: draft
+    color: yellow
+meta:
+  hot:
+    key: urgent
+    color: red
+item.title=Demo score=42
+item.tags.size=2 first=urgent/red
+item.meta[hot]=urgent/red
+item round-trip equal=true
+name: Bread
+steps:
+  - order: 1
+    note: mix
+  - order: 2
+    note: bake
+recipe.steps.size=2
+recipe round-trip equal=true
+rows:
+  -
+    - value: 1
+      tag: a
+    - value: 2
+      tag: b
+  -
+    - value: 3
+      tag: c
+grid.rows.size=2
+grid.rows[0].size=2 first=1/a
+grid round-trip equal=true

--- a/internal/transpiler/transformer/codec.go
+++ b/internal/transpiler/transformer/codec.go
@@ -69,10 +69,110 @@ func (t *galaASTTransformer) transformStructMetaConstruction(fun ast.Expr, line,
 // ---- code generation ----
 
 // finalizeCodecs generates all StructMeta Go declarations.
+//
+// Before codegen runs we close over the set of nested struct types
+// reachable from the registered top-level metas — every field whose
+// (unwrapped) type is itself a struct, including struct elements inside
+// Array/List/HashMap, gets its own _StructMeta_X registered so the
+// recursive EncodeFields/DecodeFields dispatch in codec_typed.go can
+// find it.  The walk is a simple worklist fixpoint.
 func (t *galaASTTransformer) finalizeCodecs(file *ast.File) {
+	t.expandNestedStructMetas()
 	for _, config := range t.structMetas {
 		decls := t.generateStructMetaDecls(config)
 		file.Decls = append(file.Decls, decls...)
+	}
+}
+
+// expandNestedStructMetas walks every registered StructMeta config's fields
+// and registers fresh entries for any nested struct types that we have
+// metadata for.  Repeats until the set is closed.
+func (t *galaASTTransformer) expandNestedStructMetas() {
+	worklist := make([]string, 0, len(t.structMetas))
+	for genName := range t.structMetas {
+		worklist = append(worklist, genName)
+	}
+	for len(worklist) > 0 {
+		genName := worklist[0]
+		worklist = worklist[1:]
+		config, ok := t.structMetas[genName]
+		if !ok || config.typeMetadata == nil {
+			continue
+		}
+		for _, fieldName := range config.typeMetadata.FieldNames {
+			fieldType := config.typeMetadata.Fields[fieldName]
+			added := t.registerNestedStructMetaForType(fieldType)
+			worklist = append(worklist, added...)
+		}
+	}
+}
+
+// registerNestedStructMetaForType registers a _StructMeta_X for any struct
+// type reachable through the given field type's container layers
+// (Immutable, Option, Array, List, HashMap value).  Returns the list of
+// freshly-registered generated names so the caller can keep walking.
+func (t *galaASTTransformer) registerNestedStructMetaForType(fieldType transpiler.Type) []string {
+	var added []string
+	t.collectNestedStructTypeNames(fieldType, func(name string) {
+		genName := "_StructMeta_" + name
+		if _, exists := t.structMetas[genName]; exists {
+			return
+		}
+		typeMeta, resolved := t.getTypeMetaResolved(name)
+		if typeMeta == nil || len(typeMeta.FieldNames) == 0 {
+			return
+		}
+		t.structMetas[genName] = &structMetaConfig{
+			typeName:      name,
+			typeMetadata:  typeMeta,
+			generatedName: genName,
+			resolvedName:  resolved,
+		}
+		t.registerStructMetaTypeMeta(genName, name)
+		added = append(added, genName)
+	})
+	return added
+}
+
+// collectNestedStructTypeNames invokes `cb` for every potentially-struct
+// named type reachable from `ty` by unwrapping Immutable/Option and
+// stepping into Array/List element + HashMap value parameters.
+func (t *galaASTTransformer) collectNestedStructTypeNames(ty transpiler.Type, cb func(string)) {
+	if ty == nil {
+		return
+	}
+	if gt, ok := ty.(transpiler.GenericType); ok {
+		base := gt.Base.BaseName()
+		if base == "Immutable" || base == "std.Immutable" ||
+			base == "Option" || base == "std.Option" {
+			if len(gt.Params) > 0 {
+				t.collectNestedStructTypeNames(gt.Params[0], cb)
+			}
+			return
+		}
+		if base == "Array" || base == "List" ||
+			base == "collection_immutable.Array" || base == "collection_immutable.List" {
+			if len(gt.Params) > 0 {
+				t.collectNestedStructTypeNames(gt.Params[0], cb)
+			}
+			return
+		}
+		if base == "HashMap" || base == "collection_immutable.HashMap" {
+			if len(gt.Params) == 2 {
+				t.collectNestedStructTypeNames(gt.Params[1], cb)
+			}
+			return
+		}
+		// Other generics (user-defined) — only recurse into the base name as
+		// the candidate; their type params are not part of any struct shape
+		// the transpiler currently codegens for.
+		if name := gt.Base.BaseName(); name != "" {
+			cb(name)
+		}
+		return
+	}
+	if name := namedTypeSimpleName(ty); name != "" {
+		cb(name)
 	}
 }
 

--- a/internal/transpiler/transformer/codec_typed.go
+++ b/internal/transpiler/transformer/codec_typed.go
@@ -13,9 +13,19 @@ package transformer
 //   - Primitives: string, int, int64, float64, bool, rune
 //   - Immutable[T] for any supported T
 //   - Option[T] for any supported T  (None → null, Some(x) → encoded x)
-//   - Array[T] / List[T] of primitives                 (iteration)
-//   - HashMap[string, V] of primitive V                (iteration)
+//   - Array[T] / List[T] of primitives or nested struct
+//   - HashMap[string, V] of primitive V or nested struct
 //   - Nested struct whose metadata we also emit        (recursive dispatch)
+//
+// For nested struct dispatch (both directly-typed struct fields and
+// struct elements inside Array/List/HashMap), the generated code calls
+// the inner _StructMeta_X{}.EncodeFields / DecodeFields with a fresh
+// per-type nameFn/omitFn/lookup derived from the `naming` parameter
+// passed in by the caller.  The naming convention (SnakeCase, CamelCase,
+// AsIs, ...) propagates from the top-level codec into every level of
+// nesting; Rename/Omit/OmitEmpty overrides only apply at the top level
+// (the level where the user configured them) — nested fields use the
+// naming-only mapping.
 //
 // Unsupported field shapes fall back to `w.WriteNull()` on encode and
 // `r.Skip()` on decode so the generated code always compiles. The design
@@ -82,6 +92,7 @@ func (t *galaASTTransformer) genEncodeFields(config *structMetaConfig) *ast.Func
 				{Names: idents("t"), Type: ast.NewIdent(config.typeName)},
 				{Names: idents("nameFn"), Type: funcIntStringType()},
 				{Names: idents("omitFn"), Type: funcIntBoolType()},
+				{Names: idents("naming"), Type: funcStringStringType()},
 			}},
 		},
 		Body: &ast.BlockStmt{List: stmts},
@@ -129,28 +140,72 @@ func (t *galaASTTransformer) genTypedWrite(access ast.Expr, fieldType transpiler
 	}
 
 	// Nested struct fallback: if the type is a struct we've emitted meta for,
-	// call _StructMeta_T{}.EncodeFields recursively.  Otherwise, emit null so
-	// the generated code still compiles.
+	// call _StructMeta_T{}.EncodeFields recursively.  The inner call gets
+	// fresh nameFn/omitFn derived from `naming` and the inner StructMeta's
+	// own field names — Rename/Omit/OmitEmpty overrides do not propagate
+	// past the top level.  If the type is unknown, emit null so the
+	// generated code still compiles.
 	if name := namedTypeSimpleName(fieldType); name != "" {
 		genName := "_StructMeta_" + name
 		if _, ok := t.structMetas[genName]; ok {
-			return []ast.Stmt{exprStmt(&ast.CallExpr{
-				Fun: &ast.SelectorExpr{
-					X:   &ast.CompositeLit{Type: ast.NewIdent(genName)},
-					Sel: ast.NewIdent("EncodeFields"),
-				},
-				Args: []ast.Expr{
-					ast.NewIdent("w"),
-					access,
-					ast.NewIdent("nameFn"),
-					ast.NewIdent("omitFn"),
-				},
-			})}
+			return genNestedStructWrite(genName, access)
 		}
 	}
 
 	// Fallback.
 	return []ast.Stmt{exprStmt(methodCall("w", "WriteNull"))}
+}
+
+// genNestedStructWrite emits the call to _StructMeta_Inner{}.EncodeFields
+// with fresh per-type nameFn/omitFn closures that derive their key from the
+// inherited `naming` mapping and the inner StructMeta's FieldName.
+func genNestedStructWrite(genName string, access ast.Expr) []ast.Stmt {
+	innerNameFn := &ast.FuncLit{
+		Type: &ast.FuncType{
+			Params:  &ast.FieldList{List: []*ast.Field{{Names: idents("i"), Type: ast.NewIdent("int")}}},
+			Results: &ast.FieldList{List: []*ast.Field{{Type: ast.NewIdent("string")}}},
+		},
+		Body: &ast.BlockStmt{List: []ast.Stmt{
+			&ast.ReturnStmt{Results: []ast.Expr{&ast.CallExpr{
+				Fun: ast.NewIdent("naming"),
+				Args: []ast.Expr{&ast.CallExpr{
+					Fun: &ast.SelectorExpr{
+						X:   &ast.CompositeLit{Type: ast.NewIdent(genName)},
+						Sel: ast.NewIdent("FieldName"),
+					},
+					Args: []ast.Expr{ast.NewIdent("i")},
+				}},
+			}}},
+		}},
+	}
+	innerOmitFn := &ast.FuncLit{
+		Type: &ast.FuncType{
+			Params:  &ast.FieldList{List: []*ast.Field{{Names: idents("i"), Type: ast.NewIdent("int")}}},
+			Results: &ast.FieldList{List: []*ast.Field{{Type: ast.NewIdent("bool")}}},
+		},
+		Body: &ast.BlockStmt{List: []ast.Stmt{
+			// _ = i; return false
+			&ast.AssignStmt{
+				Lhs: []ast.Expr{ast.NewIdent("_")},
+				Tok: token.ASSIGN,
+				Rhs: []ast.Expr{ast.NewIdent("i")},
+			},
+			&ast.ReturnStmt{Results: []ast.Expr{ast.NewIdent("false")}},
+		}},
+	}
+	return []ast.Stmt{exprStmt(&ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X:   &ast.CompositeLit{Type: ast.NewIdent(genName)},
+			Sel: ast.NewIdent("EncodeFields"),
+		},
+		Args: []ast.Expr{
+			ast.NewIdent("w"),
+			access,
+			innerNameFn,
+			innerOmitFn,
+			ast.NewIdent("naming"),
+		},
+	})}
 }
 
 // genOptionWrite: if Some → write inner; if None → WriteNull.
@@ -176,31 +231,37 @@ func genOptionWrite(access ast.Expr, inner transpiler.Type) []ast.Stmt {
 	}}
 }
 
-// genCollectionWrite: write start-array, iterate, write end-array. Primitive elements only.
+// genCollectionWrite: write start-array, iterate, write end-array.
+// Supports both primitive elements (direct WriteX) and nested struct
+// elements (recursive EncodeFields dispatch through _StructMeta_X{}).
 func (t *galaASTTransformer) genCollectionWrite(access ast.Expr, elem transpiler.Type) []ast.Stmt {
-	method := primitiveWriteMethodFor(elem)
-	if method == "" {
-		return []ast.Stmt{exprStmt(methodCall("w", "WriteNull"))}
-	}
 	elemGoType := t.goTypeFor(elem)
 	if elemGoType == nil {
+		// Try named-struct path for elements like Array[Inner].
+		if name := namedTypeSimpleName(elem); name != "" {
+			if _, ok := t.structMetas["_StructMeta_"+name]; ok {
+				elemGoType = t.qualifiedTypeIdent(name)
+			}
+		}
+		if elemGoType == nil {
+			return []ast.Stmt{exprStmt(methodCall("w", "WriteNull"))}
+		}
+	}
+
+	// Body of the lambda: either a primitive WriteX, a nested struct encode,
+	// or a nested collection / hashmap encode (Array[Array[T]] etc.).
+	innerStmts := t.genElementWrite(elem, ast.NewIdent("elem"))
+	if innerStmts == nil {
 		return []ast.Stmt{exprStmt(methodCall("w", "WriteNull"))}
 	}
-	// w.WriteStartArray()
-	// access.ForEach(func(elem <ElemGoType>) { w.WriteX(elem) })
-	// w.WriteEndArray()
+
 	lambda := &ast.FuncLit{
 		Type: &ast.FuncType{
 			Params: &ast.FieldList{List: []*ast.Field{
 				{Names: idents("elem"), Type: elemGoType},
 			}},
 		},
-		Body: &ast.BlockStmt{List: []ast.Stmt{
-			exprStmt(&ast.CallExpr{
-				Fun:  &ast.SelectorExpr{X: ast.NewIdent("w"), Sel: ast.NewIdent(method)},
-				Args: []ast.Expr{ast.NewIdent("elem")},
-			}),
-		}},
+		Body: &ast.BlockStmt{List: innerStmts},
 	}
 	return []ast.Stmt{
 		exprStmt(methodCall("w", "WriteStartArray")),
@@ -212,16 +273,86 @@ func (t *galaASTTransformer) genCollectionWrite(access ast.Expr, elem transpiler
 	}
 }
 
-// genHashMapWrite: write start-object, iterate (k,v), write end-object. Primitive value only.
-func (t *galaASTTransformer) genHashMapWrite(access ast.Expr, elem transpiler.Type) []ast.Stmt {
-	method := primitiveWriteMethodFor(elem)
-	if method == "" {
-		return []ast.Stmt{exprStmt(methodCall("w", "WriteNull"))}
+// genElementWrite emits the body that serialises a single collection
+// element (or HashMap value) of type `elem`, given an access expression
+// for the element value.  Returns nil if the shape is unsupported.
+func (t *galaASTTransformer) genElementWrite(elem transpiler.Type, access ast.Expr) []ast.Stmt {
+	// Primitive element: w.WriteX(access).
+	if method := primitiveWriteMethodFor(elem); method != "" {
+		return []ast.Stmt{exprStmt(&ast.CallExpr{
+			Fun:  &ast.SelectorExpr{X: ast.NewIdent("w"), Sel: ast.NewIdent(method)},
+			Args: []ast.Expr{access},
+		})}
 	}
+	// Generic shapes (Immutable[T], Option[T], Array[T], List[T], HashMap[K, V]).
+	if gt, ok := elem.(transpiler.GenericType); ok {
+		base := gt.Base.BaseName()
+		if base == "Immutable" || base == "std.Immutable" {
+			if len(gt.Params) > 0 {
+				// Unwrap Immutable: call .Get() on the access then recurse.
+				inner := &ast.CallExpr{
+					Fun: &ast.SelectorExpr{X: access, Sel: ast.NewIdent("Get")},
+				}
+				return t.genElementWrite(gt.Params[0], inner)
+			}
+		}
+		if base == "Option" || base == "std.Option" {
+			if len(gt.Params) > 0 {
+				return genOptionWrite(access, gt.Params[0])
+			}
+		}
+		if base == "Array" || base == "List" ||
+			base == "collection_immutable.Array" || base == "collection_immutable.List" {
+			if len(gt.Params) > 0 {
+				return t.genCollectionWrite(access, gt.Params[0])
+			}
+		}
+		if base == "HashMap" || base == "collection_immutable.HashMap" {
+			if len(gt.Params) == 2 {
+				return t.genHashMapWrite(access, gt.Params[1])
+			}
+		}
+	}
+	// Nested struct element: dispatch through _StructMeta_X{}.EncodeFields.
+	if name := namedTypeSimpleName(elem); name != "" {
+		genName := "_StructMeta_" + name
+		if _, ok := t.structMetas[genName]; ok {
+			return genNestedStructWrite(genName, access)
+		}
+	}
+	return nil
+}
+
+// genHashMapWrite: write start-object, iterate (k,v), write end-object.
+// Supports primitive values and nested struct values (recursive
+// EncodeFields dispatch through _StructMeta_X{}).
+func (t *galaASTTransformer) genHashMapWrite(access ast.Expr, elem transpiler.Type) []ast.Stmt {
 	elemGoType := t.goTypeFor(elem)
 	if elemGoType == nil {
+		// Try named-struct path for values like HashMap[string, Inner].
+		if name := namedTypeSimpleName(elem); name != "" {
+			if _, ok := t.structMetas["_StructMeta_"+name]; ok {
+				elemGoType = t.qualifiedTypeIdent(name)
+			}
+		}
+		if elemGoType == nil {
+			return []ast.Stmt{exprStmt(methodCall("w", "WriteNull"))}
+		}
+	}
+
+	valueStmts := t.genElementWrite(elem, ast.NewIdent("v"))
+	if valueStmts == nil {
 		return []ast.Stmt{exprStmt(methodCall("w", "WriteNull"))}
 	}
+
+	lambdaBody := []ast.Stmt{
+		exprStmt(&ast.CallExpr{
+			Fun:  &ast.SelectorExpr{X: ast.NewIdent("w"), Sel: ast.NewIdent("WriteKey")},
+			Args: []ast.Expr{ast.NewIdent("k")},
+		}),
+	}
+	lambdaBody = append(lambdaBody, valueStmts...)
+
 	lambda := &ast.FuncLit{
 		Type: &ast.FuncType{
 			Params: &ast.FieldList{List: []*ast.Field{
@@ -229,16 +360,7 @@ func (t *galaASTTransformer) genHashMapWrite(access ast.Expr, elem transpiler.Ty
 				{Names: idents("v"), Type: elemGoType},
 			}},
 		},
-		Body: &ast.BlockStmt{List: []ast.Stmt{
-			exprStmt(&ast.CallExpr{
-				Fun:  &ast.SelectorExpr{X: ast.NewIdent("w"), Sel: ast.NewIdent("WriteKey")},
-				Args: []ast.Expr{ast.NewIdent("k")},
-			}),
-			exprStmt(&ast.CallExpr{
-				Fun:  &ast.SelectorExpr{X: ast.NewIdent("w"), Sel: ast.NewIdent(method)},
-				Args: []ast.Expr{ast.NewIdent("v")},
-			}),
-		}},
+		Body: &ast.BlockStmt{List: lambdaBody},
 	}
 	return []ast.Stmt{
 		exprStmt(methodCall("w", "WriteStartObject")),
@@ -355,6 +477,7 @@ func (t *galaASTTransformer) genDecodeFields(config *structMetaConfig) *ast.Func
 			Params: &ast.FieldList{List: []*ast.Field{
 				{Names: idents("r"), Type: t.stdIdent("FieldDecoder")},
 				{Names: idents("lookup"), Type: funcStringIntType()},
+				{Names: idents("naming"), Type: funcStringStringType()},
 			}},
 			Results: &ast.FieldList{List: []*ast.Field{{Type: ast.NewIdent(config.typeName)}}},
 		},
@@ -379,20 +502,370 @@ func (t *galaASTTransformer) genTypedRead(localIdent ast.Expr, fieldType transpi
 				return t.genOptionRead(localIdent, gt.Params[0])
 			}
 		}
-		// TODO: Array / List / HashMap / nested struct reads.
+		if base == "Array" || base == "List" ||
+			base == "collection_immutable.Array" || base == "collection_immutable.List" {
+			if len(gt.Params) > 0 {
+				short := base
+				if dot := lastDot(base); dot >= 0 {
+					short = base[dot+1:]
+				}
+				return t.genCollectionRead(localIdent, gt.Params[0], short)
+			}
+		}
+		if base == "HashMap" || base == "collection_immutable.HashMap" {
+			if len(gt.Params) == 2 {
+				return t.genHashMapRead(localIdent, gt.Params[1])
+			}
+		}
 	}
 
-	method := primitiveReadMethodFor(fieldType)
-	if method == "" {
+	if method := primitiveReadMethodFor(fieldType); method != "" {
+		return []ast.Stmt{&ast.AssignStmt{
+			Lhs: []ast.Expr{localIdent},
+			Tok: token.ASSIGN,
+			Rhs: []ast.Expr{&ast.CallExpr{
+				Fun: &ast.SelectorExpr{X: ast.NewIdent("r"), Sel: ast.NewIdent(method)},
+			}},
+		}}
+	}
+
+	// Nested struct field: dispatch through _StructMeta_X{}.DecodeFields with
+	// a freshly-built lookup keyed by the inherited `naming` mapping.
+	if name := namedTypeSimpleName(fieldType); name != "" {
+		genName := "_StructMeta_" + name
+		if _, ok := t.structMetas[genName]; ok {
+			return []ast.Stmt{&ast.AssignStmt{
+				Lhs: []ast.Expr{localIdent},
+				Tok: token.ASSIGN,
+				Rhs: []ast.Expr{&ast.CallExpr{
+					Fun: &ast.SelectorExpr{
+						X:   &ast.CompositeLit{Type: ast.NewIdent(genName)},
+						Sel: ast.NewIdent("DecodeFields"),
+					},
+					Args: []ast.Expr{
+						ast.NewIdent("r"),
+						genNestedStructLookup(genName),
+						ast.NewIdent("naming"),
+					},
+				}},
+			}}
+		}
+	}
+	return nil
+}
+
+// genNestedStructLookup emits a closure: func(key string) int that looks up
+// the field index in _StructMeta_Inner using the inherited `naming`
+// mapping.  We bind the meta to a local so its composite-literal use does
+// not collide with for-clause syntax (Go treats `_StructMeta_T{` in a for
+// header as the start of a composite-literal block, which is a parse error).
+func genNestedStructLookup(genName string) ast.Expr {
+	// _meta := _StructMeta_Inner{}
+	// n := _meta.NumFields()
+	// for i := 0; i < n; i++ {
+	//     if naming(_meta.FieldName(i)) == key { return i }
+	// }
+	// return -1
+	body := []ast.Stmt{
+		&ast.AssignStmt{
+			Lhs: []ast.Expr{ast.NewIdent("_meta")},
+			Tok: token.DEFINE,
+			Rhs: []ast.Expr{&ast.CompositeLit{Type: ast.NewIdent(genName)}},
+		},
+		&ast.AssignStmt{
+			Lhs: []ast.Expr{ast.NewIdent("n")},
+			Tok: token.DEFINE,
+			Rhs: []ast.Expr{&ast.CallExpr{
+				Fun: &ast.SelectorExpr{X: ast.NewIdent("_meta"), Sel: ast.NewIdent("NumFields")},
+			}},
+		},
+		&ast.ForStmt{
+			Init: &ast.AssignStmt{
+				Lhs: []ast.Expr{ast.NewIdent("i")},
+				Tok: token.DEFINE,
+				Rhs: []ast.Expr{intLit(0)},
+			},
+			Cond: &ast.BinaryExpr{
+				X:  ast.NewIdent("i"),
+				Op: token.LSS,
+				Y:  ast.NewIdent("n"),
+			},
+			Post: &ast.IncDecStmt{X: ast.NewIdent("i"), Tok: token.INC},
+			Body: &ast.BlockStmt{List: []ast.Stmt{
+				&ast.IfStmt{
+					Cond: &ast.BinaryExpr{
+						X: &ast.CallExpr{
+							Fun: ast.NewIdent("naming"),
+							Args: []ast.Expr{&ast.CallExpr{
+								Fun: &ast.SelectorExpr{
+									X:   ast.NewIdent("_meta"),
+									Sel: ast.NewIdent("FieldName"),
+								},
+								Args: []ast.Expr{ast.NewIdent("i")},
+							}},
+						},
+						Op: token.EQL,
+						Y:  ast.NewIdent("key"),
+					},
+					Body: &ast.BlockStmt{List: []ast.Stmt{
+						&ast.ReturnStmt{Results: []ast.Expr{ast.NewIdent("i")}},
+					}},
+				},
+			}},
+		},
+		&ast.ReturnStmt{Results: []ast.Expr{intLit(-1)}},
+	}
+	return &ast.FuncLit{
+		Type: &ast.FuncType{
+			Params:  &ast.FieldList{List: []*ast.Field{{Names: idents("key"), Type: ast.NewIdent("string")}}},
+			Results: &ast.FieldList{List: []*ast.Field{{Type: ast.NewIdent("int")}}},
+		},
+		Body: &ast.BlockStmt{List: body},
+	}
+}
+
+// genCollectionRead emits read statements for Array[T] or List[T] fields.
+// `containerName` is "Array" or "List" — the GALA collection ctor used for
+// the final FromSlice wrap.
+func (t *galaASTTransformer) genCollectionRead(localIdent ast.Expr, elem transpiler.Type, containerName string) []ast.Stmt {
+	elemGoType := t.goTypeFor(elem)
+	if elemGoType == nil {
+		if name := namedTypeSimpleName(elem); name != "" {
+			if _, ok := t.structMetas["_StructMeta_"+name]; ok {
+				elemGoType = t.qualifiedTypeIdent(name)
+			}
+		}
+		if elemGoType == nil {
+			return nil
+		}
+	}
+
+	// Build the per-element read into a fresh local `__elem`.
+	elemLocal := ast.NewIdent("__elem")
+	elemReadStmts := t.genElementRead(elem, elemLocal)
+	if elemReadStmts == nil {
 		return nil
 	}
-	return []ast.Stmt{&ast.AssignStmt{
+
+	// var __sliceN []ElemGoType
+	sliceLocal := ast.NewIdent("__slice")
+	stmts := []ast.Stmt{
+		&ast.DeclStmt{Decl: &ast.GenDecl{
+			Tok: token.VAR,
+			Specs: []ast.Spec{
+				&ast.ValueSpec{
+					Names: []*ast.Ident{sliceLocal},
+					Type:  &ast.ArrayType{Elt: elemGoType},
+				},
+			},
+		}},
+	}
+
+	// r.StartArray()
+	stmts = append(stmts, exprStmt(methodCall("r", "StartArray")))
+
+	// for r.HasMoreElements() { var __elem T; <read>; __slice = append(__slice, __elem) }
+	loopBody := []ast.Stmt{
+		&ast.DeclStmt{Decl: &ast.GenDecl{
+			Tok: token.VAR,
+			Specs: []ast.Spec{
+				&ast.ValueSpec{
+					Names: []*ast.Ident{elemLocal},
+					Type:  elemGoType,
+				},
+			},
+		}},
+	}
+	loopBody = append(loopBody, elemReadStmts...)
+	loopBody = append(loopBody, &ast.AssignStmt{
+		Lhs: []ast.Expr{sliceLocal},
+		Tok: token.ASSIGN,
+		Rhs: []ast.Expr{&ast.CallExpr{
+			Fun:  ast.NewIdent("append"),
+			Args: []ast.Expr{sliceLocal, elemLocal},
+		}},
+	})
+	stmts = append(stmts, &ast.ForStmt{
+		Cond: methodCall("r", "HasMoreElements"),
+		Body: &ast.BlockStmt{List: loopBody},
+	})
+
+	// r.EndArray()
+	stmts = append(stmts, exprStmt(methodCall("r", "EndArray")))
+
+	// localIdent = ArrayFromSlice(__slice) (or ListFromSlice for List)
+	ctorName := "ArrayFromSlice"
+	if containerName == "List" {
+		ctorName = "ListFromSlice"
+	}
+	stmts = append(stmts, &ast.AssignStmt{
 		Lhs: []ast.Expr{localIdent},
 		Tok: token.ASSIGN,
 		Rhs: []ast.Expr{&ast.CallExpr{
-			Fun: &ast.SelectorExpr{X: ast.NewIdent("r"), Sel: ast.NewIdent(method)},
+			Fun:  t.collectionIdent(ctorName),
+			Args: []ast.Expr{sliceLocal},
 		}},
-	}}
+	})
+
+	// Wrap the whole thing in a block so the __slice / __elem locals don't
+	// leak across multiple collection reads inside the same parent.
+	return []ast.Stmt{&ast.BlockStmt{List: stmts}}
+}
+
+// genHashMapRead emits read statements for HashMap[string, V] fields.
+func (t *galaASTTransformer) genHashMapRead(localIdent ast.Expr, valueType transpiler.Type) []ast.Stmt {
+	valueGoType := t.goTypeFor(valueType)
+	if valueGoType == nil {
+		if name := namedTypeSimpleName(valueType); name != "" {
+			if _, ok := t.structMetas["_StructMeta_"+name]; ok {
+				valueGoType = t.qualifiedTypeIdent(name)
+			}
+		}
+		if valueGoType == nil {
+			return nil
+		}
+	}
+
+	// var __m HashMap[string, V] = EmptyHashMap[string, V]()
+	mLocal := ast.NewIdent("__m")
+	stringIdent := ast.NewIdent("string")
+	emptyMapType := &ast.IndexListExpr{
+		X:       t.collectionIdent("HashMap"),
+		Indices: []ast.Expr{stringIdent, valueGoType},
+	}
+	stmts := []ast.Stmt{
+		&ast.DeclStmt{Decl: &ast.GenDecl{
+			Tok: token.VAR,
+			Specs: []ast.Spec{
+				&ast.ValueSpec{
+					Names:  []*ast.Ident{mLocal},
+					Type:   emptyMapType,
+					Values: []ast.Expr{&ast.CallExpr{
+						Fun: &ast.IndexListExpr{
+							X:       t.collectionIdent("EmptyHashMap"),
+							Indices: []ast.Expr{ast.NewIdent("string"), valueGoType},
+						},
+					}},
+				},
+			},
+		}},
+	}
+
+	// r.StartObject()
+	stmts = append(stmts, exprStmt(methodCall("r", "StartObject")))
+
+	// for r.HasMoreFields() { __k := r.ReadKey(); var __v V; <read>; __m = __m.Put(__k, __v) }
+	kLocal := ast.NewIdent("__k")
+	vLocal := ast.NewIdent("__v")
+	valueReadStmts := t.genElementRead(valueType, vLocal)
+	if valueReadStmts == nil {
+		return nil
+	}
+	loopBody := []ast.Stmt{
+		&ast.AssignStmt{
+			Lhs: []ast.Expr{kLocal},
+			Tok: token.DEFINE,
+			Rhs: []ast.Expr{methodCall("r", "ReadKey")},
+		},
+		&ast.DeclStmt{Decl: &ast.GenDecl{
+			Tok: token.VAR,
+			Specs: []ast.Spec{
+				&ast.ValueSpec{
+					Names: []*ast.Ident{vLocal},
+					Type:  valueGoType,
+				},
+			},
+		}},
+	}
+	loopBody = append(loopBody, valueReadStmts...)
+	loopBody = append(loopBody, &ast.AssignStmt{
+		Lhs: []ast.Expr{mLocal},
+		Tok: token.ASSIGN,
+		Rhs: []ast.Expr{&ast.CallExpr{
+			Fun: &ast.SelectorExpr{X: mLocal, Sel: ast.NewIdent("Put")},
+			Args: []ast.Expr{kLocal, vLocal},
+		}},
+	})
+	stmts = append(stmts, &ast.ForStmt{
+		Cond: methodCall("r", "HasMoreFields"),
+		Body: &ast.BlockStmt{List: loopBody},
+	})
+
+	// r.EndObject()
+	stmts = append(stmts, exprStmt(methodCall("r", "EndObject")))
+
+	// localIdent = __m
+	stmts = append(stmts, &ast.AssignStmt{
+		Lhs: []ast.Expr{localIdent},
+		Tok: token.ASSIGN,
+		Rhs: []ast.Expr{mLocal},
+	})
+
+	return []ast.Stmt{&ast.BlockStmt{List: stmts}}
+}
+
+// genElementRead emits the read statements for a single collection element
+// or HashMap value of type `elem`, assigning to the `target` ident.
+// Returns nil for unsupported shapes.
+func (t *galaASTTransformer) genElementRead(elem transpiler.Type, target ast.Expr) []ast.Stmt {
+	if method := primitiveReadMethodFor(elem); method != "" {
+		return []ast.Stmt{&ast.AssignStmt{
+			Lhs: []ast.Expr{target},
+			Tok: token.ASSIGN,
+			Rhs: []ast.Expr{&ast.CallExpr{
+				Fun: &ast.SelectorExpr{X: ast.NewIdent("r"), Sel: ast.NewIdent(method)},
+			}},
+		}}
+	}
+	if gt, ok := elem.(transpiler.GenericType); ok {
+		base := gt.Base.BaseName()
+		if base == "Immutable" || base == "std.Immutable" {
+			if len(gt.Params) > 0 {
+				return t.genElementRead(gt.Params[0], target)
+			}
+		}
+		if base == "Option" || base == "std.Option" {
+			if len(gt.Params) > 0 {
+				return t.genOptionRead(target, gt.Params[0])
+			}
+		}
+		if base == "Array" || base == "List" ||
+			base == "collection_immutable.Array" || base == "collection_immutable.List" {
+			if len(gt.Params) > 0 {
+				short := base
+				if dot := lastDot(base); dot >= 0 {
+					short = base[dot+1:]
+				}
+				return t.genCollectionRead(target, gt.Params[0], short)
+			}
+		}
+		if base == "HashMap" || base == "collection_immutable.HashMap" {
+			if len(gt.Params) == 2 {
+				return t.genHashMapRead(target, gt.Params[1])
+			}
+		}
+	}
+	if name := namedTypeSimpleName(elem); name != "" {
+		genName := "_StructMeta_" + name
+		if _, ok := t.structMetas[genName]; ok {
+			return []ast.Stmt{&ast.AssignStmt{
+				Lhs: []ast.Expr{target},
+				Tok: token.ASSIGN,
+				Rhs: []ast.Expr{&ast.CallExpr{
+					Fun: &ast.SelectorExpr{
+						X:   &ast.CompositeLit{Type: ast.NewIdent(genName)},
+						Sel: ast.NewIdent("DecodeFields"),
+					},
+					Args: []ast.Expr{
+						ast.NewIdent("r"),
+						genNestedStructLookup(genName),
+						ast.NewIdent("naming"),
+					},
+				}},
+			}}
+		}
+	}
+	return nil
 }
 
 // genOptionRead: if r.IsNull() { r.ReadNull(); local = None[E]{}.Apply() }
@@ -603,6 +1076,13 @@ func funcStringIntType() ast.Expr {
 	return &ast.FuncType{
 		Params:  &ast.FieldList{List: []*ast.Field{{Type: ast.NewIdent("string")}}},
 		Results: &ast.FieldList{List: []*ast.Field{{Type: ast.NewIdent("int")}}},
+	}
+}
+
+func funcStringStringType() ast.Expr {
+	return &ast.FuncType{
+		Params:  &ast.FieldList{List: []*ast.Field{{Type: ast.NewIdent("string")}}},
+		Results: &ast.FieldList{List: []*ast.Field{{Type: ast.NewIdent("string")}}},
 	}
 }
 

--- a/json/json.gala
+++ b/json/json.gala
@@ -93,7 +93,14 @@ func omitFnFromKeys(keys Array[string]) func(int) bool =
 func (c JsonEncoder[T]) Encode(v T) Try[string] {
     return Try[string](() => {
         val w = NewJsonEncoder()
-        c.Meta.EncodeFields(w, v, nameFnFromKeys(c.Keys.Keys), omitFnFromKeys(c.Keys.Keys))
+        val naming = c.Config.NamingStrategy
+        c.Meta.EncodeFields(
+            w,
+            v,
+            nameFnFromKeys(c.Keys.Keys),
+            omitFnFromKeys(c.Keys.Keys),
+            (name string) => ApplyNaming(name, naming),
+        )
         return w.String()
     })
 }
@@ -112,7 +119,8 @@ func (c JsonEncoder[T]) Decode(s string) Try[T] {
     return Try[T](() => {
         val r = NewJsonDecoder(s)
         val lookup = buildLookup(c.Keys.ReverseKeys, c.Meta.NumFields(), c.Meta.FieldName)
-        return c.Meta.DecodeFields(r, lookup)
+        val naming = c.Config.NamingStrategy
+        return c.Meta.DecodeFields(r, lookup, (name string) => ApplyNaming(name, naming))
     })
 }
 

--- a/std/meta.gala
+++ b/std/meta.gala
@@ -58,9 +58,18 @@ type FieldDecoder interface {
 // ergonomic (`Codec[Person](SnakeCase())`) while the underlying
 // dispatch is fully typed — no `any`, no runtime type assertions on
 // user data.
+// The `naming` parameter on EncodeFields/DecodeFields is the GALA-field-name
+// (PascalCase) to serialized-key converter used for nested struct dispatch.
+// The generated EncodeFields/DecodeFields uses the precomputed nameFn/omitFn/
+// lookup for *its own* fields (which already account for Rename/Omit/Naming
+// at the top level), and constructs fresh per-type nameFn/omitFn/lookup for
+// any nested struct fields by composing `naming` with the inner struct's
+// FieldName.  This propagates the naming convention into nested decodes
+// without giving the std interface a dependency on json/yaml's `Naming`
+// sealed type.
 type StructMeta[T any] interface {
     NumFields() int
     FieldName(i int) string
-    EncodeFields(w FieldEncoder, t T, nameFn func(int) string, omitFn func(int) bool)
-    DecodeFields(r FieldDecoder, lookup func(string) int) T
+    EncodeFields(w FieldEncoder, t T, nameFn func(int) string, omitFn func(int) bool, naming func(string) string)
+    DecodeFields(r FieldDecoder, lookup func(string) int, naming func(string) string) T
 }

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -28,6 +28,7 @@ Welcome to the GALA documentation hub. Here you will find everything you need to
 | [Concurrency]({{ '/features/concurrency/' | relative_url }}) | `Future[T]`, `Promise[T]`, `ExecutionContext`, `Await`, and `Zip` |
 | [Go Interop]({{ '/features/go-interop/' | relative_url }}) | Import and use any Go package, type, or function directly from GALA |
 | [Json]({{ '/docs/json/' | relative_url }}) | Type-safe JSON serialization, deserialization, and pattern matching extractors |
+| [Yaml]({{ '/docs/yaml/' | relative_url }}) | Type-safe YAML serialization, deserialization, and pattern matching extractors |
 | [Regex]({{ '/docs/regex/' | relative_url }}) | Regular expressions with pattern matching and Array destructuring |
 | [IO Effect]({{ '/docs/io/' | relative_url }}) | Lazy composable side effects with `IO[T]` |
 

--- a/website/docs/yaml.md
+++ b/website/docs/yaml.md
@@ -1,19 +1,19 @@
 ---
 layout: default
-title: "Json in GALA — Zero-Reflection JSON Codec with Builder Pattern"
-description: "GALA's json package provides zero-reflection, compile-time JSON serialization with builder pattern configuration, naming strategies, and pattern matching support."
-keywords: "gala json, golang json alternative, go type safe json, gala json codec, gala json pattern matching, go json serialization, zero reflection json"
-permalink: /docs/json/
+title: "Yaml in GALA — Zero-Reflection YAML Codec with Builder Pattern"
+description: "GALA's yaml package provides zero-reflection, compile-time YAML serialization with builder pattern configuration, naming strategies, and pattern matching support."
+keywords: "gala yaml, golang yaml alternative, go type safe yaml, gala yaml codec, gala yaml pattern matching, go yaml serialization, zero reflection yaml"
+permalink: /docs/yaml/
 ---
 
-<p class="breadcrumb"><a href="/">Home</a> / <a href="/docs/">Docs</a> / Json</p>
+<p class="breadcrumb"><a href="/">Home</a> / <a href="/docs/">Docs</a> / Yaml</p>
 
-# Json — Zero-Reflection JSON Codec
+# Yaml — Zero-Reflection YAML Codec
 
-GALA's `json` package provides compile-time JSON serialization powered by `StructMeta[T]`. No reflection, no struct tags, fully typed. All operations return `Try[T]` — no unchecked errors. Combined with builder pattern configuration and pattern matching, you get a clean, composable JSON pipeline.
+GALA's `yaml` package provides compile-time YAML serialization powered by `StructMeta[T]`. No reflection, no struct tags, fully typed. All operations return `Try[T]` — no unchecked errors. The API mirrors `json.Codec[T]` exactly; the only difference is the emitted format: block-style YAML.
 
 ```gala
-import . "martianoff/gala/json"
+import . "martianoff/gala/yaml"
 ```
 
 ---
@@ -26,10 +26,13 @@ struct Person(FirstName string, LastName string, Age int)
 val codec = Codec[Person](SnakeCase())
 
 val person = Person("Alice", "Smith", 30)
-val jsonStr = codec.Encode(person).Get()
-// => {"first_name":"Alice","last_name":"Smith","age":30}
+val yamlStr = codec.Encode(person).Get()
+// =>
+// first_name: Alice
+// last_name: Smith
+// age: 30
 
-val decoded = codec.Decode(jsonStr)
+val decoded = codec.Decode(yamlStr)
 // decoded: Try[Person] — fully typed!
 ```
 
@@ -63,26 +66,21 @@ Each builder method returns a new immutable codec instance — safe to share acr
 
 ```gala
 val person = Person("Alice", "Smith", 30)
-
-// Compact JSON
-val jsonStr = codec.Encode(person).Get()
-// => {"first_name":"Alice","last_name":"Smith","age":30}
-
-// Pretty-printed JSON
-val pretty = codec.EncodePretty(person).Get()
-// => {
-//   "first_name": "Alice",
-//   "last_name": "Smith",
-//   "age": 30
-// }
+val yamlStr = codec.Encode(person).Get()
+// =>
+// first_name: Alice
+// last_name: Smith
+// age: 30
 ```
+
+Block-style YAML is already human-readable, so there is no separate pretty-print method.
 
 ---
 
 ## Deserialization
 
 ```gala
-val decoded = codec.Decode(jsonStr)
+val decoded = codec.Decode(yamlStr)
 // decoded: Try[Person]
 
 // Safe access via Map
@@ -101,9 +99,9 @@ decoded.ForEach((p) => {
 Codec instances work as pattern matching extractors via `Unapply`. If decoding fails, the case does not match — no exception, no panic:
 
 ```gala
-val result = jsonStr match {
+val result = yamlStr match {
     case codec(p) => s"Found: ${p.FirstName}, age ${p.Age}"
-    case _ => "invalid JSON"
+    case _ => "invalid YAML"
 }
 ```
 
@@ -137,10 +135,16 @@ val codec = Codec[User](SnakeCase())
 val tags = EmptyArray[Tag]().Append(Tag("urgent", "red")).Append(Tag("draft", "yellow"))
 val user = User("alice", tags)
 
-val jsonStr = codec.Encode(user).Get()
-// => {"name":"alice","tags":[{"key":"urgent","color":"red"},{"key":"draft","color":"yellow"}]}
+val yamlStr = codec.Encode(user).Get()
+// =>
+// name: alice
+// tags:
+//   - key: urgent
+//     color: red
+//   - key: draft
+//     color: yellow
 
-val decoded = codec.Decode(jsonStr).Get()
+val decoded = codec.Decode(yamlStr).Get()
 Println(s"first tag: ${decoded.Tags.Get(0).Key}/${decoded.Tags.Get(0).Color}")
 ```
 
@@ -157,13 +161,13 @@ struct Point(X int, Y int)
 val codec = Codec[Point](SnakeCase())
 
 // "z" is not declared on Point — it is skipped on decode.
-val raw = "{\"x\":1,\"y\":2,\"z\":99}"
+val raw = "x: 1\ny: 2\nz: 99\n"
 val decoded = codec.Decode(raw).Get()
 Println(s"x=${decoded.X} y=${decoded.Y}")
 // => x=1 y=2
 ```
 
-Skipping handles all JSON value shapes — strings, numbers, booleans, `null`, and nested objects/arrays — so an unknown field can carry an arbitrarily complex payload without breaking the decode.
+Skipping handles all YAML scalar and nested-mapping/sequence shapes, so an unknown field can carry an arbitrarily complex payload without breaking the decode.
 
 ---
 
@@ -172,9 +176,9 @@ Skipping handles all JSON value shapes — strings, numbers, booleans, `null`, a
 For projects that prefer explicit package prefixes:
 
 ```gala
-import "martianoff/gala/json"
+import "martianoff/gala/yaml"
 
-val codec = json.Codec[Person](json.SnakeCase())
+val codec = yaml.Codec[Person](yaml.SnakeCase())
 codec.Encode(person)
 ```
 
@@ -193,7 +197,20 @@ The transpiler:
 2. Auto-generates `_StructMeta_Person` with typed `EncodeFields` / `DecodeFields` methods
 3. Injects it as the first argument: `Codec[Person]{}.Apply(_StructMeta_Person{}, SnakeCase())`
 
-No reflection at runtime. Field names, types, and access patterns are all resolved at compile time.
+No reflection at runtime. Field names, types, and access patterns are all resolved at compile time. The same `StructMeta[T]` machinery powers both the JSON and YAML codecs — only the underlying `FieldEncoder` / `FieldDecoder` implementation differs.
+
+### Supported YAML Subset
+
+The codec emits and parses a focused, predictable subset of YAML:
+
+- block-style mappings
+- block-style sequences
+- scalars (`string`, `int`, `float`, `bool`, `null`)
+- literal block scalars (`|`)
+- comments
+- nested structures
+
+Out of scope: anchors, aliases, flow style, custom tags. If your input requires these, preprocess it through a richer YAML library before handing it to `Codec[T]`.
 
 ---
 
@@ -201,21 +218,20 @@ No reflection at runtime. Field names, types, and access patterns are all resolv
 
 | Method | Signature | Description |
 |--------|-----------|-------------|
-| `Codec[T](naming)` | `Naming → JsonEncoder[T]` | Create codec (StructMeta auto-injected) |
-| `.Naming(n)` | `Naming → JsonEncoder[T]` | Set naming strategy |
-| `.Omit(field)` | `string → JsonEncoder[T]` | Exclude field from serialization |
-| `.Rename(field, key)` | `string, string → JsonEncoder[T]` | Map field to custom JSON key |
-| `.OmitEmpty(field)` | `string → JsonEncoder[T]` | Skip field when value is zero |
-| `.Encode(v)` | `T → Try[string]` | Serialize to compact JSON |
-| `.EncodePretty(v)` | `T → Try[string]` | Serialize to pretty-printed JSON |
-| `.Decode(s)` | `string → Try[T]` | Deserialize from JSON string |
+| `Codec[T](naming)` | `Naming → YamlEncoder[T]` | Create codec (StructMeta auto-injected) |
+| `.Naming(n)` | `Naming → YamlEncoder[T]` | Set naming strategy |
+| `.Omit(field)` | `string → YamlEncoder[T]` | Exclude field from serialization |
+| `.Rename(field, key)` | `string, string → YamlEncoder[T]` | Map field to custom YAML key |
+| `.OmitEmpty(field)` | `string → YamlEncoder[T]` | Skip field when value is zero |
+| `.Encode(v)` | `T → Try[string]` | Serialize to block-style YAML |
+| `.Decode(s)` | `string → Try[T]` | Deserialize from YAML string |
 | `.Unapply(s)` | `string → Option[T]` | Pattern matching extractor |
 
 ---
 
 ## Further Reading
 
-- [Yaml](/docs/yaml/) — same builder API, block-style YAML output
+- [Json](/docs/json/) — same builder API, compact or pretty-printed JSON output
 - [Error Handling](/features/error-handling/) — Option, Either, and Try monads
 - [Pattern Matching](/features/pattern-matching/) — extractors, guards, and exhaustive matching
 - [Regex](/docs/regex/) — regular expressions with pattern matching extractors

--- a/yaml/yaml.gala
+++ b/yaml/yaml.gala
@@ -90,7 +90,14 @@ func omitFnFromKeys(keys Array[string]) func(int) bool =
 func (c YamlEncoder[T]) Encode(v T) Try[string] {
     return Try[string](() => {
         val w = NewYamlEncoder()
-        c.Meta.EncodeFields(w, v, nameFnFromKeys(c.Keys.Keys), omitFnFromKeys(c.Keys.Keys))
+        val naming = c.Config.NamingStrategy
+        c.Meta.EncodeFields(
+            w,
+            v,
+            nameFnFromKeys(c.Keys.Keys),
+            omitFnFromKeys(c.Keys.Keys),
+            (name string) => ApplyNaming(name, naming),
+        )
         return w.String()
     })
 }
@@ -102,7 +109,8 @@ func (c YamlEncoder[T]) Decode(s string) Try[T] {
     return Try[T](() => {
         val r = NewYamlDecoder(s)
         val lookup = buildLookup(c.Keys.ReverseKeys, c.Meta.NumFields(), c.Meta.FieldName)
-        return c.Meta.DecodeFields(r, lookup)
+        val naming = c.Config.NamingStrategy
+        return c.Meta.DecodeFields(r, lookup, (name string) => ApplyNaming(name, naming))
     })
 }
 


### PR DESCRIPTION
## Summary

- Extend `Codec[T]` to handle `Array[Struct]` / `List[Struct]` / `HashMap[string, Struct]` field shapes (and nesting like `Array[Array[Struct]]`). Previously these silently decoded to empty collections and encoded as `null`.
- Fix is in shared transpiler codegen (`codec_typed.go`), so **both JSON and YAML** codecs benefit from the same patch.
- Naming convention (SnakeCase / CamelCase / PascalCase) now propagates into nested struct field-name resolution. Cross-package nested decode works.

## What changed

- `internal/transpiler/transformer/codec_typed.go` — new `genElementRead`/`genElementWrite` recursion that walks Immutable/Option/Array/List/HashMap layers and lands on either a primitive read/write or a recursive `_StructMeta_X.{DecodeFields,EncodeFields}` call. Also derives fresh per-type `nameFn`/`omitFn` for nested dispatch (previously the inner struct incorrectly reused the outer's closures — a latent bug, not exercised by existing tests).
- `internal/transpiler/transformer/codec.go` — `expandNestedStructMetas` worklist fixpoint auto-registers `_StructMeta_X` for every struct reachable through field types, including across package boundaries. Users only declare `Codec[Top]` and the transpiler discovers the rest.
- `std/meta.gala` — `EncodeFields`/`DecodeFields` get a `naming func(string) string` parameter so nested calls can derive their own field-name lookup with the same naming config. Plain `func(string) string` rather than the sealed `Naming` type, to keep `std/meta.gala` free of JSON/YAML-specific imports.
- `json/json.gala` and `yaml/yaml.gala` — pass `(name) => ApplyNaming(name, c.Config.NamingStrategy)` through. Same edit in both files; codegen is format-agnostic.
- `examples/` — new `json_codec_array_of_structs.{gala,out}`, `yaml_codec_array_of_structs.{gala,out}`, `yaml_codec_collections.{gala,out}`, `json_codec_cross_pkg/`. Existing `json_codec_collections.gala` extended to cover `Array[Struct]`, `List[Struct]`, `HashMap[string, Struct]`, `Array[Array[Struct]]`, mixed primitives + structs.

## Design notes

- Rename / Omit / OmitEmpty overrides intentionally do **not** propagate past the top level — there's no API for declaring per-type config on inner types today, and the spec only required Naming to propagate. Easy to add later if needed.

## Test plan

- [x] `bazel build //...` passes
- [x] `bazel test //...` passes — 328 / 328, no regressions in existing primitive-collection or codec tests
- [x] JSON repro from the FIX doc prints `content size=1`, `first text=hello` (was `content size=0` + panic before)
- [x] YAML twin round-trips cleanly through the YAML codec
- [x] `Array[Struct]`, `List[Struct]`, `HashMap[string, Struct]`, `Array[Array[Struct]]`, mixed primitives + structs — all round-trip equal in both JSON and YAML
- [x] SnakeCase naming propagates into nested struct field resolution
- [x] Cross-package nested decode works (parent struct in main, inner struct in another package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)