### PR TITLE
fix(release): bump gala.mod to 0.41.0

### DIFF
--- a/gala.mod
+++ b/gala.mod
@@ -1,3 +1,3 @@
 module martianoff/gala
 
-gala 0.40.0
+gala 0.41.0


### PR DESCRIPTION
Mechanical release-prep bump for 0.41.0. Tag follows.