### PR TITLE
revert(transpiler): speculative func-field call return type fallback (#330)

### DIFF
--- a/internal/transpiler/transformer/type_inference_calls.go
+++ b/internal/transpiler/transformer/type_inference_calls.go
@@ -339,16 +339,6 @@ func (t *galaASTTransformer) inferCallSelectorType(e *ast.CallExpr, sel *ast.Sel
 		if retType := t.getGoMethodReturnType(xTypeName, sel.Sel.Name); !retType.IsNil() {
 			return retType
 		}
-		// Fallback: a Go struct field of function type invoked as a method,
-		// e.g., proc.Process(x) where Process is `func(int) (string, error)`.
-		// getGoFieldType already understands the field surface; consult it
-		// here so the call's return type tracks the field's declared results
-		// instead of collapsing to NilType (issue #326).
-		if fType := t.getGoFieldType(xTypeName, sel.Sel.Name); !fType.IsNil() {
-			if funcType, ok := fType.(transpiler.FuncType); ok && len(funcType.Results) > 0 {
-				return funcType.Results[0]
-			}
-		}
 	}
 
 	if isStdQualified {


### PR DESCRIPTION
## Summary

Reverts the inferCallSelectorType fallback added in #330. **Keeps the regression tests** — those stay as coverage for the func-field-call surface.

## What's reverted

`internal/transpiler/transformer/type_inference_calls.go` — the 10-line getGoFieldType fallback after the getGoMethodReturnType branch.

## What stays from #330

- `examples/go_struct_bridge/bridge.go` — Processor (func(int) (string, error)) and CookieBuilder (func(string) Cookie) Go types
- `examples/multifile_lib_regress/go_interop.gala` — ProcessorRun, CookieBuilderDescribe, CookieBuilderOption
- `examples/multifile_lib_regress_test.gala` + `.out` — wired into the regression test binary

## Why

The fallback was based on the issue's static analysis alone — the bug never actually reproduced. All three shapes added in #330 pass on master without the fallback:
- `var s, err = p.Process(x)` — Go's own destructure handles the multi-return
- `b.Build(s).String()` — emitted verbatim; Go resolves `.String()` on Cookie
- `Some(b.Build(s))` — the `[Cookie]` type arg comes from the function's declared return via downward inference

So the fallback fired only as a safety net with no observed effect. Per project policy: no speculative fallbacks without a guarding test. Issue #326 stays open; if a real GALA-side repro surfaces, we'll reopen with a test that actually fails on master.

## Verification

`bazel test //examples:multifile_lib_regress_test` passes on this branch without the fallback (confirms the original concern: the tests don't actually exercise the broken path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)