### PR TITLE
**Crypto MVP — hash functions only. Lead is now 3 commits ahead of ...

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -28,6 +28,7 @@ filegroup(
         "//collection_immutable:gala_sources",
         "//collection_mutable:gala_sources",
         "//concurrent:gala_sources",
+        "//crypto:gala_sources",
         "//examples:gala_sources",
         "//io:gala_sources",
         "//lazy:lazy.gala",

--- a/cmd/stdlib_gen/main.go
+++ b/cmd/stdlib_gen/main.go
@@ -33,6 +33,7 @@ func packageFromPath(path string) string {
 		"json",
 		"yaml",
 		"test",
+		"crypto",
 		"std",
 	}
 
@@ -149,6 +150,7 @@ var PackageImportPaths = map[string]string{
 	"subprocess":           "martianoff/gala/subprocess",
 	"yaml":                 "martianoff/gala/yaml",
 	"test":                 "martianoff/gala/test",
+	"crypto":               "martianoff/gala/crypto",
 }
 `)
 

--- a/crypto/BUILD.bazel
+++ b/crypto/BUILD.bazel
@@ -1,0 +1,38 @@
+load("//:gala.bzl", "gala_bootstrap_transpile", "gala_go_test", "gala_library")
+
+exports_files(["crypto.gala"])
+
+gala_bootstrap_transpile(
+    name = "crypto_go",
+    src = "crypto.gala",
+    out = "crypto.gen.go",
+)
+
+filegroup(
+    name = "gala_sources",
+    srcs = glob(
+        ["*.gala"],
+        exclude = ["*_test.gala"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+gala_library(
+    name = "crypto",
+    src = "crypto.gala",
+    importpath = "martianoff/gala/crypto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//collection_immutable",
+    ],
+)
+
+gala_go_test(
+    name = "crypto_test",
+    srcs = ["crypto_test.gala"],
+    deps = [
+        ":crypto",
+        "//collection_immutable",
+        "//go_interop",
+    ],
+)

--- a/crypto/crypto.gala
+++ b/crypto/crypto.gala
@@ -1,0 +1,150 @@
+package crypto
+
+import (
+    "crypto/md5"
+    "crypto/sha1"
+    "crypto/sha256"
+    "crypto/sha512"
+    "crypto/subtle"
+    "encoding/base64"
+    "encoding/hex"
+    "hash"
+    . "martianoff/gala/collection_immutable"
+)
+
+// Digest is the opaque output of a hash function. The internal
+// representation is Array[byte]; the only way out is via the encoding
+// methods below.
+struct Digest(bytes Array[byte])
+
+// Bytes returns the raw digest as an immutable Array[byte].
+func (d Digest) Bytes() Array[byte] = d.bytes
+
+// Size returns the length of the digest in bytes.
+func (d Digest) Size() int = d.bytes.Size()
+
+// Hex returns the lowercase hex encoding of the digest.
+func (d Digest) Hex() string {
+    var goBytes = d.bytes.ToGoSlice()
+    return hex.EncodeToString(goBytes)
+}
+
+// Base64 returns the standard (padded) base64 encoding of the digest.
+func (d Digest) Base64() string {
+    var goBytes = d.bytes.ToGoSlice()
+    return base64.StdEncoding.EncodeToString(goBytes)
+}
+
+// String returns the hex encoding (same as Hex).
+func (d Digest) String() string = d.Hex()
+
+// Equal compares two digests in constant time. Different sizes compare
+// as not equal (subtle.ConstantTimeCompare returns 0 on length mismatch).
+func (d Digest) Equal(other Digest) bool {
+    var a = d.bytes.ToGoSlice()
+    var b = other.bytes.ToGoSlice()
+    return subtle.ConstantTimeCompare(a, b) == 1
+}
+
+// Hasher is a streaming hash. Holds a Go hash.Hash; mutable because the
+// underlying stdlib hashers are inherently stateful. Hasher is the only
+// place that mutability lives — Digest is fully immutable.
+type Hasher struct {
+    algorithm string
+    var h     hash.Hash
+}
+
+// Update feeds more bytes into the running hash and returns the receiver
+// for chaining: h.Update(a).Update(b).Finish().
+func (h *Hasher) Update(data Array[byte]) *Hasher {
+    var goData = data.ToGoSlice()
+    var _, _ = h.h.Write(goData)
+    return h
+}
+
+// Finish returns the current digest. The hasher remains usable, but
+// continuing to feed bytes will produce a digest of the full stream so
+// far rather than just what came after Finish.
+func (h *Hasher) Finish() Digest {
+    val sum = h.h.Sum(nil)
+    return Digest(bytes = ArrayFromSlice(sum))
+}
+
+// Algorithm returns the human-readable algorithm name (e.g. "SHA-256").
+func (h *Hasher) Algorithm() string = h.algorithm
+
+// ---- algorithm objects ---------------------------------------------------
+
+// Sha256 is the SHA-256 algorithm (FIPS 180-4), 32-byte digest.
+type Sha256 struct {}
+
+func (s Sha256) Algorithm() string = "SHA-256"
+func (s Sha256) Size() int = 32
+
+func (s Sha256) Hash(data Array[byte]) Digest {
+    var goData = data.ToGoSlice()
+    var h = sha256.New()
+    var _, _ = h.Write(goData)
+    val sum = h.Sum(nil)
+    return Digest(bytes = ArrayFromSlice(sum))
+}
+
+func (s Sha256) NewHasher() *Hasher {
+    return &Hasher(algorithm = "SHA-256", h = sha256.New())
+}
+
+// Sha512 is the SHA-512 algorithm (FIPS 180-4), 64-byte digest.
+type Sha512 struct {}
+
+func (s Sha512) Algorithm() string = "SHA-512"
+func (s Sha512) Size() int = 64
+
+func (s Sha512) Hash(data Array[byte]) Digest {
+    var goData = data.ToGoSlice()
+    var h = sha512.New()
+    var _, _ = h.Write(goData)
+    val sum = h.Sum(nil)
+    return Digest(bytes = ArrayFromSlice(sum))
+}
+
+func (s Sha512) NewHasher() *Hasher {
+    return &Hasher(algorithm = "SHA-512", h = sha512.New())
+}
+
+// Sha1 is the SHA-1 algorithm, 20-byte digest. Considered cryptographically
+// broken for collision resistance — included for legacy interop only.
+type Sha1 struct {}
+
+func (s Sha1) Algorithm() string = "SHA-1"
+func (s Sha1) Size() int = 20
+
+func (s Sha1) Hash(data Array[byte]) Digest {
+    var goData = data.ToGoSlice()
+    var h = sha1.New()
+    var _, _ = h.Write(goData)
+    val sum = h.Sum(nil)
+    return Digest(bytes = ArrayFromSlice(sum))
+}
+
+func (s Sha1) NewHasher() *Hasher {
+    return &Hasher(algorithm = "SHA-1", h = sha1.New())
+}
+
+// Md5 is the MD5 algorithm, 16-byte digest. Considered cryptographically
+// broken — included for legacy interop only.
+type Md5 struct {}
+
+func (s Md5) Algorithm() string = "MD5"
+func (s Md5) Size() int = 16
+
+func (s Md5) Hash(data Array[byte]) Digest {
+    var goData = data.ToGoSlice()
+    var h = md5.New()
+    var _, _ = h.Write(goData)
+    val sum = h.Sum(nil)
+    return Digest(bytes = ArrayFromSlice(sum))
+}
+
+func (s Md5) NewHasher() *Hasher {
+    return &Hasher(algorithm = "MD5", h = md5.New())
+}

--- a/crypto/crypto_test.gala
+++ b/crypto/crypto_test.gala
@@ -1,0 +1,149 @@
+package main
+
+import (
+    . "martianoff/gala/test"
+    . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/go_interop"
+    "martianoff/gala/crypto"
+)
+
+// ---- helpers -------------------------------------------------------------
+
+func bytesOf(s string) Array[byte] = ArrayFromSlice(ToBytes(s))
+
+// ---- known-vector tables -------------------------------------------------
+
+struct HashCase(Name string, Input string, ExpectedHex string)
+
+func TestSha256KnownVectors(t T) T {
+    return RunCases[HashCase, string](t,
+        (sub T, c HashCase, _ string) => {
+            val d = crypto.Sha256{}.Hash(bytesOf(c.Input))
+            return Eq[string](sub, d.Hex(), c.ExpectedHex)
+        },
+        Case[HashCase, string](
+            Name = "empty",
+            Input = HashCase(
+                Name = "empty",
+                Input = "",
+                ExpectedHex = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            ),
+            Expected = "",
+        ),
+        Case[HashCase, string](
+            Name = "abc",
+            Input = HashCase(
+                Name = "abc",
+                Input = "abc",
+                ExpectedHex = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            ),
+            Expected = "",
+        ),
+    )
+}
+
+func TestSha512KnownVectors(t T) T {
+    val expected = "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+    val d = crypto.Sha512{}.Hash(bytesOf("abc"))
+    return Eq[string](t, d.Hex(), expected)
+}
+
+func TestSha1KnownVectors(t T) T {
+    val d = crypto.Sha1{}.Hash(bytesOf("abc"))
+    return Eq[string](t, d.Hex(), "a9993e364706816aba3e25717850c26c9cd0d89d")
+}
+
+func TestMd5KnownVectors(t T) T {
+    val d = crypto.Md5{}.Hash(bytesOf("abc"))
+    return Eq[string](t, d.Hex(), "900150983cd24fb0d6963f7d28e17f72")
+}
+
+// ---- algorithm metadata --------------------------------------------------
+
+func TestAlgorithmMetadata(t T) T {
+    var t1 = Eq[string](t, crypto.Sha256{}.Algorithm(), "SHA-256")
+    var t2 = Eq[int](t1, crypto.Sha256{}.Size(), 32)
+    var t3 = Eq[string](t2, crypto.Sha512{}.Algorithm(), "SHA-512")
+    var t4 = Eq[int](t3, crypto.Sha512{}.Size(), 64)
+    var t5 = Eq[string](t4, crypto.Sha1{}.Algorithm(), "SHA-1")
+    var t6 = Eq[int](t5, crypto.Sha1{}.Size(), 20)
+    var t7 = Eq[string](t6, crypto.Md5{}.Algorithm(), "MD5")
+    return Eq[int](t7, crypto.Md5{}.Size(), 16)
+}
+
+// ---- digest size matches algorithm --------------------------------------
+
+func TestDigestSize(t T) T {
+    val d = crypto.Sha256{}.Hash(bytesOf("hello"))
+    return Eq[int](t, d.Size(), 32)
+}
+
+// ---- streaming matches one-shot -----------------------------------------
+
+func TestStreamingMatchesOneShot(t T) T {
+    val full = "the quick brown fox jumps over the lazy dog"
+    val oneShot = crypto.Sha256{}.Hash(bytesOf(full))
+
+    val hasher = crypto.Sha256{}.NewHasher()
+    val streamed = hasher.
+        Update(bytesOf("the quick brown fox ")).
+        Update(bytesOf("jumps over ")).
+        Update(bytesOf("the lazy dog")).
+        Finish()
+
+    var t1 = Eq[string](t, oneShot.Hex(), streamed.Hex())
+    return IsTrue(t1, oneShot.Equal(streamed))
+}
+
+func TestStreamingSha512(t T) T {
+    val oneShot = crypto.Sha512{}.Hash(bytesOf("abc"))
+    val streamed = crypto.Sha512{}.NewHasher().
+        Update(bytesOf("a")).
+        Update(bytesOf("b")).
+        Update(bytesOf("c")).
+        Finish()
+    return Eq[string](t, oneShot.Hex(), streamed.Hex())
+}
+
+func TestHasherAlgorithm(t T) T {
+    val h = crypto.Sha256{}.NewHasher()
+    return Eq[string](t, h.Algorithm(), "SHA-256")
+}
+
+// ---- encoding -----------------------------------------------------------
+
+func TestDigestHex(t T) T {
+    val d = crypto.Sha256{}.Hash(bytesOf(""))
+    return Eq[string](t, d.Hex(), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+}
+
+func TestDigestBase64(t T) T {
+    // SHA-256("abc") base64-std = "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0="
+    val d = crypto.Sha256{}.Hash(bytesOf("abc"))
+    return Eq[string](t, d.Base64(), "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=")
+}
+
+func TestDigestStringEqualsHex(t T) T {
+    val d = crypto.Sha256{}.Hash(bytesOf("abc"))
+    return Eq[string](t, d.String(), d.Hex())
+}
+
+// ---- equality ------------------------------------------------------------
+
+func TestDigestEqualSame(t T) T {
+    val d1 = crypto.Sha256{}.Hash(bytesOf("abc"))
+    val d2 = crypto.Sha256{}.Hash(bytesOf("abc"))
+    return IsTrue(t, d1.Equal(d2))
+}
+
+func TestDigestEqualDifferentBytes(t T) T {
+    val d1 = crypto.Sha256{}.Hash(bytesOf("abc"))
+    val d2 = crypto.Sha256{}.Hash(bytesOf("abd"))
+    return IsFalse(t, d1.Equal(d2))
+}
+
+func TestDigestEqualDifferentSizes(t T) T {
+    val d256 = crypto.Sha256{}.Hash(bytesOf("abc"))
+    val d512 = crypto.Sha512{}.Hash(bytesOf("abc"))
+    return IsFalse(t, d256.Equal(d512))
+}

--- a/internal/build/gomod.go
+++ b/internal/build/gomod.go
@@ -85,6 +85,7 @@ var StdlibPackages = []string{
 	"subprocess",
 	"yaml",
 	"test",
+	"crypto",
 }
 
 // StdlibImportPaths maps package names to their import paths.
@@ -104,6 +105,7 @@ var StdlibImportPaths = map[string]string{
 	"subprocess":           "martianoff/gala/subprocess",
 	"yaml":                 "martianoff/gala/yaml",
 	"test":                 "martianoff/gala/test",
+	"crypto":               "martianoff/gala/crypto",
 }
 
 // GenerateGoMod generates a go.mod file content for the workspace.

--- a/internal/stdlib/BUILD.bazel
+++ b/internal/stdlib/BUILD.bazel
@@ -122,6 +122,10 @@ genrule(
         "//test:bench.gala",
         "//test:framework.gala",
         "//test:table.gala",
+        # crypto package - transpiled Go
+        "//crypto:crypto_go",
+        # crypto package - GALA source
+        "//crypto:crypto.gala",
     ],
     outs = ["embedded_gen.go"],
     cmd = "$(location //cmd/stdlib_gen) -output $@ $(SRCS)",

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -157,6 +157,13 @@ func generatePackageGoMod(pkgName, importPath string) string {
 		content += ")\n"
 		content += "\nreplace martianoff/gala/std => ../std\n"
 		content += "replace martianoff/gala/collection_immutable => ../collection_immutable\n"
+	case "crypto":
+		content += "\nrequire (\n"
+		content += "\tmartianoff/gala/std v0.0.0\n"
+		content += "\tmartianoff/gala/collection_immutable v0.0.0\n"
+		content += ")\n"
+		content += "\nreplace martianoff/gala/std => ../std\n"
+		content += "replace martianoff/gala/collection_immutable => ../collection_immutable\n"
 	}
 
 	return content

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     srcs = [
         "apply_test.go",
         "assignment_test.go",
+        "auto_method_override_test.go",
         "bare_funcref_test.go",
         "codec_boundary_test.go",
         "collect_partial_function_test.go",

--- a/internal/transpiler/transformer/auto_method_override_test.go
+++ b/internal/transpiler/transformer/auto_method_override_test.go
@@ -1,0 +1,145 @@
+package transformer_test
+
+import (
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAutoMethodOverride verifies that when the user defines their own
+// Copy/Equal/Unapply method on a struct (or sealed parent), the transpiler
+// suppresses the auto-generated counterpart so the resulting Go code does
+// not declare the method twice. This is the regression guard for the bug
+// hit while building the crypto.Digest type, where the user-defined
+// constant-time Equal collided with the auto-generated deep-equality Equal.
+func TestAutoMethodOverride(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	type override struct {
+		method string
+		// snippet appended after the struct declaration. Must define a method
+		// with the given name on type Digest.
+		snippet string
+	}
+
+	tests := []struct {
+		name    string
+		decl    string // struct declaration syntax
+		over    override
+	}{
+		{
+			name: "shorthand struct, user Equal",
+			decl: "struct Digest(bytes int)",
+			over: override{
+				method: "Equal",
+				snippet: `
+func (d Digest) Equal(other Digest) bool {
+    return d.bytes == other.bytes
+}`,
+			},
+		},
+		{
+			name: "shorthand struct, user Copy",
+			decl: "struct Digest(bytes int)",
+			over: override{
+				method: "Copy",
+				snippet: `
+func (d Digest) Copy() Digest {
+    return Digest(bytes = d.bytes)
+}`,
+			},
+		},
+		{
+			name: "shorthand struct, user Unapply",
+			// Public field (uppercase) so the transpiler would auto-generate
+			// Unapply by default — we want to confirm the user's wins instead.
+			decl: "struct Digest(Bytes int)",
+			over: override{
+				method: "Unapply",
+				snippet: `
+func (d Digest) Unapply(v Digest) int {
+    return v.Bytes
+}`,
+			},
+		},
+		{
+			name: "block struct, user Equal",
+			decl: `type Digest struct {
+    bytes int
+}`,
+			over: override{
+				method: "Equal",
+				snippet: `
+func (d Digest) Equal(other Digest) bool {
+    return d.bytes == other.bytes
+}`,
+			},
+		},
+		{
+			name: "block struct, user Copy",
+			decl: `type Digest struct {
+    bytes int
+}`,
+			over: override{
+				method: "Copy",
+				snippet: `
+func (d Digest) Copy() Digest {
+    return Digest(bytes = d.bytes)
+}`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := "package main\n\n" + tt.decl + "\n" + tt.over.snippet + "\n"
+			got, err := trans.Transpile(input, "")
+			require.NoError(t, err)
+
+			// Each method should appear exactly once in the generated Go.
+			needle := ") " + tt.over.method + "("
+			count := strings.Count(got, needle)
+			assert.Equalf(t, 1, count,
+				"expected exactly one %s method in generated Go (the user's), got %d.\n--- generated ---\n%s",
+				tt.over.method, count, got)
+		})
+	}
+}
+
+// TestAutoMethodOverride_DefaultsStillGenerate is a sanity guard ensuring that
+// when the user does NOT define Copy / Equal / Unapply, the transpiler still
+// emits all three (the common case). This pairs with TestAutoMethodOverride
+// to pin the auto-gen behavior from both sides.
+func TestAutoMethodOverride_DefaultsStillGenerate(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	// Public fields (uppercase) are required to trigger Unapply auto-generation.
+	input := `package main
+
+struct Digest(Bytes int)`
+
+	got, err := trans.Transpile(input, "")
+	require.NoError(t, err)
+
+	for _, method := range []string{"Copy", "Equal", "Unapply"} {
+		needle := ") " + method + "("
+		count := strings.Count(got, needle)
+		assert.Equalf(t, 1, count,
+			"expected auto-generated %s for plain struct, got %d occurrences.\n--- generated ---\n%s",
+			method, count, got)
+	}
+}

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -997,31 +997,29 @@ func (t *galaASTTransformer) transformStructShorthandDeclaration(ctx *grammar.St
 		},
 	}
 
-	// Copy and Equal methods
-	copyMethod, err := t.generateCopyMethod(name, fields, tParams)
-	if err != nil {
-		return nil, err
-	}
-	decls = append(decls, copyMethod)
+	// Copy and Equal methods — skip if user-defined
+	hasCopy, hasEqual, hasUnapply := t.userDefinedMethodFlags(name)
 
-	equalMethod, err := t.generateEqualMethod(name, fields, tParams)
-	if err != nil {
-		return nil, err
+	if !hasCopy {
+		copyMethod, err := t.generateCopyMethod(name, fields, tParams)
+		if err != nil {
+			return nil, err
+		}
+		decls = append(decls, copyMethod)
 	}
-	decls = append(decls, equalMethod)
+
+	if !hasEqual {
+		equalMethod, err := t.generateEqualMethod(name, fields, tParams)
+		if err != nil {
+			return nil, err
+		}
+		decls = append(decls, equalMethod)
+	}
 
 	// For generic structs, generate marker interface for wildcard pattern matching.
 	if tParams != nil {
 		interfaceDecl, markerMethod := t.generateInstanceMarker(name, tParams)
 		decls = append(decls, interfaceDecl, markerMethod)
-	}
-
-	// Check if Unapply already exists
-	hasUnapply := false
-	if meta := t.getTypeMeta(name); meta != nil {
-		if _, ok := meta.Methods["Unapply"]; ok {
-			hasUnapply = true
-		}
 	}
 
 	if !hasUnapply {
@@ -1106,31 +1104,29 @@ func (t *galaASTTransformer) transformTypeDeclaration(ctx *grammar.TypeDeclarati
 			Specs: []ast.Spec{typeSpec},
 		})
 
-		// Methods
-		copyMethod, err := t.generateCopyMethod(name, fields, tParams)
-		if err != nil {
-			return nil, err
-		}
-		decls = append(decls, copyMethod)
+		// Methods — skip Copy/Equal/Unapply if user-defined
+		hasCopy, hasEqual, hasUnapply := t.userDefinedMethodFlags(name)
 
-		equalMethod, err := t.generateEqualMethod(name, fields, tParams)
-		if err != nil {
-			return nil, err
+		if !hasCopy {
+			copyMethod, err := t.generateCopyMethod(name, fields, tParams)
+			if err != nil {
+				return nil, err
+			}
+			decls = append(decls, copyMethod)
 		}
-		decls = append(decls, equalMethod)
+
+		if !hasEqual {
+			equalMethod, err := t.generateEqualMethod(name, fields, tParams)
+			if err != nil {
+				return nil, err
+			}
+			decls = append(decls, equalMethod)
+		}
 
 		// For generic structs, generate marker interface for wildcard pattern matching
 		if tParams != nil {
 			interfaceDecl, markerMethod := t.generateInstanceMarker(name, tParams)
 			decls = append(decls, interfaceDecl, markerMethod)
-		}
-
-		// Check if Unapply already exists
-		hasUnapply := false
-		if meta := t.getTypeMeta(name); meta != nil {
-			if _, ok := meta.Methods["Unapply"]; ok {
-				hasUnapply = true
-			}
 		}
 
 		if !hasUnapply {

--- a/internal/transpiler/transformer/sealed.go
+++ b/internal/transpiler/transformer/sealed.go
@@ -224,18 +224,24 @@ func (t *galaASTTransformer) transformSealedTypeDeclaration(ctx *grammar.SealedT
 		decls = append(decls, isMethod)
 	}
 
-	// 5. Generate Copy, Equal methods on parent
-	copyMethod, err := t.generateCopyMethod(name, parentFields, tParams)
-	if err != nil {
-		return nil, err
-	}
-	decls = append(decls, copyMethod)
+	// 5. Generate Copy, Equal methods on parent — skip if user-defined
+	hasCopy, hasEqual, _ := t.userDefinedMethodFlags(name)
 
-	equalMethod, err := t.generateEqualMethod(name, parentFields, tParams)
-	if err != nil {
-		return nil, err
+	if !hasCopy {
+		copyMethod, err := t.generateCopyMethod(name, parentFields, tParams)
+		if err != nil {
+			return nil, err
+		}
+		decls = append(decls, copyMethod)
 	}
-	decls = append(decls, equalMethod)
+
+	if !hasEqual {
+		equalMethod, err := t.generateEqualMethod(name, parentFields, tParams)
+		if err != nil {
+			return nil, err
+		}
+		decls = append(decls, equalMethod)
+	}
 
 	// 6. Generate String() method on parent
 	stringMethod := t.generateSealedStringMethod(name, variants, tParams, recursiveFields, funcFields)

--- a/internal/transpiler/transformer/transformer.go
+++ b/internal/transpiler/transformer/transformer.go
@@ -568,6 +568,22 @@ func (t *galaASTTransformer) getTypeMeta(typeName string) *transpiler.TypeMetada
 	return t.typeMetas[resolved]
 }
 
+// userDefinedMethodFlags reports whether the user has explicitly declared
+// Copy / Equal / Unapply methods on the given type. The transpiler auto-generates
+// each of these methods on every struct (and sealed parent), but a user-supplied
+// definition must take precedence — emitting both would produce a duplicate-method
+// error in the generated Go.
+func (t *galaASTTransformer) userDefinedMethodFlags(typeName string) (hasCopy, hasEqual, hasUnapply bool) {
+	meta := t.getTypeMeta(typeName)
+	if meta == nil {
+		return false, false, false
+	}
+	_, hasCopy = meta.Methods["Copy"]
+	_, hasEqual = meta.Methods["Equal"]
+	_, hasUnapply = meta.Methods["Unapply"]
+	return
+}
+
 // getTypeMetaResolved returns the type metadata and the resolved (canonical) type name.
 // Use this when you need both the metadata and the resolved name to avoid double resolution.
 func (t *galaASTTransformer) getTypeMetaResolved(typeName string) (*transpiler.TypeMetadata, string) {


### PR DESCRIPTION
**Crypto MVP — hash functions only. Lead is now 3 commits ahead of master.**
```
99a2ad1 feat(stdlib): register crypto package
466190b feat(crypto): MVP hash library — SHA-256/512, SHA-1, MD5
3532348 feat(transpiler): skip auto-gen Copy/Equal/Unapply when user-defined
```
(Cherry-picked Mira's `913620d` rather than merging — her branch was parallel to Felix's, not descended from it. New SHA `99a2ad1`. The merger turn took place in cwd in foreground because three rounds of dispatch produced silent report-backs without executing.)
### What ships in `crypto/crypto.gala`
```gala
struct Digest(bytes Array[byte])
  // .Bytes() Array[byte]   .Size() int
  // .Hex() string          .Base64() string   .String() string
  // .Equal(other) bool     // constant-time via crypto/subtle
type Hasher struct { algorithm string; var h hash.Hash }
  // .Update(Array[byte]) *Hasher   // chainable
  // .Finish() Digest               // hasher remains usable
  // .Algorithm() string
// Algorithm objects — zero-field structs:
type Sha256 struct {}   // 32-byte digest
type Sha512 struct {}   // 64-byte digest
type Sha1   struct {}   // 20-byte digest, legacy
type Md5    struct {}   // 16-byte digest, legacy
//   each: .Algorithm() string  .Size() int
//         .Hash(Array[byte]) Digest
//         .NewHasher() *Hasher
```
API is fully `Array[byte]` end-to-end — no `[]byte` in any signature. Internally `.ToGoSlice()` / `ArrayFromSlice(...)` bridge to Go's `crypto/*` packages.
### Transpiler fix (commit 1)
`Digest` defines a constant-time `Equal`, but the shorthand `struct Digest(bytes Array[byte])` was unconditionally auto-generating a deep-equality `Equal`, producing a duplicate-method compile error. Per CLAUDE.md rule 6, Felix fixed the transpiler instead of renaming the user method.
The change adds a `userDefinedMethodFlags(name)` helper in `transformer.go` and calls it from the shorthand-struct path (`declarations.go`) and the sealed-type path (`sealed.go`). Auto-generation of `Copy`, `Equal`, `Unapply` is now skipped when the user has defined that method.
Pinned by tests in `internal/transpiler/transformer/auto_method_override_test.go`:
- `TestAutoMethodOverride` — 5 cases (shorthand × {Equal, Copy, Unapply}, block × {Equal, Copy}); each asserts exactly one occurrence of the method in generated Go.
- `TestAutoMethodOverride_DefaultsStillGenerate` — common-case regression guard: no user override → all three still auto-generate.
### Stdlib registration (commit 3)
Five-file pattern matching `json`/`yaml`:
- `cmd/stdlib_gen/main.go` — `packages` slice + `PackageImportPaths` map
- `internal/build/gomod.go` — `StdlibPackages` + `StdlibImportPaths`
- `internal/stdlib/BUILD.bazel` — `//crypto:crypto_go` + `//crypto:crypto.gala` in `generate_embedded` srcs
- `internal/stdlib/stdlib.go` — `case "crypto":` emitting go.mod with `std` + `collection_immutable` require/replace
- root `BUILD.bazel` — `//crypto:gala_sources` in `all_gala_sources`
### Validation
In Felix's pre-merge worktree (everything except Mira's stdlib BUILD glue):
```
//crypto:crypto_test                              PASSED in 0.1s
//internal/transpiler/transformer:transformer_test PASSED in 22.1s
```
Post-merge integration build (`bazel build //crypto:... //internal/stdlib:stdlib //cmd/gala:gala`) was kicked off in the lead worktree but not observed to completion before this summary. Recommend running `bazel test //...` before merging the PR — the only material risk is the auto-gen change (which the new transformer tests cover the boundaries of).
### Known follow-ups (not in this PR)
- No `examples/` verification program for `crypto`. Worth adding a small one-shot+streaming demo even though hash *libraries* are borderline against CLAUDE.md's "language feature" requirement.
- No pattern-matching extractor on `Digest` (e.g. `case Sha256(hex) =>`). Wasn't requested; deferred.
- The team-protocol dispatch system didn't execute branch-modifying work this turn. Worth investigating before relying on it for similar merger turns in future sessions.

---
🍎 orchestrated by [Gala Team](https://github.com/martianoff/gala-team)