### PR TITLE
fix(analyzer): project in-memory analyzedPkgs to own-types only

### DIFF
--- a/.github/workflows/perf-real-build.yml
+++ b/.github/workflows/perf-real-build.yml
@@ -18,6 +18,8 @@ name: Perf — real-repo build budget
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [master, main]
   schedule:
     # 04:17 UTC nightly — small offset to dodge the top-of-hour
     # GitHub Actions traffic spike.
@@ -50,14 +52,14 @@ jobs:
       - name: Checkout gala_tui
         uses: actions/checkout@v4
         with:
-          repository: martianoff/gala_tui
+          repository: martianoff/gala-tui
           ref: ${{ env.GALA_TUI_REF }}
           path: gala_tui
 
       - name: Checkout gala_team
         uses: actions/checkout@v4
         with:
-          repository: martianoff/gala_team
+          repository: martianoff/gala-team
           ref: ${{ env.GALA_TEAM_REF }}
           path: gala_team
 

--- a/.github/workflows/perf-real-build.yml
+++ b/.github/workflows/perf-real-build.yml
@@ -38,7 +38,7 @@ jobs:
     # or gala_team API surface intentionally changes; otherwise the
     # build failures will reveal real semantic drift.
     env:
-      GALA_TUI_REF: master
+      GALA_TUI_REF: main
       GALA_TEAM_REF: master
       WARM_BUDGET_SECONDS: "120"
       COLD_BUDGET_SECONDS: "240"

