### PR TITLE
Add Futures with timeouts

### DIFF
--- a/concurrent/future.gala
+++ b/concurrent/future.gala
@@ -143,6 +143,11 @@ struct FutureError(Message string)
 
 func (e FutureError) Error() string = e.Message
 
+// TimeoutError is returned when a Future fails to complete before its timeout expires.
+struct TimeoutError(Timeout Duration)
+
+func (e TimeoutError) Error() string = s"future timed out after ${e.Timeout}"
+
 // IsCompleted returns true if the Future has been completed (success or failure).
 func (f Future[T]) IsCompleted() bool {
     f.state.mu.RLock()
@@ -184,6 +189,27 @@ func (f Future[T]) AwaitFor(timeout Duration) Option[Try[T]] {
         return Some[Try[T]](r)
     }
     return None[Try[T]]()
+}
+
+// WithTimeout returns a new Future that completes with this Future's result
+// if it arrives before the timeout, or fails with TimeoutError if the timeout
+// expires first. The returned Future inherits this Future's ExecutionContext.
+//
+// WithTimeout does not cancel the underlying computation — side effects still
+// run in the background after a timeout fires. Make async work cancellable
+// (e.g., honor context.Context) if that matters.
+func (f Future[T]) WithTimeout(timeout Duration) Future[T] {
+    val p = NewPromiseWith[T](f.state.ec)
+    f.OnComplete((r Try[T]) => {
+        p.Complete(r)
+    })
+    f.state.ec.Execute(() => {
+        val received = go_interop.WaitSignalTimeout(f.state.done, timeout.ToGoDuration())
+        if !received {
+            p.Failure(TimeoutError(Timeout = timeout))
+        }
+    })
+    return p.Future()
 }
 
 // Get blocks until the Future is completed and returns the value.

--- a/concurrent/future_test.gala
+++ b/concurrent/future_test.gala
@@ -226,6 +226,38 @@ func TestAwaitFor(t T) T {
     return Eq[int](t1, result.Get().Get(), 42)
 }
 
