### PR TITLE
build: split gala worker into separate gala_worker binary

### DIFF
--- a/cmd/gala/BUILD.bazel
+++ b/cmd/gala/BUILD.bazel
@@ -18,3 +18,26 @@ go_binary(
         "martianoff/gala/cmd/gala/commands.BuildDate": "{BUILD_DATE}",
     },
 )
+
+# Separate binary used by the Bazel persistent worker
+# (gala.bzl::_gala_transpile_worker_impl). Same code as `gala` —
+# `worker` is just one of its subcommands — but linked into a
+# distinctly-named .exe so it doesn't share Windows mandatory file
+# locks with whatever `gala.exe` the user's IDE/LSP is running.
+#
+# Without this split, an active `gala lsp` process (the IDE plugin
+# starts one per project) holds gala.exe open, and any subsequent
+# Bazel build that needs to rebuild gala — including engineer
+# `bazel test` runs from .gala_team/worktrees/<Name>/ — fails the
+# link step with "failed to delete output files (Permission
+# denied)". The split lets the LSP and the worker coexist.
+go_binary(
+    name = "gala_worker",
+    embed = [":gala_lib"],
+    visibility = ["//visibility:public"],
+    x_defs = {
+        "martianoff/gala/cmd/gala/commands.Version": "{STABLE_GALA_VERSION}",
+        "martianoff/gala/cmd/gala/commands.GitCommit": "{STABLE_GIT_COMMIT}",
+        "martianoff/gala/cmd/gala/commands.BuildDate": "{BUILD_DATE}",
+    },
+)

--- a/gala.bzl
+++ b/gala.bzl
@@ -270,7 +270,11 @@ gala_transpile_worker_single = rule(
         "gala_deps": attr.label_list(default = []),
         "batch": attr.bool(default = False),
         "_worker": attr.label(
-            default = Label("//cmd/gala"),
+            # Use the worker-only binary (not //cmd/gala) so the
+            # persistent worker process holds a different .exe file
+            # than whatever `gala lsp` the user's IDE is running.
+            # See cmd/gala/BUILD.bazel for the rationale.
+            default = Label("//cmd/gala:gala_worker"),
             executable = True,
             cfg = "exec",
         ),
@@ -293,7 +297,11 @@ gala_transpile_worker_batch = rule(
         "gala_deps": attr.label_list(default = []),
         "batch": attr.bool(default = True),
         "_worker": attr.label(
-            default = Label("//cmd/gala"),
+            # Use the worker-only binary (not //cmd/gala) so the
+            # persistent worker process holds a different .exe file
+            # than whatever `gala lsp` the user's IDE is running.
+            # See cmd/gala/BUILD.bazel for the rationale.
+            default = Label("//cmd/gala:gala_worker"),
             executable = True,
             cfg = "exec",
         ),


### PR DESCRIPTION
## Summary

When the IDE plugin runs `gala lsp` it holds `gala.exe` open via Windows mandatory file locking. The Bazel persistent worker used the same `//cmd/gala` target — its long-lived process held the same file open. Any subsequent `bazel build` that needed to relink gala (including engineer `bazel test` runs from `.gala_team/worktrees/<Name>/`) failed at the link step with:

```
GoLink ... gala.exe failed: failed to delete output files (Permission denied)
```

This split adds a parallel `gala_worker` binary that embeds the same `gala_lib` but links into a distinctly-named .exe at `//cmd/gala:gala_worker`. The worker rule's `_worker` default now points there. LSP and the persistent worker hold different files, so neither blocks the other from rebuilding.

## Why this matters

- **Engineers can `bazel test` while LSP is running** — previously their build failed at the link step.
- **Two engineers in parallel worktrees** can both run `bazel test` without colliding (each has its own `gala_worker.exe` in its output_base).
- **Cost:** one extra link step per Bazel server. `gala_lib` stays a single compile.

## Test plan
- [x] `bazel build //cmd/gala:gala //cmd/gala:gala_worker` produces both binaries
- [x] gala_team's transitive build picks up the new `gala_worker.exe` for transpile actions
- [ ] Reviewer: confirm CI green
- [ ] Reviewer: smoke-test on Linux (file lock semantics differ; the rename is harmless on Linux/macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)