### PR TITLE
Replace panic-driven failure with explicit Try returns in `subproce...

### DIFF
--- a/crypto/crypto.gala
+++ b/crypto/crypto.gala
@@ -12,6 +12,7 @@ import (
     "crypto/subtle"
     "encoding/base64"
     "encoding/hex"
+    "errors"
     "hash"
     . "martianoff/gala/collection_immutable"
     "martianoff/gala/go_interop"
@@ -226,22 +227,21 @@ func (h HmacSha1) NewHasher() *Hasher {
 // ---- random + constant-time helpers --------------------------------------
 
 // RandomBytes returns n cryptographically secure random bytes from the OS
-// RNG. n == 0 returns an empty Array. n < 0 panics. A read failure panics
-// (matches the Go stdlib idiom — crypto/rand.Read only fails on a broken
-// OS RNG, which is unrecoverable).
-func RandomBytes(n int) Array[byte] {
+// RNG. n == 0 returns an empty Array. Returns Failure on negative size or
+// RNG read error.
+func RandomBytes(n int) Try[Array[byte]] {
     if n < 0 {
-        panic(s"crypto.RandomBytes: negative size $n")
+        return Failure[Array[byte]](errors.New(s"crypto.RandomBytes: negative size $n"))
     }
     if n == 0 {
-        return EmptyArray[byte]()
+        return Success[Array[byte]](EmptyArray[byte]())
     }
     var buf = ArrayFill[byte](n, byte(0)).ToGoSlice()
     var _, err = rand.Read(buf)
     if err != nil {
-        panic(s"crypto.RandomBytes: rand.Read failed: ${err.Error()}")
+        return Failure[Array[byte]](errors.New(s"crypto.RandomBytes: rand.Read failed: ${err.Error()}"))
     }
-    return ArrayFromSlice(buf)
+    return Success[Array[byte]](ArrayFromSlice(buf))
 }
 
 // ConstantTimeEqual reports whether a and b are byte-for-byte equal, using

--- a/crypto/crypto_test.gala
+++ b/crypto/crypto_test.gala
@@ -253,14 +253,18 @@ func TestHmacEqualDifferentData(t T) T {
 // ---- RandomBytes ---------------------------------------------------------
 
 func TestRandomBytesSize(t T) T {
-    var t1 = Eq[int](t, crypto.RandomBytes(32).Size(), 32)
-    return Eq[int](t1, crypto.RandomBytes(0).Size(), 0)
+    var t1 = Eq[int](t, crypto.RandomBytes(32).Get().Size(), 32)
+    return Eq[int](t1, crypto.RandomBytes(0).Get().Size(), 0)
 }
 
 func TestRandomBytesUnique(t T) T {
-    val a = hex.EncodeToString(crypto.RandomBytes(32).ToGoSlice())
-    val b = hex.EncodeToString(crypto.RandomBytes(32).ToGoSlice())
+    val a = hex.EncodeToString(crypto.RandomBytes(32).Get().ToGoSlice())
+    val b = hex.EncodeToString(crypto.RandomBytes(32).Get().ToGoSlice())
     return NotEq[string](t, a, b)
+}
+
+func TestRandomBytesNegative(t T) T {
+    return IsFailure[Array[byte]](t, crypto.RandomBytes(-1))
 }
 
 // ---- ConstantTimeEqual ---------------------------------------------------

--- a/subprocess/subprocess.gala
+++ b/subprocess/subprocess.gala
@@ -49,9 +49,9 @@ type Process struct {
 // On success the process is running and its stdin/stdout/stderr pipes are
 // connected. The returned Process is reaped only when Wait or Kill is called —
 // long-running consumers MUST call Wait or Kill exactly once when done.
-func Spawn(opts SpawnOpts) Try[Process] = Try[Process](() => {
+func Spawn(opts SpawnOpts) Try[Process] {
     if opts.Cmd == "" {
-        panic("subprocess.Spawn: empty Cmd")
+        return Failure[Process](errors.New("subprocess.Spawn: empty Cmd"))
     }
     val c = exec.Command(opts.Cmd, opts.Args...)
     if opts.Dir != "" {
@@ -63,14 +63,14 @@ func Spawn(opts SpawnOpts) Try[Process] = Try[Process](() => {
         c.Env = append(c.Environ(), opts.Env...)
     }
     val sin, sErr = c.StdinPipe()
-    if sErr != nil { panic(sErr) }
+    if sErr != nil { return Failure[Process](sErr) }
     val sout, oErr = c.StdoutPipe()
-    if oErr != nil { panic(oErr) }
+    if oErr != nil { return Failure[Process](oErr) }
     val serr, eErr = c.StderrPipe()
-    if eErr != nil { panic(eErr) }
+    if eErr != nil { return Failure[Process](eErr) }
     val startErr = c.Start()
-    if startErr != nil { panic(startErr) }
-    return Process(state = &processState{
+    if startErr != nil { return Failure[Process](startErr) }
+    return Success(Process(state = &processState{
         cmd:        c,
         stdin:      sin,
         stdoutScan: newLineScanner(sout),
@@ -78,24 +78,24 @@ func Spawn(opts SpawnOpts) Try[Process] = Try[Process](() => {
         stdinMu:    go_interop.NewMutex(),
         waitOnce:   go_interop.NewOnce(),
         waitDone:   go_interop.NewSignal(),
-    })
-})
+    }))
+}
 
 // WriteLine writes s + "\n" to the child's stdin, flushing immediately.
 // Concurrent callers are serialised so two writers can't interleave bytes.
 //
 // Returns Success(true) on a clean write. A failed write usually means the
 // child closed stdin or exited; Failure carries the underlying io error.
-func (p Process) WriteLine(s string) Try[bool] = Try[bool](() => {
+func (p Process) WriteLine(s string) Try[bool] {
     val st = p.state
     st.stdinMu.Lock()
     defer st.stdinMu.Unlock()
     val _, e1 = io.WriteString(st.stdin, s)
-    if e1 != nil { panic(e1) }
+    if e1 != nil { return Failure[bool](e1) }
     val _, e2 = io.WriteString(st.stdin, "\n")
-    if e2 != nil { panic(e2) }
-    return true
-})
+    if e2 != nil { return Failure[bool](e2) }
+    return Success(true)
+}
 
 // CloseStdin closes the child's stdin pipe. Required for children
 // like `claude --print` that read stdin to EOF before producing
@@ -107,36 +107,36 @@ func (p Process) WriteLine(s string) Try[bool] = Try[bool](() => {
 // swallowed — the caller wanted "stdin should be closed", and it
 // is. Concurrent with WriteLine: serialised through the stdin
 // mutex so a write in flight isn't truncated.
-func (p Process) CloseStdin() Try[bool] = Try[bool](() => {
+func (p Process) CloseStdin() Try[bool] {
     val st = p.state
     st.stdinMu.Lock()
     defer st.stdinMu.Unlock()
     val _ = st.stdin.Close()
-    return true
-})
+    return Success(true)
+}
 
 // ReadLine blocks until the child writes a complete line on stdout, then
 // returns it without the trailing newline. EOF (the child closed stdout, or
 // exited) returns Failure(io.EOF) — callers can recognise this via the std
 // Try API (e.g. .Recover) and treat it as "stream done", not as an error.
-func (p Process) ReadLine() Try[string] = Try[string](() => {
+func (p Process) ReadLine() Try[string] {
     if !p.state.stdoutScan.Scan() {
         val err = p.state.stdoutScan.Err()
-        if err != nil { panic(err) }
-        panic(io.EOF)
+        if err != nil { return Failure[string](err) }
+        return Failure[string](io.EOF)
     }
-    return p.state.stdoutScan.Text()
-})
+    return Success(p.state.stdoutScan.Text())
+}
 
 // ReadStderrLine is the stderr counterpart to ReadLine. Same EOF semantics.
-func (p Process) ReadStderrLine() Try[string] = Try[string](() => {
+func (p Process) ReadStderrLine() Try[string] {
     if !p.state.stderrScan.Scan() {
         val err = p.state.stderrScan.Err()
-        if err != nil { panic(err) }
-        panic(io.EOF)
+        if err != nil { return Failure[string](err) }
+        return Failure[string](io.EOF)
     }
-    return p.state.stderrScan.Text()
-})
+    return Success(p.state.stderrScan.Text())
+}
 
 // Wait blocks until the child exits and returns its exit code. Idempotent —
 // the underlying *exec.Cmd.Wait is called at most once. Subsequent Wait calls
@@ -145,7 +145,7 @@ func (p Process) ReadStderrLine() Try[string] = Try[string](() => {
 // Note: ReadLine / ReadStderrLine on the same Process should drain to EOF
 // before Wait, otherwise the child may block writing to a full pipe. The
 // scanner returning EOF naturally signals "you can Wait now".
-func (p Process) Wait() Try[int] = Try[int](() => {
+func (p Process) Wait() Try[int] {
     val st = p.state
     val _ = st.waitOnce.Do(() => {
         val err = st.cmd.Wait()
@@ -165,27 +165,27 @@ func (p Process) Wait() Try[int] = Try[int](() => {
         go_interop.CloseSignal(st.waitDone)
     })
     go_interop.WaitSignal(st.waitDone)
-    if st.waitErr != nil { panic(st.waitErr) }
-    return st.exitCode
-})
+    if st.waitErr != nil { return Failure[int](st.waitErr) }
+    return Success(st.exitCode)
+}
 
 // Kill terminates the child immediately (SIGKILL on Unix, TerminateProcess on
 // Windows — exec.Cmd handles the platform difference). Idempotent against an
 // already-exited process: a kill after Wait returns Success(true) without
 // error. Caller is still responsible for invoking Wait afterwards to reap.
-func (p Process) Kill() Try[bool] = Try[bool](() => {
+func (p Process) Kill() Try[bool] {
     if !p.IsAlive() {
-        return true
+        return Success(true)
     }
     val err = p.state.cmd.Process.Kill()
     if err != nil {
         // "process already finished" can race with the IsAlive check — treat
         // as success rather than confusing the caller.
-        if isProcessFinished(err) { return true }
-        panic(err)
+        if isProcessFinished(err) { return Success(true) }
+        return Failure[bool](err)
     }
-    return true
-})
+    return Success(true)
+}
 
 // IsAlive returns true if the child is still running. Non-blocking; consults
 // the cached Wait result first, then falls back to a process-state poll.


### PR DESCRIPTION
Replace panic-driven failure with explicit Try returns in `subprocess` and `crypto.RandomBytes`.

## What
- **`subprocess/subprocess.gala`**: Every public method (`Spawn`, `WriteLine`, `CloseStdin`, `ReadLine`, `ReadStderrLine`, `Wait`, `Kill`) was previously written as `func F(...) Try[T] = Try[T](() => { ... panic(err) ... })`, relying on `Try`'s panic recovery to convert pipe / I/O / spawn errors into `Failure`. Rewritten to use explicit `return Failure[T](err)` / `return Success(v)` returns. Same external return types, same behavior, no panic-recovery overhead.
- **`crypto/crypto.gala`**: `RandomBytes(n)` now returns `Try[Array[byte]]` instead of `Array[byte]`. Negative size and `crypto/rand.Read` failure produce `Failure[Array[byte]]` with the same diagnostic message strings; success path wraps in `Success(...)`. Doc comment updated.
- **`crypto/crypto_test.gala`**: `TestRandomBytesSize` and `TestRandomBytesUnique` now unwrap with `.Get()`. New `TestRandomBytesNegative` asserts `RandomBytes(-1)` is a `Failure`.

## Why
Both modules fail on real I/O conditions — broken stdin pipe, child exit, OS RNG error — that the caller needs to handle. Returning `Try[T]` directly is what the public API already advertised in `subprocess`; eliminating the inner `panic`/`Try` recovery dance makes control flow straightforward and the failure path explicit. For `crypto.RandomBytes`, the previous `Array[byte]` signature forced callers to either accept process-level panics on RNG failure or wrap every call in their own `Try(...)`. Now the failure surface lives in the type.

## Scope of "panic → Try" applied here
This change deliberately targets only the two modules where panic was being used for genuine I/O failure surfacing. It does **not** touch:
- Scala-style API contracts that intentionally panic on misuse with safe alternatives provided (`Option.Get`, `Try.Get`, `Either.GetLeft`/`GetRight`, `Array.Head`/`Last`/`Reduce`, `List.Head`/`Tail`/`Get`, `HashMap.Get(key)`, etc. — `GetOption`/`GetOrElse`/`HeadOption` remain the safe path).
- The `json` decoder's internal panic-as-control-flow (the public `Codec.Decode` already wraps it in `Try`).
- Type-system fallback panics (`HashSet`/`HashMap`/`TreeMap`/`TreeSet` "must implement Hashable/Ordered", `std.CompareValues`) — these are runtime stand-ins for static type bounds GALA cannot yet enforce.
- Test/example panics that exist precisely to exercise panic recovery (`examples/try_panic_recovery.gala`, `examples/match_arm_panic.gala`, `test/framework_test.gala`, `io/io_test.gala`).
- `test.framework.Fatal`, which uses panic by contract.

## Verification
- `bazel test //subprocess/... //crypto/...` → both pass.
- `bazel build //...` → green.

## Follow-ups
- None required. The remaining `panic()` sites listed above are intentional and should stay; revisiting them would be a separate API-design discussion (especially for the collection accessor surface, which would be a breaking change across many call sites).

---
🍎 orchestrated by [Gala Team](https://github.com/martianoff/gala-team)