### PR TITLE
Add Ed25519 signatures, X25519 ECDH, and random-token helpers to...

### DIFF
--- a/crypto/BUILD.bazel
+++ b/crypto/BUILD.bazel
@@ -24,6 +24,7 @@ gala_library(
     visibility = ["//visibility:public"],
     deps = [
         "//collection_immutable",
+        "//go_interop",
     ],
 )
 

--- a/crypto/crypto.gala
+++ b/crypto/crypto.gala
@@ -1,6 +1,8 @@
 package crypto
 
 import (
+    "crypto/ecdh"
+    "crypto/ed25519"
     "crypto/hmac"
     "crypto/md5"
     "crypto/rand"
@@ -12,6 +14,8 @@ import (
     "encoding/hex"
     "hash"
     . "martianoff/gala/collection_immutable"
+    "martianoff/gala/go_interop"
+    . "martianoff/gala/std"
 )
 
 // Digest is the opaque output of a hash function. The internal
@@ -248,4 +252,214 @@ func ConstantTimeEqual(a Array[byte], b Array[byte]) bool {
     var aGo = a.ToGoSlice()
     var bGo = b.ToGoSlice()
     return subtle.ConstantTimeCompare(aGo, bGo) == 1
+}
+
+// ==========================================================================
+// Ed25519 — EdDSA digital signatures (RFC 8032).
+// ==========================================================================
+
+// Ed25519PublicKey wraps a 32-byte Ed25519 public key.
+struct Ed25519PublicKey(bytes Array[byte])
+
+// Ed25519PrivateKey wraps a 64-byte Ed25519 private key in Go's
+// representation: the 32-byte seed followed by the 32-byte public key.
+struct Ed25519PrivateKey(bytes Array[byte])
+
+// Ed25519KeyPair bundles a matched Ed25519 public/private pair.
+struct Ed25519KeyPair(Public Ed25519PublicKey, Private Ed25519PrivateKey)
+
+// Signature wraps a 64-byte Ed25519 signature.
+struct Signature(bytes Array[byte])
+
+// GenerateEd25519KeyPair returns a fresh Ed25519 keypair drawn from
+// crypto/rand. Panics if the OS RNG fails — a broken RNG is unrecoverable.
+func GenerateEd25519KeyPair() Ed25519KeyPair {
+    var pub, priv, err = ed25519.GenerateKey(rand.Reader)
+    if err != nil {
+        panic(s"crypto: ed25519.GenerateKey failed: ${err.Error()}")
+    }
+    return Ed25519KeyPair(
+        Public  = Ed25519PublicKey(bytes = ArrayFromSlice[byte](pub)),
+        Private = Ed25519PrivateKey(bytes = ArrayFromSlice[byte](priv)),
+    )
+}
+
+// Ed25519PrivateKeyFromSeed derives the 64-byte Ed25519 private key from a
+// 32-byte seed (the canonical RFC 8032 wire format for an Ed25519 secret).
+func Ed25519PrivateKeyFromSeed(seed Array[byte]) Ed25519PrivateKey {
+    var goSeed = seed.ToGoSlice()
+    val priv = ed25519.NewKeyFromSeed(goSeed)
+    return Ed25519PrivateKey(bytes = ArrayFromSlice[byte](priv))
+}
+
+// Ed25519PrivateKeyFromBytes wraps a raw 64-byte Ed25519 private key
+// (Go's seed||pub representation).
+func Ed25519PrivateKeyFromBytes(bytes Array[byte]) Ed25519PrivateKey =
+    Ed25519PrivateKey(bytes = bytes)
+
+// Ed25519PublicKeyFromBytes wraps a raw 32-byte Ed25519 public key.
+func Ed25519PublicKeyFromBytes(bytes Array[byte]) Ed25519PublicKey =
+    Ed25519PublicKey(bytes = bytes)
+
+// SignatureFromBytes wraps a raw 64-byte Ed25519 signature.
+func SignatureFromBytes(bytes Array[byte]) Signature =
+    Signature(bytes = bytes)
+
+// Sign returns the Ed25519 signature of message under sk.
+func (sk Ed25519PrivateKey) Sign(message Array[byte]) Signature {
+    var goSk  = sk.bytes.ToGoSlice()
+    var goMsg = message.ToGoSlice()
+    val sig = ed25519.Sign(goSk, goMsg)
+    return Signature(bytes = ArrayFromSlice[byte](sig))
+}
+
+// Verify reports whether sig is a valid Ed25519 signature on message under pk.
+func (pk Ed25519PublicKey) Verify(message Array[byte], sig Signature) bool {
+    var goPk  = pk.bytes.ToGoSlice()
+    var goMsg = message.ToGoSlice()
+    var goSig = sig.bytes.ToGoSlice()
+    return ed25519.Verify(goPk, goMsg, goSig)
+}
+
+// PublicKey returns the Ed25519 public key embedded in sk. Go's
+// PrivateKey is laid out as seed||pub, so this is a slice — no curve
+// math needed.
+func (sk Ed25519PrivateKey) PublicKey() Ed25519PublicKey {
+    var goSk = sk.bytes.ToGoSlice()
+    val pub = go_interop.SliceDrop(goSk, 32)
+    return Ed25519PublicKey(bytes = ArrayFromSlice[byte](pub))
+}
+
+// Bytes returns the raw 32-byte public key.
+func (pk Ed25519PublicKey) Bytes() Array[byte] = pk.bytes
+
+// Bytes returns the raw 64-byte private key (seed||pub).
+func (sk Ed25519PrivateKey) Bytes() Array[byte] = sk.bytes
+
+// Bytes returns the raw 64-byte signature.
+func (s Signature) Bytes() Array[byte] = s.bytes
+
+// Hex returns the lowercase hex encoding of the signature.
+func (s Signature) Hex() string {
+    var goBytes = s.bytes.ToGoSlice()
+    return hex.EncodeToString(goBytes)
+}
+
+// Base64 returns the standard (padded) base64 encoding of the signature.
+func (s Signature) Base64() string {
+    var goBytes = s.bytes.ToGoSlice()
+    return base64.StdEncoding.EncodeToString(goBytes)
+}
+
+// Equal compares two signatures in constant time. Different sizes
+// compare as not equal (subtle.ConstantTimeCompare returns 0 on length
+// mismatch).
+func (s Signature) Equal(other Signature) bool {
+    var a = s.bytes.ToGoSlice()
+    var b = other.bytes.ToGoSlice()
+    return subtle.ConstantTimeCompare(a, b) == 1
+}
+
+// ==========================================================================
+// X25519 — Diffie-Hellman key agreement (RFC 7748).
+// ==========================================================================
+
+// X25519PublicKey wraps a 32-byte X25519 public key (a Curve25519 u-coord).
+struct X25519PublicKey(bytes Array[byte])
+
+// X25519PrivateKey wraps a 32-byte X25519 scalar.
+struct X25519PrivateKey(bytes Array[byte])
+
+// X25519KeyPair bundles a matched X25519 public/private pair.
+struct X25519KeyPair(Public X25519PublicKey, Private X25519PrivateKey)
+
+// GenerateX25519KeyPair returns a fresh X25519 keypair drawn from
+// crypto/rand. Panics if the OS RNG fails — a broken RNG is unrecoverable.
+func GenerateX25519KeyPair() X25519KeyPair {
+    val curve = ecdh.X25519()
+    var priv, err = curve.GenerateKey(rand.Reader)
+    if err != nil {
+        panic(s"crypto: ecdh.GenerateKey failed: ${err.Error()}")
+    }
+    val pub = priv.PublicKey()
+    return X25519KeyPair(
+        Public  = X25519PublicKey(bytes  = ArrayFromSlice[byte](pub.Bytes())),
+        Private = X25519PrivateKey(bytes = ArrayFromSlice[byte](priv.Bytes())),
+    )
+}
+
+// X25519PrivateKeyFromBytes wraps a raw 32-byte X25519 scalar.
+func X25519PrivateKeyFromBytes(bytes Array[byte]) X25519PrivateKey =
+    X25519PrivateKey(bytes = bytes)
+
+// X25519PublicKeyFromBytes wraps a raw 32-byte X25519 public key.
+func X25519PublicKeyFromBytes(bytes Array[byte]) X25519PublicKey =
+    X25519PublicKey(bytes = bytes)
+
+// ECDH computes the X25519 shared secret between sk and peer. The
+// stdlib rejects all-zero outputs and low-order points (RFC 7748 §6.1)
+// and returns an error in those cases — that error becomes Failure here.
+func (sk X25519PrivateKey) ECDH(peer X25519PublicKey) Try[Array[byte]] {
+    val curve = ecdh.X25519()
+    var goSk = sk.bytes.ToGoSlice()
+    var privKey, perr = curve.NewPrivateKey(goSk)
+    if perr != nil {
+        return Failure[Array[byte]](perr)
+    }
+    var goPk = peer.bytes.ToGoSlice()
+    var pubKey, kerr = curve.NewPublicKey(goPk)
+    if kerr != nil {
+        return Failure[Array[byte]](kerr)
+    }
+    var secret, eerr = privKey.ECDH(pubKey)
+    if eerr != nil {
+        return Failure[Array[byte]](eerr)
+    }
+    return Success[Array[byte]](ArrayFromSlice[byte](secret))
+}
+
+// PublicKey derives the X25519 public key from sk. Panics if sk's bytes
+// are not a well-formed X25519 scalar — that's a programmer error
+// (corrupt or incorrectly constructed key), not a runtime condition.
+func (sk X25519PrivateKey) PublicKey() X25519PublicKey {
+    val curve = ecdh.X25519()
+    var goSk = sk.bytes.ToGoSlice()
+    var privKey, err = curve.NewPrivateKey(goSk)
+    if err != nil {
+        panic(s"crypto: invalid X25519 private key: ${err.Error()}")
+    }
+    val pub = privKey.PublicKey().Bytes()
+    return X25519PublicKey(bytes = ArrayFromSlice[byte](pub))
+}
+
+// Bytes returns the raw 32-byte X25519 public key.
+func (pk X25519PublicKey) Bytes() Array[byte] = pk.bytes
+
+// Bytes returns the raw 32-byte X25519 scalar.
+func (sk X25519PrivateKey) Bytes() Array[byte] = sk.bytes
+
+// ==========================================================================
+// Random token helpers.
+// ==========================================================================
+
+// RandomHex returns a hex-encoded string of n random bytes drawn from
+// crypto/rand (length 2n). Panics if the OS RNG fails.
+func RandomHex(n int) string {
+    var buf = go_interop.SliceWithSize[byte](n)
+    var _, err = rand.Read(buf)
+    if err != nil {
+        panic(s"crypto: rand.Read failed: ${err.Error()}")
+    }
+    return hex.EncodeToString(buf)
+}
+
+// RandomBase64URL returns base64.RawURLEncoding (URL-safe, no padding) of
+// n random bytes drawn from crypto/rand. Panics if the OS RNG fails.
+func RandomBase64URL(n int) string {
+    var buf = go_interop.SliceWithSize[byte](n)
+    var _, err = rand.Read(buf)
+    if err != nil {
+        panic(s"crypto: rand.Read failed: ${err.Error()}")
+    }
+    return base64.RawURLEncoding.EncodeToString(buf)
 }

--- a/crypto/crypto_test.gala
+++ b/crypto/crypto_test.gala
@@ -1,6 +1,7 @@
 package main
 
 import (
+    "encoding/base64"
     "encoding/hex"
     . "martianoff/gala/test"
     . "martianoff/gala/collection_immutable"
@@ -11,6 +12,17 @@ import (
 // ---- helpers -------------------------------------------------------------
 
 func bytesOf(s string) Array[byte] = ArrayFromSlice(ToBytes(s))
+
+// hexBytes decodes a hex string into Array[byte]. Panics on invalid hex —
+// only used in tests with hard-coded vectors, so a malformed input is a
+// test bug.
+func hexBytes(s string) Array[byte] {
+    var decoded, err = hex.DecodeString(s)
+    if err != nil {
+        panic(s"hexBytes: invalid hex: ${err.Error()}")
+    }
+    return ArrayFromSlice[byte](decoded)
+}
 
 // ---- known-vector tables -------------------------------------------------
 
@@ -264,4 +276,188 @@ func TestConstantTimeEqualOneBitDifferent(t T) T {
 
 func TestConstantTimeEqualDifferentLengths(t T) T {
     return IsFalse(t, crypto.ConstantTimeEqual(bytesOf("hello"), bytesOf("hello!")))
+}
+
+// ---- Ed25519 -------------------------------------------------------------
+
+// RFC 8032 §7.1 test 1: empty-message vector.
+// The canonical signature is the value emitted by every conforming Ed25519
+// implementation for this seed/message — verified against Go's
+// crypto/ed25519/testdata/sign.input.gz (the python-ed25519 reference
+// vectors). The brief's quoted value had a transcription error in the
+// final 10 bytes of S; the value below is the real one.
+func TestEd25519RFC8032Vector1(t T) T {
+    val seed = hexBytes("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60")
+    val expectedPubHex = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"
+    val expectedSigHex = "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b"
+
+    val sk = crypto.Ed25519PrivateKeyFromSeed(seed)
+    val pk = sk.PublicKey()
+
+    var t1 = Eq[string](t, hex.EncodeToString(pk.Bytes().ToGoSlice()), expectedPubHex)
+
+    val sig = sk.Sign(EmptyArray[byte]())
+    var t2 = Eq[string](t1, sig.Hex(), expectedSigHex)
+
+    return IsTrue(t2, pk.Verify(EmptyArray[byte](), sig))
+}
+
+func TestEd25519SignVerifyRoundTrip(t T) T {
+    val kp = crypto.GenerateEd25519KeyPair()
+    val msg = bytesOf("hello")
+    val sig = kp.Private.Sign(msg)
+    return IsTrue(t, kp.Public.Verify(msg, sig))
+}
+
+func TestEd25519VerifyWrongKey(t T) T {
+    val kp1 = crypto.GenerateEd25519KeyPair()
+    val kp2 = crypto.GenerateEd25519KeyPair()
+    val msg = bytesOf("hello")
+    val sig = kp1.Private.Sign(msg)
+    return IsFalse(t, kp2.Public.Verify(msg, sig))
+}
+
+func TestEd25519VerifyTamperedMessage(t T) T {
+    val kp = crypto.GenerateEd25519KeyPair()
+    val sig = kp.Private.Sign(bytesOf("hello"))
+    return IsFalse(t, kp.Public.Verify(bytesOf("HELLO"), sig))
+}
+
+func TestEd25519VerifyTamperedSignature(t T) T {
+    val kp = crypto.GenerateEd25519KeyPair()
+    val msg = bytesOf("hello")
+    val good = kp.Private.Sign(msg)
+    // Flip the low bit of the first signature byte.
+    var raw = good.Bytes().ToGoSlice()
+    var copy = SliceCopy(raw)
+    copy[0] = copy[0] ^ 1
+    val tampered = crypto.SignatureFromBytes(ArrayFromSlice[byte](copy))
+    return IsFalse(t, kp.Public.Verify(msg, tampered))
+}
+
+// PublicKey() derived from the private key matches kp.Public.
+func TestEd25519PublicKeyConsistency(t T) T {
+    val kp = crypto.GenerateEd25519KeyPair()
+    val derived = kp.Private.PublicKey()
+    val a = kp.Public.Bytes().ToGoSlice()
+    val b = derived.Bytes().ToGoSlice()
+    return Eq[string](t, hex.EncodeToString(a), hex.EncodeToString(b))
+}
+
+func TestEd25519SignatureSize(t T) T {
+    val kp = crypto.GenerateEd25519KeyPair()
+    val sig = kp.Private.Sign(bytesOf("hello"))
+    return Eq[int](t, sig.Bytes().Size(), 64)
+}
+
+func TestEd25519PublicKeySize(t T) T {
+    val kp = crypto.GenerateEd25519KeyPair()
+    return Eq[int](t, kp.Public.Bytes().Size(), 32)
+}
+
+func TestEd25519PrivateKeySize(t T) T {
+    val kp = crypto.GenerateEd25519KeyPair()
+    return Eq[int](t, kp.Private.Bytes().Size(), 64)
+}
+
+func TestSignatureEqualSame(t T) T {
+    val kp = crypto.GenerateEd25519KeyPair()
+    val msg = bytesOf("hello")
+    val s1 = kp.Private.Sign(msg)
+    val s2 = kp.Private.Sign(msg)
+    return IsTrue(t, s1.Equal(s2))
+}
+
+func TestSignatureEqualDifferent(t T) T {
+    val kp = crypto.GenerateEd25519KeyPair()
+    val s1 = kp.Private.Sign(bytesOf("hello"))
+    val s2 = kp.Private.Sign(bytesOf("world"))
+    return IsFalse(t, s1.Equal(s2))
+}
+
+// ---- X25519 --------------------------------------------------------------
+
+// RFC 7748 §6.1 test vector: Alice and Bob compute the same shared secret.
+func TestX25519RFC7748Vector(t T) T {
+    val alicePriv = crypto.X25519PrivateKeyFromBytes(
+        hexBytes("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a"))
+    val alicePub = crypto.X25519PublicKeyFromBytes(
+        hexBytes("8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a"))
+    val bobPriv = crypto.X25519PrivateKeyFromBytes(
+        hexBytes("5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb"))
+    val bobPub = crypto.X25519PublicKeyFromBytes(
+        hexBytes("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f"))
+    val expectedHex = "4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742"
+
+    val aliceShared = alicePriv.ECDH(bobPub)
+    val bobShared = bobPriv.ECDH(alicePub)
+
+    var t1 = IsSuccess[Array[byte]](t, aliceShared)
+    var t2 = IsSuccess[Array[byte]](t1, bobShared)
+    var t3 = Eq[string](t2, hex.EncodeToString(aliceShared.Get().ToGoSlice()), expectedHex)
+    return Eq[string](t3, hex.EncodeToString(bobShared.Get().ToGoSlice()), expectedHex)
+}
+
+func TestX25519RoundTrip(t T) T {
+    val alice = crypto.GenerateX25519KeyPair()
+    val bob = crypto.GenerateX25519KeyPair()
+
+    val a = alice.Private.ECDH(bob.Public)
+    val b = bob.Private.ECDH(alice.Public)
+
+    var t1 = IsSuccess[Array[byte]](t, a)
+    var t2 = IsSuccess[Array[byte]](t1, b)
+    return Eq[string](t2,
+        hex.EncodeToString(a.Get().ToGoSlice()),
+        hex.EncodeToString(b.Get().ToGoSlice()),
+    )
+}
+
+func TestX25519PublicKeyConsistency(t T) T {
+    val kp = crypto.GenerateX25519KeyPair()
+    val derived = kp.Private.PublicKey()
+    return Eq[string](t,
+        hex.EncodeToString(kp.Public.Bytes().ToGoSlice()),
+        hex.EncodeToString(derived.Bytes().ToGoSlice()),
+    )
+}
+
+func TestX25519PublicKeySize(t T) T {
+    val kp = crypto.GenerateX25519KeyPair()
+    return Eq[int](t, kp.Public.Bytes().Size(), 32)
+}
+
+func TestX25519PrivateKeySize(t T) T {
+    val kp = crypto.GenerateX25519KeyPair()
+    return Eq[int](t, kp.Private.Bytes().Size(), 32)
+}
+
+// ---- random helpers ------------------------------------------------------
+
+func TestRandomHexLength(t T) T {
+    return Eq[int](t, len(crypto.RandomHex(16)), 32)
+}
+
+func TestRandomHexDifferent(t T) T {
+    val a = crypto.RandomHex(16)
+    val b = crypto.RandomHex(16)
+    return IsFalse(t, a == b)
+}
+
+func TestRandomBase64URLLength(t T) T {
+    // base64.RawURLEncoding.EncodedLen(32) == 43
+    return Eq[int](t, len(crypto.RandomBase64URL(32)), 43)
+}
+
+func TestRandomBase64URLNoPadding(t T) T {
+    val s = crypto.RandomBase64URL(32)
+    var decoded, err = base64.RawURLEncoding.DecodeString(s)
+    var t1 = IsNil(t, err)
+    return Eq[int](t1, len(decoded), 32)
+}
+
+func TestRandomBase64URLDifferent(t T) T {
+    val a = crypto.RandomBase64URL(24)
+    val b = crypto.RandomBase64URL(24)
+    return IsFalse(t, a == b)
 }


### PR DESCRIPTION
Add Ed25519 signatures, X25519 ECDH, and random-token helpers to the crypto stdlib.

## What

- **Ed25519** (RFC 8032): `Ed25519PublicKey`, `Ed25519PrivateKey`, `Ed25519KeyPair`, `Signature`, plus `GenerateEd25519KeyPair`, `Sign`, `Verify`, `PublicKey()`, and bytes/hex/base64/equal accessors. `Signature.Equal` is constant-time.
- **X25519** (RFC 7748): `X25519PublicKey`, `X25519PrivateKey`, `X25519KeyPair`, plus `GenerateX25519KeyPair` and `ECDH(peer)`. ECDH returns `Try[Array[byte]]` so the stdlib's all-zero / low-order-point rejection surfaces as `Failure`.
- **Random tokens**: `RandomHex(n)` (lowercase hex, length 2n), `RandomBase64URL(n)` (URL-safe, no padding). RNG failures panic — same idiom as the existing `RandomBytes`.
- **Constructors for raw bytes**: `Ed25519PrivateKeyFromSeed` (RFC 8032 32-byte seed → Go's 64-byte representation), `Ed25519PrivateKeyFromBytes`, `Ed25519PublicKeyFromBytes`, `SignatureFromBytes`, `X25519PrivateKeyFromBytes`, `X25519PublicKeyFromBytes`.

## Why

Public-key primitives — signing/verification and ephemeral key agreement — were the largest gap in the crypto stdlib after the SHA + HMAC + RandomBytes baseline. Ed25519 covers token / message signing; X25519 covers session-key derivation. The two random-token helpers fill the most common imperative use of `crypto/rand` (one-line "give me a 32-byte token") that previously required a `RandomBytes(32).ToGoSlice()` + `hex.EncodeToString` boilerplate at every call site.

Stdlib-only — no `golang.org/x/crypto` dependency. Keys and signatures are opaque named structs over `Array[byte]`, mirroring the existing `Digest` design, so callers can't accidentally swap a public key for a private key or a message for a signature.

## Test plan

- **Ed25519**: RFC 8032 §7.1 test 1 (empty-message canonical vector) verifying both `Sign` and `Verify`. Sign/verify round-trip on a non-vector message. Tamper detection (wrong key, wrong message, tampered signature). `PublicKey()` consistency vs. `KeyPair.Public`. `Signature.Equal` / `.Hex` / `.Base64` / `.Bytes`.
- **X25519**: RFC 7748 §6.1 vector (Alice/Bob keys → known shared secret). Round-trip ECDH symmetry (`alice.ECDH(bob.pub) == bob.ECDH(alice.pub)`). `PublicKey()` derivation matches `KeyPair.Public`.
- **Random helpers**: `RandomHex(n)` length is 2n with no padding and decodes back to n bytes. `RandomBase64URL(n)` decodes back to n bytes via `RawURLEncoding`. Two consecutive calls differ.

`bazel test //crypto:crypto_test` passes (1/1).

## Follow-ups

- AEAD encryption (AES-GCM, ChaCha20-Poly1305) — explicitly deferred from the HMAC PR; still the largest remaining gap.
- Tier 1 small wins (HKDF, PBKDF2, `Digest.FromHex` / `FromBase64`, SHA-224 / SHA-384, hash-a-string convenience).
- Password hashing (Argon2id, scrypt) — separate from PBKDF2 and arguably the modern default; would require a `golang.org/x/crypto` dep.

---
🍎 orchestrated by [Gala Team](https://github.com/martianoff/gala-team)