### PR TITLE
fix(transpiler): infer call return type from Go struct func-typed fields

### DIFF
--- a/examples/go_struct_bridge/bridge.go
+++ b/examples/go_struct_bridge/bridge.go
@@ -36,3 +36,36 @@ func (s *SessionData) Get(key string) (string, bool) {
 func MakeCookie(name, value, path string) Cookie {
 	return Cookie{Name: name, Value: value, Path: path}
 }
+
+// Processor exposes a function-typed field. GALA code calling p.Process(x)
+// (where Process is `func(int) (string, error)`) used to infer the call's
+// return type as NilType — inferCallSelectorType never consulted the Go
+// field type for func-typed fields after method lookups failed.
+type Processor struct {
+	Process func(int) (string, error)
+}
+
+// NewProcessor returns a *Processor whose Process field formats its
+// argument and never errors.
+func NewProcessor() *Processor {
+	return &Processor{Process: func(x int) (string, error) {
+		return fmt.Sprintf("processed-%d", x), nil
+	}}
+}
+
+// CookieBuilder exposes a single-return function-typed field whose result
+// type is a struct (Cookie). This shape exercises GALA-level method
+// dispatch on the call's result — `b.Build(s).String()` requires the
+// transpiler to know the inner call returns Cookie so it can resolve
+// String on the receiver.
+type CookieBuilder struct {
+	Build func(string) Cookie
+}
+
+// NewCookieBuilder returns a *CookieBuilder whose Build field constructs
+// a Cookie from its argument.
+func NewCookieBuilder() *CookieBuilder {
+	return &CookieBuilder{Build: func(s string) Cookie {
+		return Cookie{Name: s, Value: s, Path: "/"}
+	}}
+}

--- a/examples/multifile_lib_regress/go_interop.gala
+++ b/examples/multifile_lib_regress/go_interop.gala
@@ -1,6 +1,9 @@
 package multifile_lib_regress
 
-import "martianoff/gala/examples/go_struct_bridge"
+import (
+    "martianoff/gala/examples/go_struct_bridge"
+    . "martianoff/gala/std"
+)
 
 // --- Regression: Go struct named-arg wraps fields in Immutable ---
 // When a GALA struct and a Go struct share the same name (Cookie), the transpiler
@@ -24,3 +27,36 @@ func GoCookieString(name string, value string) string =
 
 func GalaCookieName(name string, value string) string =
     MakeGalaCookie(name, value).Name
+
+// --- Regression: method call on Go struct's func-typed field (issue #326).
+// `p.Process(42)` where Process is `func(int) (string, error)` must infer
+// the call's return type from the field's declared results. Without the
+// fix the call's return type collapsed to NilType, and the multi-return
+// destructure `var s, err = p.Process(x)` produced untyped slots that Go
+// then rejected at the consumer site (string concat, error nil-check).
+func ProcessorRun(x int) string {
+    val p = go_struct_bridge.NewProcessor()
+    var s, err = p.Process(x)
+    if err != nil { return "<error>" }
+    return s
+}
+
+// Single-return shape that exercises GALA-level method dispatch on the
+// call's result: `.Build(s)` returns a Go Cookie, and `.String()` is
+// resolved against that Cookie's Go method set. With NilType leaking as
+// the call's result type the second-stage method lookup has no receiver
+// type to consult and the transpiler can't synthesise the chained call.
+func CookieBuilderDescribe(s string) string {
+    val b = go_struct_bridge.NewCookieBuilder()
+    return b.Build(s).String()
+}
+
+// Wrapping the call result in Some(...) exercises GALA-level generic
+// inference: the function's declared return is Option[Cookie], so
+// `Some(b.Build(s))` must infer T=Cookie from the argument. Without the
+// fix the call typed as NilType, Some inferred T=NilType, and the result
+// failed to satisfy the declared Option[Cookie] return type.
+func CookieBuilderOption(s string) Option[go_struct_bridge.Cookie] {
+    val b = go_struct_bridge.NewCookieBuilder()
+    return Some(b.Build(s))
+}

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -333,4 +333,21 @@ func main() {
     // and Go must accept a bare string literal at the Eq site.
     val cfgs = multifile_lib_regress.LoadCfgs()
     Println(s"cfgs(1).Lead=${cfgs.Get(1).Lead.Name}")
+
+    // --- Regression: method call on Go struct's func-typed field (issue #326).
+    // `p.Process(42)` where Process is `func(int) (string, error)` must infer
+    // the call's return type from the field's declared results. Without the
+    // fix the call typed as NilType and the `var s, err = ...` destructure
+    // produced untyped slots that downstream code rejected.
+    Println(multifile_lib_regress.ProcessorRun(42))
+    // Single-return shape: `b.Build(s).String()` requires the GALA-level
+    // type tracker to know `b.Build(s)` returns a Cookie so the chained
+    // `.String()` call resolves to Cookie.String. Without the fix the
+    // inner call typed as NilType, the second-stage lookup had no receiver
+    // type, and the chained call could not be synthesised.
+    Println(multifile_lib_regress.CookieBuilderDescribe("session"))
+    multifile_lib_regress.CookieBuilderOption("opt") match {
+        case Some(c) => Println(c.String())
+        case None()  => Println("<no cookie>")
+    }
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -75,3 +75,6 @@ hasModel(1)=true
 modelOr(0)=<none>
 hook0.args.size=0
 cfgs(1).Lead=Theo
+processed-42
+Cookie(session=session, path=/)
+Cookie(opt=opt, path=/)

--- a/internal/transpiler/transformer/type_inference_calls.go
+++ b/internal/transpiler/transformer/type_inference_calls.go
@@ -339,6 +339,16 @@ func (t *galaASTTransformer) inferCallSelectorType(e *ast.CallExpr, sel *ast.Sel
 		if retType := t.getGoMethodReturnType(xTypeName, sel.Sel.Name); !retType.IsNil() {
 			return retType
 		}
+		// Fallback: a Go struct field of function type invoked as a method,
+		// e.g., proc.Process(x) where Process is `func(int) (string, error)`.
+		// getGoFieldType already understands the field surface; consult it
+		// here so the call's return type tracks the field's declared results
+		// instead of collapsing to NilType (issue #326).
+		if fType := t.getGoFieldType(xTypeName, sel.Sel.Name); !fType.IsNil() {
+			if funcType, ok := fType.(transpiler.FuncType); ok && len(funcType.Results) > 0 {
+				return funcType.Results[0]
+			}
+		}
 	}
 
 	if isStdQualified {


### PR DESCRIPTION
## Summary

Fixes #326. `inferCallSelectorType` resolved selector calls like `p.Process(x)` by trying `resolveMethodCallType` and `getGoMethodReturnType` and giving up with `NilType` if both returned nil — even when `Process` was a func-typed *field* on a Go struct that `getGoFieldType` already understood.

## Root cause

`internal/transpiler/transformer/type_inference_calls.go::inferCallSelectorType` had GALA-method and Go-method lookup branches but no fallback for Go fields whose type is a function. `getGoFieldType` already returns a populated `transpiler.FuncType` for that shape; the call path just never asked.

## Change

`internal/transpiler/transformer/type_inference_calls.go` — after the `getGoMethodReturnType` fallback, consult `getGoFieldType`. If the field is `FuncType` with declared results, return the first result. The new branch only runs after the existing method-lookup chain returns nil, so it cannot regress any code that already inferred a real type.

## Verification

Extends `examples/multifile_lib_regress` with three shapes that all sit on top of the new fallback:

- `ProcessorRun` — multi-return destructure `var s, err = p.Process(x)` over `func(int) (string, error)`
- `CookieBuilderDescribe` — chained call `b.Build(s).String()` over `func(string) Cookie`
- `CookieBuilderOption` — downward-inferred `Some(b.Build(s))` returning `Option[Cookie]`

`examples/go_struct_bridge/bridge.go` gains `Processor` and `CookieBuilder` Go types so the GALA library has concrete func-typed fields to call.

- ` bazel build //... ` passes
- ` bazel test //examples:multifile_lib_regress_test ` and ` //internal/transpiler/transformer:transformer_test ` pass
- Two unrelated test targets (`match_generic_return_dispatch`, `match_void_dispatch`) fail with Windows UAC \"requires elevation\" — pre-existing environmental issue triggered by the `dispatch` substring in the binary names, not caused by this change

## Repro from the issue

```gala
package main

type Processor struct {
    process func(int) (string, error)
}

func main() {
    p := Processor{process: func(x int) (string, error) {
        return fmt.Sprintf(\"%d\", x), nil
    }}
    result, err := p.process(42)  // before: typed as NilType; now: string (Results[0])
}
```

## Dependencies

None — independent fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)