### PR TITLE
refactor(transpiler): IsUnusable helpers + map capacity hints (/simplify pass)

### DIFF
--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -1816,7 +1816,7 @@ func (a *galaAnalyzer) computeExtractIndices(applyMethod *transpiler.MethodMetad
 
 	// For each parameter type in Apply, find its index in the container's type parameters
 	for _, paramType := range applyMethod.ParamTypes {
-		if paramType == nil || paramType.IsNil() {
+		if transpiler.IsUnusable(paramType) {
 			continue
 		}
 		paramTypeName := normalizeTypeName(paramType.String())
@@ -2816,7 +2816,7 @@ func synthesizeTypeMetadataFromGo(pkgAST *transpiler.RichAST, goInfo *transpiler
 // to populate ImmutFlags so downstream auto-unwrap fires on cross-package
 // access of types whose only metadata source is the generated .gen.go.
 func isGoFieldImmutable(typ transpiler.Type) bool {
-	if typ == nil || typ.IsNil() {
+	if transpiler.IsUnusable(typ) {
 		return false
 	}
 	base := typ.BaseName()

--- a/internal/transpiler/analyzer/validation.go
+++ b/internal/transpiler/analyzer/validation.go
@@ -123,7 +123,7 @@ func validateTypeReferences(ast *transpiler.RichAST) []ValidationWarning {
 // checkTypeExists verifies that a referenced type can be resolved.
 // Returns nil if the type is valid, or a warning if it cannot be found.
 func checkTypeExists(ast *transpiler.RichAST, t transpiler.Type, location string) *ValidationWarning {
-	if t == nil || t.IsNil() || t.IsAny() {
+	if transpiler.IsUnusableOrAny(t) {
 		return nil
 	}
 
@@ -404,7 +404,7 @@ func validateImportTypeConsistency(ast *transpiler.RichAST) []ValidationWarning 
 // checkPackagePrefixInType recursively checks if any NamedType in a type tree has an
 // unknown package prefix.
 func checkPackagePrefixInType(ast *transpiler.RichAST, t transpiler.Type, location string, warnings *[]ValidationWarning) {
-	if t == nil || t.IsNil() {
+	if transpiler.IsUnusable(t) {
 		return
 	}
 	switch ty := t.(type) {

--- a/internal/transpiler/transformer/bridge.go
+++ b/internal/transpiler/transformer/bridge.go
@@ -25,7 +25,7 @@ func (t *galaASTTransformer) normalizeTypeName(name string) string {
 
 // toInferType converts a transpiler.Type to an infer.Type
 func (t *galaASTTransformer) toInferType(typ transpiler.Type) infer.Type {
-	if typ == nil || typ.IsNil() {
+	if transpiler.IsUnusable(typ) {
 		return &infer.TypeConst{Name: "any"}
 	}
 

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -337,7 +337,7 @@ func (t *galaASTTransformer) tryTransformGenericMethodAsFunction(
 		inferredFromExpected := make(map[string]transpiler.Type)
 		t.unifyForInference(substitutedReturn, pendingExpected, methodMeta.TypeParams, inferredFromExpected)
 		for tp, inferred := range inferredFromExpected {
-			if inferred == nil || inferred.IsNil() || inferred.IsAny() {
+			if transpiler.IsUnusableOrAny(inferred) {
 				continue
 			}
 			if _, alreadySet := typeSubst[tp]; !alreadySet {
@@ -432,7 +432,7 @@ func (t *galaASTTransformer) tryTransformGenericMethodAsFunction(
 			}
 			preTransformed[i] = expr
 			argType := t.getExprTypeName(expr)
-			if argType == nil || argType.IsNil() || argType.IsAny() {
+			if transpiler.IsUnusableOrAny(argType) {
 				continue
 			}
 			inferredMap := make(map[string]transpiler.Type)
@@ -517,7 +517,7 @@ func (t *galaASTTransformer) tryTransformGenericMethodAsFunction(
 							if _, alreadySet := typeSubst[tp]; alreadySet {
 								continue
 							}
-							if inferred == nil || inferred.IsNil() || inferred.IsAny() {
+							if transpiler.IsUnusableOrAny(inferred) {
 								continue
 							}
 							typeSubst[tp] = inferred.String()
@@ -1174,7 +1174,7 @@ func (t *galaASTTransformer) resolveNamedArgExpectedFuncType(fun ast.Expr, argNa
 			for i, fieldName := range sv.FieldNames {
 				if fieldName == argName && i < len(sv.FieldTypes) {
 					expected := sv.FieldTypes[i]
-					if expected == nil || expected.IsNil() {
+					if transpiler.IsUnusable(expected) {
 						break
 					}
 					// Apply parent sealed type's type-param substitution when the
@@ -1764,7 +1764,7 @@ func (t *galaASTTransformer) inferTypeArgsFromPositionalArgs(
 			continue
 		}
 		valType := t.getExprTypeName(args[i])
-		if valType == nil || valType.IsNil() {
+		if transpiler.IsUnusable(valType) {
 			continue
 		}
 		if inferredTypeArgs[idx] == nil {
@@ -1827,7 +1827,7 @@ func (t *galaASTTransformer) inferTypeArgsFromNamedArgs(
 			continue
 		}
 		valType := t.getExprTypeName(val)
-		if valType == nil || valType.IsNil() {
+		if transpiler.IsUnusable(valType) {
 			continue
 		}
 		if idx, isTypeParam := typeParamIndices[fieldType.String()]; isTypeParam {
@@ -2071,7 +2071,7 @@ func (t *galaASTTransformer) injectSealedVariantTypeArgs(fun ast.Expr, expected 
 
 	typeArgs := make([]ast.Expr, len(gen.Params))
 	for i, p := range gen.Params {
-		if p == nil || p.IsNil() {
+		if transpiler.IsUnusable(p) {
 			return fun, false
 		}
 		typeArgs[i] = t.typeToExpr(p)
@@ -2450,7 +2450,7 @@ func (t *galaASTTransformer) liftToImmutableForArg(expr ast.Expr, expectedType t
 		return expr
 	}
 	inner := gen.Params[0]
-	if inner == nil || inner.IsNil() {
+	if transpiler.IsUnusable(inner) {
 		return expr
 	}
 	innerExpr := t.typeToExpr(inner)
@@ -2524,7 +2524,7 @@ func (t *galaASTTransformer) inferTypeArgsFromApply(
 
 	// Check if all type parameters were inferred with concrete types
 	for _, tp := range result {
-		if tp == nil || tp.IsNil() {
+		if transpiler.IsUnusable(tp) {
 			return nil // Could not infer all type parameters
 		}
 		// Make sure we didn't infer a type parameter (like T) instead of a concrete type
@@ -2710,7 +2710,7 @@ func (t *galaASTTransformer) inferZeroArgTypeParams(typeName string, typeMeta *t
 	// specific), then enclosing function return type (gap #11 widening).
 	sources := []transpiler.Type{t.currentMatchSubjectType, t.currentFuncReturnType}
 	for _, src := range sources {
-		if src == nil || src.IsNil() {
+		if transpiler.IsUnusable(src) {
 			continue
 		}
 		// The context type's base must match the companion's target type.
@@ -2792,10 +2792,10 @@ func (t *galaASTTransformer) inferFuncTypeSubstFromArgs(funcMeta *transpiler.Fun
 		}
 
 		argType := t.getExprTypeNameManual(expr)
-		if argType == nil || argType.IsNil() {
+		if transpiler.IsUnusable(argType) {
 			argType, _ = t.inferExprType(expr)
 		}
-		if argType == nil || argType.IsNil() {
+		if transpiler.IsUnusable(argType) {
 			argIdx++
 			continue
 		}

--- a/internal/transpiler/transformer/constructors.go
+++ b/internal/transpiler/transformer/constructors.go
@@ -153,7 +153,7 @@ func (t *galaASTTransformer) tupleElementExpectedTypes(arity int) []transpiler.T
 	}
 	candidates := []transpiler.Type{t.currentFuncReturnType}
 	for _, cand := range candidates {
-		if cand == nil || cand.IsNil() {
+		if transpiler.IsUnusable(cand) {
 			continue
 		}
 		gen, ok := cand.(transpiler.GenericType)

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -846,7 +846,7 @@ func (t *galaASTTransformer) transformExpressionBodiedFunction(exprCtx grammar.I
 func (t *galaASTTransformer) resolveReturnTypeAsFuncType(typeExpr ast.Expr) *transpiler.FuncType {
 	// Convert AST type to transpiler type
 	tp := t.astTypeToTranspilerType(typeExpr)
-	if tp == nil || tp.IsNil() {
+	if transpiler.IsUnusable(tp) {
 		return nil
 	}
 
@@ -859,7 +859,7 @@ func (t *galaASTTransformer) resolveReturnTypeAsFuncType(typeExpr ast.Expr) *tra
 // we want to thread expected lambda param/return types into a returned
 // lambda expression.
 func (t *galaASTTransformer) resolveTranspilerTypeAsFuncType(tp transpiler.Type) *transpiler.FuncType {
-	if tp == nil || tp.IsNil() {
+	if transpiler.IsUnusable(tp) {
 		return nil
 	}
 

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -544,7 +544,7 @@ func (t *galaASTTransformer) resolveMethodSignatureOnExpr(receiver ast.Expr, met
 		return nil
 	}
 	receiverType := t.getExprTypeNameManual(receiver)
-	if receiverType == nil || receiverType.IsNil() {
+	if transpiler.IsUnusable(receiverType) {
 		return nil
 	}
 	typeName := receiverType.String()
@@ -1112,12 +1112,12 @@ func (t *galaASTTransformer) transformPartialFunctionLiteral(ctx *grammar.Partia
 	}
 
 	// If we couldn't infer from context, try to infer from the patterns themselves
-	if paramType == nil || paramType.IsNil() {
+	if transpiler.IsUnusable(paramType) {
 		paramType = t.inferPartialFunctionParamType(caseClauses)
 	}
 
 	// Fall back to 'any' if we still can't infer
-	if paramType == nil || paramType.IsNil() {
+	if transpiler.IsUnusable(paramType) {
 		t.warnInference("partial function param type defaulting to 'any' — could not infer from context")
 		paramType = transpiler.BasicType{Name: "any"}
 	}
@@ -1157,7 +1157,7 @@ func (t *galaASTTransformer) transformPartialFunctionLiteral(ctx *grammar.Partia
 		return nil, err
 	}
 
-	if innerResultType == nil || innerResultType.IsNil() {
+	if transpiler.IsUnusable(innerResultType) {
 		innerResultType = transpiler.BasicType{Name: "any"}
 	}
 
@@ -1310,7 +1310,7 @@ func (t *galaASTTransformer) transformPartialCaseClause(ctx *grammar.CaseClauseC
 func (t *galaASTTransformer) wrapInSome(expr ast.Expr) ast.Expr {
 	// Infer the type of expr for the type parameter
 	exprType := t.getExprTypeNameManual(expr)
-	if exprType == nil || exprType.IsNil() {
+	if transpiler.IsUnusable(exprType) {
 		exprType, _ = t.inferExprType(expr)
 	}
 

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -150,10 +150,10 @@ func (t *galaASTTransformer) parseMatchSubject(ctx grammar.IExpressionContext) (
 
 	// Infer matched expression type (manual first, then HM fallback)
 	matchedType := t.getExprTypeNameManual(expr)
-	if matchedType == nil || matchedType.IsNil() {
+	if transpiler.IsUnusable(matchedType) {
 		matchedType, _ = t.inferExprType(expr)
 	}
-	if matchedType == nil || matchedType.IsNil() {
+	if transpiler.IsUnusable(matchedType) {
 		if parserCtx, ok := ctx.(antlr.ParserRuleContext); ok {
 			return nil, "", nil, t.semanticErrorAt(parserCtx, "cannot infer type of matched expression. Please add explicit type annotation to the variable being matched")
 		}
@@ -475,7 +475,7 @@ func (t *galaASTTransformer) validateNoBareReturnsInValueMatch(
 	resultType transpiler.Type,
 	startLine, startCol int,
 ) error {
-	if resultType == nil || resultType.IsNil() {
+	if transpiler.IsUnusable(resultType) {
 		return nil
 	}
 	if resultType != nil && resultType.IsVoid() {
@@ -508,7 +508,7 @@ func (t *galaASTTransformer) validateNoBareReturnsInValueMatch(
 // binding names each count as one field. Patterns that do not target a known
 // sealed variant are skipped. Returns nil if all patterns are well-formed.
 func (t *galaASTTransformer) validateSealedVariantArity(matchedType transpiler.Type, patternTexts []string, ctx grammar.IExpressionContext) error {
-	if matchedType == nil || matchedType.IsNil() {
+	if transpiler.IsUnusable(matchedType) {
 		return nil
 	}
 	meta := t.getTypeMeta(matchedType.BaseName())
@@ -1124,7 +1124,7 @@ func (t *galaASTTransformer) inferCommonResultType(types []transpiler.Type, patt
 		// we fall through to `any` for the out-of-scope case.
 		var sharedTypeParam transpiler.Type
 		for _, typ := range types {
-			if typ == nil || typ.IsNil() {
+			if transpiler.IsUnusable(typ) {
 				continue
 			}
 			if typ.IsVoid() {

--- a/internal/transpiler/transformer/patterns.go
+++ b/internal/transpiler/transformer/patterns.go
@@ -501,7 +501,7 @@ func (t *galaASTTransformer) getExtractedTypeAtIndexWithArgs(extractorName strin
 		extractedType = t.getGenericExtractorResultTypeWithArgs(extractorName, objType, index, numArgs)
 
 		// If not found, look up companion object metadata
-		if extractedType == nil || extractedType.IsNil() {
+		if transpiler.IsUnusable(extractedType) {
 			companionMeta := t.getCompanionObjectMetadata(extractorName)
 			if companionMeta != nil {
 				// Verify the companion works with this container type
@@ -551,7 +551,7 @@ func (t *galaASTTransformer) getExtractedTypeAtIndexWithArgs(extractorName strin
 // - Companion objects like Some matching Option[T]
 // - Non-generic struct matching (like Person matching Person) which should use UnapplyFull
 func (t *galaASTTransformer) isDirectStructMatch(patternTypeName string, matchedType transpiler.Type) bool {
-	if matchedType == nil || matchedType.IsNil() {
+	if transpiler.IsUnusable(matchedType) {
 		return false
 	}
 
@@ -850,7 +850,7 @@ func (t *galaASTTransformer) hasRestPattern(argList *grammar.ArgumentListContext
 
 // isSeqType checks if a type implements the Seq interface (has Size, Get, SeqDrop methods).
 func (t *galaASTTransformer) isSeqType(typ transpiler.Type) bool {
-	if typ == nil || typ.IsNil() {
+	if transpiler.IsUnusable(typ) {
 		return false
 	}
 
@@ -1359,7 +1359,7 @@ func (t *galaASTTransformer) inferExtractorTypeParams(extractorMeta *transpiler.
 
 	// Get the first parameter type (the type we're matching against)
 	unapplyParamType := unapplyMeta.ParamTypes[0]
-	if unapplyParamType == nil || unapplyParamType.IsNil() {
+	if transpiler.IsUnusable(unapplyParamType) {
 		return nil
 	}
 
@@ -1429,13 +1429,13 @@ func (t *galaASTTransformer) getGenericExtractorResultTypeWithArgs(extractorName
 
 	// Substitute type parameters in the return type
 	returnType := t.substituteConcreteTypes(unapplyMeta.ReturnType, extractorMeta.TypeParams, inferredTypes)
-	if returnType == nil || returnType.IsNil() {
+	if transpiler.IsUnusable(returnType) {
 		return transpiler.NilType{}
 	}
 
 	// Unwrap Option[X] to get X
 	innerType := t.unwrapOptionType(returnType)
-	if innerType == nil || innerType.IsNil() {
+	if transpiler.IsUnusable(innerType) {
 		return transpiler.NilType{}
 	}
 
@@ -1496,7 +1496,7 @@ func (t *galaASTTransformer) unwrapOptionType(typ transpiler.Type) transpiler.Ty
 // - bool (guard pattern)
 // - Option[T] (extractor pattern)
 func (t *galaASTTransformer) isDirectUnapplyReturnType(typ transpiler.Type) bool {
-	if typ == nil || typ.IsNil() {
+	if transpiler.IsUnusable(typ) {
 		return false
 	}
 	// Check for bool

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -412,15 +412,15 @@ func (t *galaASTTransformer) transformPostfixMatchExpression(ctx *grammar.Postfi
 func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, paramName string, caseClauses []grammar.ICaseClauseContext, ctx antlr.ParserRuleContext) (ast.Expr, error) {
 	// Get the type of the matched expression
 	matchedType := t.getExprTypeNameManual(subject)
-	if matchedType == nil || matchedType.IsNil() {
+	if transpiler.IsUnusable(matchedType) {
 		matchedType, _ = t.inferExprType(subject)
 	}
-	if matchedType == nil || matchedType.IsNil() {
+	if transpiler.IsUnusable(matchedType) {
 		// Fallback: try to infer the sealed parent type from the case patterns.
 		// If cases are Some/None, the subject must be Option; Success/Failure → Try; etc.
 		matchedType = t.inferMatchedTypeFromCases(caseClauses)
 	}
-	if matchedType == nil || matchedType.IsNil() {
+	if transpiler.IsUnusable(matchedType) {
 		if len(caseClauses) > 0 {
 			cc := caseClauses[0].(*grammar.CaseClauseContext)
 			return nil, galaerr.NewSemanticErrorAt(cc.GetStart().GetLine(), cc.GetStart().GetColumn(), "cannot infer type of matched expression")

--- a/internal/transpiler/transformer/scope.go
+++ b/internal/transpiler/transformer/scope.go
@@ -42,7 +42,7 @@ func (t *galaASTTransformer) addVar(name string, typeName transpiler.Type) {
 }
 
 func (t *galaASTTransformer) recordLSPVarType(name string, typeName transpiler.Type) {
-	if t.lspVarTypes == nil || typeName == nil || typeName.IsNil() {
+	if t.lspVarTypes == nil || transpiler.IsUnusable(typeName) {
 		return
 	}
 	key := name

--- a/internal/transpiler/transformer/sealed.go
+++ b/internal/transpiler/transformer/sealed.go
@@ -854,7 +854,7 @@ func isSelfReferentialSealedField(fieldTypeText, parentName string) bool {
 // `Tuple[A, MsgCmd[X]]` and `Tuple[A, Cmd[X]]` are treated as incompatible
 // match-arm result types even though `MsgCmd[X]` is a value of `Cmd[X]`.
 func (t *galaASTTransformer) sealedCaseParent(caseType transpiler.Type) transpiler.Type {
-	if caseType == nil || caseType.IsNil() {
+	if transpiler.IsUnusable(caseType) {
 		return nil
 	}
 	// Extract the case's bare base name and any type arguments.

--- a/internal/transpiler/transformer/transformer.go
+++ b/internal/transpiler/transformer/transformer.go
@@ -74,22 +74,31 @@ type galaASTTransformer struct {
 }
 
 // NewGalaASTTransformer creates a new instance of ASTTransformer for GALA.
+//
+// Capacity hints reduce map reallocations during the transform pass. The
+// values are sized for a representative GALA package: ~50 types, ~50
+// functions, and a few hundred expressions in the type-inference cache.
+// Small packages waste a kilobyte or two of bucket space; large ones
+// avoid the doubling-and-rehash cycle that an empty map walks through
+// at 8, 16, 32, ... entries. CPU profile of an apex-shaped transpile
+// flagged growing these maps as a contributor to allocation pressure
+// (gcDrain / scanobject 18% of cumulative samples).
 func NewGalaASTTransformer() transpiler.ASTTransformer {
 	return &galaASTTransformer{
-		immutFields:       make(map[string]bool),
-		structImmutFields: make(map[string][]bool),
-		activeTypeParams:  make(map[string]bool),
-		structFields:      make(map[string][]string),
-		structFieldTypes:  make(map[string]map[string]transpiler.Type),
-		genericMethods:    make(map[string]map[string]bool),
-		functions:         make(map[string]*transpiler.FunctionMetadata),
-		typeMetas:         make(map[string]*transpiler.TypeMetadata),
-		companionObjects:  make(map[string]*transpiler.CompanionObjectMetadata),
+		immutFields:       make(map[string]bool, 64),
+		structImmutFields: make(map[string][]bool, 32),
+		activeTypeParams:  make(map[string]bool, 16),
+		structFields:      make(map[string][]string, 32),
+		structFieldTypes:  make(map[string]map[string]transpiler.Type, 32),
+		genericMethods:    make(map[string]map[string]bool, 16),
+		functions:         make(map[string]*transpiler.FunctionMetadata, 64),
+		typeMetas:         make(map[string]*transpiler.TypeMetadata, 64),
+		companionObjects:  make(map[string]*transpiler.CompanionObjectMetadata, 16),
 		importManager:     NewImportManager(),
 		inferer:           infer.NewInferer(),
-		typeAliases:       make(map[string]transpiler.Type),
-		exprTypeCache:     make(map[ast.Expr]transpiler.Type),
-		structMetas:       make(map[string]*structMetaConfig),
+		typeAliases:       make(map[string]transpiler.Type, 16),
+		exprTypeCache:     make(map[ast.Expr]transpiler.Type, 256),
+		structMetas:       make(map[string]*structMetaConfig, 16),
 	}
 }
 

--- a/internal/transpiler/transformer/type_inference.go
+++ b/internal/transpiler/transformer/type_inference.go
@@ -352,7 +352,7 @@ func (t *galaASTTransformer) instantiateFuncMetaType(fm *transpiler.FunctionMeta
 // For example, if returnType is Pair[B, A], typeParams is ["A", "B"], and concreteTypes is [int, string],
 // the result will be Pair[string, int].
 func (t *galaASTTransformer) substituteConcreteTypes(returnType transpiler.Type, typeParams []string, concreteTypes []transpiler.Type) transpiler.Type {
-	if returnType == nil || returnType.IsNil() {
+	if transpiler.IsUnusable(returnType) {
 		return returnType
 	}
 
@@ -394,10 +394,10 @@ func (t *galaASTTransformer) inferMethodTypeParamsFromArgs(methodMeta *transpile
 
 		// Get the actual type of the argument
 		argType := t.getExprTypeNameManual(arg)
-		if argType == nil || argType.IsNil() {
+		if transpiler.IsUnusable(argType) {
 			argType, _ = t.inferExprType(arg)
 		}
-		if argType == nil || argType.IsNil() {
+		if transpiler.IsUnusable(argType) {
 			continue
 		}
 
@@ -455,10 +455,10 @@ func (t *galaASTTransformer) inferFuncTypeParamsFromArgs(fMeta *transpiler.Funct
 
 		// Get the actual type of the argument
 		argType := t.getExprTypeNameManual(arg)
-		if argType == nil || argType.IsNil() {
+		if transpiler.IsUnusable(argType) {
 			argType, _ = t.inferExprType(arg)
 		}
-		if argType == nil || argType.IsNil() {
+		if transpiler.IsUnusable(argType) {
 			continue
 		}
 
@@ -594,7 +594,7 @@ func (t *galaASTTransformer) substituteInType(typ transpiler.Type, paramMap map[
 // subterm. A runtime-visible panic would mask the root cause; the defensive
 // return surfaces via failed type checks in the caller.
 func (t *galaASTTransformer) substituteInTypeDepth(typ transpiler.Type, paramMap map[string]transpiler.Type, depth int) transpiler.Type {
-	if typ == nil || typ.IsNil() {
+	if transpiler.IsUnusable(typ) {
 		return typ
 	}
 	const maxTypeSubstDepth = 64
@@ -708,7 +708,7 @@ func (t *galaASTTransformer) getTupleTypeFromName(name string) string {
 // getReceiverTypeArgs extracts type arguments from a receiver type and converts them to ast.Expr.
 // For example, for *Array[int] or Array[int], it returns [int] as []ast.Expr.
 func (t *galaASTTransformer) getReceiverTypeArgs(recvType transpiler.Type) []ast.Expr {
-	if recvType == nil || recvType.IsNil() {
+	if transpiler.IsUnusable(recvType) {
 		return nil
 	}
 	// Unwrap pointer type
@@ -729,7 +729,7 @@ func (t *galaASTTransformer) getReceiverTypeArgs(recvType transpiler.Type) []ast
 // getReceiverTypeArgStrings extracts type arguments from a receiver type as strings.
 // For example, for *Container[int], it returns ["int"].
 func (t *galaASTTransformer) getReceiverTypeArgStrings(recvType transpiler.Type) []string {
-	if recvType == nil || recvType.IsNil() {
+	if transpiler.IsUnusable(recvType) {
 		return nil
 	}
 	// Unwrap pointer type

--- a/internal/transpiler/transformer/type_inference_calls.go
+++ b/internal/transpiler/transformer/type_inference_calls.go
@@ -586,7 +586,7 @@ func (t *galaASTTransformer) inferGetMethodType(e *ast.CallExpr, sel *ast.Select
 			}
 		}
 	}
-	if xType == nil || xType.IsNil() {
+	if transpiler.IsUnusable(xType) {
 		xType = t.getExprTypeNameManual(sel.X)
 	}
 	// For vals and immutable field access, .Get() unwraps the implicit Immutable wrapper

--- a/internal/transpiler/types.go
+++ b/internal/transpiler/types.go
@@ -20,6 +20,27 @@ type Type interface {
 	GetPackage() string // Returns the package of the type, or "" if none
 }
 
+// IsUnusable reports whether t cannot drive type-directed code
+// generation: either the value is nil (no type info at all) or it
+// resolved to NilType (the analyzer's "I gave up" placeholder).
+//
+// Centralizes the `t == nil || t.IsNil()` pattern that appeared in
+// 25+ call sites across the transformer. Inline copies were always
+// vulnerable to forgetting the nil check before dereferencing into
+// IsNil(), which would panic on a nil interface — the helper makes
+// that impossible.
+func IsUnusable(t Type) bool {
+	return t == nil || t.IsNil()
+}
+
+// IsUnusableOrAny extends IsUnusable to also reject the unparametrized
+// `any` placeholder. Use this in type-inference contexts where falling
+// back to `any` would defeat the inference (e.g. resolving a generic
+// param from a call-site arg type — `any` carries no information).
+func IsUnusableOrAny(t Type) bool {
+	return t == nil || t.IsNil() || t.IsAny()
+}
+
 // BasicType represents a basic type like int, string, bool.
 type BasicType struct {
 	Name string


### PR DESCRIPTION
## Summary

`/simplify` review of `internal/transpiler/` (~30k LOC across 45 files) surfaced two cleanups worth landing now.

### 1. `IsUnusable` / `IsUnusableOrAny` helpers

The pattern `t == nil || t.IsNil()` appeared in **47 sites** across the analyzer and transformer; the stricter `t == nil || t.IsNil() || t.IsAny()` in another **4 sites**. Centralized into:

```go
// internal/transpiler/types.go
func IsUnusable(t Type) bool       { return t == nil || t.IsNil() }
func IsUnusableOrAny(t Type) bool  { return t == nil || t.IsNil() || t.IsAny() }
```

Why this matters beyond LOC reduction:
- Inline copies were vulnerable to forgetting the nil check before dereferencing into `IsNil()` and would panic on a nil interface.
- The two semantically distinct checks (rejecting a placeholder vs rejecting any unresolved type) become explicit at the call site instead of buried in a triple-OR condition.

51 sites converted by mechanical perl substitution. The 4 remaining sites have non-identifier LHS (e.g. `applyMethod.ReturnType == nil || applyMethod.ReturnType.IsNil()`) and are left for a follow-up.

### 2. Map capacity hints in `NewGalaASTTransformer`

CPU profile of `TestTranspile_ApexShape` (added in PR #320) flagged `gcDrain` / `scanobject` at 18% of cumulative samples. The transformer's dozen internal caches were all allocated empty and walked through doubling-and-rehash at 8, 16, 32, ... entries. Sizes calibrated for a representative GALA package (~50 types / ~50 functions / few hundred expressions in `exprTypeCache`).

## Test plan

- [x] `bazel test //...` - 331/331 pass (including LSP, transformer, analyzer)
- [x] No behavior change - pure helper extraction + allocation tuning
- [ ] Perf-real-build CI - confirms no regression on the apex transpile

## Out of scope (separate PRs if you want them)

The /simplify pass also flagged:

- **God functions**: `analyzer.Analyze` (1039 lines), `extractSiblingFullMetadata` (427 lines) — phase split would be valuable but invasive
- **Stringly-typed `any` fallbacks**: `transformer/calls.go:539`, `transformer/patterns.go:737` — TODO comments suggest these should be hard errors per project rule #3 ("ALWAYS generate concrete types"). Wants its own PR with golden-file tests
- **`mergeAnalyzedClosureAt` could parallelize** per direct-import (analogous to PR #319's `parseFilesConcurrent`) — needs benchmark
- **Type-walking visitor consolidation** in `transformer/types.go` — three nearly-identical recursive walkers (`typeExprsEqual`, `getBaseTypeAndArgs`, `typeArgToString`) could share a visitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)