+func TestWithTimeoutDoesNotFire(t T) T {
+    val f = FutureOf[int](42)
+    val result = f.WithTimeout(Seconds(5)).Await()
+    var t1 = IsSuccess(t, result)
+    return Eq[int](t1, result.Get(), 42)
+}
+
+func TestWithTimeoutFires(t T) T {
+    val p = NewPromise[int]()
+    val result = p.Future().WithTimeout(Milliseconds(50)).Await()
+    var t1 = IsFailure(t, result)
+    return Contains(t1, result.Err.Error(), "timed out")
+}
+
+func TestWithTimeoutPreservesOriginalFailure(t T) T {
+    val f = FutureFailed[int](FutureError(Message = "original error"))
+    val result = f.WithTimeout(Seconds(5)).Await()
+    var t1 = IsFailure(t, result)
+    return Eq[string](t1, result.Err.Error(), "original error")
+}
+
+func TestWithTimeoutSlowFutureBeats(t T) T {
+    val p = NewPromise[int]()
+    Spawn(() => {
+        Sleep(Milliseconds(10))
+        p.Success(7)
+    })
+    val result = p.Future().WithTimeout(Milliseconds(200)).Await()
+    var t1 = IsSuccess(t, result)
+    return Eq[int](t1, result.Get(), 7)
+}
+
 func TestTransform(t T) T {
     val f = FutureOf[int](5)
     val transformed = f.Transform[string](

--- a/docs/CONCURRENT.MD
+++ b/docs/CONCURRENT.MD
@@ -59,6 +59,26 @@ val recovered = failed.Recover((e) => 0)
 val recoveredWith = failed.RecoverWith((e) => FutureOf[int](0))
 ```
 
+### Timeouts
+
+Two complementary primitives:
+
+- `AwaitFor(duration) Option[Try[T]]` — blocks the caller; `None` on timeout.
+- `WithTimeout(duration) Future[T]` — monadic; the returned Future fails with `TimeoutError` if the original doesn't complete in time, otherwise mirrors its result.
+
+```gala
+val slow = FutureApply[int](() => { Sleep(Seconds(2)); 42 })
+
+// Monadic: stays a Future, composes with Map/Recover/etc.
+val bounded = slow.WithTimeout(Milliseconds(500))
+    .Recover((e) => 0)                            // 0 on timeout
+
+// Blocking: returns Option[Try[T]] inline.
+val maybe = slow.AwaitFor(Milliseconds(500))      // None on timeout
+```
+
+`WithTimeout` does not cancel the underlying computation — side effects still run after the timeout fires. Make async work cancellable (e.g., honor `context.Context`) if that matters.
+
 ### Combining Futures
 
 ```gala
@@ -211,6 +231,7 @@ pool.Shutdown()
 | `Value()` | Get current result as Option[Try[T]] |
 | `Await()` | Block until completion, returns Try[T] |
 | `AwaitFor(duration)` | Block with timeout, returns Option[Try[T]] |
+| `WithTimeout(duration)` | Return Future that fails with TimeoutError if not done in time (inherits EC) |
 | `Get()` | Block and get value, panics on failure |
 | `GetOrElse(default)` | Block and get value or default |
 | `ExecutionContext()` | Get the associated ExecutionContext |


### PR DESCRIPTION
## What

Adds `Future.WithTimeout(duration) Future[T]` — the monadic counterpart to the existing blocking `AwaitFor`. Returns a new `Future[T]` that mirrors the original result if it arrives in time, or fails with a new `TimeoutError(Timeout Duration)` sentinel if the timeout fires first. The returned Future inherits the source's `ExecutionContext`.

Implementation: a single `Promise` is fed by both an `OnComplete` forwarder and a watcher that races `WaitSignalTimeout` against the source signal. The watcher loses cleanly when the source completes first because `Promise.Complete` is `sync.Once`-protected — whichever side loses the race is a no-op.

Also:
- New `TimeoutError` struct (with `Error()` returning `"future timed out after <duration>"`) so callers can pattern-match on timeout vs other failures.
- Four new tests covering both race outcomes, original-failure preservation, and a slow-but-in-budget Future.
- `docs/CONCURRENT.MD` gains a `### Timeouts` section showing the two primitives side by side, plus a row in the methods table.

All 45 tests in `concurrent/future_test.gala` pass.

## Why

`AwaitFor` returns `Option[Try[T]]` — useful at a sync boundary, useless inside a monadic chain. Without `WithTimeout`, the only way to bound an in-flight computation while staying in the Future world was to spawn a Promise and a manual timer goroutine on every call site. This adds the standard Scala-style primitive so timeouts compose with `Map`, `Recover`, `Zip`, etc.

## Gaps

`WithTimeout` does not cancel the underlying computation — side effects still run in the background after the timeout fires. The doc paragraph and the method comment both flag this. Real cancellation requires threading a token through `ExecutionContext` and `FutureApply`; out of scope here.

## Follow-ups

Worth considering as separate PRs, in rough order of payoff:

1. **Cancellation token.** A `CancelToken` that callers can pass into `FutureApplyWith` and that `WithTimeout` trips when it fires. Closes the "side effects still run" gap above. Biggest design lift — needs to interact with `context.Context` for Go interop.
2. **`WithDeadline(deadline Instant) Future[T]`.** Absolute-time twin of `WithTimeout`. Matters when chaining: with deadlines a budget doesn't reset at every hop, so end-to-end SLAs are enforceable.
3. **Dedicated scheduler.** `WithTimeout` currently parks one EC worker per pending timeout via `WaitSignalTimeout`. Fine for `UnboundedExecutionContext`, problematic for `FixedPoolEC` under load. A single timer goroutine + min-heap of deadlines would decouple timeout count from pool size.
4. **`SequenceAll[T](futures) Future[Array[Try[T]]]`.** Current `Sequence` fails fast on the first failure — common need is to collect every result regardless. Pairs naturally with timeouts (a partial-success view of a fan-out).
5. **Minor: `Sequence` invariant.** `concurrent/future.gala:408` falls back to `r.Value` for a missing index in the result map. The fallback never triggers (only runs when `remaining == 0`), but `resultMap.Get(i).Get()` would make the invariant explicit and panic loudly if it ever broke.

---
🍎 orchestrated by [Gala Team](https://github.com/martianoff/gala-team)