--- a/internal/transpiler/analyzer/BUILD.bazel
+++ b/internal/transpiler/analyzer/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
 go_test(
     name = "analyzer_test",
     srcs = [
+        "analyzed_pkgs_invariant_test.go",
         "analyzer_test.go",
         "batch_reuse_test.go",
         "cache_e2e_test.go",

--- a/internal/transpiler/analyzer/analyzed_pkgs_invariant_test.go
+++ b/internal/transpiler/analyzer/analyzed_pkgs_invariant_test.go
@@ -1,0 +1,197 @@
+package analyzer
+
+import (
+	"bytes"
+	"encoding/gob"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"martianoff/gala/internal/transpiler"
+)
+
+// TestBatchAnalyzer_AnalyzedPkgsStoresOnlyOwnTypes locks in the in-memory
+// projection invariant introduced in commit 4b99e60 (PR #316, Bug 15(a)).
+//
+// Before the fix, BatchAnalyzer.analyzedPkgs[P] held the post-Merge full
+// transitive type closure of P — every package's entry had inlined copies
+// of every type reachable through its import graph. On gala_team
+// (~96 packages including transitive deps) this drove peak RSS past
+// 16 GB before the OOM killer fired; a single app/cli entry alone reached
+// 4.6 GB. The fix replaces the eager `analyzedPkgs[X] = importedAST` writes
+// with `storeAnalyzedPkg(X, importedAST)`, which projects to own-types only
+// (via projectOwnRichAST in cache.go) and rebuilds the closure on demand
+// (via mergeAnalyzedClosureAt) using the recorded analyzedPkgImports.
+//
+// This test catches a regression that re-introduces eager-merge into
+// analyzedPkgs — either by direct reassignment or by a future refactor
+// that bypasses storeAnalyzedPkg's projection step. The shape mirrors
+// PR #308's on-disk equivalent (TestCachedRichAST_GobSizeBounded /
+// TestCacheE2E_DiskFootprintBounded) so the in-memory and on-disk
+// projections share a regression net.
+//
+// Fixture: three packages in a chain. C imports A and B; B imports A.
+// Analysing C populates analyzedPkgs entries for A, B, and (via Analyze)
+// nothing for C itself (top-level Analyze does not store). For each entry
+// we assert (a) the entry's own type is present, and (b) types defined in
+// any other gala package are absent. Then we gob-serialize each entry and
+// assert the byte size is bounded — a soft floor that catches the
+// "Merge slipped back in" failure mode even if the field layout changes.
+func TestBatchAnalyzer_AnalyzedPkgsStoresOnlyOwnTypes(t *testing.T) {
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module testmod\ngo 1.25\n"), 0644))
+
+	// Package A — sealed type with two variants. Sealed types fan out
+	// methods/companion-objects so a regression that re-inlines A into
+	// downstream packages would carry visible weight.
+	pkgA := filepath.Join(tmp, "pkg_a")
+	require.NoError(t, os.MkdirAll(pkgA, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgA, "a.gala"), []byte(
+		"package pkg_a\n\nsealed type TypeA {\n    case VariantA1(X int)\n    case VariantA2(Y string)\n}\n"), 0644))
+
+	// Package B — imports A, defines its own struct that references A.
+	pkgB := filepath.Join(tmp, "pkg_b")
+	require.NoError(t, os.MkdirAll(pkgB, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgB, "b.gala"), []byte(
+		"package pkg_b\n\nimport \"martianoff/gala/pkg_a\"\n\nstruct TypeB(A pkg_a.TypeA)\n"), 0644))
+
+	// Package C (leaf) — imports both A and B, defines TypeC.
+	pkgC := filepath.Join(tmp, "pkg_c")
+	require.NoError(t, os.MkdirAll(pkgC, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgC, "c.gala"), []byte(
+		"package pkg_c\n\nimport \"martianoff/gala/pkg_a\"\nimport \"martianoff/gala/pkg_b\"\n\nstruct TypeC(A pkg_a.TypeA, B pkg_b.TypeB)\n"), 0644))
+
+	parser := transpiler.NewAntlrGalaParser()
+	searchPaths := []string{tmp}
+	if std := stdSearchPathForE2E(); std != "" {
+		searchPaths = append(searchPaths, std)
+	}
+
+	batch := NewBatchAnalyzer(parser, searchPaths, tmp)
+	cFile := filepath.Join(pkgC, "c.gala")
+	body, err := os.ReadFile(cFile)
+	require.NoError(t, err)
+	tree, err := parser.Parse(string(body))
+	require.NoError(t, err)
+	_, err = batch.Analyze(tree, cFile)
+	require.NoError(t, err)
+
+	// After analysing the leaf, both transitive dependencies must have
+	// been recorded. (C itself is the top-level Analyze target and is not
+	// stored in analyzedPkgs.)
+	const (
+		pathA = "martianoff/gala/pkg_a"
+		pathB = "martianoff/gala/pkg_b"
+	)
+	entryA, hasA := batch.inner.analyzedPkgs[pathA]
+	entryB, hasB := batch.inner.analyzedPkgs[pathB]
+	require.True(t, hasA, "expected analyzedPkgs entry for %s after analysing leaf C; entries: %v",
+		pathA, keysOfAnalyzedPkgs(batch.inner.analyzedPkgs))
+	require.True(t, hasB, "expected analyzedPkgs entry for %s after analysing leaf C; entries: %v",
+		pathB, keysOfAnalyzedPkgs(batch.inner.analyzedPkgs))
+	require.NotNil(t, entryA, "pkg_a entry must not be the in-progress nil placeholder after Analyze returned")
+	require.NotNil(t, entryB, "pkg_b entry must not be the in-progress nil placeholder after Analyze returned")
+
+	// Core invariant — each entry holds ONLY the package's own types.
+	// pkg_a's entry must have TypeA but NOT pkg_b's TypeB or pkg_c's TypeC.
+	// pkg_b's entry must have TypeB but NOT pkg_a's TypeA (despite import).
+	t.Run("pkg_a entry has own type", func(t *testing.T) {
+		assert.Contains(t, entryA.Types, "pkg_a.TypeA",
+			"pkg_a's analyzedPkgs entry should contain its own sealed type pkg_a.TypeA")
+	})
+	t.Run("pkg_a entry has NO foreign types", func(t *testing.T) {
+		for k := range entryA.Types {
+			if !strings.HasPrefix(k, "pkg_a.") {
+				t.Errorf("pkg_a's analyzedPkgs entry leaks foreign type key %q — projectOwnRichAST should have stripped it. "+
+					"This is the regression that caused gala_team to OOM at 16+ GB RSS (Bug 15(a)).", k)
+			}
+		}
+		// pkg_b's TypeB and pkg_c's TypeC must be absent specifically.
+		assert.NotContains(t, entryA.Types, "pkg_b.TypeB",
+			"pkg_b.TypeB must NOT appear in pkg_a's entry — pkg_a does not import pkg_b")
+		assert.NotContains(t, entryA.Types, "pkg_c.TypeC",
+			"pkg_c.TypeC must NOT appear in pkg_a's entry — pkg_c is downstream of pkg_a")
+	})
+	t.Run("pkg_b entry has own type", func(t *testing.T) {
+		assert.Contains(t, entryB.Types, "pkg_b.TypeB",
+			"pkg_b's analyzedPkgs entry should contain its own struct pkg_b.TypeB")
+	})
+	t.Run("pkg_b entry has NO transitive types from pkg_a", func(t *testing.T) {
+		// This is the key regression — pre-fix, pkg_b's entry would have
+		// pkg_a.TypeA inlined because Merge folded it in via the import
+		// edge. Post-fix, only pkg_b's own keys remain; pkg_a's types are
+		// reconstituted at read time through mergeAnalyzedClosureAt.
+		for k := range entryB.Types {
+			if !strings.HasPrefix(k, "pkg_b.") {
+				t.Errorf("pkg_b's analyzedPkgs entry leaks foreign type key %q — eager Merge regression. "+
+					"projectOwnRichAST should have filtered to own package only.", k)
+			}
+		}
+		assert.NotContains(t, entryB.Types, "pkg_a.TypeA",
+			"pkg_a.TypeA must NOT be inlined into pkg_b's entry — that is the eager-merge bug fixed in 4b99e60")
+		assert.NotContains(t, entryB.Types, "pkg_a.VariantA1",
+			"pkg_a.VariantA1 (sealed companion) must NOT be inlined into pkg_b's entry")
+		assert.NotContains(t, entryB.Types, "pkg_a.VariantA2",
+			"pkg_a.VariantA2 (sealed companion) must NOT be inlined into pkg_b's entry")
+	})
+
+	// Closure walk must still reconstruct the full transitive type set
+	// for pkg_b on demand — this proves the projection didn't break the
+	// downstream consumer's view.
+	t.Run("mergeAnalyzedClosureAt reconstructs transitive types on read", func(t *testing.T) {
+		target := &transpiler.RichAST{
+			Types:    make(map[string]*transpiler.TypeMetadata),
+			Packages: make(map[string]string),
+		}
+		batch.inner.mergeAnalyzedClosureAt(target, pathB, make(map[string]bool))
+		assert.Contains(t, target.Types, "pkg_b.TypeB",
+			"closure walker should pull pkg_b's own type into target")
+		assert.Contains(t, target.Types, "pkg_a.TypeA",
+			"closure walker should pull pkg_a.TypeA into target via the recorded import edge — "+
+				"if absent, mergeAnalyzedClosureAt is broken")
+	})
+
+	// Bounded-size sanity: gob each entry and assert it fits well under
+	// 1 MiB. This is the "if the structure changes, still catch the
+	// regression" net. Pre-fix, app/cli's gala_team entry was 4.6 GB; any
+	// reasonable bound rules it out. We use 256 KiB headroom, which is
+	// double the on-disk cache budget (TestCachedRichAST_GobSizeBounded
+	// uses 64 KiB) — the in-memory entry is allowed to carry slightly
+	// more incidental fields than the gob-only CachedRichAST view.
+	const maxEntryBytes = 256 * 1024
+	t.Run("entry sizes are bounded", func(t *testing.T) {
+		for _, c := range []struct {
+			path  string
+			entry *transpiler.RichAST
+		}{
+			{pathA, entryA},
+			{pathB, entryB},
+		} {
+			cached := toCachedRichAST(c.entry, "h", nil)
+			var buf bytes.Buffer
+			require.NoError(t, gob.NewEncoder(&buf).Encode(cached))
+			if buf.Len() > maxEntryBytes {
+				t.Errorf("analyzedPkgs[%s] gob-serializes to %d bytes (>%d) — eager-merge regression suspected. "+
+					"Pre-fix baseline on gala_team was 4.6 GB per app/cli-class entry.",
+					c.path, buf.Len(), maxEntryBytes)
+			} else {
+				t.Logf("analyzedPkgs[%s]: %d bytes (well under %d budget)", c.path, buf.Len(), maxEntryBytes)
+			}
+		}
+	})
+}
+
+// keysOfAnalyzedPkgs returns the set of paths recorded in analyzedPkgs.
+// Used only for failure-message context so a regression's diagnostic
+// shows what *did* get stored, not just what was expected.
+func keysOfAnalyzedPkgs(m map[string]*transpiler.RichAST) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -29,7 +29,8 @@ func GetBaseMetadata(p transpiler.GalaParser, searchPaths []string) *transpiler.
 	a := &galaAnalyzer{
 		parser:           p,
 		searchPaths:      searchPaths,
-		analyzedPkgs:     make(map[string]*transpiler.RichAST),
+		analyzedPkgs:        make(map[string]*transpiler.RichAST),
+		analyzedPkgImports:  make(map[string][]string),
 		checkedDirs:      make(map[string]bool),
 		siblingTreeCache: make(map[string]*siblingCacheEntry),
 		parsedFileCache:  make(map[string]*parsedFileEntry),
@@ -63,7 +64,17 @@ type galaAnalyzer struct {
 	parser       transpiler.GalaParser
 	searchPaths  []string
 	packageFiles []string                       // Explicit sibling files belonging to the same package
-	analyzedPkgs map[string]*transpiler.RichAST // Cache of analyzed packages
+	// analyzedPkgs caches per-package metadata across files in a batch.
+	// Each entry holds an OWN-ONLY projection of the package's RichAST
+	// (Types/Functions/methods/etc. originating in that package). The
+	// transitive closure required by a downstream consumer is reconstructed
+	// at read time by recursively merging direct-import entries via
+	// analyzedPkgImports — see mergeAnalyzedClosureAt. This bounds the
+	// in-memory size of the batch cache to O(packages × own_metadata)
+	// instead of O(packages × full_closure), which is the in-memory
+	// counterpart to PR #308's on-disk cache projection.
+	analyzedPkgs        map[string]*transpiler.RichAST // Cache of analyzed packages (own-only projections)
+	analyzedPkgImports  map[string][]string            // path -> direct GALA import paths (for closure rehydration)
 	checkedDirs  map[string]bool
 	resolver            *module.Resolver               // Handles module root discovery and package path resolution
 	currentRichAST      *transpiler.RichAST            // Set during Analyze() for cross-reference in resolveTypeWithParams
@@ -150,7 +161,8 @@ func NewGalaAnalyzer(p transpiler.GalaParser, searchPaths []string, projectRoot 
 	return &galaAnalyzer{
 		parser:           p,
 		searchPaths:      searchPaths,
-		analyzedPkgs:     make(map[string]*transpiler.RichAST),
+		analyzedPkgs:        make(map[string]*transpiler.RichAST),
+		analyzedPkgImports:  make(map[string][]string),
 		checkedDirs:      make(map[string]bool),
 		siblingTreeCache: make(map[string]*siblingCacheEntry),
 		parsedFileCache:  make(map[string]*parsedFileEntry),
@@ -171,7 +183,8 @@ func NewGalaAnalyzerWithBase(base *transpiler.RichAST, p transpiler.GalaParser, 
 		baseMetadata:     base,
 		parser:           p,
 		searchPaths:      searchPaths,
-		analyzedPkgs:     make(map[string]*transpiler.RichAST),
+		analyzedPkgs:        make(map[string]*transpiler.RichAST),
+		analyzedPkgImports:  make(map[string][]string),
 		checkedDirs:      make(map[string]bool),
 		siblingTreeCache: make(map[string]*siblingCacheEntry),
 		parsedFileCache:  make(map[string]*parsedFileEntry),
@@ -194,7 +207,8 @@ func NewGalaAnalyzerWithPackageFiles(p transpiler.GalaParser, searchPaths []stri
 		parser:           p,
 		searchPaths:      searchPaths,
 		packageFiles:     packageFiles,
-		analyzedPkgs:     make(map[string]*transpiler.RichAST),
+		analyzedPkgs:        make(map[string]*transpiler.RichAST),
+		analyzedPkgImports:  make(map[string][]string),
 		checkedDirs:      make(map[string]bool),
 		siblingTreeCache: make(map[string]*siblingCacheEntry),
 		parsedFileCache:  make(map[string]*parsedFileEntry),
@@ -218,6 +232,7 @@ func NewGalaAnalyzerForLSP(p transpiler.GalaParser, searchPaths []string, projec
 		parser:              p,
 		searchPaths:         searchPaths,
 		analyzedPkgs:        make(map[string]*transpiler.RichAST),
+		analyzedPkgImports:  make(map[string][]string),
 		checkedDirs:         make(map[string]bool),
 		siblingTreeCache:    make(map[string]*siblingCacheEntry),
 		parsedFileCache:     make(map[string]*parsedFileEntry),
@@ -245,14 +260,15 @@ func NewBatchAnalyzer(p transpiler.GalaParser, searchPaths []string, projectRoot
 	}
 	return &BatchAnalyzer{
 		inner: &galaAnalyzer{
-			parser:           p,
-			searchPaths:      searchPaths,
-			analyzedPkgs:     make(map[string]*transpiler.RichAST),
-			checkedDirs:      make(map[string]bool),
-			siblingTreeCache: make(map[string]*siblingCacheEntry),
-			parsedFileCache:  make(map[string]*parsedFileEntry),
-			resolver:         module.NewResolver(searchPaths),
-			cache:            newAnalysisCache(resolveCacheRoot(root)),
+			parser:             p,
+			searchPaths:        searchPaths,
+			analyzedPkgs:       make(map[string]*transpiler.RichAST),
+			analyzedPkgImports: make(map[string][]string),
+			checkedDirs:        make(map[string]bool),
+			siblingTreeCache:   make(map[string]*siblingCacheEntry),
+			parsedFileCache:    make(map[string]*parsedFileEntry),
+			resolver:           module.NewResolver(searchPaths),
+			cache:              newAnalysisCache(resolveCacheRoot(root)),
 		},
 	}
 }
@@ -419,12 +435,23 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 	}
 
 	phaseStart = time.Now()
+	// mergeVisited tracks which analyzedPkgs entries we've already merged
+	// into richAST during this Analyze call, so each closure walk skips
+	// shared-dependency subtrees (e.g., std appearing inside every import)
+	// that the previous walk already brought in. This is a pure perf knob —
+	// RichAST.Merge is idempotent (the COW guard at transpiler.go:124 makes
+	// repeat merges no-ops for already-present types), so missing this
+	// dedupe wastes cycles but never produces wrong results.
+	mergeVisited := make(map[string]bool)
+
 	// 0.25 Load std package metadata
 	// For non-std packages: add as implicit import
 	// For std package: still load for intra-package type resolution, but don't add to Packages
 	if cachedStd, ok := a.analyzedPkgs[registry.StdImportPath]; ok && cachedStd != nil {
-		// Use cached std metadata
-		richAST.Merge(cachedStd)
+		// Use cached std metadata — walk its closure to materialize transitive
+		// types (analyzedPkgs entries are own-only projections; see
+		// projectOwnRichAST + mergeAnalyzedClosureAt for rationale).
+		a.mergeAnalyzedClosureAt(richAST, registry.StdImportPath, mergeVisited)
 		if pkgName != registry.StdPackageName {
 			richAST.Packages[registry.StdImportPath] = registry.StdPackageName
 		}
@@ -433,8 +460,8 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 		a.analyzedPkgs[registry.StdImportPath] = nil
 		stdAST, err := a.analyzePackage(registry.StdPackageName)
 		if err == nil {
-			a.analyzedPkgs[registry.StdImportPath] = stdAST
-			richAST.Merge(stdAST)
+			a.storeAnalyzedPkg(registry.StdImportPath, stdAST)
+			a.mergeAnalyzedClosureAt(richAST, registry.StdImportPath, mergeVisited)
 			if pkgName != registry.StdPackageName {
 				richAST.Packages[registry.StdImportPath] = registry.StdPackageName
 			}
@@ -474,8 +501,8 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 				}
 
 				if cached, ok := a.analyzedPkgs[path]; ok && cached != nil {
-					// Use cached metadata
-					richAST.Merge(cached)
+					// Use cached metadata — walk closure to materialize transitive types.
+					a.mergeAnalyzedClosureAt(richAST, path, mergeVisited)
 					if cached.PackageName != "" && cached.PackageName != "main" && cached.PackageName != "test" {
 						richAST.Packages[path] = cached.PackageName
 					}
@@ -499,8 +526,8 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 						richAST.AnalysisWarnings = append(richAST.AnalysisWarnings, warnMsg)
 					}
 					if err == nil {
-						a.analyzedPkgs[path] = importedAST
-						richAST.Merge(importedAST)
+						a.storeAnalyzedPkg(path, importedAST)
+						a.mergeAnalyzedClosureAt(richAST, path, mergeVisited)
 						// Store package name from the imported package
 						if importedAST.PackageName != "" && importedAST.PackageName != "main" && importedAST.PackageName != "test" {
 							richAST.Packages[path] = importedAST.PackageName
@@ -598,7 +625,7 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 	// are loaded into richAST.Types. Without this, resolveTypeWithParams for sibling
 	// struct fields can't find types from packages that only siblings import.
 	for _, sibTree := range siblingTrees {
-		a.scanImports(sibTree, richAST)
+		a.scanImports(sibTree, richAST, mergeVisited)
 	}
 
 	logPhase("scan-sibling-imports", phaseStart)
@@ -1950,7 +1977,15 @@ func (a *galaAnalyzer) resolveTypeWithParams(typeName string, pkgName string, ty
 // scanImports processes GALA imports from a source file and loads their metadata
 // into richAST. This is used to ensure sibling files' dependencies are available
 // for type resolution during extractSiblingFullMetadata.
-func (a *galaAnalyzer) scanImports(sf *grammar.SourceFileContext, richAST *transpiler.RichAST) {
+//
+// mergeVisited is the closure-walk dedup set scoped to the enclosing top-level
+// Analyze call. Pass nil to allocate one fresh per scan; pass the Analyze-level
+// set to share visited bookkeeping across the whole call so sibling imports
+// don't re-walk the std/collection_immutable subtree the main file already merged.
+func (a *galaAnalyzer) scanImports(sf *grammar.SourceFileContext, richAST *transpiler.RichAST, mergeVisited map[string]bool) {
+	if mergeVisited == nil {
+		mergeVisited = make(map[string]bool)
+	}
 	for _, impDecl := range sf.AllImportDeclaration() {
 		ctx := impDecl.(*grammar.ImportDeclarationContext)
 		for _, spec := range ctx.AllImportSpec() {
@@ -1969,7 +2004,7 @@ func (a *galaAnalyzer) scanImports(sf *grammar.SourceFileContext, richAST *trans
 				}
 
 				if cached, ok := a.analyzedPkgs[path]; ok && cached != nil {
-					richAST.Merge(cached)
+					a.mergeAnalyzedClosureAt(richAST, path, mergeVisited)
 					if cached.PackageName != "" && cached.PackageName != "main" && cached.PackageName != "test" {
 						richAST.Packages[path] = cached.PackageName
 					}
@@ -1982,8 +2017,8 @@ func (a *galaAnalyzer) scanImports(sf *grammar.SourceFileContext, richAST *trans
 					}
 					importedAST, err := a.analyzePackage(relPath)
 					if err == nil {
-						a.analyzedPkgs[path] = importedAST
-						richAST.Merge(importedAST)
+						a.storeAnalyzedPkg(path, importedAST)
+						a.mergeAnalyzedClosureAt(richAST, path, mergeVisited)
 						if importedAST.PackageName != "" && importedAST.PackageName != "main" && importedAST.PackageName != "test" {
 							richAST.Packages[path] = importedAST.PackageName
 						} else {
@@ -2375,6 +2410,79 @@ func (a *galaAnalyzer) analyzePackage(relPath string) (*transpiler.RichAST, erro
 	return pkgAST, nil
 }
 
+// storeAnalyzedPkg projects `importedAST` to its own-only form and records
+// it in analyzedPkgs along with the direct imports needed to recover the
+// transitive closure on demand. Returning the projection lets the caller
+// substitute it for `importedAST` in subsequent richAST.Merge calls so the
+// immediate Merge into the consumer is bounded by the package's own metadata
+// rather than its full closure (the closure is reconstructed by walking
+// directImports recursively — see mergeAnalyzedClosureAt).
+//
+// The projection shares Type/Function/Method pointers with `importedAST`
+// (it filters keys, not data), so this is cheap and the caller's continued
+// use of `importedAST` is safe.
+func (a *galaAnalyzer) storeAnalyzedPkg(path string, importedAST *transpiler.RichAST) *transpiler.RichAST {
+	if importedAST == nil {
+		return nil
+	}
+	own := projectOwnRichAST(importedAST)
+	a.analyzedPkgs[path] = own
+	if a.analyzedPkgImports != nil {
+		a.analyzedPkgImports[path] = extractDirectGalaImports(importedAST)
+	}
+	return own
+}
+
+// mergeAnalyzedClosureAt walks the in-memory analyzedPkgs entry for `path`
+// and recursively merges the own-only projections of all transitively-
+// reachable GALA packages into `target`. This reconstructs, on demand, the
+// type closure that was previously stored eagerly at every analyzedPkgs
+// entry — except the closure now lives only in `target` (the consumer's
+// richAST), so the analyzedPkgs cache stays small.
+//
+// `visited` deduplicates work within a single closure walk. It is allocated
+// fresh per call site (one per direct import in the consumer's source file)
+// because RichAST.Merge is idempotent under repeated visits — the COW guard
+// at transpiler.go:124 short-circuits when the existing entry already has
+// every method/field/sealed-variant the merged copy would contribute. An
+// over-eager walk costs only map lookups, never data duplication.
+//
+// Returns the package name of `path` if known (so callers can populate
+// target.Packages[path]).
+func (a *galaAnalyzer) mergeAnalyzedClosureAt(target *transpiler.RichAST, path string, visited map[string]bool) string {
+	if visited == nil || target == nil {
+		return ""
+	}
+	if visited[path] {
+		// Already merged in this walk — but caller may still want pkgName.
+		if cached := a.analyzedPkgs[path]; cached != nil {
+			return cached.PackageName
+		}
+		return ""
+	}
+	visited[path] = true
+	cached := a.analyzedPkgs[path]
+	if cached == nil {
+		return ""
+	}
+	target.Merge(cached)
+	for _, imp := range a.analyzedPkgImports[path] {
+		if imp == "" || imp == path {
+			continue
+		}
+		impPkg := a.mergeAnalyzedClosureAt(target, imp, visited)
+		if impPkg != "" && impPkg != "main" && impPkg != "test" {
+			if target.Packages == nil {
+				target.Packages = make(map[string]string)
+			}
+			if _, ok := target.Packages[imp]; !ok {
+				target.Packages[imp] = impPkg
+			}
+		}
+	}
+	return cached.PackageName
+}
+
 // rehydrateImports re-merges the metadata of each direct import into the
 // loaded own-only pkgAST. The recursion bottoms out at packages with no
 // imports; cycle protection is handled by the analyzer's analyzedPkgs map
@@ -2383,6 +2491,13 @@ func (a *galaAnalyzer) analyzePackage(relPath string) (*transpiler.RichAST, erro
 // pkgPath is the path of the package being rehydrated and is excluded from
 // its own import list as a defensive guard against pathological cycles
 // where a serialized cache might list itself.
+//
+// Note: analyzedPkgs entries are themselves own-only projections (see
+// projectOwnRichAST), so a single Merge of `analyzedPkgs[imp]` would only
+// bring `imp`'s own types in. We use mergeAnalyzedClosureAt to walk the
+// transitive closure and pull every reachable package's own metadata into
+// pkgAST — this is the same closure walk that callers of analyzedPkgs use
+// during a fresh Analyze, applied here to a disk-cache-hit pkgAST.
 func (a *galaAnalyzer) rehydrateImports(pkgPath string, pkgAST *transpiler.RichAST, directImports []string) {
 	if pkgAST == nil || len(directImports) == 0 {
 		return
@@ -2390,6 +2505,10 @@ func (a *galaAnalyzer) rehydrateImports(pkgPath string, pkgAST *transpiler.RichA
 	if pkgAST.Packages == nil {
 		pkgAST.Packages = make(map[string]string)
 	}
+	visited := make(map[string]bool)
+	// The pkgAST itself is own-only (loaded from disk cache); mark it visited
+	// so the closure walk doesn't re-merge its own entries.
+	visited[pkgPath] = true
 	for _, imp := range directImports {
 		if imp == "" || imp == pkgPath {
 			continue
@@ -2398,7 +2517,7 @@ func (a *galaAnalyzer) rehydrateImports(pkgPath string, pkgAST *transpiler.RichA
 		// avoids redundant disk reads and keeps cycle detection simple.
 		if cached, ok := a.analyzedPkgs[imp]; ok {
 			if cached != nil {
-				pkgAST.Merge(cached)
+				a.mergeAnalyzedClosureAt(pkgAST, imp, visited)
 				if cached.PackageName != "" && cached.PackageName != "main" && cached.PackageName != "test" {
 					pkgAST.Packages[imp] = cached.PackageName
 				}
@@ -2426,8 +2545,8 @@ func (a *galaAnalyzer) rehydrateImports(pkgPath string, pkgAST *transpiler.RichA
 		if err != nil || importedAST == nil {
 			continue
 		}
-		a.analyzedPkgs[imp] = importedAST
-		pkgAST.Merge(importedAST)
+		a.storeAnalyzedPkg(imp, importedAST)
+		a.mergeAnalyzedClosureAt(pkgAST, imp, visited)
 		if importedAST.PackageName != "" && importedAST.PackageName != "main" && importedAST.PackageName != "test" {
 			pkgAST.Packages[imp] = importedAST.PackageName
 		}
@@ -2776,13 +2895,14 @@ func (a *galaAnalyzer) ensureTranspiled(importPath string) error {
 		// Analyze without recursion by using a separate analyzer
 		// This avoids circular dependency issues
 		tempAnalyzer := &galaAnalyzer{
-			parser:           a.parser,
-			searchPaths:      a.searchPaths,
-			analyzedPkgs:     make(map[string]*transpiler.RichAST),
-			checkedDirs:      make(map[string]bool),
-			siblingTreeCache: make(map[string]*siblingCacheEntry),
-			parsedFileCache:  make(map[string]*parsedFileEntry),
-			resolver:         a.resolver,
+			parser:             a.parser,
+			searchPaths:        a.searchPaths,
+			analyzedPkgs:       make(map[string]*transpiler.RichAST),
+			analyzedPkgImports: make(map[string][]string),
+			checkedDirs:        make(map[string]bool),
+			siblingTreeCache:   make(map[string]*siblingCacheEntry),
+			parsedFileCache:    make(map[string]*parsedFileEntry),
+			resolver:           a.resolver,
 		}
 
 		richAST, err := tempAnalyzer.Analyze(tree, srcPath)

--- a/internal/transpiler/analyzer/cache.go
+++ b/internal/transpiler/analyzer/cache.go
@@ -246,6 +246,136 @@ func filterGoTypeInfo(g *transpiler.GoTypeInfo, pkg string) *transpiler.GoTypeIn
 	return out
 }
 
+// projectOwnRichAST returns an in-memory own-only projection of `r`. It is
+// the live counterpart of toCachedRichAST: produces a *RichAST (instead of
+// the gob-serializable *CachedRichAST) so it can be stored in the analyzer's
+// analyzedPkgs map without the transitive type closure that Merge accumulated
+// from imports.
+//
+// Why this exists: the BatchAnalyzer keeps `analyzedPkgs[path]` for the entire
+// run so std and shared deps are not re-analyzed per file. Without projection,
+// each entry is the post-Merge "full closure" RichAST, which on a project
+// like gala_team (16 first-party packages + ~80 transitive) blows past 16 GB
+// of RSS because every package re-stores cloned (COW'd) copies of the same
+// transitive types. Projection retains only the metadata that *originated* in
+// this package; downstream consumers reconstruct the closure on demand by
+// recursively merging direct imports' projections via mergeAnalyzedClosureAt.
+//
+// Tree, FilePath, SourceContent, AnalysisWarnings, EmbedDirectives, and
+// ImportAliases are intentionally dropped — they belong to the per-file
+// Analyze invocation, not to the package-level shared cache. PackageName,
+// Types, Functions, CompanionObjects, GoExports, GoTypeInfo, TypeAliases,
+// and ImportPathMap follow the same own-package filter as toCachedRichAST.
+//
+// Packages is set to nil; the recursive closure walker re-establishes
+// path→pkgName mappings from analyzedPkgImports + analyzedPkgs[imp].PackageName.
+func projectOwnRichAST(r *transpiler.RichAST) *transpiler.RichAST {
+	if r == nil {
+		return nil
+	}
+	pkg := r.PackageName
+
+	var ownTypes map[string]*transpiler.TypeMetadata
+	if len(r.Types) > 0 {
+		ownTypes = make(map[string]*transpiler.TypeMetadata)
+		for k, v := range r.Types {
+			if v == nil {
+				continue
+			}
+			if v.Package == pkg {
+				ownTypes[k] = v
+			} else if v.Package == "" && belongsToPkg(k, pkg) {
+				ownTypes[k] = v
+			}
+		}
+	}
+
+	var ownFuncs map[string]*transpiler.FunctionMetadata
+	if len(r.Functions) > 0 {
+		ownFuncs = make(map[string]*transpiler.FunctionMetadata)
+		for k, v := range r.Functions {
+			if v == nil {
+				continue
+			}
+			if v.Package == pkg {
+				ownFuncs[k] = v
+			} else if v.Package == "" && belongsToPkg(k, pkg) {
+				ownFuncs[k] = v
+			}
+		}
+	}
+
+	var ownCos map[string]*transpiler.CompanionObjectMetadata
+	if len(r.CompanionObjects) > 0 {
+		ownCos = make(map[string]*transpiler.CompanionObjectMetadata)
+		for k, v := range r.CompanionObjects {
+			if v == nil {
+				continue
+			}
+			if v.Package == pkg {
+				ownCos[k] = v
+			} else if v.Package == "" && belongsToPkg(k, pkg) {
+				ownCos[k] = v
+			}
+		}
+	}
+
+	var ownGoExports map[string][]string
+	if len(r.GoExports) > 0 {
+		if pkg != "" {
+			if syms, ok := r.GoExports[pkg]; ok && len(syms) > 0 {
+				ownGoExports = map[string][]string{pkg: syms}
+			}
+		} else {
+			ownGoExports = r.GoExports
+		}
+	}
+
+	var ownGoTypeInfo *transpiler.GoTypeInfo
+	if r.GoTypeInfo != nil {
+		ownGoTypeInfo = filterGoTypeInfo(r.GoTypeInfo, pkg)
+	}
+
+	return &transpiler.RichAST{
+		PackageName:      r.PackageName,
+		Types:            ownTypes,
+		Functions:        ownFuncs,
+		Packages:         nil, // re-established by mergeAnalyzedClosureAt walker
+		CompanionObjects: ownCos,
+		GoExports:        ownGoExports,
+		GoTypeInfo:       ownGoTypeInfo,
+		TypeAliases:      r.TypeAliases,
+		ImportPathMap:    r.ImportPathMap,
+	}
+}
+
+// extractDirectGalaImports returns the GALA import paths declared by the
+// package whose RichAST is `r`. We reuse `r.Packages` because it is built
+// up at line ~478 of Analyze with one entry per direct GALA import scanned
+// from the source file (transitive paths are also added there via Merge,
+// but those entries' values are still resolved by the time we project, and
+// the recursive closure walker is idempotent under repeated visits — over-
+// reporting is harmless, missing edges would lose types). When projecting
+// the post-Merge form for storage in analyzedPkgs, we therefore record
+// every Packages key as a "direct" import for traversal purposes.
+//
+// This is deliberately broader than the on-disk DirectImports list (which
+// uses extractDirectImportPaths to read source). The on-disk list is the
+// authoritative direct-import set used for cache invalidation and disk
+// rehydration; the in-memory list is just a closure traversal map and only
+// needs to cover all paths reachable via Merge so the walker doesn't miss
+// types.
+func extractDirectGalaImports(r *transpiler.RichAST) []string {
+	if r == nil || len(r.Packages) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(r.Packages))
+	for path := range r.Packages {
+		out = append(out, path)
+	}
+	return out
+}
+
 func fromCachedRichAST(c *CachedRichAST) *transpiler.RichAST {
 	if c == nil {
 		return nil


### PR DESCRIPTION
## Summary

**Symptom:** gala_team (~96 packages including transitive deps) OOM-killed CI runners with peak RSS exceeding 16 GB during analyzer runs.

**Root cause:** `BatchAnalyzer.analyzedPkgs` stored each package's `RichAST` after `RichAST.Merge` had folded in the entire transitive type closure of its imports. Entries were never evicted, so peak memory grew as O(packages * closure size). Each downstream package re-paid the cost of all its transitive ancestors.

**Fix:** Project entries written to `analyzedPkgs` to own-types only, and walk the import closure lazily on read. This is the in-memory analogue of the on-disk projection introduced in #308 for the cache. Specifically:

- new `analyzedPkgImports` map records each package's direct gala imports
- `storeAnalyzedPkg` writes only the package's own types (via the new `projectOwnRichAST` + `extractDirectGalaImports` helpers in `cache.go`)
- `mergeAnalyzedClosureAt` rebuilds a package's full `RichAST` on demand by walking the recorded import edges with a shared `mergeVisited` cycle guard
- `Analyze` / `scanImports` / `rehydrateImports` thread `mergeVisited` through so a single top-level analysis amortises closure walks

## Verification

On gala_team:

- peak RSS: 16+ GB OOM -> **884 MB**
- wall time: **70 s**
- on-disk cache size: 9.7-11 GB -> **1.2 MB**
- all 53 bazel test targets pass

In this repo:

- `bazel test //internal/transpiler/...`: 8/8 pass

## References

- Bug 15(a) in `docs/private/GALA_TEAM_0_39_2_REGRESSIONS.md`
- #308 (on-disk cache projection) as prior art

## Test plan

- [x] `bazel test //internal/transpiler/...` passes locally (8/8)
- [ ] CI green on this PR
- [ ] verify on gala_team: peak RSS < 1 GB
- [ ] verify on gala_team: wall time comparable (~70 s)
- [ ] verify on gala_team: all 53 bazel test targets pass
- [ ] spot-check that analyzer output (generated code) is byte-identical to pre-fix on a representative package