### PR TITLE
feat(crypto): HMAC + RandomBytes + ConstantTimeEqual

### DIFF
--- a/crypto/BUILD.bazel
+++ b/crypto/BUILD.bazel
@@ -24,7 +24,6 @@ gala_library(
     visibility = ["//visibility:public"],
     deps = [
         "//collection_immutable",
-        "//go_interop",
     ],
 )
 

--- a/crypto/BUILD.bazel
+++ b/crypto/BUILD.bazel
@@ -24,6 +24,7 @@ gala_library(
     visibility = ["//visibility:public"],
     deps = [
         "//collection_immutable",
+        "//go_interop",
     ],
 )
 

--- a/crypto/crypto.gala
+++ b/crypto/crypto.gala
@@ -3,6 +3,7 @@ package crypto
 import (
     "crypto/hmac"
     "crypto/md5"
+    "crypto/rand"
     "crypto/sha1"
     "crypto/sha256"
     "crypto/sha512"
@@ -11,6 +12,7 @@ import (
     "encoding/hex"
     "hash"
     . "martianoff/gala/collection_immutable"
+    "martianoff/gala/go_interop"
 )
 
 // Digest is the opaque output of a hash function. The internal
@@ -216,4 +218,36 @@ func (h HmacSha1) Sum(data Array[byte]) Digest {
 func (h HmacSha1) NewHasher() *Hasher {
     var goKey = h.Key.ToGoSlice()
     return &Hasher(algorithm = "HMAC-SHA1", h = hmac.New(sha1.New, goKey))
+}
+
+// ---- random + constant-time helpers --------------------------------------
+
+// RandomBytes returns n cryptographically secure random bytes from the OS
+// RNG. n == 0 returns an empty Array. n < 0 panics. A read failure panics
+// (matches the Go stdlib idiom — crypto/rand.Read only fails on a broken
+// OS RNG, which is unrecoverable).
+func RandomBytes(n int) Array[byte] {
+    if n < 0 {
+        panic(s"crypto.RandomBytes: negative size $n")
+    }
+    if n == 0 {
+        return EmptyArray[byte]()
+    }
+    var buf = go_interop.SliceWithSize[byte](n)
+    var _, err = rand.Read(buf)
+    if err != nil {
+        panic(s"crypto.RandomBytes: rand.Read failed: ${err.Error()}")
+    }
+    return ArrayFromSlice(buf)
+}
+
+// ConstantTimeEqual reports whether a and b are byte-for-byte equal, using
+// a constant-time comparison. Different lengths return false (subtle
+// handles this). Generalizes Digest.Equal to arbitrary byte slices — useful
+// for comparing tokens, MACs, or any secret-bearing bytes.
+func ConstantTimeEqual(a Array[byte], b Array[byte]) bool {
+    var aGo = a.ToGoSlice()
+    var bGo = b.ToGoSlice()
+    return subtle.ConstantTimeCompare(aGo, bGo) == 1
+}
 }

--- a/crypto/crypto.gala
+++ b/crypto/crypto.gala
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+    "crypto/hmac"
     "crypto/md5"
     "crypto/sha1"
     "crypto/sha256"
@@ -147,4 +148,72 @@ func (s Md5) Hash(data Array[byte]) Digest {
 
 func (s Md5) NewHasher() *Hasher {
     return &Hasher(algorithm = "MD5", h = md5.New())
+}
+
+// ---- HMAC ----------------------------------------------------------------
+//
+// HMAC (RFC 2104) keyed-hash message authentication. Construct with a key
+// and call Sum / NewHasher; the resulting Hasher reuses the same streaming
+// machinery as the unkeyed hashes, so .Update().Update().Finish() works
+// identically. Tags compare in constant time via Digest.Equal.
+
+// HmacSha256 is HMAC-SHA-256, 32-byte tag.
+struct HmacSha256(Key Array[byte])
+
+func (h HmacSha256) Algorithm() string = "HMAC-SHA256"
+func (h HmacSha256) Size() int = 32
+
+func (h HmacSha256) Sum(data Array[byte]) Digest {
+    var goKey = h.Key.ToGoSlice()
+    var goData = data.ToGoSlice()
+    var mac = hmac.New(sha256.New, goKey)
+    var _, _ = mac.Write(goData)
+    val tag = mac.Sum(nil)
+    return Digest(bytes = ArrayFromSlice(tag))
+}
+
+func (h HmacSha256) NewHasher() *Hasher {
+    var goKey = h.Key.ToGoSlice()
+    return &Hasher(algorithm = "HMAC-SHA256", h = hmac.New(sha256.New, goKey))
+}
+
+// HmacSha512 is HMAC-SHA-512, 64-byte tag.
+struct HmacSha512(Key Array[byte])
+
+func (h HmacSha512) Algorithm() string = "HMAC-SHA512"
+func (h HmacSha512) Size() int = 64
+
+func (h HmacSha512) Sum(data Array[byte]) Digest {
+    var goKey = h.Key.ToGoSlice()
+    var goData = data.ToGoSlice()
+    var mac = hmac.New(sha512.New, goKey)
+    var _, _ = mac.Write(goData)
+    val tag = mac.Sum(nil)
+    return Digest(bytes = ArrayFromSlice(tag))
+}
+
+func (h HmacSha512) NewHasher() *Hasher {
+    var goKey = h.Key.ToGoSlice()
+    return &Hasher(algorithm = "HMAC-SHA512", h = hmac.New(sha512.New, goKey))
+}
+
+// HmacSha1 is HMAC-SHA-1, 20-byte tag. SHA-1 collision resistance is
+// broken, but HMAC-SHA-1 remains in use for legacy interop.
+struct HmacSha1(Key Array[byte])
+
+func (h HmacSha1) Algorithm() string = "HMAC-SHA1"
+func (h HmacSha1) Size() int = 20
+
+func (h HmacSha1) Sum(data Array[byte]) Digest {
+    var goKey = h.Key.ToGoSlice()
+    var goData = data.ToGoSlice()
+    var mac = hmac.New(sha1.New, goKey)
+    var _, _ = mac.Write(goData)
+    val tag = mac.Sum(nil)
+    return Digest(bytes = ArrayFromSlice(tag))
+}
+
+func (h HmacSha1) NewHasher() *Hasher {
+    var goKey = h.Key.ToGoSlice()
+    return &Hasher(algorithm = "HMAC-SHA1", h = hmac.New(sha1.New, goKey))
 }

--- a/crypto/crypto.gala
+++ b/crypto/crypto.gala
@@ -249,4 +249,3 @@ func ConstantTimeEqual(a Array[byte], b Array[byte]) bool {
     var bGo = b.ToGoSlice()
     return subtle.ConstantTimeCompare(aGo, bGo) == 1
 }
-}

--- a/crypto/crypto.gala
+++ b/crypto/crypto.gala
@@ -12,7 +12,6 @@ import (
     "encoding/hex"
     "hash"
     . "martianoff/gala/collection_immutable"
-    "martianoff/gala/go_interop"
 )
 
 // Digest is the opaque output of a hash function. The internal
@@ -233,7 +232,7 @@ func RandomBytes(n int) Array[byte] {
     if n == 0 {
         return EmptyArray[byte]()
     }
-    var buf = go_interop.SliceWithSize[byte](n)
+    var buf = ArrayFill[byte](n, byte(0)).ToGoSlice()
     var _, err = rand.Read(buf)
     if err != nil {
         panic(s"crypto.RandomBytes: rand.Read failed: ${err.Error()}")

--- a/crypto/crypto_test.gala
+++ b/crypto/crypto_test.gala
@@ -1,6 +1,7 @@
 package main
 
 import (
+    "encoding/hex"
     . "martianoff/gala/test"
     . "martianoff/gala/collection_immutable"
     . "martianoff/gala/go_interop"
@@ -235,4 +236,32 @@ func TestHmacEqualDifferentData(t T) T {
     val m1 = crypto.HmacSha256(key).Sum(bytesOf("payload-a"))
     val m2 = crypto.HmacSha256(key).Sum(bytesOf("payload-b"))
     return IsFalse(t, m1.Equal(m2))
+}
+
+// ---- RandomBytes ---------------------------------------------------------
+
+func TestRandomBytesSize(t T) T {
+    var t1 = Eq[int](t, crypto.RandomBytes(32).Size(), 32)
+    return Eq[int](t1, crypto.RandomBytes(0).Size(), 0)
+}
+
+func TestRandomBytesUnique(t T) T {
+    val a = hex.EncodeToString(crypto.RandomBytes(32).ToGoSlice())
+    val b = hex.EncodeToString(crypto.RandomBytes(32).ToGoSlice())
+    return NotEq[string](t, a, b)
+}
+
+// ---- ConstantTimeEqual ---------------------------------------------------
+
+func TestConstantTimeEqualSame(t T) T {
+    return IsTrue(t, crypto.ConstantTimeEqual(bytesOf("hello"), bytesOf("hello")))
+}
+
+func TestConstantTimeEqualOneBitDifferent(t T) T {
+    // "hello" vs "hellp" — last byte differs by one bit ('o' = 0x6F, 'p' = 0x70).
+    return IsFalse(t, crypto.ConstantTimeEqual(bytesOf("hello"), bytesOf("hellp")))
+}
+
+func TestConstantTimeEqualDifferentLengths(t T) T {
+    return IsFalse(t, crypto.ConstantTimeEqual(bytesOf("hello"), bytesOf("hello!")))
 }

--- a/crypto/crypto_test.gala
+++ b/crypto/crypto_test.gala
@@ -147,3 +147,92 @@ func TestDigestEqualDifferentSizes(t T) T {
     val d512 = crypto.Sha512{}.Hash(bytesOf("abc"))
     return IsFalse(t, d256.Equal(d512))
 }
+
+// ---- HMAC ----------------------------------------------------------------
+//
+// RFC 4231 test case 1: key = 20 bytes of 0x0b, data = "Hi There".
+// Covers HMAC-SHA-256 / HMAC-SHA-512 (RFC 4231) and HMAC-SHA-1 (RFC 2202
+// test 1, which uses the same key/data and is the canonical SHA-1 vector).
+
+func rfc4231TestKey() Array[byte] = ArrayFill(20, byte(0x0b))
+
+func TestHmacSha256Rfc4231Case1(t T) T {
+    // RFC 4231 §4.2:
+    //   b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7
+    val mac = crypto.HmacSha256(rfc4231TestKey()).Sum(bytesOf("Hi There"))
+    return Eq[string](t, mac.Hex(),
+        "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7")
+}
+
+func TestHmacSha512Rfc4231Case1(t T) T {
+    // RFC 4231 §4.2:
+    //   87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cde
+    //   daa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854
+    val mac = crypto.HmacSha512(rfc4231TestKey()).Sum(bytesOf("Hi There"))
+    return Eq[string](t, mac.Hex(),
+        "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854")
+}
+
+func TestHmacSha1Rfc2202Case1(t T) T {
+    // RFC 2202 §3 test 1:
+    //   b617318655057264e28bc0b6fb378c8ef146be00
+    val mac = crypto.HmacSha1(rfc4231TestKey()).Sum(bytesOf("Hi There"))
+    return Eq[string](t, mac.Hex(),
+        "b617318655057264e28bc0b6fb378c8ef146be00")
+}
+
+// ---- HMAC streaming matches one-shot ------------------------------------
+
+func TestHmacStreamingMatchesOneShot(t T) T {
+    val key = bytesOf("secret-key")
+    val full = "the quick brown fox jumps over the lazy dog"
+    val oneShot = crypto.HmacSha256(key).Sum(bytesOf(full))
+
+    val streamed = crypto.HmacSha256(key).NewHasher().
+        Update(bytesOf("the quick brown fox ")).
+        Update(bytesOf("jumps over ")).
+        Update(bytesOf("the lazy dog")).
+        Finish()
+
+    var t1 = Eq[string](t, oneShot.Hex(), streamed.Hex())
+    return IsTrue(t1, oneShot.Equal(streamed))
+}
+
+// ---- HMAC metadata -------------------------------------------------------
+
+func TestHmacAlgorithmMetadata(t T) T {
+    val key = bytesOf("k")
+    var t1 = Eq[string](t, crypto.HmacSha256(key).Algorithm(), "HMAC-SHA256")
+    var t2 = Eq[int](t1, crypto.HmacSha256(key).Size(), 32)
+    var t3 = Eq[string](t2, crypto.HmacSha512(key).Algorithm(), "HMAC-SHA512")
+    var t4 = Eq[int](t3, crypto.HmacSha512(key).Size(), 64)
+    var t5 = Eq[string](t4, crypto.HmacSha1(key).Algorithm(), "HMAC-SHA1")
+    return Eq[int](t5, crypto.HmacSha1(key).Size(), 20)
+}
+
+func TestHmacHasherAlgorithm(t T) T {
+    val h = crypto.HmacSha256(bytesOf("k")).NewHasher()
+    return Eq[string](t, h.Algorithm(), "HMAC-SHA256")
+}
+
+// ---- HMAC tag equality (constant-time) -----------------------------------
+
+func TestHmacEqualSameKeySameData(t T) T {
+    val key = bytesOf("shared-secret")
+    val m1 = crypto.HmacSha256(key).Sum(bytesOf("payload"))
+    val m2 = crypto.HmacSha256(key).Sum(bytesOf("payload"))
+    return IsTrue(t, m1.Equal(m2))
+}
+
+func TestHmacEqualDifferentKey(t T) T {
+    val m1 = crypto.HmacSha256(bytesOf("key-a")).Sum(bytesOf("payload"))
+    val m2 = crypto.HmacSha256(bytesOf("key-b")).Sum(bytesOf("payload"))
+    return IsFalse(t, m1.Equal(m2))
+}
+
+func TestHmacEqualDifferentData(t T) T {
+    val key = bytesOf("shared-secret")
+    val m1 = crypto.HmacSha256(key).Sum(bytesOf("payload-a"))
+    val m2 = crypto.HmacSha256(key).Sum(bytesOf("payload-b"))
+    return IsFalse(t, m1.Equal(m2))
+}


### PR DESCRIPTION
## What

Extend the `crypto` package with HMAC, secure random bytes, and a standalone constant-time byte comparator.

- **HMAC**: `HmacSha256`, `HmacSha512`, `HmacSha1` constructor structs. Each takes a key `Array[byte]` and exposes `Algorithm()` / `Size()` / `Sum(data)` / `NewHasher()`. Tags reuse the existing `Digest` type, so `.Equal()` (constant-time), `.Hex()`, and `.Base64()` all work unchanged. The streaming `*Hasher` is shared with the unkeyed hashes — `.Update().Update().Finish()` works identically with the algorithm field reading e.g. `"HMAC-SHA256"`.
- **`RandomBytes(n int) Array[byte]`**: `n` cryptographically secure bytes from `crypto/rand`. `n == 0` returns an empty array; `n < 0` panics with a clear message; OS RNG read failure panics (matches the Go stdlib idiom — `rand.Read` only fails on a broken kernel RNG).
- **`ConstantTimeEqual(a, b Array[byte]) bool`**: wraps `subtle.ConstantTimeCompare`. Generalizes `Digest.Equal` to arbitrary byte slices for token / secret / MAC comparison. Different lengths return false.
- Tests cover RFC 4231 Case 1 vectors for HMAC-SHA-256 / SHA-512 and RFC 2202 Case 1 for HMAC-SHA-1, streaming-equals-one-shot for HMAC, metadata, tag equality across same/different keys and data, `RandomBytes` size + uniqueness, and `ConstantTimeEqual` across equal / one-bit-different / different-length inputs.

## Why

HMAC is the baseline primitive for keyed authentication — JWT signing, AWS sigv4, webhook signature verification, signed cookies. Pairing it with the existing hash family makes the package a complete keyed-and-unkeyed surface without exposing `crypto/hmac` directly to user code. Secure random bytes and a generalized constant-time compare close the two most common gaps callers hit when wiring auth: generating tokens / salts / IVs, and comparing secrets without leaking timing.

## Follow-ups

- HKDF / PBKDF2: deferred. Both depend on HMAC (now available) and would form a small follow-up PR.
- AEAD (AES-GCM, ChaCha20-Poly1305): not requested; a much larger surface with key/nonce lifecycle decisions worth designing on its own.
- SHA-3 / Keccak: deferred — would pull in `golang.org/x/crypto`, a third-party dep this package currently avoids.
- HMAC for MD5: deliberately omitted. SHA-1 is included for legacy interop only; MD5-HMAC has no remaining legitimate use case.
