### PR TITLE
fix(release): bump gala.mod to 0.42.0

### DIFF
--- a/gala.mod
+++ b/gala.mod
@@ -1,3 +1,3 @@
 module martianoff/gala
 
-gala 0.41.0
+gala 0.42.0


### PR DESCRIPTION
## Summary

Bumps `gala.mod` from 0.41.0 → 0.42.0 ahead of the GitHub release tag.

Mirrors the 0.41.0 release flow (#315).

## What's in 0.42.0

- **#316** — analyzer in-memory `analyzedPkgs` projected to own-types only with lazy closure walk on read. Fixes 16 GB OOM on multi-package downstream projects (`gala_team`'s `app/cli` cache was 4.6 GB pre-fix). In-memory analogue of #308's on-disk projection. Includes regression test for the own-types invariant.
- **#317** — Bazel persistent-worker mode for `gala transpile`, plus analyzer perf work:
  - One long-lived `gala --persistent_worker` process per Bazel worker_key amortizes analyzer warm-up across ~100 per-package transpiles.
  - Memoized per-package fingerprint, per-package analyze, resolver lookups, and `AnalyzeGoFiles`.
  - Hand-rolled binary cache codec replaces `encoding/gob` (3.35× faster decode, 5.8× faster encode, no new deps).
  - Cumulative impact on `gala_team` CI: cold build 1162s → ~440s (-62%), apex transpile 794s → 299s (-62%).
  - Worker `ctx.actions.run` sets `use_default_shell_env=True` so GOROOT/PATH propagate (fixes `func(any)` widening regression on Linux).

## Test plan

- [x] `bazel test //internal/transpiler/...` passes (8/8 + worker proto tests).
- [x] `bazel test //examples/... //bazel_test_fixtures/...` passes (294/294).
- [x] Perf workflow on master builds gala_team within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)