### PR TITLE
fix(analyzer): strict redeclaration errors for all object kinds

### DIFF
--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -206,6 +206,47 @@ const (
 	// (same-package) declarations always shadow dot-imports, so this code
 	// only fires when the conflict is across two imports.
 	CodeAmbiguousSealedVariant ErrorCode = "GALA-E0026"
+
+	// E0027: a top-level function with the same name is declared more than
+	// once within a package. Mirrors Go's "redeclared in this block" rule.
+	// The analyzer previously silently overwrote the earlier metadata entry
+	// with the latter one, causing the second declaration to win and the
+	// first to be lost; now both are surfaced as a hard error so the user
+	// can rename or remove one.
+	CodeFunctionRedeclared ErrorCode = "GALA-E0027"
+
+	// E0028: a type alias (`type Foo = Bar`) with the same name is declared
+	// more than once in the same file. Without this guard the second
+	// alias silently replaced the first in the transformer's lookup table,
+	// leading to surprising type resolution at unrelated call sites.
+	CodeTypeAliasRedeclared ErrorCode = "GALA-E0028"
+
+	// E0029: an interface lists two method specs with the same name. The
+	// earlier method metadata was silently overwritten by the later one,
+	// which could mask a parameter-list or return-type mismatch the user
+	// intended to keep distinct (and would have hit at the Go compiler
+	// otherwise, with a less useful message).
+	CodeInterfaceMethodRedeclared ErrorCode = "GALA-E0029"
+
+	// E0030: a struct declares two fields with the same name. The earlier
+	// field type was silently overwritten by the later one, and the
+	// `FieldNames` slice would contain the name twice — producing invalid
+	// Go output. Rejecting at the analyzer keeps the error close to the
+	// source.
+	CodeStructFieldRedeclared ErrorCode = "GALA-E0030"
+
+	// E0031: a sealed type lists two `case` variants with the same name.
+	// The earlier variant's companion type, Apply/Unapply, and isXxx
+	// methods would all be overwritten by the later variant, so only one
+	// remained reachable — silent loss of code the user wrote.
+	CodeSealedVariantCaseRedeclared ErrorCode = "GALA-E0031"
+
+	// E0032: two dot-imported packages export the same identifier. Go
+	// would reject the resulting generated code with "redeclared in this
+	// block"; surfacing the collision at the GALA level lets the user
+	// resolve it by qualifying or aliasing one import. Previously this
+	// case was reported as an uncoded semantic error.
+	CodeDotImportCollision ErrorCode = "GALA-E0032"
 )
 
 // MultiError collects multiple GALA errors.

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -777,6 +777,21 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 				for _, field := range structType.AllStructField() {
 					fctx := field.(*grammar.StructFieldContext)
 					fieldName := fctx.Identifier().GetText()
+					// Reject duplicate field names within a single struct
+					// declaration. Without this, the second declaration
+					// silently overwrote the first in the Fields map and
+					// duplicated the name in FieldNames, producing invalid
+					// Go output. This guard is scoped to one parse of one
+					// struct (Fields was cleared on re-analysis at line ~740),
+					// so it does not need an existing.DefinedIn check.
+					if _, exists := meta.Fields[fieldName]; exists {
+						return nil, galaerr.NewCodedSemanticError(
+							galaerr.CodeStructFieldRedeclared,
+							fctx.Identifier().GetStart().GetLine(), fctx.Identifier().GetStart().GetColumn(),
+							fmt.Sprintf("field %q already declared in struct %q", fieldName, typeName),
+							"rename or remove the duplicate field",
+						)
+					}
 					meta.Fields[fieldName] = a.resolveTypeWithParams(fctx.Type_().GetText(), pkgName, meta.TypeParams)
 					meta.FieldNames = append(meta.FieldNames, fieldName)
 					meta.ImmutFlags = append(meta.ImmutFlags, fctx.VAR() == nil)
@@ -791,9 +806,24 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 			// Extract interface method signatures as type methods
 			if ctx.InterfaceType() != nil {
 				ifaceType := ctx.InterfaceType().(*grammar.InterfaceTypeContext)
+				// seenSpecs is a per-declaration dedup so re-analysis (which
+				// preserves the Methods map across calls) does not falsely
+				// trigger the redeclaration check on already-registered
+				// specs. Within ONE iteration of AllMethodSpec() we still
+				// catch genuine duplicates.
+				seenSpecs := make(map[string]bool)
 				for _, ms := range ifaceType.AllMethodSpec() {
 					msCtx := ms.(*grammar.MethodSpecContext)
 					methodName := msCtx.Identifier().GetText()
+					if seenSpecs[methodName] {
+						return nil, galaerr.NewCodedSemanticError(
+							galaerr.CodeInterfaceMethodRedeclared,
+							msCtx.Identifier().GetStart().GetLine(), msCtx.Identifier().GetStart().GetColumn(),
+							fmt.Sprintf("method %q already declared in interface %q", methodName, typeName),
+							"rename or remove the duplicate method",
+						)
+					}
+					seenSpecs[methodName] = true
 					methodMeta := &transpiler.MethodMetadata{
 						Name:      methodName,
 						Package:   pkgName,
@@ -898,6 +928,17 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 					for _, param := range paramsCtx.ParameterList().(*grammar.ParameterListContext).AllParameter() {
 						pctx := param.(*grammar.ParameterContext)
 						fieldName := pctx.Identifier().GetText()
+						// Reject duplicate field names within a shorthand
+						// struct declaration. Fields was cleared above on
+						// re-analysis, so this check is scoped to one parse.
+						if _, exists := meta.Fields[fieldName]; exists {
+							return nil, galaerr.NewCodedSemanticError(
+								galaerr.CodeStructFieldRedeclared,
+								pctx.Identifier().GetStart().GetLine(), pctx.Identifier().GetStart().GetColumn(),
+								fmt.Sprintf("field %q already declared in struct %q", fieldName, typeName),
+								"rename or remove the duplicate field",
+							)
+						}
 						fieldType := ""
 						if pctx.Type_() != nil {
 							fieldType = pctx.Type_().GetText()
@@ -937,7 +978,9 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 					"remove the duplicate declaration or rename one of the types",
 				)
 			}
-			a.analyzeSealedType(ctx, pkgName, richAST)
+			if err := a.analyzeSealedType(ctx, pkgName, richAST); err != nil {
+				return nil, err
+			}
 			if meta, ok := richAST.Types[fullSealedName]; ok {
 				meta.DefinedIn = filePath
 				for _, v := range meta.SealedVariants {
@@ -1174,6 +1217,23 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 				// Validate default parameter rules
 				if err := validateDefaultParams(funcMeta, ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(), filePath); err != nil {
 					return nil, err
+				}
+				// Reject redeclaration of a top-level function within the same
+				// package. The sibling-metadata pass may have already registered
+				// the function from another file; if it lives in a different
+				// file, that's a true redeclaration (mirrors Go's "redeclared
+				// in this block"). Skip when the existing entry is empty
+				// (placeholder / cache) or refers to this same file
+				// (re-analysis of the same source).
+				if existing, ok := richAST.Functions[fullFuncName]; ok {
+					if existing.DefinedIn != "" && !(existing.DefinedIn != filePath && isSameFile(existing.DefinedIn, absFilePath)) {
+						return nil, galaerr.NewCodedSemanticError(
+							galaerr.CodeFunctionRedeclared,
+							ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+							fmt.Sprintf("function %q in package %q redeclared (first defined in %s)", funcName, pkgName, existing.DefinedIn),
+							"remove the duplicate declaration or rename one of the functions",
+						)
+					}
 				}
 				richAST.Functions[fullFuncName] = funcMeta
 			}
@@ -1467,7 +1527,9 @@ func countErrors(warnings []ValidationWarning) int {
 // analyzeSealedType registers metadata for a sealed type declaration.
 // It creates the parent type (with all variant fields merged + _variant),
 // companion types for each case, and Apply/Unapply/IsXxx methods.
-func (a *galaAnalyzer) analyzeSealedType(ctx *grammar.SealedTypeDeclarationContext, pkgName string, richAST *transpiler.RichAST) {
+// Returns a non-nil error if the declaration is rejected (e.g. duplicate
+// variant case names within the same sealed type).
+func (a *galaAnalyzer) analyzeSealedType(ctx *grammar.SealedTypeDeclarationContext, pkgName string, richAST *transpiler.RichAST) error {
 	typeName := ctx.Identifier().GetText()
 
 	fullTypeName := typeName
@@ -1515,6 +1577,21 @@ func (a *galaAnalyzer) analyzeSealedType(ctx *grammar.SealedTypeDeclarationConte
 	for _, caseCtx := range ctx.AllSealedCase() {
 		sc := caseCtx.(*grammar.SealedCaseContext)
 		variantName := sc.Identifier().GetText()
+		// Reject duplicate sealed-variant case names within a single sealed
+		// type declaration. Without this guard the second variant's
+		// companion type and Apply/Unapply/isXxx methods would be silently
+		// overwritten by the later case, dropping reachable code. Scoped to
+		// one parse of one sealed type, so no re-analysis guard is needed.
+		for _, existing := range variants {
+			if existing.name == variantName {
+				return galaerr.NewCodedSemanticError(
+					galaerr.CodeSealedVariantCaseRedeclared,
+					sc.Identifier().GetStart().GetLine(), sc.Identifier().GetStart().GetColumn(),
+					fmt.Sprintf("sealed case %q already declared in sealed type %q", variantName, typeName),
+					"rename or remove the duplicate case",
+				)
+			}
+		}
 		vi := variantInfo{
 			name: variantName,
 			pos:  transpiler.PosFromToken(sc.Identifier().GetStart()),
@@ -1701,6 +1778,7 @@ func (a *galaAnalyzer) analyzeSealedType(ctx *grammar.SealedTypeDeclarationConte
 			ReturnType: transpiler.BasicType{Name: "bool"},
 		}
 	}
+	return nil
 }
 
 // discoverCompanionObjects identifies types that can be used as pattern extractors.
@@ -3334,7 +3412,9 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 					continue
 				}
 			}
-			a.analyzeSealedType(ctx, pkgName, richAST)
+			if err := a.analyzeSealedType(ctx, pkgName, richAST); err != nil {
+				return err
+			}
 			// Set DefinedIn on the parent and all companion variants (only when empty).
 			if meta, ok := richAST.Types[fullTypeName]; ok {
 				if meta.DefinedIn == "" {

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -1190,6 +1190,24 @@ func (t *galaASTTransformer) transformTypeDeclaration(ctx *grammar.TypeDeclarati
 		// (e.g., Handler -> func(string) Future[string])
 		if targetType != nil {
 			if underlyingType := t.astTypeToTranspilerType(targetType); !underlyingType.IsNil() {
+				// Reject duplicate alias names. The map is seeded from
+				// sibling files at Transform() entry, so this catches
+				// both within-file dups and cross-file dups in the same
+				// package. Without the guard the second alias silently
+				// replaced the first in t.typeAliases.
+				if _, exists := t.typeAliases[name]; exists {
+					line, col := 0, 0
+					if ctx.Identifier() != nil && ctx.Identifier().GetStart() != nil {
+						line = ctx.Identifier().GetStart().GetLine()
+						col = ctx.Identifier().GetStart().GetColumn()
+					}
+					return nil, galaerr.NewCodedSemanticError(
+						galaerr.CodeTypeAliasRedeclared,
+						line, col,
+						fmt.Sprintf("type alias %q already declared in package %q", name, t.packageName),
+						"remove the duplicate declaration or rename one of the aliases",
+					)
+				}
 				t.typeAliases[name] = underlyingType
 			}
 		}

--- a/internal/transpiler/transformer/dot_import_test.go
+++ b/internal/transpiler/transformer/dot_import_test.go
@@ -118,6 +118,10 @@ func test() int {
 	assert.Contains(t, transpileErr.Error(), "Greet")
 	assert.Contains(t, transpileErr.Error(), "pkg_a")
 	assert.Contains(t, transpileErr.Error(), "pkg_b")
+	// Should carry the stable error code GALA-E0032 so tools and tests
+	// can pin against the kind of collision rather than the message text.
+	assert.Contains(t, transpileErr.Error(), "GALA-E0032",
+		"dot-import collision must surface as a coded error")
 }
 
 // TestDotImportVarReExportClash checks that when a Go package re-exports

--- a/internal/transpiler/transformer/error_codes_test.go
+++ b/internal/transpiler/transformer/error_codes_test.go
@@ -248,6 +248,92 @@ func main() {
 			expectCode:     galaerr.CodeEmptyParenExpression,
 			expectContains: "empty parenthesized expression",
 		},
+		{
+			// Two top-level functions with the same name in one file must
+			// surface as a redeclaration error rather than silently keeping
+			// only the second definition.
+			name: "GALA-E0027 function redeclared",
+			input: `package main
+
+func greet(name string) string = "hello " + name
+func greet(other string) string = "hi " + other
+
+func main() {
+    Println(greet("world"))
+}`,
+			expectCode:     galaerr.CodeFunctionRedeclared,
+			expectContains: `function "greet"`,
+		},
+		{
+			// Two `type Foo = Bar` aliases with the same name silently
+			// overwrote one another in the transformer; now rejected.
+			name: "GALA-E0028 type alias redeclared",
+			input: `package main
+
+type Handler = func(string) string
+type Handler = func(int) int
+
+func main() {
+    Println("unused")
+}`,
+			expectCode:     galaerr.CodeTypeAliasRedeclared,
+			expectContains: `type alias "Handler"`,
+		},
+		{
+			// Two method specs with the same name within one interface
+			// are now rejected. The grammar accepts the form but Go would
+			// only see the second.
+			name: "GALA-E0029 interface method redeclared",
+			input: `package main
+
+type Repo interface {
+    Find(id int) string
+    Find(name string) string
+}
+
+func main() {
+    Println("unused")
+}`,
+			expectCode:     galaerr.CodeInterfaceMethodRedeclared,
+			expectContains: `method "Find"`,
+		},
+		{
+			// Two struct fields with the same name now rejected; previously
+			// the second silently overwrote the first in metadata.
+			name: "GALA-E0030 struct field redeclared",
+			input: `package main
+
+type Point struct {
+    val x int
+    val x int
+}
+
+func main() {
+    val p = Point(x = 1)
+    Println(p.x)
+}`,
+			expectCode:     galaerr.CodeStructFieldRedeclared,
+			expectContains: `field "x"`,
+		},
+		{
+			// Two sealed cases sharing a name now rejected. Without this
+			// guard the second case overwrote the first's companion type
+			// and methods.
+			name: "GALA-E0031 sealed variant case redeclared",
+			input: `package main
+
+sealed type Shape {
+    case Box(W int)
+    case Box(H int)
+}
+
+func main() {
+    val b = Box(1)
+    Println(b)
+}`,
+			expectCode:     galaerr.CodeSealedVariantCaseRedeclared,
+			expectContains: `sealed case "Box"`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/transpiler/transformer/imports.go
+++ b/internal/transpiler/transformer/imports.go
@@ -513,7 +513,11 @@ func (m *ImportManager) ValidateDotImports(richAST *transpiler.RichAST, line, co
 			"\n(Some stdlib packages intentionally re-export names from another package as a convenience facade —" +
 			" e.g. `concurrent` re-exports `go_interop`'s execution-context helpers — so dot-importing both is never" +
 			" meaningful. Pick the facade you want.)"
-		return galaerr.NewSemanticErrorAt(line, col, msg)
+		return galaerr.NewCodedSemanticError(
+			galaerr.CodeDotImportCollision,
+			line, col, msg,
+			"qualify or alias one of the dot-imports to disambiguate",
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Closes the remaining redeclaration-enforcement gaps the audit surfaced. GALA already rejected duplicate **struct/sealed types** (GALA-E0011) and duplicate **methods on types** (GALA-E0012). Five other object kinds were silently overwritten by `map[name] = newValue` assignments with no `if _, exists := m[name]` guard. The existing dot-import collision detector caught its case but emitted an uncoded error.

## New error codes

| Code | Kind |
|------|------|
| `GALA-E0027` | Top-level function redeclared |
| `GALA-E0028` | Type alias redeclared |
| `GALA-E0029` | Interface method redeclared (within one interface) |
| `GALA-E0030` | Struct field redeclared (within one struct) |
| `GALA-E0031` | Sealed variant case redeclared (within one sealed type) |
| `GALA-E0032` | Dot-import name collision |

## Changes

- **`galaerr/errors.go`** — register the six new codes alongside the existing redeclaration codes.
- **`internal/transpiler/analyzer/analyzer.go`** — guards at:
  - `richAST.Functions[fullFuncName]` (top-level function) with `existing.DefinedIn` + `isSameFile` re-analysis guard, same shape as E0011's struct-type check.
  - `analyzeSealedType` variant-name dedup loop (within one sealed). Function signature gains `error` return; both callers updated.
  - `meta.Fields[fieldName]` for both the long-form `struct { ... }` extractor and the shorthand `case Foo(...)`-style struct field path. `Fields`/`FieldNames`/`ImmutFlags`/`FieldPositions` stay clean if the guard fires.
  - `meta.Methods[methodName]` inside interface method-spec extraction, using a local `seenSpecs` set (the persistent `meta.Methods` map is also populated by a later pass, so a direct `_, exists` check there would false-positive).
- **`internal/transpiler/transformer/declarations.go`** — guard at `t.typeAliases[name]`.
- **`internal/transpiler/transformer/imports.go`** — promote the existing dot-import collision error from uncoded to coded (`CodeDotImportCollision`); message preserved verbatim for backward compat.
- **`internal/transpiler/transformer/error_codes_test.go`** — five new entries in `TestErrorPathAssertions` exercising E0027–E0031.
- **`internal/transpiler/transformer/dot_import_test.go`** — `TestDotImportClashError` extended to assert on E0032.

## Re-analysis safety

The `existing.DefinedIn` re-analysis guard (analyzer.go's strict checks for struct types / sealed types use this to distinguish \"same declaration re-registered by an incremental pass\" from \"different declaration redeclared\") is applied to **top-level functions only** — that's the one new site whose backing map persists across `Analyze()` calls. The other four within-decl-scope checks (sealed variant cases, struct fields, interface methods) scan a freshly-populated local list/map within a single iteration of `AllSealedCase()` / `AllStructField()` / `AllMethodSpec()`, so cross-pass collision is impossible there. Type aliases similarly init fresh on every `Transform()`.

## Verification

- `bazel build //...` — green (1284 targets).
- `bazel test //...` — 345/345 pass + 6 new error-code assertions.
- No existing test relied on the silent overwrite — none had to be updated to accommodate the new strict behavior.

## Interactions

- `CodeDotImportCollision` (E0032) fires earlier (in `ImportManager.ValidateDotImports` during import-setup) than `CodeAmbiguousSealedVariant` (E0026, from PR #351 in `calls.go` during named-arg resolution). Transpilation stops on the first error, so E0032 always reaches the user first when its precondition holds — no double-emit.

## Dependencies

None — depends on master (post #351 merge).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)