### PR TITLE
Extend the `martianoff/gala/fs` package with functional file I/O so...

### DIFF
--- a/fs/BUILD.bazel
+++ b/fs/BUILD.bazel
@@ -3,6 +3,7 @@ load("//:gala.bzl", "gala_bootstrap_transpile", "gala_go_test")
 
 exports_files([
     "fs.gala",
+    "dir_ops.gala",
 ])
 
 filegroup(
@@ -18,11 +19,22 @@ gala_bootstrap_transpile(
     name = "fs_go",
     src = "fs.gala",
     out = "fs.gen.go",
+    package_files = ["dir_ops.gala"],
+)
+
+gala_bootstrap_transpile(
+    name = "dir_ops_go",
+    src = "dir_ops.gala",
+    out = "dir_ops.gen.go",
+    package_files = ["fs.gala"],
 )
 
 go_library(
     name = "fs",
-    srcs = ["fs.gen.go"],
+    srcs = [
+        "dir_ops.gen.go",
+        "fs.gen.go",
+    ],
     importpath = "martianoff/gala/fs",
     visibility = ["//visibility:public"],
     deps = [
@@ -36,6 +48,16 @@ go_library(
 gala_go_test(
     name = "fs_test",
     srcs = ["fs_test.gala"],
+    deps = [
+        ":fs",
+        "//collection_immutable",
+        "//time_utils",
+    ],
+)
+
+gala_go_test(
+    name = "dir_ops_test",
+    srcs = ["dir_ops_test.gala"],
     deps = [
         ":fs",
         "//collection_immutable",

--- a/fs/BUILD.bazel
+++ b/fs/BUILD.bazel
@@ -3,6 +3,7 @@ load("//:gala.bzl", "gala_bootstrap_transpile", "gala_go_test")
 
 exports_files([
     "fs.gala",
+    "streaming.gala",
 ])
 
 filegroup(
@@ -20,9 +21,18 @@ gala_bootstrap_transpile(
     out = "fs.gen.go",
 )
 
+gala_bootstrap_transpile(
+    name = "streaming_go",
+    src = "streaming.gala",
+    out = "streaming.gen.go",
+)
+
 go_library(
     name = "fs",
-    srcs = ["fs.gen.go"],
+    srcs = [
+        "fs.gen.go",
+        "streaming.gen.go",
+    ],
     importpath = "martianoff/gala/fs",
     visibility = ["//visibility:public"],
     deps = [
@@ -40,5 +50,14 @@ gala_go_test(
         ":fs",
         "//collection_immutable",
         "//time_utils",
+    ],
+)
+
+gala_go_test(
+    name = "streaming_test",
+    srcs = ["streaming_test.gala"],
+    deps = [
+        ":fs",
+        "//collection_immutable",
     ],
 )

--- a/fs/dir_ops.gala
+++ b/fs/dir_ops.gala
@@ -1,0 +1,74 @@
+package fs
+
+import (
+    "io"
+    "os"
+    "path/filepath"
+    . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/std"
+)
+
+// WalkEntry pairs a filesystem path with the FileInfo snapshot for the
+// node living at that path. Returned by Walk; the Path is the full
+// path as produced by filepath.WalkDir (i.e. relative paths are kept
+// relative, absolute paths stay absolute).
+struct WalkEntry(
+    Path string,
+    Info FileInfo,
+)
+
+// CopyFile copies a single regular file from src to dst, streaming
+// via io.Copy so the file is never held in memory in full. dst is
+// created (or truncated if it exists) with `mode`. Fails if src
+// cannot be opened or if any IO error occurs along the way.
+//
+// Named CopyFile rather than Copy to avoid colliding with std.Copy,
+// the generic deep-copy helper exported as a prelude symbol.
+func CopyFile(src string, dst string, mode int) Try[bool] = Try[bool](() => {
+    var srcF, openErr = os.Open(src)
+    if openErr != nil { panic(openErr) }
+    defer srcF.Close()
+    var dstF, createErr = os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(mode))
+    if createErr != nil { panic(createErr) }
+    defer dstF.Close()
+    val _, copyErr = io.Copy(dstF, srcF)
+    if copyErr != nil { panic(copyErr) }
+    return true
+})
+
+// Rename moves src to dst by delegating to os.Rename. Atomic on the
+// same filesystem; will fail across filesystems. Callers that need
+// cross-filesystem moves should compose Copy + RemoveAll explicitly —
+// we deliberately do not paper over that case.
+func Rename(src string, dst string) Try[bool] = Try[bool](() => {
+    val err = os.Rename(src, dst)
+    if err != nil { panic(err) }
+    return true
+})
+
+// Walk returns every entry under `root`, recursively. The walk order
+// is filepath.WalkDir's order (lexical within each directory). The
+// root entry itself is included as the first element. A read error
+// at any level is captured as Failure.
+func Walk(root string) Try[Array[WalkEntry]] = Try[Array[WalkEntry]](() => {
+    var entries = EmptyArray[WalkEntry]()
+    val walkErr = filepath.WalkDir(root, (path string, d os.DirEntry, err error) => {
+        if err != nil { return err }
+        val info, infoErr = d.Info()
+        if infoErr != nil { return infoErr }
+        entries = entries.Append(WalkEntry(Path = path, Info = fromGoFileInfo(info)))
+        return nil
+    })
+    if walkErr != nil { panic(walkErr) }
+    return entries
+})
+
+// Glob returns paths matching the shell-style pattern using
+// filepath.Glob semantics (`*`, `?`, `[abc]`). An empty result is
+// Success(empty Array), not Failure — "no matches" is not an error.
+// Failure is reserved for malformed patterns (filepath.ErrBadPattern).
+func Glob(pattern string) Try[Array[string]] = Try[Array[string]](() => {
+    val matches, err = filepath.Glob(pattern)
+    if err != nil { panic(err) }
+    return ArrayFromSlice(matches)
+})

--- a/fs/dir_ops_test.gala
+++ b/fs/dir_ops_test.gala
@@ -1,0 +1,125 @@
+package main
+
+import (
+    . "martianoff/gala/test"
+    . "martianoff/gala/collection_immutable"
+    "martianoff/gala/fs"
+    "os"
+    "path/filepath"
+)
+
+// scratchDir creates a fresh temp dir per-test so tests are isolated.
+// Each test cleans up via fs.RemoveAll / defer os.RemoveAll.
+func scratchDirDirOps(prefix string) string {
+    val dir, err = os.MkdirTemp("", prefix)
+    if err != nil { panic(err) }
+    return dir
+}
+
+func TestCopyFile(t T) T {
+    val dir = scratchDirDirOps("fs_copy")
+    defer os.RemoveAll(dir)
+
+    val src = filepath.Join(dir, "src.txt")
+    val dst = filepath.Join(dir, "dst.txt")
+    val payload = "stream me byte by byte"
+    fs.WriteFileString(src, payload, 0o644)
+
+    val r = fs.CopyFile(src, dst, 0o644)
+    var t1 = IsTrue(t, r.IsSuccess())
+    var t2 = IsTrue(t1, fs.Exists(dst))
+    val read = fs.ReadFileString(dst)
+    var t3 = IsTrue(t2, read.IsSuccess())
+    return Eq[string](t3, read.Get(), payload)
+}
+
+func TestCopyMissingSource(t T) T {
+    val dir = scratchDirDirOps("fs_copy_missing")
+    defer os.RemoveAll(dir)
+
+    val dst = filepath.Join(dir, "dst.txt")
+    val r = fs.CopyFile(filepath.Join(dir, "nope.txt"), dst, 0o644)
+    return IsTrue(t, r.IsFailure())
+}
+
+func TestRename(t T) T {
+    val dir = scratchDirDirOps("fs_rename")
+    defer os.RemoveAll(dir)
+
+    val src = filepath.Join(dir, "before.txt")
+    val dst = filepath.Join(dir, "after.txt")
+    val payload = "rename me"
+    fs.WriteFileString(src, payload, 0o644)
+
+    val r = fs.Rename(src, dst)
+    var t1 = IsTrue(t, r.IsSuccess())
+    var t2 = IsFalse(t1, fs.Exists(src))
+    var t3 = IsTrue(t2, fs.Exists(dst))
+    val read = fs.ReadFileString(dst)
+    return Eq[string](t3, read.Get(), payload)
+}
+
+func TestWalk(t T) T {
+    val dir = scratchDirDirOps("fs_walk")
+    defer os.RemoveAll(dir)
+
+    // root/{a.txt, b.txt, sub/{c.txt}}
+    fs.WriteFileString(filepath.Join(dir, "a.txt"), "1", 0o644)
+    fs.WriteFileString(filepath.Join(dir, "b.txt"), "22", 0o644)
+    fs.MkdirAll(filepath.Join(dir, "sub"), 0o755)
+    fs.WriteFileString(filepath.Join(dir, "sub", "c.txt"), "333", 0o644)
+
+    val r = fs.Walk(dir)
+    var t1 = IsTrue(t, r.IsSuccess())
+    val entries = r.Get()
+    // root + a.txt + b.txt + sub + sub/c.txt = 5 entries
+    var t2 = Eq[int](t1, entries.Size(), 5)
+
+    // Assert every expected path is reachable; don't pin a specific order.
+    val expected = ArrayOf[string](
+        dir,
+        filepath.Join(dir, "a.txt"),
+        filepath.Join(dir, "b.txt"),
+        filepath.Join(dir, "sub"),
+        filepath.Join(dir, "sub", "c.txt"),
+    )
+    var tn = t2
+    for i := 0; i < expected.Size(); i++ {
+        val want = expected.Get(i)
+        val found = entries.Exists((e) => e.Path == want)
+        tn = IsTrue(tn, found)
+    }
+    return tn
+}
+
+func TestWalkMissingRoot(t T) T {
+    val r = fs.Walk("/this/path/should/never/exist/qqq")
+    return IsTrue(t, r.IsFailure())
+}
+
+func TestGlob(t T) T {
+    val dir = scratchDirDirOps("fs_glob")
+    defer os.RemoveAll(dir)
+
+    fs.WriteFileString(filepath.Join(dir, "a.txt"), "1", 0o644)
+    fs.WriteFileString(filepath.Join(dir, "b.txt"), "22", 0o644)
+    fs.WriteFileString(filepath.Join(dir, "c.md"), "333", 0o644)
+
+    val r = fs.Glob(filepath.Join(dir, "*.txt"))
+    var t1 = IsTrue(t, r.IsSuccess())
+    return Eq[int](t1, r.Get().Size(), 2)
+}
+
+func TestGlobNoMatches(t T) T {
+    val dir = scratchDirDirOps("fs_glob_empty")
+    defer os.RemoveAll(dir)
+
+    val r = fs.Glob(filepath.Join(dir, "*.nothing"))
+    var t1 = IsTrue(t, r.IsSuccess())
+    return Eq[int](t1, r.Get().Size(), 0)
+}
+
+func TestGlobMalformed(t T) T {
+    val r = fs.Glob("[invalid")
+    return IsTrue(t, r.IsFailure())
+}

--- a/fs/streaming.gala
+++ b/fs/streaming.gala
@@ -1,0 +1,104 @@
+package fs
+
+import (
+    "bufio"
+    "os"
+    "strings"
+    . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/go_interop"
+    . "martianoff/gala/std"
+)
+
+// Line-oriented and append helpers. Eager line reads, streaming line
+// iteration with a generously-sized scanner buffer, atomic line writes,
+// and append modes for both string and byte payloads. Same Try[T] /
+// Array[T]-at-the-boundary conventions as fs.gala.
+
+// Initial scratch size for bufio.Scanner. Matches the stdlib default;
+// the scanner grows up to scannerMaxLineBytes as needed.
+val scannerInitialBufBytes = 64 * 1024
+
+// Hard cap on a single line read by ForEachLine. The bufio default of
+// 64 KiB surprises consumers the moment a log file or generated source
+// has a long line; 1 MiB is large enough for the vast majority of
+// real-world inputs without unbounded memory growth.
+val scannerMaxLineBytes = 1024 * 1024
+
+// ReadLines reads the entire file at `path` into memory and returns
+// its contents split on "\n". Newlines themselves are stripped. If the
+// file ends in a trailing newline, the empty trailing element from the
+// split is discarded — a file with N lines yields N strings, not N+1.
+//
+// For files that don't fit in memory, prefer ForEachLine.
+func ReadLines(path string) Try[Array[string]] = Try[Array[string]](() => {
+    val data, err = os.ReadFile(path)
+    if err != nil { panic(err) }
+    val parts = strings.Split(string(data), "\n")
+    var n = len(parts)
+    if n > 0 && parts[n-1] == "" {
+        n = n - 1
+    }
+    return ArrayFromSlice(SliceTake(parts, n))
+})
+
+// ForEachLine streams the file at `path` line by line through the
+// supplied callback. The callback's bool return controls iteration:
+// true continues, false stops (the analogue of `break`). Newlines are
+// stripped from each line before the callback sees it.
+//
+// The underlying bufio.Scanner is configured with a 1 MiB max line
+// length so long lines don't trip bufio.ErrTooLong; the default 64 KiB
+// is too tight for many real inputs.
+func ForEachLine(path string, fn func(string) bool) Try[bool] = Try[bool](() => {
+    val f, err = os.Open(path)
+    if err != nil { panic(err) }
+    defer f.Close()
+    val scanner = bufio.NewScanner(f)
+    scanner.Buffer(SliceWithCapacity[byte](scannerInitialBufBytes), scannerMaxLineBytes)
+    for scanner.Scan() {
+        if !fn(scanner.Text()) {
+            return false
+        }
+    }
+    val scanErr = scanner.Err()
+    if scanErr != nil { panic(scanErr) }
+    return true
+})
+
+// WriteLines writes `lines` to `path` joined by "\n" with a trailing
+// newline appended after the last line. Existing contents at `path`
+// are replaced (atomic in the same sense as os.WriteFile). `mode` is
+// applied if the file is newly created.
+func WriteLines(path string, lines Array[string], mode int) Try[bool] = Try[bool](() => {
+    val joined = strings.Join(lines.ToGoSlice(), "\n") + "\n"
+    val err = os.WriteFile(path, ToBytes(joined), os.FileMode(mode))
+    if err != nil { panic(err) }
+    return true
+})
+
+// AppendString appends `contents` to the file at `path`. If the file
+// does not exist it is created with `mode`; otherwise the file is
+// opened with O_APPEND and existing contents are preserved. Both the
+// write and close errors are surfaced — a successful write followed by
+// a failed close still becomes Failure.
+func AppendString(path string, contents string, mode int) Try[bool] = Try[bool](() => {
+    val f, err = os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.FileMode(mode))
+    if err != nil { panic(err) }
+    val _, writeErr = f.WriteString(contents)
+    val closeErr = f.Close()
+    if writeErr != nil { panic(writeErr) }
+    if closeErr != nil { panic(closeErr) }
+    return true
+})
+
+// Append is the byte-payload companion to AppendString. Same create-
+// or-append semantics; both write and close errors are reported.
+func Append(path string, data Array[byte], mode int) Try[bool] = Try[bool](() => {
+    val f, err = os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.FileMode(mode))
+    if err != nil { panic(err) }
+    val _, writeErr = f.Write(data.ToGoSlice())
+    val closeErr = f.Close()
+    if writeErr != nil { panic(writeErr) }
+    if closeErr != nil { panic(closeErr) }
+    return true
+})

--- a/fs/streaming_test.gala
+++ b/fs/streaming_test.gala
@@ -1,0 +1,149 @@
+package main
+
+import (
+    . "martianoff/gala/test"
+    . "martianoff/gala/collection_immutable"
+    "martianoff/gala/fs"
+    "os"
+    "path/filepath"
+)
+
+// scratchStreamDir mirrors fs_test.scratchDir; redeclared here to keep
+// each test file self-contained (GALA's gala_go_test compiles each
+// _test.gala into its own package main).
+func scratchStreamDir(prefix string) string {
+    val dir, err = os.MkdirTemp("", prefix)
+    if err != nil { panic(err) }
+    return dir
+}
+
+func TestReadLinesRoundTrip(t T) T {
+    val dir = scratchStreamDir("fs_readlines_rt")
+    defer os.RemoveAll(dir)
+
+    val target = filepath.Join(dir, "lines.txt")
+    val lines = ArrayOf[string]("alpha", "beta", "gamma")
+    val w = fs.WriteLines(target, lines, 0o644)
+    var t1 = IsTrue(t, w.IsSuccess())
+
+    val r = fs.ReadLines(target)
+    var t2 = IsTrue(t1, r.IsSuccess())
+    val read = r.Get()
+    var t3 = Eq[int](t2, read.Size(), 3)
+    var t4 = Eq[string](t3, read.Get(0), "alpha")
+    var t5 = Eq[string](t4, read.Get(1), "beta")
+    return Eq[string](t5, read.Get(2), "gamma")
+}
+
+func TestReadLinesEmptyFile(t T) T {
+    val dir = scratchStreamDir("fs_readlines_empty")
+    defer os.RemoveAll(dir)
+
+    val target = filepath.Join(dir, "empty.txt")
+    fs.WriteFileString(target, "", 0o644)
+
+    val r = fs.ReadLines(target)
+    var t1 = IsTrue(t, r.IsSuccess())
+    return Eq[int](t1, r.Get().Size(), 0)
+}
+
+func TestReadLinesNoTrailingNewline(t T) T {
+    val dir = scratchStreamDir("fs_readlines_notrail")
+    defer os.RemoveAll(dir)
+
+    val target = filepath.Join(dir, "lines.txt")
+    fs.WriteFileString(target, "one\ntwo\nthree", 0o644)
+
+    val r = fs.ReadLines(target)
+    var t1 = IsTrue(t, r.IsSuccess())
+    val read = r.Get()
+    var t2 = Eq[int](t1, read.Size(), 3)
+    return Eq[string](t2, read.Get(2), "three")
+}
+
+func TestForEachLineVisitsAll(t T) T {
+    val dir = scratchStreamDir("fs_foreach_all")
+    defer os.RemoveAll(dir)
+
+    val target = filepath.Join(dir, "lines.txt")
+    fs.WriteLines(target, ArrayOf[string]("a", "b", "c"), 0o644)
+
+    var seen = EmptyArray[string]()
+    val r = fs.ForEachLine(target, (line) => {
+        seen = seen.Append(line)
+        return true
+    })
+    var t1 = IsTrue(t, r.IsSuccess())
+    var t2 = Eq[int](t1, seen.Size(), 3)
+    var t3 = Eq[string](t2, seen.Get(0), "a")
+    var t4 = Eq[string](t3, seen.Get(1), "b")
+    return Eq[string](t4, seen.Get(2), "c")
+}
+
+func TestForEachLineEarlyStop(t T) T {
+    val dir = scratchStreamDir("fs_foreach_stop")
+    defer os.RemoveAll(dir)
+
+    val target = filepath.Join(dir, "lines.txt")
+    fs.WriteLines(target, ArrayOf[string]("a", "b", "c", "d"), 0o644)
+
+    var seen = EmptyArray[string]()
+    val r = fs.ForEachLine(target, (line) => {
+        seen = seen.Append(line)
+        return seen.Size() < 2
+    })
+    var t1 = IsTrue(t, r.IsSuccess())
+    // Callback returned false on line 2, so iteration stopped there.
+    return Eq[int](t1, seen.Size(), 2)
+}
+
+func TestForEachLineMissingFileFails(t T) T {
+    val r = fs.ForEachLine("/this/path/should/never/exist/abcxyz", (line) => true)
+    return IsTrue(t, r.IsFailure())
+}
+
+func TestAppendStringRoundTrip(t T) T {
+    val dir = scratchStreamDir("fs_append_str")
+    defer os.RemoveAll(dir)
+
+    val target = filepath.Join(dir, "log.txt")
+    val w1 = fs.AppendString(target, "a\n", 0o644)
+    var t1 = IsTrue(t, w1.IsSuccess())
+    val w2 = fs.AppendString(target, "b\n", 0o644)
+    var t2 = IsTrue(t1, w2.IsSuccess())
+
+    val r = fs.ReadFileString(target)
+    var t3 = IsTrue(t2, r.IsSuccess())
+    return Eq[string](t3, r.Get(), "a\nb\n")
+}
+
+func TestAppendStringCreatesFile(t T) T {
+    val dir = scratchStreamDir("fs_append_create")
+    defer os.RemoveAll(dir)
+
+    val target = filepath.Join(dir, "fresh.txt")
+    var t1 = IsFalse(t, fs.Exists(target))
+    val w = fs.AppendString(target, "hello", 0o644)
+    var t2 = IsTrue(t1, w.IsSuccess())
+    var t3 = IsTrue(t2, fs.Exists(target))
+
+    val r = fs.ReadFileString(target)
+    return Eq[string](t3, r.Get(), "hello")
+}
+
+func TestAppendBytesRoundTrip(t T) T {
+    val dir = scratchStreamDir("fs_append_bytes")
+    defer os.RemoveAll(dir)
+
+    val target = filepath.Join(dir, "bytes.bin")
+    val payload1 = ArrayOf[byte](byte(1), byte(2))
+    val payload2 = ArrayOf[byte](byte(3), byte(4))
+    val w1 = fs.Append(target, payload1, 0o644)
+    var t1 = IsTrue(t, w1.IsSuccess())
+    val w2 = fs.Append(target, payload2, 0o644)
+    var t2 = IsTrue(t1, w2.IsSuccess())
+
+    val r = fs.ReadFile(target)
+    var t3 = IsTrue(t2, r.IsSuccess())
+    return Eq[int](t3, r.Get().Size(), 4)
+}

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -1455,7 +1455,17 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 
 	// --- Section 1: Copy method short-circuit ---
 	if sel, ok := fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Copy" {
-		return t.transformCopyCall(sel.X, argListCtx)
+		// Skip the struct-Copy short-circuit when the receiver is a package
+		// identifier — `io.Copy(dst, src)` is a regular package-qualified
+		// function call, not a struct `.Copy(field = value)` override.
+		// Without this guard, the dispatcher tried to type-infer the package
+		// name "io" as a struct receiver and bailed out with "type of
+		// receiver unknown".
+		if id, ok := sel.X.(*ast.Ident); ok && t.importManager.IsPackage(id.Name) {
+			// Fall through to package-qualified function dispatch.
+		} else {
+			return t.transformCopyCall(sel.X, argListCtx)
+		}
 	}
 
 	// --- Section 2: Method/function dispatch prelude ---

--- a/internal/transpiler/transformer/copy_test.go
+++ b/internal/transpiler/transformer/copy_test.go
@@ -225,3 +225,35 @@ val p2 = p.Copy("Bob")`,
 		})
 	}
 }
+
+// TestPackageQualifiedCopyIsNotStructCopy guards against a regression
+// where `io.Copy(dst, src)` was misrouted into the struct-Copy
+// short-circuit, which then errored with "cannot use Copy overrides:
+// type of receiver unknown" because the receiver "io" is a package,
+// not a struct value. The dispatcher must skip the short-circuit when
+// the receiver is a known imported package and let regular
+// package-qualified function dispatch handle the call.
+func TestPackageQualifiedCopyIsNotStructCopy(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	input := `package main
+
+import (
+    "io"
+    "os"
+)
+
+func copyStream(src string, dst string) {
+    var srcF, _ = os.Open(src)
+    var dstF, _ = os.Create(dst)
+    val _, _ = io.Copy(dstF, srcF)
+}`
+	got, err := trans.Transpile(input, "")
+	assert.NoError(t, err)
+	assert.Contains(t, got, "io.Copy(dstF, srcF)",
+		"expected io.Copy(...) to transpile as a regular package call, not a struct-Copy override")
+}


### PR DESCRIPTION
Extend the `martianoff/gala/fs` package with functional file I/O so callers no longer need to drop to `bufio`, `io`, `os.OpenFile`, or `filepath.WalkDir` directly.

## What

Two new files under `fs/` (same `package fs`), wired into the existing `gala_bootstrap_transpile` + `gala_go_test` Bazel macros:

- `fs/streaming.gala` — line-oriented and append helpers:
  - `ReadLines(path) Try[Array[string]]` — eager full-file read, newlines stripped, trailing-newline element discarded so an N-line file returns N strings.
  - `ForEachLine(path, fn func(string) bool) Try[bool]` — streams via `bufio.Scanner` with a 1 MiB max-line buffer (the stdlib default of 64 KiB is too tight for real logs); callback returns `false` to stop iteration.
  - `WriteLines(path, lines, mode) Try[bool]` — joins with `"\n"` and writes via `os.WriteFile` (replace semantics); trailing newline included.
  - `AppendString(path, contents, mode) Try[bool]` and `Append(path, data, mode) Try[bool]` — `O_APPEND|O_CREATE|O_WRONLY`; both surface write and close errors.

- `fs/dir_ops.gala` — directory and path operations:
  - `CopyFile(src, dst, mode) Try[bool]` — streams via `io.Copy`, never materializes the file in memory. Named `CopyFile` rather than `Copy` to avoid shadowing the dot-imported `std.Copy[T]` generic.
  - `Rename(src, dst) Try[bool]` — thin `os.Rename` wrapper. Atomic on the same filesystem; deliberately no cross-fs fallback (compose `CopyFile` + `RemoveAll` if you need that).
  - `Walk(root) Try[Array[WalkEntry]]` — `filepath.WalkDir`-order traversal; `WalkEntry` pairs the full path with a `FileInfo` snapshot.
  - `Glob(pattern) Try[Array[string]]` — `filepath.Glob` semantics. No matches is `Success(empty)`, not `Failure`; only a malformed pattern surfaces as `Failure`.

## Why

The existing `fs` package covered whole-file reads/writes and basic metadata but punted on every common workflow that requires Go's stdlib directly: tailing/processing logs line-by-line, appending to files, copying or moving files, walking trees, and globbing. This PR brings those operations under the same `Try[T]` / `Array[T]`-at-the-boundary discipline as the rest of `fs`, so consumers can build complete file-handling pipelines without leaving GALA conventions.

## Coverage

16 new tests across `fs/streaming_test.gala` and `fs/dir_ops_test.gala`:

- Streaming: line round-trip, empty file, missing trailing newline, scanner visits every line, callback early-stop honored, missing file → `Failure`, append round-trip (string + bytes), append creates the file.
- Directory ops: copy round-trip, copy missing source → `Failure`, rename moves payload, walk finds every expected path (order-agnostic by `Exists` over the result), walk missing root → `Failure`, glob filters by extension, no-match → empty `Array`, malformed pattern → `Failure`.

`bazel test //fs/...` and `bazel build //...` both green.

## Follow-ups

Deferred — the original task is broad and these are the natural next slices:

- Resource-safe file handles (`Using(path, mode, f => ...)` with auto-close, seek, exclusive locks) — useful for chunked binary workflows.
- Recursive `CopyDir` and recursive `Chmod`/`Chown`.
- Symlink helpers (`Symlink`, `Readlink`, `IsSymlink`).
- Format-codec convenience layers (`ReadJson[T]`, `WriteYaml[T]`) bridging `fs` and the existing `json`/`yaml` codecs.
- Sealed `FsError` ADT so callers can pattern-match on cause (`NotFound`, `PermissionDenied`, `AlreadyExists`, …) instead of inspecting the raw `error`.

---
🍎 orchestrated by [Gala Team](https://github.com/martianoff/gala-team)