### PR TITLE
Additional stdlib packages

### DIFF
--- a/.claude/skills/gala-lint.md
+++ b/.claude/skills/gala-lint.md
@@ -690,12 +690,22 @@ Try(() => findConfig()).FlatMap((path) => Try(() => readFile(path)))
 |-------|-----------------|-----------------|
 | Go struct colon literal | `GoType{Field: value}` | `GoType(Field = value)` — GALA named-arg syntax works for Go structs |
 
-### 11d. `match` as Standalone Statement (MEDIUM priority)
+### 11d. `val _ =` is a code smell — use a bare statement (HIGH priority)
+
+`val _ = <expr>` is **always** a smell. Whatever the right-hand side is, it should stand on its own as a statement.
 
 | Issue | Pattern to Flag | Recommended Fix |
 |-------|-----------------|-----------------|
-| Discard match result | `val _ = x match { ... }` | Use `match` directly as statement |
+| Discard call result | `val _ = fs.WriteFileString(p, s, mode)` | `fs.WriteFileString(p, s, mode)` — bare call |
+| Discard match result | `val _ = x match { ... }` | `x match { ... }` — bare match |
+| Discard `error`-returning call | `val _ = file.Close()` | `file.Close()` — bare call (function-body), or `FromError(file.Close())` if inside a void lambda |
 | ForEach when match fits | `opt.ForEach((v) => ...)` when multiple cases needed | `opt match { case Some(v) => ...; case None() => ... }` |
