### PR TITLE
Add `Str.TitleCase()` to the `string_utils` package — capitalize...

### DIFF
--- a/docs/STRING_UTILS.MD
+++ b/docs/STRING_UTILS.MD
@@ -77,6 +77,7 @@ S("hello") match {
 | `ToLower() Str` | Convert to lowercase |
 | `Capitalize() Str` | Uppercase first character |
 | `Uncapitalize() Str` | Lowercase first character |
+| `TitleCase() Str` | Capitalize each whitespace-separated word; whitespace runs collapse to single space |
 
 ### Trimming
 

--- a/string_utils/strings.gala
+++ b/string_utils/strings.gala
@@ -217,6 +217,12 @@ func (s Str) Uncapitalize() Str {
     return strFromRunes(EmptyArray[rune]().Append(first).AppendAll(s.runes.Get().Tail()))
 }
 
+// TitleCase capitalizes each whitespace-separated word.
+// "hello world" -> "Hello World", "perf_guide" -> "Perf_guide".
+// Whitespace runs collapse to a single space (matches strings.Fields).
+// Empty input returns empty.
+func (s Str) TitleCase() Str = Join(s.Words().Map((w) => w.Capitalize()), " ")
+
 // Split splits the string by separator.
 func (s Str) Split(sep string) Array[Str] {
     val parts = strings.Split(s.str, sep)

--- a/string_utils/strings_test.gala
+++ b/string_utils/strings_test.gala
@@ -156,6 +156,18 @@ func TestCapitalize(t T) T {
     return Eq(t3, S("").Uncapitalize().ToString(), "")
 }
 
+// Test TitleCase
+func TestTitleCase(t T) T = RunCases[string, string](t,
+    (sub T, input string, expected string) => Eq(sub, S(input).TitleCase().ToString(), expected),
+    Case[string, string](Name = "empty", Input = "", Expected = ""),
+    Case[string, string](Name = "single word", Input = "hello", Expected = "Hello"),
+    Case[string, string](Name = "two words", Input = "hello world", Expected = "Hello World"),
+    Case[string, string](Name = "whitespace runs collapse", Input = "  hello   world  ", Expected = "Hello World"),
+    Case[string, string](Name = "apostrophe inside word", Input = "alice's cat", Expected = "Alice's Cat"),
+    Case[string, string](Name = "tab and newline split", Input = "\thello\nworld", Expected = "Hello World"),
+    Case[string, string](Name = "unicode", Input = "héllo wörld", Expected = "Héllo Wörld"),
+)
+
 // Test Split
 func TestSplit(t T) T {
     val parts = S("a,b,c").Split(",")


### PR DESCRIPTION
Add `Str.TitleCase()` to the `string_utils` package — capitalize each whitespace-separated word in an immutable `Str`.

## What
- New method `func (s Str) TitleCase() Str` on the `Str` wrapper, implemented as `Join(s.Words().Map((w) => w.Capitalize()), " ")` over existing primitives.
- 7 table-driven test cases covering empty, single word, multi-word, whitespace-run collapse, intra-word apostrophe, mixed whitespace (tabs/newlines), and Unicode.
- One-line entry in the `Str` method table in `docs/STRING_UTILS.MD`.

## Why
Title-casing a multi-word string is a recurring need (slot labels, slugified-name rendering, etc.) that previously required composing `Words()` + `Map(Capitalize)` + `Join` by hand at every call site, or — far more often — falling back to a hand-rolled imperative loop over `strings.Split` and `[]rune`. A single named method removes the discoverability gap and makes the functional form the obvious one.

The implementation deliberately delegates to `Words()` (`strings.Fields`-based) rather than splitting on a literal space, so runs of whitespace collapse cleanly and any whitespace character splits — matching what hand-rolled versions in the wild were trying to do but typically getting wrong on tabs.

## Follow-ups
- A locale-aware variant is out of scope. `Capitalize()` already uses `unicode.ToUpper`, so this inherits Unicode-correct behaviour for the cases that matter; nothing here pretends to handle Turkish dotted-i or other locale-specific casing rules.
- Acronym handling (e.g. preserving "URL" as-is) is not addressed and would belong in a separate, opt-in helper if ever needed.

---
🍎 orchestrated by [Gala Team](https://github.com/martianoff/gala-team)