### PR TITLE
docs(showcase): add gala-team and gala-tui to README and website

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -436,6 +436,7 @@ Mutable variants of all collection types are available in `collection_mutable` f
 | [Log Analyzer](https://github.com/martianoff/gala-log-analyzer) | Structured log parsing with Go stdlib interop (strings, strconv, fmt) + functional pipelines (FoldLeft, Filter, AppendAll) (with Go comparison) |
 | [GALA Server](https://github.com/martianoff/gala-server) | Immutable HTTP server library with builder-pattern configuration, route groups, filters, and pattern matching -- written entirely in GALA |
 | [GALA TUI](https://github.com/martianoff/gala-tui) | Elm-architecture TUI framework -- immutable widgets, differential renderer, async runtime, fuzzy command palette, markdown, mouse, themes -- written entirely in GALA |
+| [GALA Team](https://github.com/martianoff/gala-team) | Multi-agent Claude CLI orchestrator -- a Team Lead delegates to Engineers and QAs, reviews their work, and hands you a PR for sign-off -- written entirely in GALA with gala_tui |
 
 ---
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -48,3 +48,5 @@ Welcome to the GALA documentation hub. Here you will find everything you need to
 | [State Machine Example](https://github.com/martianoff/gala-state-machine-example) | State machines with sealed types and pattern matching |
 | [Log Analyzer](https://github.com/martianoff/gala-log-analyzer) | Structured log parsing with Go stdlib interop and functional pipelines |
 | [GALA Server](https://github.com/martianoff/gala-server) | Immutable HTTP server library with builder-pattern configuration |
+| [GALA TUI](https://github.com/martianoff/gala-tui) | Elm-architecture TUI framework -- immutable widgets, differential renderer, async runtime |
+| [GALA Team](https://github.com/martianoff/gala-team) | Multi-agent Claude CLI orchestrator -- Team Lead delegates to Engineers and QAs, reviews work, hands you a PR |

--- a/website/getting-started.md
+++ b/website/getting-started.md
@@ -356,3 +356,5 @@ You are set up and running. Here is where to go from here:
 | [State Machine Example](https://github.com/martianoff/gala-state-machine-example) | State machines with sealed types and pattern matching |
 | [Log Analyzer](https://github.com/martianoff/gala-log-analyzer) | Structured log parsing with Go stdlib interop and functional pipelines |
 | [GALA Server](https://github.com/martianoff/gala-server) | Immutable HTTP server library with builder-pattern configuration |
+| [GALA TUI](https://github.com/martianoff/gala-tui) | Elm-architecture TUI framework -- immutable widgets, differential renderer, async runtime |
+| [GALA Team](https://github.com/martianoff/gala-team) | Multi-agent Claude CLI orchestrator -- Team Lead delegates to Engineers and QAs, reviews work, hands you a PR |

--- a/website/index.md
+++ b/website/index.md
@@ -260,3 +260,5 @@ All collections support `Map`, `Filter`, `FoldLeft`, `ForEach`, `Exists`, `Find`
 | [State Machine Example](https://github.com/martianoff/gala-state-machine-example) | State machines with sealed types and pattern matching |
 | [Log Analyzer](https://github.com/martianoff/gala-log-analyzer) | Structured log parsing with Go stdlib interop and functional pipelines |
 | [GALA Server](https://github.com/martianoff/gala-server) | Immutable HTTP server library with builder-pattern configuration |
+| [GALA TUI](https://github.com/martianoff/gala-tui) | Elm-architecture TUI framework — immutable widgets, differential renderer, async runtime |
+| [GALA Team](https://github.com/martianoff/gala-team) | Multi-agent Claude CLI orchestrator — Team Lead delegates to Engineers and QAs, reviews work, hands you a PR |


### PR DESCRIPTION
## Summary
- Appends **GALA Team** ([martianoff/gala-team](https://github.com/martianoff/gala-team)) to the Showcase table in `README.MD` and to all three website Showcase tables (`website/index.md`, `website/getting-started.md`, `website/docs/index.md`).
- Backfills **GALA TUI** in the three website tables, which was missing from the website Showcase even though it already shipped in the README.

## Test plan
- [ ] Visual review of the updated Showcase tables
- [ ] Verify gala-team and gala-tui links resolve to the correct repos
- [ ] Confirm Jekyll renders the website tables correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)