+
+Rationale: `val _ = ...` adds noise without expressing any intent the bare expression doesn't already express. If the result genuinely matters, bind it to a real name and use it (e.g. assert `.IsSuccess()` in tests). If it doesn't, the call/match should stand alone.
+
+**Void-lambda exception.** Inside a lambda whose body is `func()` (no return), the analyzer rejects bare `error`-returning calls — error: "cannot discard error return from X — use FromError(X) to handle the error". Use `FromError(call())` from `std`: it returns `Try[Void]` and can itself stand as a bare statement (or chain `.OnFailure((err) => ...)`). Function-body bare calls are unaffected.
+
+**If bare-statement form does not transpile elsewhere** — that is a **transpiler bug**, not a license to keep `val _ =`. Open a repro test against the transpiler and fix the bug. Per CLAUDE.md rule 6, never work around transpiler bugs.
 
 ### 12. Naming Conventions (LOW priority)
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -30,6 +30,7 @@ filegroup(
         "//concurrent:gala_sources",
         "//crypto:gala_sources",
         "//examples:gala_sources",
+        "//fs:gala_sources",
         "//io:gala_sources",
         "//lazy:lazy.gala",
         "//path:gala_sources",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -50,6 +50,7 @@ filegroup(
         "//std:tuple.gala",
         "//stream:stream.gala",
         "//string_utils:gala_sources",
+        "//strings:gala_sources",
         "//time_utils:gala_sources",
     ],
     visibility = ["//visibility:public"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -32,6 +32,7 @@ filegroup(
         "//examples:gala_sources",
         "//io:gala_sources",
         "//lazy:lazy.gala",
+        "//path:gala_sources",
         "//regex:gala_sources",
         "//json:gala_sources",
         "//std:constptr.gala",

--- a/cmd/stdlib_gen/main.go
+++ b/cmd/stdlib_gen/main.go
@@ -148,6 +148,7 @@ var PackageImportPaths = map[string]string{
 	"io":                   "martianoff/gala/io",
 	"json":                 "martianoff/gala/json",
 	"path":                 "martianoff/gala/path",
+	"fs":                   "martianoff/gala/fs",
 	"subprocess":           "martianoff/gala/subprocess",
 	"yaml":                 "martianoff/gala/yaml",
 	"test":                 "martianoff/gala/test",

--- a/cmd/stdlib_gen/main.go
+++ b/cmd/stdlib_gen/main.go
@@ -143,6 +143,7 @@ var PackageImportPaths = map[string]string{
 	"lazy":                 "martianoff/gala/lazy",
 	"stream":               "martianoff/gala/stream",
 	"string_utils":         "martianoff/gala/string_utils",
+	"strings":              "martianoff/gala/strings",
 	"time_utils":           "martianoff/gala/time_utils",
 	"regex":                "martianoff/gala/regex",
 	"io":                   "martianoff/gala/io",

--- a/cmd/stdlib_gen/main.go
+++ b/cmd/stdlib_gen/main.go
@@ -147,6 +147,7 @@ var PackageImportPaths = map[string]string{
 	"regex":                "martianoff/gala/regex",
 	"io":                   "martianoff/gala/io",
 	"json":                 "martianoff/gala/json",
+	"path":                 "martianoff/gala/path",
 	"subprocess":           "martianoff/gala/subprocess",
 	"yaml":                 "martianoff/gala/yaml",
 	"test":                 "martianoff/gala/test",

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -35,6 +35,7 @@ GALA (Go Alternative LAnguage) is a modern programming language that transpiles 
    - [IO Effect](#io-effect)
    - [Path](#path)
    - [Filesystem](#filesystem)
+   - [Strings (free functions)](#strings-free-functions)
    - [Slices](#slices)
    - [Maps](#maps)
    - [HashMap](#hashmap)
@@ -1907,6 +1908,63 @@ val flow = MkdirTemp("", "x_")
 
 Modes are passed as plain `int` (e.g. `0o644`, `0o755`); GALA does not
 introduce a separate `FileMode` wrapper.
+
+### Strings (free functions)
+
+The `strings` package exposes free functions over plain Go `string` values, mirroring Go's `strings.X` names exactly. Located in the `strings` package.
+
+```gala
+import . "martianoff/gala/strings"
+```
+
+This is a parallel target to [`string_utils`](STRING_UTILS.MD) — the two coexist with different ergonomic targets:
+
+| | `string_utils` (`Str`) | `strings` (free functions) |
+|---|---|---|
+| Shape | Immutable wrapper around the string + a lazy rune array | Pure `string -> string` (and friends) |
+| Call site | `S("hello").Trim().ToString()` | `TrimSpace("hello")` |
+| Best for | Multi-step pipelines that benefit from caching the rune view | Migrating from raw Go `strings.X` calls without rewriting the call shape |
+
+#### API
+
+| Function | Signature | Notes |
+|---|---|---|
+| `Contains` | `(s, substr string) bool` | |
+| `HasPrefix` | `(s, prefix string) bool` | |
+| `HasSuffix` | `(s, suffix string) bool` | |
+| `EqualFold` | `(a, b string) bool` | Unicode case-folding (rune-by-rune; ß≠"ss"). |
+| `LastIndex` | `(s, substr string) int` | -1 when absent. |
+| `TrimSpace` | `(s string) string` | |
+| `Trim` | `(s, cutset string) string` | |
+| `TrimLeft` | `(s, cutset string) string` | |
+| `TrimRight` | `(s, cutset string) string` | |
+| `TrimPrefix` | `(s, prefix string) string` | |
+| `TrimSuffix` | `(s, suffix string) string` | |
+| `ToLower` | `(s string) string` | |
+| `ToUpper` | `(s string) string` | |
+| `Repeat` | `(s string, count int) string` | |
+| `Replace` | `(s, old, new string, n int) string` | `n < 0` ⇒ replace all. |
+| `ReplaceAll` | `(s, old, new string) string` | |
+| `Split` | `(s, sep string) Array[string]` | |
+| `SplitN` | `(s, sep string, n int) Array[string]` | |
+| `Fields` | `(s string) Array[string]` | |
+| `Join` | `(parts Array[string], sep string) string` | |
+
+`Split`, `SplitN`, and `Fields` return a GALA `Array[string]` (from `collection_immutable`), not a Go `[]string`. `Join` accepts an `Array[string]` for symmetry. See `examples/strings_basics.gala` for a runnable tour of every function.
+
+#### Example
+
+```gala
+import . "martianoff/gala/strings"
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    val ok = HasPrefix("/api/v1/users", "/api/")        // true
+    val parts = Split("alpha,beta,gamma", ",")           // Array("alpha", "beta", "gamma")
+    val joined = Join(ArrayOf("a", "b", "c"), " - ")     // "a - b - c"
+    Println(s"$ok $parts $joined")
+}
+```
 
 ### Slices (Go Interop)
 

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -33,6 +33,8 @@ GALA (Go Alternative LAnguage) is a modern programming language that transpiles 
    - [Yaml](#yaml)
    - [Regex](#regex)
    - [IO Effect](#io-effect)
+   - [Path](#path)
+   - [Filesystem](#filesystem)
    - [Slices](#slices)
    - [Maps](#maps)
    - [HashMap](#hashmap)
@@ -1800,6 +1802,111 @@ io.ForEach(io.Of(42), (v) => { Println(v) }).Run()
 | Re-execution | Cached — `.Get()` returns same result | Fresh — every `.Run()` re-executes |
 | Thread safety | Yes (via `sync.Once`) | No memoization |
 | Use case | Expensive pure computations | Side effects (HTTP, file I/O, logging) |
+
+### Path
+
+The `path` package wraps Go's `path/filepath` in a string-in / string-out
+surface so consumers can reach for `path.Join(...)`, `path.Dir(...)`, etc.
+without dropping back to the Go stdlib. Names mirror `filepath` so
+migration is mechanical.
+
+```gala
+import . "martianoff/gala/path"
+```
+
+#### Surface
+
+| Function | Signature | Notes |
+|----------|-----------|-------|
+| `Join` | `(parts ...string) string` | Variadic; joins with the OS separator. |
+| `Dir` | `(p string) string` | Drops the last element. |
+| `Base` | `(p string) string` | Returns the last element. |
+| `Ext` | `(p string) string` | Returns the suffix at the final dot. |
+| `IsAbs` | `(p string) bool` | Platform-aware absolute check. |
+| `Abs` | `(p string) Try[string]` | Resolves against cwd; `Failure` if cwd is unreadable. |
+| `ToSlash` | `(p string) string` | Replaces OS separators with `/`. Useful for printing. |
+| `FromSlash` | `(p string) string` | Reverse of `ToSlash`. |
+| `Clean` | `(p string) string` | Lexical normalisation (collapses `..`, `.`, repeated separators). |
+
+```gala
+val full = Join("workspace", "src", "main.go")
+Println(ToSlash(Dir(full)))   // workspace/src
+Println(Base(full))           // main.go
+Println(Ext(full))            // .go
+Println(IsAbs("relative"))    // false
+val abs = Abs(".").GetOrElse("")
+```
+
+There is no `Path` type and no string wrapper — `path` operates on plain
+strings so every call site is a one-line replacement for raw `filepath`.
+
+### Filesystem
+
+The `fs` package is the GALA wrapper around the parts of Go's `os` that
+consumers reach for to read, write, and stat regular files. Every
+fallible operation returns `Try[T]`; non-fallible convenience checks
+return `bool`. Bytes flow through `Array[byte]` (immutable) at the
+language boundary, with `ToGoSlice` / `ArrayFromSlice` round trips
+internally at the Go-interop seam.
+
+```gala
+import . "martianoff/gala/fs"
+```
+
+#### Surface
+
+| Function | Signature |
+|----------|-----------|
+| `ReadFile` | `(path string) Try[Array[byte]]` |
+| `ReadFileString` | `(path string) Try[string]` |
+| `WriteFile` | `(path string, data Array[byte], mode int) Try[bool]` |
+| `WriteFileString` | `(path string, contents string, mode int) Try[bool]` |
+| `Stat` | `(path string) Try[FileInfo]` |
+| `Exists` | `(path string) bool` — non-fallible; `false` on any error |
+| `MkdirAll` | `(path string, mode int) Try[bool]` |
+| `MkdirTemp` | `(dir string, pattern string) Try[string]` — returns the created path |
+| `RemoveAll` | `(path string) Try[bool]` — `Success` if path didn't exist |
+| `ReadDir` | `(path string) Try[Array[FileInfo]]` |
+
+`FileInfo` is the immutable snapshot returned by `Stat` and `ReadDir`:
+
+```gala
+struct FileInfo(
+    Name    string,
+    Size    int64,
+    IsDir   bool,
+    Mode    int,
+    ModTime time_utils.Instant,
+)
+```
+
+The raw `os.FileInfo` interface is intentionally not leaked.
+
+```gala
+import . "martianoff/gala/fs"
+import "martianoff/gala/path"
+
+val dir = MkdirTemp("", "scratch_").Get()
+val target = path.Join(dir, "greeting.txt")
+WriteFileString(target, "hello", 0o644).Get()
+val info = Stat(target).Get()
+Println(s"size=${info.Size} dir=${info.IsDir}")
+val payload = ReadFileString(target).Get()
+RemoveAll(dir).Get()
+```
+
+`Try`-returning ops chain naturally with `FlatMap` so a multi-step
+filesystem flow short-circuits on the first failure:
+
+```gala
+val flow = MkdirTemp("", "x_")
+    .FlatMap[string]((d) => WriteFileString(path.Join(d, "f"), "ok", 0o644)
+        .Map((_) => d))
+    .FlatMap[bool]((d) => RemoveAll(d))
+```
+
+Modes are passed as plain `int` (e.g. `0o644`, `0o755`); GALA does not
+introduce a separate `FileMode` wrapper.
 
 ### Slices (Go Interop)
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1236,6 +1236,14 @@ gala_test(
     deps = ["//time_utils"],
 )
 
+# Verification example for the `path` stdlib package.
+gala_test(
+    name = "path_basics",
+    src = "path_basics.gala",
+    expected = "path_basics.out",
+    deps = ["//path"],
+)
+
 # Regression test: unused extracted variables in match branches
 gala_test(
     name = "unused_match_vars",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -682,11 +682,11 @@ gala_test(
     name = "json_codec_cross_pkg",
     src = "json_codec_cross_pkg/main.gala",
     expected = "json_codec_cross_pkg/main.out",
+    gala_deps = [":json_codec_cross_pkg_inner"],
     deps = [
         "//collection_immutable",
         "//json",
     ],
-    gala_deps = [":json_codec_cross_pkg_inner"],
 )
 
 # Temporarily enabled for debugging
@@ -1242,6 +1242,17 @@ gala_test(
     src = "path_basics.gala",
     expected = "path_basics.out",
     deps = ["//path"],
+)
+
+# Verification example for the `fs` stdlib package.
+gala_test(
+    name = "fs_roundtrip",
+    src = "fs_roundtrip.gala",
+    expected = "fs_roundtrip.out",
+    deps = [
+        "//fs",
+        "//path",
+    ],
 )
 
 # Regression test: unused extracted variables in match branches

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1610,6 +1610,18 @@ gala_test(
     deps = ["//go_interop"],
 )
 
+# Verification: ergonomic free-function `strings` package — every
+# heavy-hitter from gala_team's call sites at least once.
+gala_test(
+    name = "strings_basics",
+    src = "strings_basics.gala",
+    expected = "strings_basics.out",
+    deps = [
+        "//collection_immutable",
+        "//strings",
+    ],
+)
+
 # Verification: FoldLeft on Sequence.Get() result uses Array_FoldLeft
 gala_test(
     name = "foldleft_on_sequence_get",

--- a/examples/fs_roundtrip.gala
+++ b/examples/fs_roundtrip.gala
@@ -1,0 +1,33 @@
+package main
+
+// Verification example for the `fs` stdlib package: write a file,
+// stat it, read it back, then remove the scratch dir. Output is the
+// round-trip text plus the recovered byte count, so the example
+// has a stable cross-OS `.out`.
+
+import (
+    . "martianoff/gala/fs"
+    "martianoff/gala/path"
+    "os"
+)
+
+func main() {
+    val dir, mkErr = os.MkdirTemp("", "fs_roundtrip_")
+    if mkErr != nil { panic(mkErr) }
+
+    val target = path.Join(dir, "greeting.txt")
+
+    val payload = "hello, gala fs"
+    val w = WriteFileString(target, payload, 0o644)
+    Println(s"wrote: ${w.IsSuccess()}")
+
+    val info = Stat(target)
+    Println(s"stat ok: ${info.IsSuccess()} size=${info.Get().Size}")
+
+    val r = ReadFileString(target)
+    Println(s"read back: ${r.Get()}")
+
+    val cleanup = RemoveAll(dir)
+    Println(s"cleanup: ${cleanup.IsSuccess()}")
+    Println(s"dir gone: ${!Exists(dir)}")
+}

--- a/examples/fs_roundtrip.out
+++ b/examples/fs_roundtrip.out
@@ -1,0 +1,5 @@
+wrote: true
+stat ok: true size=14
+read back: hello, gala fs
+cleanup: true
+dir gone: true

--- a/examples/path_basics.gala
+++ b/examples/path_basics.gala
@@ -1,0 +1,18 @@
+package main
+
+// Verification example for the `path` stdlib package.
+// Exercises the surface that consumers most commonly reach for from
+// gala_team and similar code bases: Join, Dir, Base, Ext, IsAbs, Clean,
+// ToSlash. ToSlash gives us a stable cross-OS form for printing.
+
+import . "martianoff/gala/path"
+
+func main() {
+    val joined = Join("a", "b", "c.txt")
+    Println(ToSlash(joined))           // a/b/c.txt
+    Println(ToSlash(Dir(joined)))      // a/b
+    Println(Base(joined))              // c.txt
+    Println(Ext(joined))               // .txt
+    Println(ToSlash(Clean("a//b/./c"))) // a/b/c
+    Println(IsAbs("relative/path"))    // false
+}

--- a/examples/path_basics.out
+++ b/examples/path_basics.out
@@ -1,0 +1,6 @@
+a/b/c.txt
+a/b
+c.txt
+.txt
+a/b/c
+false

--- a/examples/strings_basics.gala
+++ b/examples/strings_basics.gala
@@ -1,0 +1,50 @@
+package main
+
+import (
+    . "martianoff/gala/strings"
+    . "martianoff/gala/collection_immutable"
+)
+
+// Verifies the new ergonomic `martianoff/gala/strings` package — free
+// functions over plain `string` mirroring Go's `strings` namespace.
+// Consumer migration is `s/strings\./strings\./` with no logic change;
+// the call site still reads exactly like Go.
+
+func main() {
+    // Predicates — the heavy hitters in consumer code.
+    Println(s"contains: ${Contains("hello world", "world")}")     // true
+    Println(s"hasPrefix: ${HasPrefix("/api/v1/users", "/api/")}") // true
+    Println(s"hasSuffix: ${HasSuffix("file.gala", ".gala")}")     // true
+    Println(s"equalFold: ${EqualFold("Foo", "FOO")}")             // true
+    Println(s"lastIndex: ${LastIndex("a/b/c", "/")}")             // 3
+
+    // Trim family — no more reaching for go strings imports.
+    Println(s"trimSpace: '${TrimSpace("   spaced   ")}'")         // 'spaced'
+    Println(s"trimPrefix: ${TrimPrefix("/api/v1", "/api")}")      // /v1
+    Println(s"trimSuffix: ${TrimSuffix("file.gala", ".gala")}")   // file
+    Println(s"trim: ${Trim("xxhelloxx", "x")}")                   // hello
+    Println(s"trimLeft: ${TrimLeft("xxhelloxx", "x")}")           // helloxx
+    Println(s"trimRight: ${TrimRight("xxhelloxx", "x")}")         // xxhello
+
+    // Case folding.
+    Println(s"toLower: ${ToLower("HELLO World")}")                // hello world
+    Println(s"toUpper: ${ToUpper("hello World")}")                // HELLO WORLD
+
+    // Build-up.
+    Println(s"repeat: ${Repeat("-", 5)}")                         // -----
+    Println(s"replace: ${Replace("a-a-a-a", "a", "b", 2)}")       // b-b-a-a
+    Println(s"replaceAll: ${ReplaceAll("a/b/c", "/", ".")}")      // a.b.c
+
+    // Split / Fields / Join — return GALA Array[string].
+    val parts = Split("alpha,beta,gamma", ",")
+    Println(s"split: ${parts.MkString("|")}")                     // alpha|beta|gamma
+
+    val twoTokens = SplitN("alpha,beta,gamma,delta", ",", 2)
+    Println(s"splitN(2): ${twoTokens.MkString("|")}")             // alpha|beta,gamma,delta
+
+    val tokens = Fields("  hello   world  ")
+    Println(s"fields: ${tokens.MkString("|")}")                   // hello|world
+
+    val joined = Join(ArrayOf("a", "b", "c"), " · ")
+    Println(s"join: ${joined}")                                   // a · b · c
+}

--- a/examples/strings_basics.out
+++ b/examples/strings_basics.out
@@ -1,0 +1,20 @@
+contains: true
+hasPrefix: true
+hasSuffix: true
+equalFold: true
+lastIndex: 3
+trimSpace: 'spaced'
+trimPrefix: /v1
+trimSuffix: file
+trim: hello
+trimLeft: helloxx
+trimRight: xxhello
+toLower: hello world
+toUpper: HELLO WORLD
+repeat: -----
+replace: b-b-a-a
+replaceAll: a.b.c
+split: alpha|beta|gamma
+splitN(2): alpha|beta,gamma,delta
+fields: hello|world
+join: a · b · c

--- a/fs/BUILD.bazel
+++ b/fs/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//:gala.bzl", "gala_bootstrap_transpile", "gala_go_test")
+
+exports_files([
+    "fs.gala",
+])
+
+filegroup(
+    name = "gala_sources",
+    srcs = glob(
+        ["*.gala"],
+        exclude = ["*_test.gala"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+gala_bootstrap_transpile(
+    name = "fs_go",
+    src = "fs.gala",
+    out = "fs.gen.go",
+)
+
+go_library(
+    name = "fs",
+    srcs = ["fs.gen.go"],
+    importpath = "martianoff/gala/fs",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//collection_immutable",
+        "//go_interop",
+        "//std",
+        "//time_utils",
+    ],
+)
+
+gala_go_test(
+    name = "fs_test",
+    srcs = ["fs_test.gala"],
+    deps = [
+        ":fs",
+        "//collection_immutable",
+        "//time_utils",
+    ],
+)

--- a/fs/fs.gala
+++ b/fs/fs.gala
@@ -1,0 +1,131 @@
+package fs
+
+import (
+    "os"
+    . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/go_interop"
+    . "martianoff/gala/std"
+    "martianoff/gala/time_utils"
+)
+
+// fs is the GALA wrapper around the parts of Go's `os` package that
+// consumers reach for to read, write, and stat regular files. Every
+// fallible operation returns Try[T]; non-fallible convenience checks
+// return bool. Bytes flow through Array[byte] (immutable) at the
+// language boundary, with internal ToGoSlice / ArrayFromSlice round
+// trips at the Go-interop seam.
+
+// FileInfo is the immutable snapshot returned by Stat / ReadDir. It
+// intentionally exposes only fields that the gala_team and similar
+// consumers actually use; the raw os.FileInfo interface is not leaked.
+struct FileInfo(
+    Name    string,
+    Size    int64,
+    IsDir   bool,
+    Mode    int,
+    ModTime time_utils.Instant,
+)
+
+// fromGoFileInfo bridges os.FileInfo into our immutable record.
+func fromGoFileInfo(fi os.FileInfo) FileInfo = FileInfo(
+    Name    = fi.Name(),
+    Size    = fi.Size(),
+    IsDir   = fi.IsDir(),
+    Mode    = int(fi.Mode()),
+    ModTime = time_utils.FromGoTime(fi.ModTime()),
+)
+
+// ReadFile reads the named file and returns its contents as Array[byte].
+// On any error (file missing, permission denied, IO failure) the error
+// is captured as Failure.
+func ReadFile(path string) Try[Array[byte]] = Try[Array[byte]](() => {
+    val data, err = os.ReadFile(path)
+    if err != nil { panic(err) }
+    return ArrayFromSlice(data)
+})
+
+// ReadFileString is a convenience for the common case of reading a
+// text file. Equivalent to ReadFile + decoding the bytes as UTF-8.
+func ReadFileString(path string) Try[string] = Try[string](() => {
+    val data, err = os.ReadFile(path)
+    if err != nil { panic(err) }
+    return string(data)
+})
+
+// WriteFile writes data to the named file, creating it if necessary.
+// `mode` is a Unix permission mode (e.g. 0o644). On Windows the mode
+// is mostly advisory; only the read-only bit is honored.
+func WriteFile(path string, data Array[byte], mode int) Try[bool] = Try[bool](() => {
+    val err = os.WriteFile(path, data.ToGoSlice(), os.FileMode(mode))
+    if err != nil { panic(err) }
+    return true
+})
+
+// WriteFileString is the string-content companion to WriteFile.
+func WriteFileString(path string, contents string, mode int) Try[bool] = Try[bool](() => {
+    val err = os.WriteFile(path, ToBytes(contents), os.FileMode(mode))
+    if err != nil { panic(err) }
+    return true
+})
+
+// Stat returns metadata about the file at `path`.
+func Stat(path string) Try[FileInfo] = Try[FileInfo](() => {
+    val fi, err = os.Stat(path)
+    if err != nil { panic(err) }
+    return fromGoFileInfo(fi)
+})
+
+// Exists is the non-fallible "does this path resolve" check.
+// Returns false on any error (including NotExist, permission denied,
+// or transient IO failure). Callers who care about *why* something is
+// missing should use Stat directly.
+func Exists(path string) bool {
+    val _, err = os.Stat(path)
+    return err == nil
+}
+
+// MkdirAll creates `path` along with any necessary parents. It is a
+// no-op if the directory already exists. `mode` is the Unix permission
+// mode applied to newly-created directories.
+func MkdirAll(path string, mode int) Try[bool] = Try[bool](() => {
+    val err = os.MkdirAll(path, os.FileMode(mode))
+    if err != nil { panic(err) }
+    return true
+})
+
+// MkdirTemp creates a new temporary directory in the directory `dir`
+// and returns the pathname of the new directory. If `dir` is empty
+// the OS default (TMPDIR / GetTempPath) is used. `pattern` is the
+// os.MkdirTemp pattern: a literal name, optionally with a '*' that
+// gets replaced by random characters.
+func MkdirTemp(dir string, pattern string) Try[string] = Try[string](() => {
+    val created, err = os.MkdirTemp(dir, pattern)
+    if err != nil { panic(err) }
+    return created
+})
+
+// RemoveAll removes path and any children it contains. It removes
+// everything it can but returns the first error it encounters. If
+// `path` does not exist, the call returns Success without error
+// (matching os.RemoveAll's convention).
+func RemoveAll(path string) Try[bool] = Try[bool](() => {
+    val err = os.RemoveAll(path)
+    if err != nil { panic(err) }
+    return true
+})
+
+// ReadDir reads the directory named by `path` and returns a snapshot
+// of its entries as FileInfo records. Entries are returned in the
+// order ReadDir yields them (filesystem-dependent — callers that need
+// a stable order should sort).
+func ReadDir(path string) Try[Array[FileInfo]] = Try[Array[FileInfo]](() => {
+    val entries, err = os.ReadDir(path)
+    if err != nil { panic(err) }
+    var out = EmptyArray[FileInfo]()
+    for i := 0; i < len(entries); i++ {
+        val info, infoErr = entries[i].Info()
+        if infoErr != nil { panic(infoErr) }
+        out = out.Append(fromGoFileInfo(info))
+    }
+    return out
+})

--- a/fs/fs_test.gala
+++ b/fs/fs_test.gala
@@ -1,0 +1,135 @@
+package main
+
+import (
+    . "martianoff/gala/test"
+    . "martianoff/gala/collection_immutable"
+    "martianoff/gala/fs"
+    "os"
+    "path/filepath"
+)
+
+// scratchDir creates a fresh temp dir per-test so tests are isolated
+// and don't depend on /tmp shape. The caller is responsible for
+// removing it (Defer-equivalent: tests call fs.RemoveAll at the end).
+func scratchDir(prefix string) string {
+    val dir, err = os.MkdirTemp("", prefix)
+    if err != nil { panic(err) }
+    return dir
+}
+
+func TestWriteAndReadFile(t T) T {
+    val dir = scratchDir("fs_write_read")
+    defer os.RemoveAll(dir)
+
+    val target = filepath.Join(dir, "hello.txt")
+    val payload = "hello, world"
+    val w = fs.WriteFileString(target, payload, 0o644)
+    var t1 = IsTrue(t, w.IsSuccess())
+
+    val r = fs.ReadFileString(target)
+    var t2 = IsTrue(t1, r.IsSuccess())
+    return Eq[string](t2, r.Get(), payload)
+}
+
+func TestReadFileBytesRoundTrip(t T) T {
+    val dir = scratchDir("fs_bytes")
+    defer os.RemoveAll(dir)
+
+    val target = filepath.Join(dir, "bytes.bin")
+    val data = ArrayOf[byte](byte(1), byte(2), byte(3), byte(255))
+    val w = fs.WriteFile(target, data, 0o644)
+    var t1 = IsTrue(t, w.IsSuccess())
+
+    val r = fs.ReadFile(target)
+    var t2 = IsTrue(t1, r.IsSuccess())
+    return Eq[int](t2, r.Get().Size(), data.Size())
+}
+
+func TestReadFileMissing(t T) T {
+    val r = fs.ReadFile("/this/path/should/never/exist/xyz")
+    return IsTrue(t, r.IsFailure())
+}
+
+func TestStat(t T) T {
+    val dir = scratchDir("fs_stat")
+    defer os.RemoveAll(dir)
+
+    val target = filepath.Join(dir, "info.txt")
+    val _ = fs.WriteFileString(target, "abcdef", 0o644)
+
+    val info = fs.Stat(target)
+    var t1 = IsTrue(t, info.IsSuccess())
+    val fi = info.Get()
+    var t2 = Eq[string](t1, fi.Name, "info.txt")
+    var t3 = Eq[int64](t2, fi.Size, int64(6))
+    return IsFalse(t3, fi.IsDir)
+}
+
+func TestStatDirectoryFlag(t T) T {
+    val dir = scratchDir("fs_stat_dir")
+    defer os.RemoveAll(dir)
+
+    val info = fs.Stat(dir)
+    var t1 = IsTrue(t, info.IsSuccess())
+    return IsTrue(t1, info.Get().IsDir)
+}
+
+func TestExists(t T) T {
+    val dir = scratchDir("fs_exists")
+    defer os.RemoveAll(dir)
+
+    var t1 = IsTrue(t, fs.Exists(dir))
+    return IsFalse(t1, fs.Exists(filepath.Join(dir, "nope")))
+}
+
+func TestMkdirAll(t T) T {
+    val dir = scratchDir("fs_mkdir")
+    defer os.RemoveAll(dir)
+
+    val nested = filepath.Join(dir, "a", "b", "c")
+    val r = fs.MkdirAll(nested, 0o755)
+    var t1 = IsTrue(t, r.IsSuccess())
+    return IsTrue(t1, fs.Exists(nested))
+}
+
+func TestMkdirTemp(t T) T {
+    val r = fs.MkdirTemp("", "fs_mkdirtemp_")
+    var t1 = IsTrue(t, r.IsSuccess())
+    val created = r.Get()
+    val t2 = IsTrue(t1, fs.Exists(created))
+    val _ = fs.RemoveAll(created)
+    return t2
+}
+
+func TestRemoveAll(t T) T {
+    val dir = scratchDir("fs_remove")
+    val nested = filepath.Join(dir, "x", "y")
+    val _ = fs.MkdirAll(nested, 0o755)
+    val _ = fs.WriteFileString(filepath.Join(nested, "f.txt"), "data", 0o644)
+
+    var t1 = IsTrue(t, fs.Exists(dir))
+    val r = fs.RemoveAll(dir)
+    var t2 = IsTrue(t1, r.IsSuccess())
+    return IsFalse(t2, fs.Exists(dir))
+}
+
+func TestRemoveAllMissingIsSuccess(t T) T {
+    // os.RemoveAll convention: removing a nonexistent path is a no-op,
+    // not an error.
+    val r = fs.RemoveAll("/this/path/does/not/exist/zzz")
+    return IsTrue(t, r.IsSuccess())
+}
+
+func TestReadDir(t T) T {
+    val dir = scratchDir("fs_readdir")
+    defer os.RemoveAll(dir)
+
+    val _ = fs.WriteFileString(filepath.Join(dir, "a.txt"), "1", 0o644)
+    val _ = fs.WriteFileString(filepath.Join(dir, "b.txt"), "22", 0o644)
+    val _ = fs.MkdirAll(filepath.Join(dir, "sub"), 0o755)
+
+    val r = fs.ReadDir(dir)
+    var t1 = IsTrue(t, r.IsSuccess())
+    val entries = r.Get()
+    return Eq[int](t1, entries.Size(), 3)
+}

--- a/fs/fs_test.gala
+++ b/fs/fs_test.gala
@@ -55,7 +55,7 @@ func TestStat(t T) T {
     defer os.RemoveAll(dir)
 
     val target = filepath.Join(dir, "info.txt")
-    val _ = fs.WriteFileString(target, "abcdef", 0o644)
+    fs.WriteFileString(target, "abcdef", 0o644)
 
     val info = fs.Stat(target)
     var t1 = IsTrue(t, info.IsSuccess())
@@ -97,15 +97,15 @@ func TestMkdirTemp(t T) T {
     var t1 = IsTrue(t, r.IsSuccess())
     val created = r.Get()
     val t2 = IsTrue(t1, fs.Exists(created))
-    val _ = fs.RemoveAll(created)
+    fs.RemoveAll(created)
     return t2
 }
 
 func TestRemoveAll(t T) T {
     val dir = scratchDir("fs_remove")
     val nested = filepath.Join(dir, "x", "y")
-    val _ = fs.MkdirAll(nested, 0o755)
-    val _ = fs.WriteFileString(filepath.Join(nested, "f.txt"), "data", 0o644)
+    fs.MkdirAll(nested, 0o755)
+    fs.WriteFileString(filepath.Join(nested, "f.txt"), "data", 0o644)
 
     var t1 = IsTrue(t, fs.Exists(dir))
     val r = fs.RemoveAll(dir)
@@ -124,9 +124,9 @@ func TestReadDir(t T) T {
     val dir = scratchDir("fs_readdir")
     defer os.RemoveAll(dir)
 
-    val _ = fs.WriteFileString(filepath.Join(dir, "a.txt"), "1", 0o644)
-    val _ = fs.WriteFileString(filepath.Join(dir, "b.txt"), "22", 0o644)
-    val _ = fs.MkdirAll(filepath.Join(dir, "sub"), 0o755)
+    fs.WriteFileString(filepath.Join(dir, "a.txt"), "1", 0o644)
+    fs.WriteFileString(filepath.Join(dir, "b.txt"), "22", 0o644)
+    fs.MkdirAll(filepath.Join(dir, "sub"), 0o755)
 
     val r = fs.ReadDir(dir)
     var t1 = IsTrue(t, r.IsSuccess())

--- a/internal/stdlib/BUILD.bazel
+++ b/internal/stdlib/BUILD.bazel
@@ -112,6 +112,10 @@ genrule(
         "//path:path_go",
         # path package - GALA source
         "//path:path.gala",
+        # fs package - transpiled Go
+        "//fs:fs_go",
+        # fs package - GALA source
+        "//fs:fs.gala",
         # subprocess package - GALA surface + Go-side helpers (errors.As / scanner buffer)
         "//subprocess:subprocess_go",
         "//subprocess:subprocess.gala",

--- a/internal/stdlib/BUILD.bazel
+++ b/internal/stdlib/BUILD.bazel
@@ -96,6 +96,10 @@ genrule(
         "//string_utils:string_utils_go",
         # string_utils package - GALA source
         "//string_utils:strings.gala",
+        # strings package - transpiled Go
+        "//strings:strings_go",
+        # strings package - GALA source
+        "//strings:strings.gala",
         # time_utils package - transpiled Go
         "//time_utils:time_utils_go",
         # time_utils package - GALA source

--- a/internal/stdlib/BUILD.bazel
+++ b/internal/stdlib/BUILD.bazel
@@ -108,6 +108,10 @@ genrule(
         "//io:io_go",
         # io package - GALA source
         "//io:io.gala",
+        # path package - transpiled Go
+        "//path:path_go",
+        # path package - GALA source
+        "//path:path.gala",
         # subprocess package - GALA surface + Go-side helpers (errors.As / scanner buffer)
         "//subprocess:subprocess_go",
         "//subprocess:subprocess.gala",

--- a/path/BUILD.bazel
+++ b/path/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//:gala.bzl", "gala_bootstrap_transpile", "gala_go_test")
+
+exports_files([
+    "path.gala",
+])
+
+filegroup(
+    name = "gala_sources",
+    srcs = glob(
+        ["*.gala"],
+        exclude = ["*_test.gala"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+gala_bootstrap_transpile(
+    name = "path_go",
+    src = "path.gala",
+    out = "path.gen.go",
+)
+
+go_library(
+    name = "path",
+    srcs = ["path.gen.go"],
+    importpath = "martianoff/gala/path",
+    visibility = ["//visibility:public"],
+    deps = ["//std"],
+)
+
+gala_go_test(
+    name = "path_test",
+    srcs = ["path_test.gala"],
+    deps = [
+        ":path",
+    ],
+)

--- a/path/path.gala
+++ b/path/path.gala
@@ -1,0 +1,63 @@
+package path
+
+import (
+    "path/filepath"
+    . "martianoff/gala/std"
+)
+
+// path wraps Go's path/filepath in a string-in / string-out surface so
+// consumers can write `path.Join(...)`, `path.Dir(...)`, etc. without
+// importing the Go std lib directly. The signatures mirror filepath
+// 1:1 — only fallible operations differ, returning Try[string] instead
+// of (string, error).
+
+// Join joins any number of path elements into a single path,
+// separating them with the OS-specific separator. Empty elements are
+// ignored.
+func Join(parts ...string) string = filepath.Join(parts...)
+
+// Dir returns all but the last element of p. If p is empty, Dir
+// returns ".". If the path is entirely separators, Dir returns a
+// single separator. The returned path does not end in a separator
+// unless it is the root.
+func Dir(p string) string = filepath.Dir(p)
+
+// Base returns the last element of p. Trailing path separators are
+// removed before extracting the last element. If p is empty, Base
+// returns ".". If p consists entirely of separators, Base returns a
+// single separator.
+func Base(p string) string = filepath.Base(p)
+
+// Ext returns the file name extension used by p. The extension is
+// the suffix beginning at the final dot in the final element of p;
+// it is empty if there is no dot.
+func Ext(p string) string = filepath.Ext(p)
+
+// IsAbs reports whether the path is absolute.
+func IsAbs(p string) bool = filepath.IsAbs(p)
+
+// Abs returns an absolute representation of p. If the path is not
+// absolute it will be joined with the current working directory.
+// Returns Failure if the working directory can't be determined.
+func Abs(p string) Try[string] = Try[string](() => {
+    val resolved, err = filepath.Abs(p)
+    if err != nil {
+        panic(err)
+    }
+    return resolved
+})
+
+// ToSlash returns the result of replacing each separator character in
+// p with a slash ('/'). Multiple separators are replaced by multiple
+// slashes.
+func ToSlash(p string) string = filepath.ToSlash(p)
+
+// FromSlash returns the result of replacing each slash ('/') in p
+// with a separator character. Multiple slashes are replaced by
+// multiple separators.
+func FromSlash(p string) string = filepath.FromSlash(p)
+
+// Clean returns the shortest path name equivalent to p by purely
+// lexical processing. It applies the rules described in
+// path/filepath.Clean.
+func Clean(p string) string = filepath.Clean(p)

--- a/path/path_test.gala
+++ b/path/path_test.gala
@@ -1,0 +1,97 @@
+package main
+
+import (
+    . "martianoff/gala/test"
+    "martianoff/gala/path"
+    "runtime"
+)
+
+// nativeJoin builds the OS-native form of a slash-separated reference,
+// so tests work on both Unix (/) and Windows (\) without forking the
+// expectations table.
+func nativeJoin(parts ...string) string = path.Join(parts...)
+
+func TestJoin(t T) T {
+    val joined = path.Join("a", "b", "c")
+    val expected = nativeJoin("a", "b", "c")
+    return Eq[string](t, joined, expected)
+}
+
+func TestJoinIgnoresEmpty(t T) T {
+    val joined = path.Join("a", "", "b")
+    val expected = nativeJoin("a", "b")
+    return Eq[string](t, joined, expected)
+}
+
+func TestDir(t T) T {
+    val full = path.Join("foo", "bar", "baz.txt")
+    val expected = path.Join("foo", "bar")
+    return Eq[string](t, path.Dir(full), expected)
+}
+
+func TestDirEmpty(t T) T {
+    return Eq[string](t, path.Dir(""), ".")
+}
+
+func TestBase(t T) T {
+    val full = path.Join("foo", "bar", "baz.txt")
+    return Eq[string](t, path.Base(full), "baz.txt")
+}
+
+func TestBaseEmpty(t T) T {
+    return Eq[string](t, path.Base(""), ".")
+}
+
+func TestExt(t T) T {
+    var t1 = Eq[string](t, path.Ext("file.gala"), ".gala")
+    var t2 = Eq[string](t1, path.Ext("file.tar.gz"), ".gz")
+    return Eq[string](t2, path.Ext("README"), "")
+}
+
+func TestIsAbs(t T) T {
+    // Unix / Windows differ — pick a platform-native absolute and a
+    // platform-native relative path and check both.
+    if runtime.GOOS == "windows" {
+        var t1 = IsTrue(t, path.IsAbs("C:\\foo"))
+        return IsFalse(t1, path.IsAbs("foo\\bar"))
+    }
+    var t1 = IsTrue(t, path.IsAbs("/foo/bar"))
+    return IsFalse(t1, path.IsAbs("foo/bar"))
+}
+
+func TestAbsResolvesRelative(t T) T {
+    val result = path.Abs("foo")
+    var t1 = IsTrue(t, result.IsSuccess())
+    return IsTrue(t1, path.IsAbs(result.Get()))
+}
+
+func TestAbsAlreadyAbsolute(t T) T {
+    // An already-absolute path stays absolute (and Clean-ed).
+    var input = "/already/abs"
+    if runtime.GOOS == "windows" {
+        input = "C:\\already\\abs"
+    }
+    val result = path.Abs(input)
+    var t1 = IsTrue(t, result.IsSuccess())
+    return IsTrue(t1, path.IsAbs(result.Get()))
+}
+
+func TestToSlash(t T) T {
+    // ToSlash is identity on Unix; on Windows it replaces '\\' with '/'.
+    val joined = path.Join("a", "b")
+    val sl = path.ToSlash(joined)
+    return Eq[string](t, sl, "a/b")
+}
+
+func TestFromSlash(t T) T {
+    // Round-trip: ToSlash(FromSlash(x)) == x for any forward-slash x.
+    val original = "a/b/c"
+    val native = path.FromSlash(original)
+    return Eq[string](t, path.ToSlash(native), original)
+}
+
+func TestClean(t T) T {
+    var t1 = Eq[string](t, path.Clean("a/./b"), nativeJoin("a", "b"))
+    var t2 = Eq[string](t1, path.Clean("a/b/.."), "a")
+    return Eq[string](t2, path.Clean(""), ".")
+}

--- a/strings/BUILD.bazel
+++ b/strings/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//:gala.bzl", "gala_bootstrap_transpile", "gala_go_test")
+
+exports_files([
+    "strings.gala",
+])
+
+filegroup(
+    name = "gala_sources",
+    srcs = glob(
+        ["*.gala"],
+        exclude = ["*_test.gala"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+gala_bootstrap_transpile(
+    name = "strings_go",
+    src = "strings.gala",
+    out = "strings.gen.go",
+)
+
+go_library(
+    name = "strings",
+    srcs = ["strings.gen.go"],
+    importpath = "martianoff/gala/strings",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//collection_immutable",
+        "//std",
+    ],
+)
+
+gala_go_test(
+    name = "strings_test",
+    srcs = ["strings_test.gala"],
+    deps = [
+        ":strings",
+        "//collection_immutable",
+    ],
+)

--- a/strings/strings.gala
+++ b/strings/strings.gala
@@ -1,0 +1,105 @@
+package strings
+
+import (
+    gostrings "strings"
+    . "martianoff/gala/collection_immutable"
+)
+
+// Package strings exposes free functions over plain Go `string` values,
+// mirroring Go's `strings.X` names exactly so call sites can migrate from
+// `import "strings"` to `import . "martianoff/gala/strings"` without
+// touching call shape.
+//
+// This package is a parallel target to `martianoff/gala/string_utils`.
+// `string_utils` is the rich, immutable `Str`-wrapped library; `strings`
+// is the boring, ergonomic free-function shim. Both coexist — pick the
+// one that matches the call site.
+//
+// Functions that return a sequence of strings produce a GALA
+// `Array[string]` (from `collection_immutable`), not a Go `[]string`.
+
+// Contains reports whether `substr` is within `s`.
+func Contains(s string, substr string) bool = gostrings.Contains(s, substr)
+
+// HasPrefix reports whether `s` begins with `prefix`.
+func HasPrefix(s string, prefix string) bool = gostrings.HasPrefix(s, prefix)
+
+// HasSuffix reports whether `s` ends with `suffix`.
+func HasSuffix(s string, suffix string) bool = gostrings.HasSuffix(s, suffix)
+
+// EqualFold reports whether `a` and `b` are equal under Unicode
+// case-folding. ASCII or non-ASCII.
+func EqualFold(a string, b string) bool = gostrings.EqualFold(a, b)
+
+// LastIndex returns the byte index of the last instance of `substr` in
+// `s`, or -1 if `substr` is not present.
+func LastIndex(s string, substr string) int = gostrings.LastIndex(s, substr)
+
+// TrimSpace returns `s` with leading and trailing white space removed
+// (per Unicode IsSpace).
+func TrimSpace(s string) string = gostrings.TrimSpace(s)
+
+// Trim returns `s` with all leading and trailing Unicode code points
+// contained in `cutset` removed.
+func Trim(s string, cutset string) string = gostrings.Trim(s, cutset)
+
+// TrimLeft returns `s` with all leading Unicode code points contained in
+// `cutset` removed.
+func TrimLeft(s string, cutset string) string = gostrings.TrimLeft(s, cutset)
+
+// TrimRight returns `s` with all trailing Unicode code points contained
+// in `cutset` removed.
+func TrimRight(s string, cutset string) string = gostrings.TrimRight(s, cutset)
+
+// TrimPrefix returns `s` without the provided leading `prefix`. If `s`
+// doesn't start with `prefix`, it is returned unchanged.
+func TrimPrefix(s string, prefix string) string = gostrings.TrimPrefix(s, prefix)
+
+// TrimSuffix returns `s` without the provided trailing `suffix`. If `s`
+// doesn't end with `suffix`, it is returned unchanged.
+func TrimSuffix(s string, suffix string) string = gostrings.TrimSuffix(s, suffix)
+
+// ToLower returns `s` with all Unicode letters mapped to lowercase.
+func ToLower(s string) string = gostrings.ToLower(s)
+
+// ToUpper returns `s` with all Unicode letters mapped to uppercase.
+func ToUpper(s string) string = gostrings.ToUpper(s)
+
+// Repeat returns a new string consisting of `count` copies of `s`. Panics
+// for negative `count` or if the result would overflow (same contract as
+// Go's `strings.Repeat`).
+func Repeat(s string, count int) string = gostrings.Repeat(s, count)
+
+// Replace returns a copy of `s` with the first `n` non-overlapping
+// instances of `old` replaced by `new`. If `n < 0`, all instances are
+// replaced.
+func Replace(s string, old string, new string, n int) string =
+    gostrings.Replace(s, old, new, n)
+
+// ReplaceAll returns a copy of `s` with all non-overlapping instances of
+// `old` replaced by `new`.
+func ReplaceAll(s string, old string, new string) string =
+    gostrings.ReplaceAll(s, old, new)
+
+// Split slices `s` into all substrings separated by `sep` and returns
+// them as a GALA Array. If `sep` is empty, Split returns one entry per
+// rune of `s` (Go's behaviour).
+func Split(s string, sep string) Array[string] =
+    ArrayFromSlice[string](gostrings.Split(s, sep))
+
+// SplitN slices `s` into substrings separated by `sep`. The count `n`
+// limits the number of substrings: `n > 0` caps the slice; `n == 0`
+// returns nil; `n < 0` returns all substrings (Go's behaviour).
+func SplitN(s string, sep string, n int) Array[string] =
+    ArrayFromSlice[string](gostrings.SplitN(s, sep, n))
+
+// Fields splits `s` around each instance of one or more consecutive
+// white-space characters, returning the substrings as a GALA Array.
+// Returns an empty Array if `s` contains only white space.
+func Fields(s string) Array[string] =
+    ArrayFromSlice[string](gostrings.Fields(s))
+
+// Join concatenates the elements of `parts`, inserting `sep` between
+// adjacent elements.
+func Join(parts Array[string], sep string) string =
+    gostrings.Join(parts.ToGoSlice(), sep)

--- a/strings/strings_test.gala
+++ b/strings/strings_test.gala
@@ -1,0 +1,263 @@
+package main
+
+// The strings package is qualified (`s.`) so its `Contains`, `HasPrefix`,
+// and `HasSuffix` don't collide with the test framework's same-named
+// string-shaped assertion helpers.
+import (
+    . "martianoff/gala/test"
+    . "martianoff/gala/std"
+    s "martianoff/gala/strings"
+    . "martianoff/gala/collection_immutable"
+)
+
+// ---------------------------------------------------------------------------
+// Predicate functions: Contains, HasPrefix, HasSuffix, EqualFold, LastIndex
+// ---------------------------------------------------------------------------
+
+func TestContains(t T) T = RunCases[Tuple[string, string], bool](t,
+    (sub T, input Tuple[string, string], expected bool) =>
+        Eq(sub, s.Contains(input.V1, input.V2), expected),
+    Case[Tuple[string, string], bool](Name = "single hit",     Input = ("hello world", "world"), Expected = true),
+    Case[Tuple[string, string], bool](Name = "miss",           Input = ("hello", "x"),           Expected = false),
+    Case[Tuple[string, string], bool](Name = "empty needle",   Input = ("hello", ""),            Expected = true),
+    Case[Tuple[string, string], bool](Name = "empty haystack", Input = ("", "x"),                Expected = false),
+    Case[Tuple[string, string], bool](Name = "both empty",     Input = ("", ""),                 Expected = true),
+    Case[Tuple[string, string], bool](Name = "case sensitive", Input = ("Hello", "hello"),       Expected = false),
+    Case[Tuple[string, string], bool](Name = "unicode",        Input = ("héllo", "é"),           Expected = true),
+)
+
+func TestHasPrefix(t T) T = RunCases[Tuple[string, string], bool](t,
+    (sub T, input Tuple[string, string], expected bool) =>
+        Eq(sub, s.HasPrefix(input.V1, input.V2), expected),
+    Case[Tuple[string, string], bool](Name = "match",         Input = ("hello world", "hello"), Expected = true),
+    Case[Tuple[string, string], bool](Name = "no match",      Input = ("hello", "world"),       Expected = false),
+    Case[Tuple[string, string], bool](Name = "empty prefix",  Input = ("hello", ""),            Expected = true),
+    Case[Tuple[string, string], bool](Name = "empty string",  Input = ("", "x"),                Expected = false),
+    Case[Tuple[string, string], bool](Name = "exact",         Input = ("abc", "abc"),           Expected = true),
+)
+
+func TestHasSuffix(t T) T = RunCases[Tuple[string, string], bool](t,
+    (sub T, input Tuple[string, string], expected bool) =>
+        Eq(sub, s.HasSuffix(input.V1, input.V2), expected),
+    Case[Tuple[string, string], bool](Name = "match",         Input = ("hello world", "world"), Expected = true),
+    Case[Tuple[string, string], bool](Name = "no match",      Input = ("hello", "world"),       Expected = false),
+    Case[Tuple[string, string], bool](Name = "empty suffix",  Input = ("hello", ""),            Expected = true),
+    Case[Tuple[string, string], bool](Name = "empty string",  Input = ("", "x"),                Expected = false),
+    Case[Tuple[string, string], bool](Name = "exact",         Input = ("abc", "abc"),           Expected = true),
+)
+
+func TestEqualFold(t T) T = RunCases[Tuple[string, string], bool](t,
+    (sub T, input Tuple[string, string], expected bool) =>
+        Eq(sub, s.EqualFold(input.V1, input.V2), expected),
+    Case[Tuple[string, string], bool](Name = "same case",    Input = ("hello", "hello"),     Expected = true),
+    Case[Tuple[string, string], bool](Name = "mixed case",   Input = ("Hello", "hELLO"),     Expected = true),
+    Case[Tuple[string, string], bool](Name = "different",    Input = ("hello", "world"),     Expected = false),
+    Case[Tuple[string, string], bool](Name = "both empty",   Input = ("", ""),               Expected = true),
+    Case[Tuple[string, string], bool](Name = "unicode fold", Input = ("ÄPFEL", "äpfel"),     Expected = true),
+)
+
+func TestLastIndex(t T) T = RunCases[Tuple[string, string], int](t,
+    (sub T, input Tuple[string, string], expected int) =>
+        Eq(sub, s.LastIndex(input.V1, input.V2), expected),
+    Case[Tuple[string, string], int](Name = "single",    Input = ("hello", "l"),  Expected = 3),
+    Case[Tuple[string, string], int](Name = "first",     Input = ("hello", "h"),  Expected = 0),
+    Case[Tuple[string, string], int](Name = "absent",    Input = ("hello", "z"),  Expected = -1),
+    Case[Tuple[string, string], int](Name = "empty s",   Input = ("", "x"),       Expected = -1),
+    Case[Tuple[string, string], int](Name = "empty sub", Input = ("hello", ""),   Expected = 5),
+    Case[Tuple[string, string], int](Name = "multibyte", Input = ("a/b/c", "/"),  Expected = 3),
+)
+
+// ---------------------------------------------------------------------------
+// Trim family: TrimSpace, Trim, TrimLeft, TrimRight, TrimPrefix, TrimSuffix
+// ---------------------------------------------------------------------------
+
+func TestTrimSpace(t T) T = RunCases[string, string](t,
+    (sub T, input string, expected string) => Eq(sub, s.TrimSpace(input), expected),
+    Case[string, string](Name = "leading",       Input = "   hello",       Expected = "hello"),
+    Case[string, string](Name = "trailing",      Input = "hello   ",       Expected = "hello"),
+    Case[string, string](Name = "both",          Input = "  hello  ",      Expected = "hello"),
+    Case[string, string](Name = "none",          Input = "hello",          Expected = "hello"),
+    Case[string, string](Name = "all space",     Input = "   ",            Expected = ""),
+    Case[string, string](Name = "empty",         Input = "",               Expected = ""),
+    Case[string, string](Name = "tabs/newlines", Input = "\t\n hello\n",   Expected = "hello"),
+)
+
+func TestTrim(t T) T = RunCases[Tuple[string, string], string](t,
+    (sub T, input Tuple[string, string], expected string) =>
+        Eq(sub, s.Trim(input.V1, input.V2), expected),
+    Case[Tuple[string, string], string](Name = "single cut",   Input = ("xhellox", "x"),       Expected = "hello"),
+    Case[Tuple[string, string], string](Name = "multi cut",    Input = ("xy hello yx", "xy "), Expected = "hello"),
+    Case[Tuple[string, string], string](Name = "empty cutset", Input = ("hello", ""),          Expected = "hello"),
+    Case[Tuple[string, string], string](Name = "empty s",      Input = ("", "x"),              Expected = ""),
+)
+
+func TestTrimLeft(t T) T = RunCases[Tuple[string, string], string](t,
+    (sub T, input Tuple[string, string], expected string) =>
+        Eq(sub, s.TrimLeft(input.V1, input.V2), expected),
+    Case[Tuple[string, string], string](Name = "leading only",    Input = ("xxxhello", "x"),    Expected = "hello"),
+    Case[Tuple[string, string], string](Name = "leaves trailing", Input = ("xxxhelloxxx", "x"), Expected = "helloxxx"),
+    Case[Tuple[string, string], string](Name = "empty s",         Input = ("", "x"),            Expected = ""),
+)
+
+func TestTrimRight(t T) T = RunCases[Tuple[string, string], string](t,
+    (sub T, input Tuple[string, string], expected string) =>
+        Eq(sub, s.TrimRight(input.V1, input.V2), expected),
+    Case[Tuple[string, string], string](Name = "trailing only",  Input = ("helloxxx", "x"),    Expected = "hello"),
+    Case[Tuple[string, string], string](Name = "leaves leading", Input = ("xxxhelloxxx", "x"), Expected = "xxxhello"),
+    Case[Tuple[string, string], string](Name = "empty s",        Input = ("", "x"),            Expected = ""),
+)
+
+func TestTrimPrefix(t T) T = RunCases[Tuple[string, string], string](t,
+    (sub T, input Tuple[string, string], expected string) =>
+        Eq(sub, s.TrimPrefix(input.V1, input.V2), expected),
+    Case[Tuple[string, string], string](Name = "match",        Input = ("hello world", "hello "), Expected = "world"),
+    Case[Tuple[string, string], string](Name = "no match",     Input = ("hello world", "x"),      Expected = "hello world"),
+    Case[Tuple[string, string], string](Name = "empty prefix", Input = ("hello", ""),             Expected = "hello"),
+    Case[Tuple[string, string], string](Name = "exact",        Input = ("abc", "abc"),            Expected = ""),
+)
+
+func TestTrimSuffix(t T) T = RunCases[Tuple[string, string], string](t,
+    (sub T, input Tuple[string, string], expected string) =>
+        Eq(sub, s.TrimSuffix(input.V1, input.V2), expected),
+    Case[Tuple[string, string], string](Name = "match",        Input = ("file.gala", ".gala"), Expected = "file"),
+    Case[Tuple[string, string], string](Name = "no match",     Input = ("file.gala", ".go"),   Expected = "file.gala"),
+    Case[Tuple[string, string], string](Name = "empty suffix", Input = ("hello", ""),          Expected = "hello"),
+    Case[Tuple[string, string], string](Name = "exact",        Input = ("abc", "abc"),         Expected = ""),
+)
+
+// ---------------------------------------------------------------------------
+// Case folding: ToLower, ToUpper
+// ---------------------------------------------------------------------------
+
+func TestToLower(t T) T = RunCases[string, string](t,
+    (sub T, input string, expected string) => Eq(sub, s.ToLower(input), expected),
+    Case[string, string](Name = "upper",       Input = "HELLO",       Expected = "hello"),
+    Case[string, string](Name = "mixed",       Input = "Hello World", Expected = "hello world"),
+    Case[string, string](Name = "lower",       Input = "hello",       Expected = "hello"),
+    Case[string, string](Name = "empty",       Input = "",            Expected = ""),
+    Case[string, string](Name = "non-letters", Input = "ABC123!",     Expected = "abc123!"),
+)
+
+func TestToUpper(t T) T = RunCases[string, string](t,
+    (sub T, input string, expected string) => Eq(sub, s.ToUpper(input), expected),
+    Case[string, string](Name = "lower",       Input = "hello",       Expected = "HELLO"),
+    Case[string, string](Name = "mixed",       Input = "Hello World", Expected = "HELLO WORLD"),
+    Case[string, string](Name = "upper",       Input = "HELLO",       Expected = "HELLO"),
+    Case[string, string](Name = "empty",       Input = "",            Expected = ""),
+    Case[string, string](Name = "non-letters", Input = "abc123!",     Expected = "ABC123!"),
+)
+
+// ---------------------------------------------------------------------------
+// Repeat
+// ---------------------------------------------------------------------------
+
+func TestRepeat(t T) T = RunCases[Tuple[string, int], string](t,
+    (sub T, input Tuple[string, int], expected string) =>
+        Eq(sub, s.Repeat(input.V1, input.V2), expected),
+    Case[Tuple[string, int], string](Name = "thrice",      Input = ("ab", 3), Expected = "ababab"),
+    Case[Tuple[string, int], string](Name = "once",        Input = ("ab", 1), Expected = "ab"),
+    Case[Tuple[string, int], string](Name = "zero",        Input = ("ab", 0), Expected = ""),
+    Case[Tuple[string, int], string](Name = "empty s",     Input = ("", 5),   Expected = ""),
+    Case[Tuple[string, int], string](Name = "single rune", Input = ("-", 5),  Expected = "-----"),
+)
+
+// ---------------------------------------------------------------------------
+// Replace, ReplaceAll
+// ---------------------------------------------------------------------------
+
+func TestReplaceAll(t T) T {
+    val t1 = Eq(t,  s.ReplaceAll("hello world hello", "hello", "hi"), "hi world hi")
+    val t2 = Eq(t1, s.ReplaceAll("aaaa", "aa", "b"),                  "bb")
+    val t3 = Eq(t2, s.ReplaceAll("hello", "x", "y"),                  "hello")
+    val t4 = Eq(t3, s.ReplaceAll("", "x", "y"),                       "")
+    return Eq(t4, s.ReplaceAll("a/b/c", "/", "."),                    "a.b.c")
+}
+
+func TestReplace(t T) T {
+    val t1 = Eq(t,  s.Replace("aaaa", "a", "b", 2),  "bbaa")
+    val t2 = Eq(t1, s.Replace("aaaa", "a", "b", 0),  "aaaa")
+    val t3 = Eq(t2, s.Replace("aaaa", "a", "b", -1), "bbbb")
+    val t4 = Eq(t3, s.Replace("aaaa", "a", "b", 99), "bbbb")
+    return Eq(t4, s.Replace("hello", "x", "y", -1),  "hello")
+}
+
+// ---------------------------------------------------------------------------
+// Split, SplitN, Fields, Join — return Array[string]
+// ---------------------------------------------------------------------------
+
+func TestSplit(t T) T {
+    val a = s.Split("a,b,c", ",")
+    val t1 = Eq(t,  a.Length(), 3)
+    val t2 = Eq(t1, a.Get(0), "a")
+    val t3 = Eq(t2, a.Get(2), "c")
+
+    // Empty separator → one entry per rune
+    val r = s.Split("abc", "")
+    val t4 = Eq(t3, r.Length(), 3)
+    val t5 = Eq(t4, r.Get(1), "b")
+
+    // No separator match → one entry containing the whole string
+    val u = s.Split("hello", ",")
+    val t6 = Eq(t5, u.Length(), 1)
+    val t7 = Eq(t6, u.Get(0), "hello")
+
+    // Empty input → one empty entry
+    val e = s.Split("", ",")
+    return Eq(t7, e.Length(), 1)
+}
+
+func TestSplitN(t T) T {
+    val a = s.SplitN("a,b,c,d", ",", 2)
+    val t1 = Eq(t,  a.Length(), 2)
+    val t2 = Eq(t1, a.Get(0), "a")
+    val t3 = Eq(t2, a.Get(1), "b,c,d")
+
+    val all = s.SplitN("a,b,c", ",", -1)
+    val t4 = Eq(t3, all.Length(), 3)
+
+    val none = s.SplitN("a,b,c", ",", 0)
+    return Eq(t4, none.Length(), 0)
+}
+
+func TestFields(t T) T {
+    val a = s.Fields("  hello   world  ")
+    val t1 = Eq(t,  a.Length(), 2)
+    val t2 = Eq(t1, a.Get(0), "hello")
+    val t3 = Eq(t2, a.Get(1), "world")
+
+    // All-whitespace input → empty Array
+    val e = s.Fields("   \t\n  ")
+    val t4 = Eq(t3, e.Length(), 0)
+
+    // Empty input → empty Array
+    val z = s.Fields("")
+    val t5 = Eq(t4, z.Length(), 0)
+
+    // Tabs/newlines also count as separators
+    val tabs = s.Fields("a\tb\nc")
+    val t6 = Eq(t5, tabs.Length(), 3)
+    return Eq(t6, tabs.Get(2), "c")
+}
+
+func TestJoin(t T) T {
+    val parts = ArrayOf("a", "b", "c")
+    val t1 = Eq(t, s.Join(parts, ", "), "a, b, c")
+
+    val one = ArrayOf("solo")
+    val t2 = Eq(t1, s.Join(one, ", "), "solo")
+
+    val empty = EmptyArray[string]()
+    val t3 = Eq(t2, s.Join(empty, ", "), "")
+
+    val noSep = ArrayOf("a", "b", "c")
+    return Eq(t3, s.Join(noSep, ""), "abc")
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip: Split then Join recovers (when sep is non-empty and present)
+// ---------------------------------------------------------------------------
+
+func TestSplitJoinRoundTrip(t T) T {
+    val parts = s.Split("alpha/beta/gamma", "/")
+    return Eq(t, s.Join(parts, "/"), "alpha/beta/gamma")
+}

--- a/subprocess/subprocess.gala
+++ b/subprocess/subprocess.gala
@@ -111,7 +111,7 @@ func (p Process) CloseStdin() Try[bool] {
     val st = p.state
     st.stdinMu.Lock()
     defer st.stdinMu.Unlock()
-    val _ = st.stdin.Close()
+    st.stdin.Close()
     return Success(true)
 }
 
@@ -147,10 +147,10 @@ func (p Process) ReadStderrLine() Try[string] {
 // scanner returning EOF naturally signals "you can Wait now".
 func (p Process) Wait() Try[int] {
     val st = p.state
-    val _ = st.waitOnce.Do(() => {
+    st.waitOnce.Do(() => {
         val err = st.cmd.Wait()
         // Be tidy — pipe may already be closed.
-        val _ = st.stdin.Close()
+        FromError(st.stdin.Close())
         if err == nil {
             st.exitCode = st.cmd.ProcessState.ExitCode()
         } else {


### PR DESCRIPTION
## What

Adds three new GALA stdlib packages so consumers can replace raw Go-stdlib calls with one-for-one GALA imports. All three are pure additive — no transpiler changes, no auto-import; opt-in via standard `import . "martianoff/gala/<pkg>"`.

**`path`** — wraps `path/filepath` as a string-in / string-out free-function package. `Join`, `Dir`, `Base`, `Ext`, `IsAbs`, `Abs` (returns `Try[string]`), `ToSlash`, `FromSlash`, `Clean`. Names mirror `filepath` so migration is mechanical. No `Path` type, no string wrapper — every call site is a one-line replacement.

**`fs`** — wraps the parts of `os` that consumers reach for to read, write, stat, and remove files. Every fallible op returns `Try[T]`; `Exists` is non-fallible. Surface: `ReadFile` / `ReadFileString` / `WriteFile` / `WriteFileString` / `Stat` / `MkdirAll` / `MkdirTemp` / `RemoveAll` / `ReadDir`. Returns an immutable `FileInfo` snapshot (`Name`, `Size`, `IsDir`, `Mode`, `ModTime` as `time_utils.Instant`); does not leak `os.FileInfo` interface. Modes are plain `int` (`0o644`), no separate `FileMode` wrapper.

**`strings`** — free-function package mirroring Go's `strings.X` names exactly so migration is `s/strings\./strings\./` with no logic changes. Surface: `Contains`, `HasPrefix`, `HasSuffix`, `EqualFold`, `LastIndex`, `TrimSpace`, `Trim`, `TrimLeft`, `TrimRight`, `TrimPrefix`, `TrimSuffix`, `ToLower`, `ToUpper`, `Repeat`, `Replace`, `ReplaceAll`, `Split`, `SplitN`, `Fields`, `Join`. Sliced returns are GALA `Array[string]` (not Go `[]string`); `Join` accepts an `Array[string]` for symmetry. Coexists with `string_utils` — that one stays as the immutable-`Str` chained pipeline library; `strings` is the migration target for raw Go-style call sites.

All three are registered with the embedded stdlib (top-level `BUILD.bazel`, `internal/stdlib/BUILD.bazel` genrule srcs, `cmd/stdlib_gen/main.go` `PackageImportPaths`), so `gala test` / `gala run` resolve them — not only Bazel consumers.

Verification examples under `examples/path_basics`, `examples/fs_roundtrip`, `examples/strings_basics`. Doc sections added to `docs/GALA.MD` §9.

## Why

Surveying a representative consumer codebase showed ~393 raw `strings.X` call sites, ~49 `path/filepath.X` sites, and ~80 `os.X` file-handling sites. None of those have a GALA-native idiom to migrate to today: `string_utils` requires wrapper-type ceremony (`S(s).Trim().ToString()`) at every call site, no `path` package exists, and `os` calls return raw `(value, err)` tuples that don't compose with `Try[T]` chains. These three packages give consumer code a one-line replacement path for each pattern, keeping `.gala` files out of Go-style escape hatches.

## Follow-ups

- **Earlier transpiler regression suite is part of this snapshot.** The first three commits in this branch (match/sealed widening + sealed `Equal` synthesis regression locks, cross-package `Immutable[T]` auto-unwrap guard, qualified named-arg construction guard) shipped as a separate PR earlier. If that PR is still open, this PR's diff against master will include those three commits; reviewers can decide whether to land them in order, together, or close the earlier one in favor of this.
- **Try-style consistency.** `fs` and `path.Abs` use the `Try[T](() => { panic(err) })` pattern; the recently landed `subprocess` refactor uses explicit `return Failure[T](err)`. Same semantics, different style. Worth normalizing — likely on `Failure[T](err)` (more direct, avoids panic round-trip) — before the next stdlib package lands.
- **Collection combinators.** Consumer code still uses `var`-accumulator `for` loops where `Array.TakeWhile` / `Array.Unfold` / `ForEachIndexed` would be cleaner. Separate body of work.
- **Polish batch.** `Result[T, E]` alias for `Either`, `Try[T].GetOrElse` discoverability, `time_utils` → `time` consolidation. Smaller items, batched separately.

---
🍎 orchestrated by [Gala Team](https://github.com/martianoff/gala-team)