### PR TITLE
feat(gazelle): GALA Gazelle language extension + gala imports helper

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,4 @@
 .claude
 .gala_team
 docs/private
+gazelle

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@gazelle//:def.bzl", "gazelle")
+load("@gazelle//:def.bzl", "gazelle", "gazelle_binary")
 
 exports_files(
     ["go.mod"],
@@ -9,6 +9,20 @@ exports_files(
 gazelle(
     name = "gazelle",
     args = [],
+)
+
+# Dogfood the in-repo GALA Gazelle extension (nested //gazelle module). The
+# binary bundles the GALA language so `bazel run //:gazelle-gala` regenerates
+# gala_library / gala_binary / gala_test targets from .gala sources.
+gazelle_binary(
+    name = "gazelle_gala_bin",
+    languages = ["@gala_gazelle//gala"],
+)
+
+# gazelle:gala_prefix martianoff/gala
+gazelle(
+    name = "gazelle-gala",
+    gazelle = ":gazelle_gala_bin",
 )
 
 # gazelle:prefix martianoff/gala

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -53,6 +53,17 @@ local_path_override(
     path = "bazel_test_fixtures/external_gala_module",
 )
 
+# GALA's own Gazelle language extension, kept as a nested Bazel module under
+# //gazelle (excluded from this module's package graph via .bazelignore).
+# Routing it through bazel_dep + local_path_override lets the root build a
+# gazelle_binary that bundles "@gala_gazelle//gala" so we can dogfood it. This
+# is the same standalone-module shape an external consumer would use.
+bazel_dep(name = "gala_gazelle", version = "0.1.0", dev_dependency = True)
+local_path_override(
+    module_name = "gala_gazelle",
+    path = "gazelle",
+)
+
 # ANTLR tool jar (not in BCR, loaded via use_repo_rule)
 http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
 

--- a/cmd/gala/commands/BUILD.bazel
+++ b/cmd/gala/commands/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "build.go",
         "cache.go",
         "clean.go",
+        "imports.go",
         "lsp.go",
         "mod.go",
         "mod_add.go",
@@ -40,6 +41,8 @@ go_library(
         "//internal/depman/sum",
         "//internal/depman/version",
         "//internal/lsp",
+        "//internal/parser",
+        "//internal/parser/grammar",
         "//internal/transpiler",
         "//internal/transpiler/analyzer",
         "//internal/transpiler/generator",
@@ -58,6 +61,7 @@ go_library(
 go_test(
     name = "commands_test",
     srcs = [
+        "imports_test.go",
         "new_test.go",
         "project_test.go",
         "run_test.go",
@@ -65,5 +69,7 @@ go_test(
     embed = [":commands"],
     deps = [
         "@com_github_spf13_cobra//:cobra",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cmd/gala/commands/imports.go
+++ b/cmd/gala/commands/imports.go
@@ -1,0 +1,141 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"martianoff/gala/internal/parser"
+	"martianoff/gala/internal/parser/grammar"
+
+	"github.com/spf13/cobra"
+)
+
+// importInfo is a single import declaration extracted from a .gala file.
+// Field order in the JSON output preserves the source order of the imports.
+type importInfo struct {
+	Path  string `json:"path"`
+	Alias string `json:"alias"`
+	Dot   bool   `json:"dot"`
+}
+
+// fileImports is the per-file result. Package is the file's package name,
+// Imports preserves source order, and Error holds the parse error message
+// (empty when the file parsed successfully).
+type fileImports struct {
+	File    string       `json:"file"`
+	Package string       `json:"package"`
+	Imports []importInfo `json:"imports"`
+	Error   string       `json:"error"`
+}
+
+var importsJSON bool
+
+var importsCmd = &cobra.Command{
+	Use:   "imports --json <file1.gala> [file2.gala ...]",
+	Short: "Extract package name and imports from .gala files (parse-only)",
+	Long: `Extract the package name and import declarations from one or more .gala files.
+
+This is a fast, dependency-free parse: it runs only the ANTLR parser, never the
+analyzer or transpiler, so no Go SDK is required. It is intended as a helper for
+build tooling such as the Gazelle extension.
+
+Output is a JSON array, one entry per input file, with imports in source order.
+Files that fail to parse produce an entry with a non-empty "error" field and an
+empty "imports" array; processing continues and the exit code stays 0. The exit
+code is non-zero only for usage errors (no files given, or a file not found).`,
+	Args:          cobra.ArbitraryArgs,
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	RunE:          runImports,
+}
+
+func runImports(cmd *cobra.Command, args []string) error {
+	if !importsJSON {
+		return fmt.Errorf("--json is required (it is currently the only supported output format)")
+	}
+	if len(args) == 0 {
+		return fmt.Errorf("no input files given")
+	}
+
+	results := make([]fileImports, 0, len(args))
+	p := parser.NewAntlrGalaParser()
+
+	for _, file := range args {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			return fmt.Errorf("cannot read %q: %w", file, err)
+		}
+		results = append(results, extractImports(p, file, string(src)))
+	}
+
+	out, err := json.Marshal(results)
+	if err != nil {
+		return fmt.Errorf("failed to encode JSON: %w", err)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), string(out))
+	return nil
+}
+
+// extractImports parses a single file and returns its package name and imports.
+// A parse failure is reported in the Error field with an empty Imports slice.
+func extractImports(p *parser.AntlrGalaParser, file, src string) fileImports {
+	result := fileImports{
+		File:    file,
+		Imports: []importInfo{},
+	}
+
+	tree, err := p.Parse(src)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+
+	sourceFile, ok := tree.(grammar.ISourceFileContext)
+	if !ok {
+		result.Error = "unexpected parse tree type"
+		return result
+	}
+
+	if pkg := sourceFile.PackageClause(); pkg != nil {
+		if pkgCtx, ok := pkg.(*grammar.PackageClauseContext); ok {
+			if ident := pkgCtx.Identifier(); ident != nil {
+				result.Package = ident.GetText()
+			}
+		}
+	}
+
+	for _, impDecl := range sourceFile.AllImportDeclaration() {
+		ctx, ok := impDecl.(*grammar.ImportDeclarationContext)
+		if !ok {
+			continue
+		}
+		for _, spec := range ctx.AllImportSpec() {
+			s, ok := spec.(*grammar.ImportSpecContext)
+			if !ok {
+				continue
+			}
+			info := importInfo{
+				Path: strings.Trim(s.STRING().GetText(), "\""),
+			}
+			if aliasIdent := s.Identifier(); aliasIdent != nil {
+				// Named alias (e.g. import m "math"). A "." identifier is not
+				// produced here — dot imports have no Identifier child.
+				if alias := aliasIdent.GetText(); alias != "." {
+					info.Alias = alias
+				}
+			} else if s.GetChildCount() > 1 {
+				// Dot import: no identifier, but an extra child — the '.' terminal.
+				info.Dot = true
+			}
+			result.Imports = append(result.Imports, info)
+		}
+	}
+
+	return result
+}
+
+func init() {
+	importsCmd.Flags().BoolVar(&importsJSON, "json", false, "Emit JSON output (currently the only supported format)")
+}

--- a/cmd/gala/commands/imports_test.go
+++ b/cmd/gala/commands/imports_test.go
@@ -1,0 +1,235 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFixture writes content to a uniquely-named .gala file in dir and
+// returns the full path.
+func writeFixture(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestImportsExtraction(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantPkg  string
+		wantImps []importInfo
+	}{
+		{
+			name: "plain import",
+			content: `package main
+
+import "fmt"
+
+func main() {
+	Println("hi")
+}
+`,
+			wantPkg:  "main",
+			wantImps: []importInfo{{Path: "fmt", Alias: "", Dot: false}},
+		},
+		{
+			name: "aliased import",
+			content: `package main
+
+import m "math"
+
+func main() {
+	val x = m.Sqrt(4.0)
+}
+`,
+			wantPkg:  "main",
+			wantImps: []importInfo{{Path: "math", Alias: "m", Dot: false}},
+		},
+		{
+			name: "dot import",
+			content: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+	val a = ArrayOf(1, 2, 3)
+}
+`,
+			wantPkg:  "main",
+			wantImps: []importInfo{{Path: "martianoff/gala/collection_immutable", Alias: "", Dot: true}},
+		},
+		{
+			name: "grouped imports preserve order",
+			content: `package main
+
+import (
+	"fmt"
+	m "math"
+	. "martianoff/gala/collection_immutable"
+)
+
+func main() {
+	Println("hi")
+}
+`,
+			wantPkg: "main",
+			wantImps: []importInfo{
+				{Path: "fmt", Alias: "", Dot: false},
+				{Path: "math", Alias: "m", Dot: false},
+				{Path: "martianoff/gala/collection_immutable", Alias: "", Dot: true},
+			},
+		},
+		{
+			name: "library package no imports",
+			content: `package shapes
+
+func area() int = 0
+`,
+			wantPkg:  "shapes",
+			wantImps: []importInfo{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			file := writeFixture(t, dir, "input.gala", tt.content)
+
+			cmd, out := newImportsTestCmd()
+			cmd.SetArgs([]string{"--json", file})
+			require.NoError(t, cmd.Execute())
+
+			results := decodeResults(t, out.Bytes())
+			require.Len(t, results, 1)
+			assert.Equal(t, tt.wantPkg, results[0].Package)
+			assert.Equal(t, file, results[0].File)
+			assert.Empty(t, results[0].Error)
+			assert.Equal(t, tt.wantImps, results[0].Imports)
+		})
+	}
+}
+
+func TestImportsMultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	a := writeFixture(t, dir, "a.gala", `package main
+
+import "fmt"
+
+func main() {
+	Println("a")
+}
+`)
+	b := writeFixture(t, dir, "b.gala", `package lib
+
+import m "math"
+
+func sq(x float64) float64 = m.Sqrt(x)
+`)
+
+	cmd, out := newImportsTestCmd()
+	cmd.SetArgs([]string{"--json", a, b})
+	require.NoError(t, cmd.Execute())
+
+	results := decodeResults(t, out.Bytes())
+	require.Len(t, results, 2)
+
+	assert.Equal(t, a, results[0].File)
+	assert.Equal(t, "main", results[0].Package)
+	assert.Equal(t, []importInfo{{Path: "fmt"}}, results[0].Imports)
+
+	assert.Equal(t, b, results[1].File)
+	assert.Equal(t, "lib", results[1].Package)
+	assert.Equal(t, []importInfo{{Path: "math", Alias: "m"}}, results[1].Imports)
+}
+
+func TestImportsParseErrorMixedWithGood(t *testing.T) {
+	dir := t.TempDir()
+	good := writeFixture(t, dir, "good.gala", `package main
+
+import "fmt"
+
+func main() {
+	Println("ok")
+}
+`)
+	// Missing the required empty line after the package clause and a broken
+	// body — guaranteed to fail the parser.
+	bad := writeFixture(t, dir, "bad.gala", `package main
+func main( {
+`)
+
+	cmd, out := newImportsTestCmd()
+	cmd.SetArgs([]string{"--json", good, bad})
+	// Parse failures must NOT fail the command.
+	require.NoError(t, cmd.Execute())
+
+	results := decodeResults(t, out.Bytes())
+	require.Len(t, results, 2)
+
+	assert.Equal(t, "main", results[0].Package)
+	assert.Empty(t, results[0].Error)
+	assert.Equal(t, []importInfo{{Path: "fmt"}}, results[0].Imports)
+
+	// The bad file reports an error, an empty imports array, and is still present.
+	assert.Equal(t, bad, results[1].File)
+	assert.NotEmpty(t, results[1].Error)
+	assert.Equal(t, []importInfo{}, results[1].Imports)
+}
+
+func TestImportsUsageErrors(t *testing.T) {
+	t.Run("no files", func(t *testing.T) {
+		cmd, _ := newImportsTestCmd()
+		cmd.SetArgs([]string{"--json"})
+		assert.Error(t, cmd.Execute())
+	})
+
+	t.Run("missing --json flag", func(t *testing.T) {
+		dir := t.TempDir()
+		file := writeFixture(t, dir, "x.gala", "package main\n")
+		cmd, _ := newImportsTestCmd()
+		cmd.SetArgs([]string{file})
+		assert.Error(t, cmd.Execute())
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		cmd, _ := newImportsTestCmd()
+		cmd.SetArgs([]string{"--json", filepath.Join(t.TempDir(), "nope.gala")})
+		assert.Error(t, cmd.Execute())
+	})
+}
+
+// newImportsTestCmd builds a fresh imports command with its own --json flag and
+// captured stdout, isolated from package-global flag state.
+func newImportsTestCmd() (*cobra.Command, *bytes.Buffer) {
+	var jsonFlag bool
+	out := &bytes.Buffer{}
+	cmd := &cobra.Command{
+		Use:           importsCmd.Use,
+		Args:          importsCmd.Args,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(c *cobra.Command, args []string) error {
+			importsJSON = jsonFlag
+			return runImports(c, args)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonFlag, "json", false, "")
+	cmd.SetOut(out)
+	return cmd, out
+}
+
+func decodeResults(t *testing.T, data []byte) []fileImports {
+	t.Helper()
+	var results []fileImports
+	require.NoError(t, json.Unmarshal(data, &results))
+	return results
+}

--- a/cmd/gala/commands/root.go
+++ b/cmd/gala/commands/root.go
@@ -92,6 +92,7 @@ func init() {
 	// Add subcommands
 	rootCmd.AddCommand(transpileCmd)
 	rootCmd.AddCommand(transpilePackageCmd)
+	rootCmd.AddCommand(importsCmd)
 	rootCmd.AddCommand(modCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(buildCmd)

--- a/gazelle/.gitignore
+++ b/gazelle/.gitignore
@@ -1,0 +1,2 @@
+/bazel-*
+/bazel-gazelle

--- a/gazelle/BUILD.bazel
+++ b/gazelle/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@gazelle//:def.bzl", "gazelle_binary")
+
+# Standalone gazelle binary bundling the GALA language extension. Consumers
+# normally declare their own gazelle_binary listing "@gala_gazelle//gala"
+# among `languages`; this one lets the module dogfood and test itself.
+gazelle_binary(
+    name = "gazelle_gala",
+    languages = [
+        "@gazelle//language/go",
+        "@gazelle//language/proto",
+        "//gala",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+exports_files([
+    "go.mod",
+    "go.sum",
+])

--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -1,0 +1,20 @@
+"""gala_gazelle — a Gazelle language extension for GALA.
+
+Distribution model 2 (standalone module): consumers add this module via
+`bazel_dep(name = "gala_gazelle", version = ...)`, then build a gazelle_binary
+that lists "@gala_gazelle//gala" among its `languages`. See README.md.
+"""
+
+module(
+    name = "gala_gazelle",
+    version = "0.1.0",
+)
+
+bazel_dep(name = "gazelle", version = "0.47.0")
+bazel_dep(name = "rules_go", version = "0.59.0")
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.25.5")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")

--- a/gazelle/MODULE.bazel.lock
+++ b/gazelle/MODULE.bazel.lock
@@ -1,0 +1,249 @@
+{
+  "lockFileVersion": 16,
+  "registryFileHashes": {
+    "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
+    "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
+    "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/MODULE.bazel": "70390338f7a5106231d20620712f7cccb659cd0e9d073d1991c038eb9fc57589",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230125.1/MODULE.bazel": "89047429cb0207707b2dface14ba7f8df85273d484c2572755be4bab7ce9c3a0",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0.bcr.1/MODULE.bazel": "1c8cec495288dccd14fdae6e3f95f772c1c91857047a098fad772034264cc8cb",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
+    "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
+    "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
+    "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
+    "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
+    "https://bcr.bazel.build/modules/bazel_features/1.28.0/source.json": "16a3fc5b4483cb307643791f5a4b7365fa98d2e70da7c378cdbde55f0c0b32cf",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.1/MODULE.bazel": "a0dcb779424be33100dcae821e9e27e4f2901d9dfd5333efe5ac6a8d7ab75e1d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.2/MODULE.bazel": "3bd40978e7a1fac911d5989e6b09d8f64921865a45822d8b09e815eaa726a651",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.5.0/MODULE.bazel": "32880f5e2945ce6a03d1fbd588e9198c0a959bb42297b2cfaf1685b7bc32e138",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
+    "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",
+    "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
+    "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
+    "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
+    "https://bcr.bazel.build/modules/gazelle/0.47.0/MODULE.bazel": "b61bb007c4efad134aa30ee7f4a8e2a39b22aa5685f005edaa022fbd1de43ebc",
+    "https://bcr.bazel.build/modules/gazelle/0.47.0/source.json": "aeb2e5df14b7fb298625d75d08b9c65bdb0b56014c5eb89da9e5dd0572280ae6",
+    "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
+    "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/source.json": "41e9e129f80d8c8bf103a7acc337b76e54fad1214ac0a7084bf24f4cd924b8b4",
+    "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
+    "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.5/MODULE.bazel": "ef4f9439e3270fdd6b9fd4dbc3d2f29d13888e44c529a1b243f7a31dfbc2e8e4",
+    "https://bcr.bazel.build/modules/package_metadata/0.0.5/source.json": "2326db2f6592578177751c3e1f74786b79382cd6008834c9d01ec865b9126a85",
+    "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
+    "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
+    "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
+    "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
+    "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
+    "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
+    "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
+    "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
+    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2.bcr.1/MODULE.bazel": "52f4126f63a2f0bbf36b99c2a87648f08467a4eaf92ba726bc7d6a500bbf770c",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
+    "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
+    "https://bcr.bazel.build/modules/protobuf/29.0/source.json": "b857f93c796750eef95f0d61ee378f3420d00ee1dd38627b27193aa482f4f981",
+    "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
+    "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/source.json": "be4789e951dd5301282729fe3d4938995dc4c1a81c2ff150afc9f1b0504c6022",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/source.json": "e044ce89c2883cd957a2969a43e79f7752f9656f6b20050b62f90ede21ec6eb4",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.5/source.json": "4bb4fed7f5499775d495739f785a5494a1f854645fa1bac5de131264f5acdf01",
+    "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
+    "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
+    "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
+    "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
+    "https://bcr.bazel.build/modules/rules_go/0.53.0/MODULE.bazel": "a4ed760d3ac0dbc0d7b967631a9a3fd9100d28f7d9fcf214b4df87d4bfff5f9a",
+    "https://bcr.bazel.build/modules/rules_go/0.59.0/MODULE.bazel": "b7e43e7414a3139a7547d1b4909b29085fbe5182b6c58cbe1ed4c6272815aeae",
+    "https://bcr.bazel.build/modules/rules_go/0.59.0/source.json": "1df17bb7865cfc029492c30163cee891d0dd8658ea0d5bfdf252c4b6db5c1ef6",
+    "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
+    "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
+    "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
+    "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
+    "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
+    "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
+    "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
+    "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
+    "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/source.json": "f18d9ad3c4c54945bf422ad584fa6c5ca5b3116ff55a5b1bc77e5c1210be5960",
+    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
+    "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
+    "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
+    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
+    "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
+    "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0/MODULE.bazel": "b531d7f09f58dce456cd61b4579ce8c86b38544da75184eadaf0a7cb7966453f",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
+    "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
+    "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
+    "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
+    "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
+    "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
+    "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/source.json": "939d4bd2e3110f27bfb360292986bb79fd8dcefb874358ccd6cdaa7bda029320",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/source.json": "c55ed591aa5009401ddf80ded9762ac32c358d2517ee7820be981e2de9756cf3",
+    "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
+    "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
+    "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
+    "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/source.json": "b6500ffcd7b48cd72c29bb67bcac781e12701cc0d6d55d266a652583cfcdab01",
+    "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
+    "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
+    "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d",
+    "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
+  },
+  "selectedYankedVersions": {},
+  "moduleExtensions": {
+    "@@rules_java+//java:rules_java_deps.bzl%compatibility_proxy": {
+      "general": {
+        "bzlTransitiveDigest": "84xJEZ1jnXXwo8BXMprvBm++rRt4jsTu9liBxz0ivps=",
+        "usagesDigest": "jTQDdLDxsS43zuRmg1faAjIEPWdLAbDAowI1pInQSoo=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "compatibility_proxy": {
+            "repoRuleId": "@@rules_java+//java:rules_java_deps.bzl%_compatibility_proxy_repo_rule",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_java+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
+      "general": {
+        "bzlTransitiveDigest": "sFhcgPbDQehmbD1EOXzX4H1q/CD5df8zwG4kp4jbvr8=",
+        "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_jetbrains_kotlin_git": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
+              ],
+              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
+            }
+          },
+          "com_github_jetbrains_kotlin": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_capabilities_repository",
+            "attributes": {
+              "git_repository_name": "com_github_jetbrains_kotlin_git",
+              "compiler_version": "1.9.23"
+            }
+          },
+          "com_github_google_ksp": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:ksp.bzl%ksp_compiler_plugin_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
+              ],
+              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
+              "strip_version": "1.9.23-1.0.20"
+            }
+          },
+          "com_github_pinterest_ktlint": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
+              "urls": [
+                "https://github.com/pinterest/ktlint/releases/download/1.3.0/ktlint"
+              ],
+              "executable": true
+            }
+          },
+          "rules_android": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+              "strip_prefix": "rules_android-0.1.1",
+              "urls": [
+                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_kotlin+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/gazelle/README.md
+++ b/gazelle/README.md
@@ -1,0 +1,115 @@
+# gala_gazelle — a Gazelle extension for GALA
+
+`gala_gazelle` teaches [Gazelle](https://github.com/bazelbuild/bazel-gazelle)
+to generate and maintain BUILD targets for [GALA](https://github.com/martianoff/gala)
+source. It manages `gala_library`, `gala_binary`, `gala_test`, and
+`gala_exec_test` rules (loaded from `@rules_gala//gala:defs.bzl`) and resolves
+GALA `import` strings to Bazel labels.
+
+Import extraction is delegated to a small helper binary — `gala imports --json`
+— instead of re-implementing the ANTLR grammar, mirroring the helper model used
+by the rules_python Gazelle plugin.
+
+## Adding the extension (consumer setup)
+
+This is a standalone Bazel module. In your `MODULE.bazel`:
+
+```starlark
+bazel_dep(name = "gala_gazelle", version = "0.1.0")
+```
+
+Then build a `gazelle_binary` that bundles the GALA language alongside any
+others you use, and an invocation target, in a `BUILD.bazel`:
+
+```starlark
+load("@gazelle//:def.bzl", "gazelle", "gazelle_binary")
+
+gazelle_binary(
+    name = "gazelle_bin",
+    languages = [
+        "@gazelle//language/go",      # optional: keep Go support
+        "@gala_gazelle//gala",        # GALA support
+    ],
+)
+
+# gazelle:gala_prefix github.com/you/project
+gazelle(
+    name = "gazelle",
+    gazelle = ":gazelle_bin",
+)
+```
+
+Run it with `bazel run //:gazelle`.
+
+The helper binary must be discoverable. By default the extension shells out to
+`gala` on `PATH`; override with the `-gala_helper` flag or the
+`# gazelle:gala_helper` directive (see below).
+
+## What it generates
+
+Per directory containing `.gala` files:
+
+- **`gala_library`** for the non-test sources, with `importpath` derived from
+  the configured prefix plus the directory's repo-relative path, and
+  `visibility = ["//visibility:public"]`.
+- **`gala_binary`** instead of a library when a source declares `package main`
+  and defines a zero-argument `main()`.
+- **`gala_test`** for the directory's `*_test.gala` files.
+
+`srcs` are sorted; `deps` are resolved from each file's GALA imports.
+
+## Dependency resolution
+
+For every GALA import in a rule's sources:
+
+- **In-repo packages** (under the `gala_prefix`) resolve to in-repo labels —
+  preferring an indexed `gala_library` with a matching `importpath`, otherwise
+  `//<relpath>`.
+- **GALA stdlib / external packages** (under `gala_stdlib_prefix`, default
+  `martianoff/gala`) resolve to the matching in-repo package if one exists, and
+  otherwise to `@<gala_stdlib_repo>//<relpath>` (default repo `gala`).
+- **Go stdlib and other non-GALA imports** (`fmt`, `strings`, …) are skipped.
+- **Macro-injected deps** (`martianoff/gala/std`, `martianoff/gala/test`) are
+  skipped — the `gala_*` macros add them automatically, so emitting them in
+  `deps` would be redundant.
+
+## Directives
+
+| Directive | Default | Meaning |
+|-----------|---------|---------|
+| `# gazelle:gala_prefix <path>` | `martianoff/gala` | Import-path prefix for in-repo packages. |
+| `# gazelle:gala_helper <path>` | `gala` | Path to the import-extraction helper binary. |
+| `# gazelle:gala_stdlib_prefix <path>` | `martianoff/gala` | Import namespace of the GALA standard library. |
+| `# gazelle:gala_stdlib_repo <name>` | `gala` | Bazel external repo for out-of-repo stdlib imports. |
+| `# gazelle:gala_implicit_dep <paths…>` | `martianoff/gala/std martianoff/gala/test` | Space-separated import paths the macros inject automatically (excluded from `deps`). `none` clears the set. |
+
+Flags `-gala_prefix` and `-gala_helper` mirror the first two directives.
+
+## Helper contract
+
+The extension invokes `<helper> imports --json <files…>` (working directory =
+the package directory) and parses a JSON array:
+
+```json
+[
+  {
+    "file": "a.gala",
+    "package": "main",
+    "imports": [{"path": "fmt", "alias": "", "dot": false}],
+    "error": ""
+  }
+]
+```
+
+Entries with a non-empty `"error"` are skipped (the helper could not parse that
+file).
+
+## Development
+
+```sh
+cd gazelle
+go test ./...      # unit tests (testdata-driven Generate + Resolve)
+```
+
+Unit tests inject a fake helper that emits the JSON contract directly, so they
+run without an installed `gala` binary.

--- a/gazelle/cmd/galaimports/BUILD.bazel
+++ b/gazelle/cmd/galaimports/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "galaimports_lib",
+    srcs = ["main.go"],
+    importpath = "martianoff/gala/gazelle/cmd/galaimports",
+    visibility = ["//visibility:private"],
+)
+
+# A lightweight stand-in for `gala imports --json` used to develop and dogfood
+# the extension before the production subcommand ships.
+go_binary(
+    name = "galaimports",
+    embed = [":galaimports_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "galaimports_test",
+    srcs = ["main_test.go"],
+    embed = [":galaimports_lib"],
+)

--- a/gazelle/cmd/galaimports/main.go
+++ b/gazelle/cmd/galaimports/main.go
@@ -1,0 +1,127 @@
+// Command galaimports is a lightweight stand-in for `gala imports --json`.
+//
+// It implements the helper contract the Gazelle extension depends on, scanning
+// each .gala file for its package declaration and import block with simple
+// line parsing (no grammar). It exists so the extension can be developed and
+// dogfooded before the production `gala imports` subcommand ships; the real
+// producer (owned by the transpiler) should emit the identical JSON shape.
+//
+// Usage:
+//
+//	galaimports imports --json <file.gala> [<file.gala> ...]
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type rawImport struct {
+	Path  string `json:"path"`
+	Alias string `json:"alias"`
+	Dot   bool   `json:"dot"`
+}
+
+type rawFile struct {
+	File    string      `json:"file"`
+	Package string      `json:"package"`
+	Imports []rawImport `json:"imports"`
+	Error   string      `json:"error"`
+}
+
+var (
+	packageRe = regexp.MustCompile(`^\s*package\s+([A-Za-z_][A-Za-z0-9_]*)`)
+	// A single-line import: optional alias / dot, then a quoted path. The alias
+	// or dot may be separated from the path by whitespace.
+	importLineRe = regexp.MustCompile(`^\s*(?:(\.)|([A-Za-z_][A-Za-z0-9_]*))?\s*"([^"]+)"`)
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) < 1 || args[0] != "imports" {
+		fmt.Fprintln(os.Stderr, "usage: galaimports imports --json <files...>")
+		os.Exit(2)
+	}
+	args = args[1:]
+	// Tolerate the --json flag in any position.
+	files := make([]string, 0, len(args))
+	for _, a := range args {
+		if a == "--json" || a == "-json" {
+			continue
+		}
+		files = append(files, a)
+	}
+
+	out := make([]rawFile, 0, len(files))
+	for _, f := range files {
+		out = append(out, scanFile(f))
+	}
+	enc := json.NewEncoder(os.Stdout)
+	if err := enc.Encode(out); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func scanFile(path string) rawFile {
+	rf := rawFile{File: path}
+	file, err := os.Open(path)
+	if err != nil {
+		rf.Error = err.Error()
+		return rf
+	}
+	defer file.Close()
+
+	sc := bufio.NewScanner(file)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	inBlock := false
+	for sc.Scan() {
+		line := sc.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		if rf.Package == "" {
+			if m := packageRe.FindStringSubmatch(line); m != nil {
+				rf.Package = m[1]
+				continue
+			}
+		}
+		switch {
+		case inBlock:
+			if trimmed == ")" {
+				inBlock = false
+				continue
+			}
+			if imp, ok := parseImport(line); ok {
+				rf.Imports = append(rf.Imports, imp)
+			}
+		case strings.HasPrefix(trimmed, "import ("):
+			inBlock = true
+		case strings.HasPrefix(trimmed, "import "):
+			if imp, ok := parseImport(strings.TrimPrefix(trimmed, "import")); ok {
+				rf.Imports = append(rf.Imports, imp)
+			}
+		}
+	}
+	if err := sc.Err(); err != nil {
+		rf.Error = err.Error()
+	}
+	return rf
+}
+
+func parseImport(line string) (rawImport, bool) {
+	m := importLineRe.FindStringSubmatch(line)
+	if m == nil {
+		return rawImport{}, false
+	}
+	return rawImport{
+		Path:  m[3],
+		Alias: m[2],
+		Dot:   m[1] == ".",
+	}, true
+}

--- a/gazelle/cmd/galaimports/main_test.go
+++ b/gazelle/cmd/galaimports/main_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestScanFile(t *testing.T) {
+	dir := t.TempDir()
+	src := `package regex
+
+import (
+    "regexp"
+    . "martianoff/gala/std"
+    m "math"
+    "martianoff/gala/go_interop"
+)
+
+type Regex struct {}
+`
+	path := filepath.Join(dir, "regex.gala")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rf := scanFile(path)
+	if rf.Error != "" {
+		t.Fatalf("unexpected error: %s", rf.Error)
+	}
+	if rf.Package != "regex" {
+		t.Errorf("package = %q, want regex", rf.Package)
+	}
+	want := []rawImport{
+		{Path: "regexp"},
+		{Path: "martianoff/gala/std", Dot: true},
+		{Path: "math", Alias: "m"},
+		{Path: "martianoff/gala/go_interop"},
+	}
+	if !reflect.DeepEqual(rf.Imports, want) {
+		t.Errorf("imports = %+v, want %+v", rf.Imports, want)
+	}
+}
+
+func TestScanSingleLineImport(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.gala")
+	if err := os.WriteFile(path, []byte("package main\n\nimport . \"martianoff/gala/collection_immutable\"\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rf := scanFile(path)
+	if rf.Package != "main" {
+		t.Errorf("package = %q", rf.Package)
+	}
+	want := []rawImport{{Path: "martianoff/gala/collection_immutable", Dot: true}}
+	if !reflect.DeepEqual(rf.Imports, want) {
+		t.Errorf("imports = %+v, want %+v", rf.Imports, want)
+	}
+}
+
+func TestScanMissingFile(t *testing.T) {
+	rf := scanFile(filepath.Join(t.TempDir(), "nope.gala"))
+	if rf.Error == "" {
+		t.Errorf("expected error for missing file")
+	}
+}

--- a/gazelle/gala/BUILD.bazel
+++ b/gazelle/gala/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "gala",
+    srcs = [
+        "config.go",
+        "generate.go",
+        "imports.go",
+        "lang.go",
+        "resolve.go",
+    ],
+    importpath = "martianoff/gala/gazelle/gala",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@gazelle//config",
+        "@gazelle//label",
+        "@gazelle//language",
+        "@gazelle//repo",
+        "@gazelle//resolve",
+        "@gazelle//rule",
+    ],
+)
+
+go_test(
+    name = "gala_test",
+    srcs = [
+        "generate_test.go",
+        "imports_test.go",
+        "resolve_test.go",
+    ],
+    data = glob(["testdata/**"]),
+    embed = [":gala"],
+    deps = [
+        "@gazelle//config",
+        "@gazelle//label",
+        "@gazelle//language",
+        "@gazelle//resolve",
+        "@gazelle//rule",
+    ],
+)

--- a/gazelle/gala/config.go
+++ b/gazelle/gala/config.go
@@ -1,0 +1,147 @@
+package gala
+
+import (
+	"flag"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// Directive keys understood by the GALA extension.
+const (
+	// galaPrefixDirective sets the import-path prefix for in-repo packages.
+	// The importpath of a generated gala_library is <prefix>/<relpath>.
+	galaPrefixDirective = "gala_prefix"
+	// galaHelperDirective sets the path to the helper binary used to extract
+	// imports ("gala imports --json <files...>"). Defaults to "gala" on PATH.
+	galaHelperDirective = "gala_helper"
+	// galaStdlibPrefixDirective sets the import-path namespace of the GALA
+	// standard library. Imports under this namespace that are not found in the
+	// repo are mapped to the external stdlib repo.
+	galaStdlibPrefixDirective = "gala_stdlib_prefix"
+	// galaStdlibRepoDirective sets the Bazel external repo name used for GALA
+	// stdlib imports not present in-repo (e.g. "@gala//collection_immutable").
+	galaStdlibRepoDirective = "gala_stdlib_repo"
+	// galaImplicitDepDirective replaces the set of import paths that the
+	// gala_* macros inject automatically and which must NOT be emitted in
+	// "deps". Space-separated list; default is the std and test packages.
+	galaImplicitDepDirective = "gala_implicit_dep"
+)
+
+const (
+	defaultPrefix       = "martianoff/gala"
+	defaultHelper       = "gala"
+	defaultStdlibPrefix = "martianoff/gala"
+	defaultStdlibRepo   = "gala"
+)
+
+// galaConfig is the per-directory configuration for the GALA extension. A copy
+// is threaded through config.Config.Exts keyed by the language name.
+type galaConfig struct {
+	// Prefix is the import-path prefix for in-repo GALA packages.
+	Prefix string
+	// Helper is the path to the import-extraction helper binary.
+	Helper string
+	// StdlibPrefix is the import namespace of the GALA standard library.
+	StdlibPrefix string
+	// StdlibRepo is the Bazel external repo name for out-of-repo stdlib imports.
+	StdlibRepo string
+	// ImplicitDeps maps import paths injected by the gala_* macros. Imports in
+	// this set are skipped when computing "deps".
+	ImplicitDeps map[string]bool
+}
+
+func newGalaConfig() *galaConfig {
+	return &galaConfig{
+		Prefix:       defaultPrefix,
+		Helper:       defaultHelper,
+		StdlibPrefix: defaultStdlibPrefix,
+		StdlibRepo:   defaultStdlibRepo,
+		ImplicitDeps: map[string]bool{
+			defaultStdlibPrefix + "/std":  true,
+			defaultStdlibPrefix + "/test": true,
+		},
+	}
+}
+
+func (gc *galaConfig) clone() *galaConfig {
+	cp := *gc
+	cp.ImplicitDeps = make(map[string]bool, len(gc.ImplicitDeps))
+	for k, v := range gc.ImplicitDeps {
+		cp.ImplicitDeps[k] = v
+	}
+	return &cp
+}
+
+// getGalaConfig returns the GALA config for the current directory, creating a
+// root one on first access.
+func getGalaConfig(c *config.Config) *galaConfig {
+	if gc, ok := c.Exts[languageName].(*galaConfig); ok {
+		return gc
+	}
+	gc := newGalaConfig()
+	c.Exts[languageName] = gc
+	return gc
+}
+
+// RegisterFlags implements config.Configurer.
+func (*galaLang) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
+	gc := newGalaConfig()
+	c.Exts[languageName] = gc
+	fs.StringVar(&gc.Helper, "gala_helper", gc.Helper,
+		"path to the GALA helper binary used to extract imports (gala imports --json)")
+	fs.StringVar(&gc.Prefix, "gala_prefix", gc.Prefix,
+		"import-path prefix for in-repo GALA packages")
+}
+
+// CheckFlags implements config.Configurer.
+func (*galaLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error { return nil }
+
+// KnownDirectives implements config.Configurer.
+func (*galaLang) KnownDirectives() []string {
+	return []string{
+		galaPrefixDirective,
+		galaHelperDirective,
+		galaStdlibPrefixDirective,
+		galaStdlibRepoDirective,
+		galaImplicitDepDirective,
+	}
+}
+
+// Configure implements config.Configurer. It starts from a clone of the parent
+// directory's config and applies any directives found in this directory's
+// build file.
+func (*galaLang) Configure(c *config.Config, rel string, f *rule.File) {
+	var gc *galaConfig
+	if parent, ok := c.Exts[languageName].(*galaConfig); ok {
+		gc = parent.clone()
+	} else {
+		gc = newGalaConfig()
+	}
+	c.Exts[languageName] = gc
+
+	if f == nil {
+		return
+	}
+	for _, d := range f.Directives {
+		value := strings.TrimSpace(d.Value)
+		switch d.Key {
+		case galaPrefixDirective:
+			gc.Prefix = value
+		case galaHelperDirective:
+			gc.Helper = value
+		case galaStdlibPrefixDirective:
+			gc.StdlibPrefix = value
+		case galaStdlibRepoDirective:
+			gc.StdlibRepo = value
+		case galaImplicitDepDirective:
+			gc.ImplicitDeps = map[string]bool{}
+			for _, dep := range strings.Fields(value) {
+				if dep != "" && dep != "none" {
+					gc.ImplicitDeps[dep] = true
+				}
+			}
+		}
+	}
+}

--- a/gazelle/gala/generate.go
+++ b/gazelle/gala/generate.go
@@ -33,26 +33,38 @@ type galaImports struct {
 func (gl *galaLang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
 	gc := getGalaConfig(args.Config)
 
-	var srcFiles, testFiles []string
+	var galaFiles []string
 	for _, f := range args.RegularFiles {
-		if !strings.HasSuffix(f, ".gala") {
-			continue
+		if strings.HasSuffix(f, ".gala") {
+			galaFiles = append(galaFiles, f)
 		}
+	}
+	if len(galaFiles) == 0 {
+		return language.GenerateResult{}
+	}
+
+	infos, err := extractImports(gl.runner, gc.Helper, args.Dir, galaFiles)
+	if err != nil {
+		log.Printf("gazelle(gala): %s: extracting imports: %v", args.Rel, err)
+		infos = map[string]fileInfo{}
+	}
+
+	// Partition into library/binary sources and framework-test files. A
+	// *_test.gala file that declares `package main` with a `main()` is a
+	// runnable benchmark binary, not a framework test — those are hand-wired
+	// gala_binary targets (e.g. perf_gala), so the extension leaves them alone
+	// rather than minting a colliding gala_test.
+	var srcFiles, testFiles []string
+	for _, f := range galaFiles {
 		if strings.HasSuffix(f, "_test.gala") {
+			if fileIsMain(args.Dir, f, infos) {
+				log.Printf("gazelle(gala): %s: skipping %s (package main with main(); manage it as a gala_binary by hand)", args.Rel, f)
+				continue
+			}
 			testFiles = append(testFiles, f)
 		} else {
 			srcFiles = append(srcFiles, f)
 		}
-	}
-	if len(srcFiles) == 0 && len(testFiles) == 0 {
-		return language.GenerateResult{}
-	}
-
-	allFiles := append(append([]string{}, srcFiles...), testFiles...)
-	infos, err := extractImports(gl.runner, gc.Helper, args.Dir, allFiles)
-	if err != nil {
-		log.Printf("gazelle(gala): %s: extracting imports: %v", args.Rel, err)
-		infos = map[string]fileInfo{}
 	}
 
 	var res language.GenerateResult
@@ -81,14 +93,18 @@ func (gl *galaLang) GenerateRules(args language.GenerateArgs) language.GenerateR
 		})
 	}
 
-	// Test sources: a single gala_test for the directory.
-	if len(testFiles) > 0 {
-		sort.Strings(testFiles)
-		r := rule.NewRule("gala_test", name+"_test")
-		r.SetAttr("srcs", testFiles)
+	// Test sources: one gala_test per *_test.gala file, named after the file
+	// stem, carrying that file's own resolved deps. This matches the repo
+	// convention (one test target per file) and avoids name collisions with
+	// existing per-file rules when regenerating.
+	sort.Strings(testFiles)
+	for _, tf := range testFiles {
+		testName := strings.TrimSuffix(tf, ".gala")
+		r := rule.NewRule("gala_test", testName)
+		r.SetAttr("srcs", []string{tf})
 		res.Gen = append(res.Gen, r)
 		res.Imports = append(res.Imports, &galaImports{
-			imports: collectImports(testFiles, infos),
+			imports: collectImports([]string{tf}, infos),
 			self:    "",
 		})
 	}
@@ -118,19 +134,24 @@ func joinImportPath(prefix, rel string) string {
 // one file declares "package main" and contains a zero-arg main() function.
 func detectMain(dir string, srcFiles []string, infos map[string]fileInfo) bool {
 	for _, f := range srcFiles {
-		info, ok := infos[f]
-		if !ok || info.Package != "main" {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(dir, f))
-		if err != nil {
-			continue
-		}
-		if mainFuncRe.Match(data) {
+		if fileIsMain(dir, f, infos) {
 			return true
 		}
 	}
 	return false
+}
+
+// fileIsMain reports whether a single file declares "package main" and defines
+// a zero-arg main() function.
+func fileIsMain(dir, f string, infos map[string]fileInfo) bool {
+	if info, ok := infos[f]; !ok || info.Package != "main" {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(dir, f))
+	if err != nil {
+		return false
+	}
+	return mainFuncRe.Match(data)
 }
 
 // collectImports returns the sorted, deduped union of import paths declared by

--- a/gazelle/gala/generate.go
+++ b/gazelle/gala/generate.go
@@ -1,0 +1,155 @@
+package gala
+
+import (
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// mainFuncRe matches a zero-argument main function declaration, used together
+// with a "package main" declaration to identify a gala_binary. This is a
+// lightweight content check, not a re-parse of the grammar.
+var mainFuncRe = regexp.MustCompile(`(?m)^\s*func\s+main\s*\(\s*\)`)
+
+// galaImports is the opaque payload carried from GenerateRules to Resolve for
+// each generated rule (GenerateResult.Imports).
+type galaImports struct {
+	// imports is the deduped set of GALA import paths across the rule's files.
+	imports []string
+	// self is the rule's own importpath, excluded from its own deps.
+	self string
+}
+
+// GenerateRules implements language.Language. It produces one gala_library (or
+// gala_binary for a "package main" with a main()) for the non-test sources in a
+// directory, plus a gala_test for any *_test.gala files.
+func (gl *galaLang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
+	gc := getGalaConfig(args.Config)
+
+	var srcFiles, testFiles []string
+	for _, f := range args.RegularFiles {
+		if !strings.HasSuffix(f, ".gala") {
+			continue
+		}
+		if strings.HasSuffix(f, "_test.gala") {
+			testFiles = append(testFiles, f)
+		} else {
+			srcFiles = append(srcFiles, f)
+		}
+	}
+	if len(srcFiles) == 0 && len(testFiles) == 0 {
+		return language.GenerateResult{}
+	}
+
+	allFiles := append(append([]string{}, srcFiles...), testFiles...)
+	infos, err := extractImports(gl.runner, gc.Helper, args.Dir, allFiles)
+	if err != nil {
+		log.Printf("gazelle(gala): %s: extracting imports: %v", args.Rel, err)
+		infos = map[string]fileInfo{}
+	}
+
+	var res language.GenerateResult
+	name := dirName(args.Rel)
+
+	// Non-test sources: gala_library, or gala_binary for a runnable main.
+	if len(srcFiles) > 0 {
+		sort.Strings(srcFiles)
+		isMain := detectMain(args.Dir, srcFiles, infos)
+		importPath := joinImportPath(gc.Prefix, args.Rel)
+
+		var r *rule.Rule
+		if isMain {
+			r = rule.NewRule("gala_binary", name)
+			r.SetAttr("srcs", srcFiles)
+		} else {
+			r = rule.NewRule("gala_library", name)
+			r.SetAttr("srcs", srcFiles)
+			r.SetAttr("importpath", importPath)
+			r.SetAttr("visibility", []string{"//visibility:public"})
+		}
+		res.Gen = append(res.Gen, r)
+		res.Imports = append(res.Imports, &galaImports{
+			imports: collectImports(srcFiles, infos),
+			self:    importPath,
+		})
+	}
+
+	// Test sources: a single gala_test for the directory.
+	if len(testFiles) > 0 {
+		sort.Strings(testFiles)
+		r := rule.NewRule("gala_test", name+"_test")
+		r.SetAttr("srcs", testFiles)
+		res.Gen = append(res.Gen, r)
+		res.Imports = append(res.Imports, &galaImports{
+			imports: collectImports(testFiles, infos),
+			self:    "",
+		})
+	}
+
+	return res
+}
+
+// dirName returns the rule base name for a directory: the final path segment,
+// or "root" for the repository root.
+func dirName(rel string) string {
+	if rel == "" {
+		return "root"
+	}
+	return path.Base(rel)
+}
+
+// joinImportPath builds the importpath for a directory from the prefix and the
+// repo-relative directory path.
+func joinImportPath(prefix, rel string) string {
+	if rel == "" {
+		return prefix
+	}
+	return prefix + "/" + rel
+}
+
+// detectMain reports whether the source set forms a runnable binary: at least
+// one file declares "package main" and contains a zero-arg main() function.
+func detectMain(dir string, srcFiles []string, infos map[string]fileInfo) bool {
+	for _, f := range srcFiles {
+		info, ok := infos[f]
+		if !ok || info.Package != "main" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, f))
+		if err != nil {
+			continue
+		}
+		if mainFuncRe.Match(data) {
+			return true
+		}
+	}
+	return false
+}
+
+// collectImports returns the sorted, deduped union of import paths declared by
+// the given files.
+func collectImports(files []string, infos map[string]fileInfo) []string {
+	set := map[string]bool{}
+	for _, f := range files {
+		info, ok := infos[f]
+		if !ok {
+			continue
+		}
+		for _, imp := range info.Imports {
+			set[imp] = true
+		}
+	}
+	out := make([]string, 0, len(set))
+	for imp := range set {
+		out = append(out, imp)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/gazelle/gala/generate_test.go
+++ b/gazelle/gala/generate_test.go
@@ -38,6 +38,29 @@ var fakeImports = map[string]rawFile{
 		Package: "main",
 		Imports: []rawImport{{Path: "martianoff/gala/collection_immutable", Dot: true}},
 	},
+	"core.gala": {File: "core.gala", Package: "core"},
+	"coll.gala": {File: "coll.gala", Package: "coll"},
+	"perf_test.gala": {
+		File:    "perf_test.gala",
+		Package: "main",
+		Imports: []rawImport{{Path: "martianoff/gala/collection_immutable", Dot: true}},
+	},
+	"alpha_test.gala": {
+		File:    "alpha_test.gala",
+		Package: "main",
+		Imports: []rawImport{
+			{Path: "martianoff/gala/test", Dot: true},
+			{Path: "martianoff/gala/multitest"},
+		},
+	},
+	"beta_test.gala": {
+		File:    "beta_test.gala",
+		Package: "main",
+		Imports: []rawImport{
+			{Path: "martianoff/gala/test", Dot: true},
+			{Path: "martianoff/gala/collection_immutable", Dot: true},
+		},
+	},
 }
 
 // fakeRunner is an importRunner that emits the JSON contract for the requested
@@ -94,12 +117,111 @@ func TestGenerateLibraryAndTest(t *testing.T) {
 		t.Errorf("lib srcs = %v", got)
 	}
 	test := res.Gen[1]
-	if test.Kind() != "gala_test" || test.Name() != "regexlike_test" {
-		t.Errorf("rule1 = %s %q, want gala_test regexlike_test", test.Kind(), test.Name())
+	// One gala_test per file, named after the file stem.
+	if test.Kind() != "gala_test" || test.Name() != "regex_test" {
+		t.Errorf("rule1 = %s %q, want gala_test regex_test", test.Kind(), test.Name())
 	}
 	if got := attrStrings(test, "srcs"); !reflect.DeepEqual(got, []string{"regex_test.gala"}) {
 		t.Errorf("test srcs = %v", got)
 	}
+}
+
+func TestGenerateOneTestPerFile(t *testing.T) {
+	gl := &galaLang{runner: fakeRunner}
+	c := testConfig()
+	res := gl.GenerateRules(genArgs(c, "multitest",
+		[]string{"core.gala", "alpha_test.gala", "beta_test.gala"}))
+
+	// Expect: 1 library + 2 separate per-file gala_test rules.
+	if len(res.Gen) != 3 {
+		t.Fatalf("got %d rules, want 3 (library + 2 per-file tests)", len(res.Gen))
+	}
+	if res.Gen[0].Kind() != "gala_library" {
+		t.Errorf("rule0 = %s, want gala_library", res.Gen[0].Kind())
+	}
+
+	// Collect the test rules by name and check each carries only its own src
+	// and its own import payload.
+	tests := map[string]*rule.Rule{}
+	payloads := map[string]*galaImports{}
+	for i, r := range res.Gen {
+		if r.Kind() == "gala_test" {
+			tests[r.Name()] = r
+			payloads[r.Name()] = res.Imports[i].(*galaImports)
+		}
+	}
+	if len(tests) != 2 {
+		t.Fatalf("got %d gala_test rules, want 2: %v", len(tests), keys(tests))
+	}
+	for name, wantSrc := range map[string]string{
+		"alpha_test": "alpha_test.gala",
+		"beta_test":  "beta_test.gala",
+	} {
+		r, ok := tests[name]
+		if !ok {
+			t.Errorf("missing per-file test rule %q", name)
+			continue
+		}
+		if got := attrStrings(r, "srcs"); !reflect.DeepEqual(got, []string{wantSrc}) {
+			t.Errorf("%s srcs = %v, want [%s]", name, got, wantSrc)
+		}
+	}
+
+	// Per-file deps must not be unioned: alpha imports multitest, beta imports
+	// collection_immutable — neither should see the other's import.
+	if got := payloads["alpha_test"].imports; !contains(got, "martianoff/gala/multitest") || contains(got, "martianoff/gala/collection_immutable") {
+		t.Errorf("alpha_test imports leaked across files: %v", got)
+	}
+	if got := payloads["beta_test"].imports; !contains(got, "martianoff/gala/collection_immutable") || contains(got, "martianoff/gala/multitest") {
+		t.Errorf("beta_test imports leaked across files: %v", got)
+	}
+}
+
+func TestGenerateSkipsBenchmarkMainTest(t *testing.T) {
+	gl := &galaLang{runner: fakeRunner}
+	c := testConfig()
+	res := gl.GenerateRules(genArgs(c, "benchlike",
+		[]string{"coll.gala", "perf_test.gala"}))
+
+	// perf_test.gala is package main with main() — a benchmark binary, not a
+	// framework test. It must NOT produce a gala_test (which would collide with
+	// the hand-wired gala_binary). Only the library should be generated.
+	if len(res.Gen) != 1 {
+		t.Fatalf("got %d rules, want 1 (library only): %v", len(res.Gen), ruleKinds(res.Gen))
+	}
+	if res.Gen[0].Kind() != "gala_library" {
+		t.Errorf("rule0 = %s, want gala_library", res.Gen[0].Kind())
+	}
+	for _, r := range res.Gen {
+		if r.Kind() == "gala_test" {
+			t.Errorf("unexpected gala_test %q generated for a benchmark main", r.Name())
+		}
+	}
+}
+
+func ruleKinds(rules []*rule.Rule) []string {
+	out := make([]string, len(rules))
+	for i, r := range rules {
+		out[i] = r.Kind() + ":" + r.Name()
+	}
+	return out
+}
+
+func keys(m map[string]*rule.Rule) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func contains(xs []string, v string) bool {
+	for _, x := range xs {
+		if x == v {
+			return true
+		}
+	}
+	return false
 }
 
 func TestGenerateLibraryNoImports(t *testing.T) {

--- a/gazelle/gala/generate_test.go
+++ b/gazelle/gala/generate_test.go
@@ -1,0 +1,142 @@
+package gala
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// fakeImports maps a file name to the imports the fake helper should report.
+var fakeImports = map[string]rawFile{
+	"regex.gala": {
+		File:    "regex.gala",
+		Package: "regex",
+		Imports: []rawImport{
+			{Path: "regexp"},
+			{Path: "martianoff/gala/std", Dot: true},
+			{Path: "martianoff/gala/collection_immutable", Dot: true},
+			{Path: "martianoff/gala/go_interop"},
+		},
+	},
+	"regex_test.gala": {
+		File:    "regex_test.gala",
+		Package: "main",
+		Imports: []rawImport{
+			{Path: "martianoff/gala/test", Dot: true},
+			{Path: "martianoff/gala/regex"},
+		},
+	},
+	"math.gala": {File: "math.gala", Package: "mathlib"},
+	"main.gala": {
+		File:    "main.gala",
+		Package: "main",
+		Imports: []rawImport{{Path: "martianoff/gala/collection_immutable", Dot: true}},
+	},
+}
+
+// fakeRunner is an importRunner that emits the JSON contract for the requested
+// files from fakeImports, so tests never touch a real "gala" binary.
+func fakeRunner(helper, dir string, files []string) ([]byte, error) {
+	out := make([]rawFile, 0, len(files))
+	for _, f := range files {
+		if rf, ok := fakeImports[f]; ok {
+			out = append(out, rf)
+		} else {
+			out = append(out, rawFile{File: f})
+		}
+	}
+	return json.Marshal(out)
+}
+
+func testConfig() *config.Config {
+	c := config.New()
+	c.Exts[languageName] = newGalaConfig()
+	return c
+}
+
+func genArgs(c *config.Config, rel string, files []string) language.GenerateArgs {
+	return language.GenerateArgs{
+		Config:       c,
+		Dir:          filepath.Join("testdata", rel),
+		Rel:          rel,
+		RegularFiles: files,
+	}
+}
+
+func attrStrings(r *rule.Rule, key string) []string {
+	v := r.AttrStrings(key)
+	sort.Strings(v)
+	return v
+}
+
+func TestGenerateLibraryAndTest(t *testing.T) {
+	gl := &galaLang{runner: fakeRunner}
+	c := testConfig()
+	res := gl.GenerateRules(genArgs(c, "regexlike", []string{"regex.gala", "regex_test.gala"}))
+
+	if len(res.Gen) != 2 {
+		t.Fatalf("got %d rules, want 2 (library + test)", len(res.Gen))
+	}
+	lib := res.Gen[0]
+	if lib.Kind() != "gala_library" || lib.Name() != "regexlike" {
+		t.Errorf("rule0 = %s %q, want gala_library regexlike", lib.Kind(), lib.Name())
+	}
+	if got := lib.AttrString("importpath"); got != "martianoff/gala/regexlike" {
+		t.Errorf("importpath = %q", got)
+	}
+	if got := attrStrings(lib, "srcs"); !reflect.DeepEqual(got, []string{"regex.gala"}) {
+		t.Errorf("lib srcs = %v", got)
+	}
+	test := res.Gen[1]
+	if test.Kind() != "gala_test" || test.Name() != "regexlike_test" {
+		t.Errorf("rule1 = %s %q, want gala_test regexlike_test", test.Kind(), test.Name())
+	}
+	if got := attrStrings(test, "srcs"); !reflect.DeepEqual(got, []string{"regex_test.gala"}) {
+		t.Errorf("test srcs = %v", got)
+	}
+}
+
+func TestGenerateLibraryNoImports(t *testing.T) {
+	gl := &galaLang{runner: fakeRunner}
+	c := testConfig()
+	res := gl.GenerateRules(genArgs(c, "mathlike", []string{"math.gala"}))
+	if len(res.Gen) != 1 {
+		t.Fatalf("got %d rules, want 1", len(res.Gen))
+	}
+	r := res.Gen[0]
+	if r.Kind() != "gala_library" || r.AttrString("importpath") != "martianoff/gala/mathlike" {
+		t.Errorf("got %s importpath=%q", r.Kind(), r.AttrString("importpath"))
+	}
+}
+
+func TestGenerateBinary(t *testing.T) {
+	gl := &galaLang{runner: fakeRunner}
+	c := testConfig()
+	res := gl.GenerateRules(genArgs(c, "binlike", []string{"main.gala"}))
+	if len(res.Gen) != 1 {
+		t.Fatalf("got %d rules, want 1", len(res.Gen))
+	}
+	r := res.Gen[0]
+	if r.Kind() != "gala_binary" || r.Name() != "binlike" {
+		t.Errorf("got %s %q, want gala_binary binlike", r.Kind(), r.Name())
+	}
+	if r.AttrString("importpath") != "" {
+		t.Errorf("binary should not have importpath, got %q", r.AttrString("importpath"))
+	}
+}
+
+func TestGeneratePrefixDirective(t *testing.T) {
+	gl := &galaLang{runner: fakeRunner}
+	c := testConfig()
+	getGalaConfig(c).Prefix = "github.com/me/app"
+	res := gl.GenerateRules(genArgs(c, "mathlike", []string{"math.gala"}))
+	if got := res.Gen[0].AttrString("importpath"); got != "github.com/me/app/mathlike" {
+		t.Errorf("importpath = %q, want github.com/me/app/mathlike", got)
+	}
+}

--- a/gazelle/gala/imports.go
+++ b/gazelle/gala/imports.go
@@ -1,0 +1,90 @@
+package gala
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+// rawImport mirrors one entry of the "imports" array emitted by the helper.
+type rawImport struct {
+	Path  string `json:"path"`
+	Alias string `json:"alias"`
+	Dot   bool   `json:"dot"`
+}
+
+// rawFile mirrors one element of the JSON array emitted by
+// "gala imports --json <files...>".
+type rawFile struct {
+	File    string      `json:"file"`
+	Package string      `json:"package"`
+	Imports []rawImport `json:"imports"`
+	Error   string      `json:"error"`
+}
+
+// fileInfo is the parsed, error-free view of one source file.
+type fileInfo struct {
+	Name    string
+	Package string
+	Imports []string
+}
+
+// importRunner executes the helper binary and returns its raw stdout. It is an
+// interface so tests can inject a fake that emits the JSON contract directly,
+// avoiding any dependency on an installed "gala" binary.
+type importRunner func(helper, dir string, files []string) ([]byte, error)
+
+// execRunner is the production importRunner: it shells out to the helper.
+func execRunner(helper, dir string, files []string) ([]byte, error) {
+	args := append([]string{"imports", "--json"}, files...)
+	cmd := exec.Command(helper, args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("%s imports failed: %v: %s", helper, err, ee.Stderr)
+		}
+		return nil, fmt.Errorf("running %s imports: %w", helper, err)
+	}
+	return out, nil
+}
+
+// extractImports runs the helper over files (relative to dir) and returns a map
+// keyed by file name. Files whose entry carries a non-empty error are skipped.
+func extractImports(run importRunner, helper, dir string, files []string) (map[string]fileInfo, error) {
+	if len(files) == 0 {
+		return map[string]fileInfo{}, nil
+	}
+	out, err := run(helper, dir, files)
+	if err != nil {
+		return nil, err
+	}
+	return parseImports(out)
+}
+
+// parseImports decodes the helper's JSON output into fileInfo records. Entries
+// reporting an error are dropped (the helper could not parse that file).
+func parseImports(data []byte) (map[string]fileInfo, error) {
+	var raws []rawFile
+	if err := json.Unmarshal(data, &raws); err != nil {
+		return nil, fmt.Errorf("parsing gala imports JSON: %w", err)
+	}
+	result := make(map[string]fileInfo, len(raws))
+	for _, rf := range raws {
+		if rf.Error != "" {
+			continue
+		}
+		imps := make([]string, 0, len(rf.Imports))
+		for _, imp := range rf.Imports {
+			if imp.Path != "" {
+				imps = append(imps, imp.Path)
+			}
+		}
+		result[rf.File] = fileInfo{
+			Name:    rf.File,
+			Package: rf.Package,
+			Imports: imps,
+		}
+	}
+	return result, nil
+}

--- a/gazelle/gala/imports_test.go
+++ b/gazelle/gala/imports_test.go
@@ -1,0 +1,37 @@
+package gala
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseImports(t *testing.T) {
+	data := []byte(`[
+		{"file":"a.gala","package":"main","imports":[{"path":"fmt","alias":"","dot":false},{"path":"martianoff/gala/collection_immutable","alias":"","dot":true}],"error":""},
+		{"file":"broken.gala","package":"","imports":[],"error":"parse error at line 3"}
+	]`)
+	got, err := parseImports(data)
+	if err != nil {
+		t.Fatalf("parseImports: %v", err)
+	}
+	if _, ok := got["broken.gala"]; ok {
+		t.Errorf("file with error should be skipped, but was present")
+	}
+	a, ok := got["a.gala"]
+	if !ok {
+		t.Fatalf("a.gala missing from result")
+	}
+	if a.Package != "main" {
+		t.Errorf("package = %q, want main", a.Package)
+	}
+	want := []string{"fmt", "martianoff/gala/collection_immutable"}
+	if !reflect.DeepEqual(a.Imports, want) {
+		t.Errorf("imports = %v, want %v", a.Imports, want)
+	}
+}
+
+func TestParseImportsInvalidJSON(t *testing.T) {
+	if _, err := parseImports([]byte("not json")); err == nil {
+		t.Errorf("expected error for invalid JSON, got nil")
+	}
+}

--- a/gazelle/gala/lang.go
+++ b/gazelle/gala/lang.go
@@ -1,0 +1,102 @@
+// Package gala implements a Gazelle language extension for the GALA language.
+//
+// It generates and maintains gala_library, gala_binary, gala_test, and
+// gala_exec_test rules (loaded from @rules_gala//gala:defs.bzl) and resolves
+// GALA import strings to Bazel labels. Import extraction is delegated to a
+// helper binary ("gala imports --json <files...>") rather than re-parsing the
+// grammar, mirroring the rules_python gazelle plugin's helper model.
+package gala
+
+import (
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// languageName is the Gazelle language identifier. It is also the prefix of the
+// rule kinds this extension manages (gala_library, gala_test, ...).
+const languageName = "gala"
+
+// The defs.bzl file that the gala_* rules are loaded from. The extension only
+// needs the load-string and attribute shapes — not the rules_gala source — so
+// this label is hardcoded.
+const galaDefs = "@rules_gala//gala:defs.bzl"
+
+// galaLang is the language.Language implementation for GALA.
+type galaLang struct {
+	// runner extracts imports from a set of .gala files. It is injectable so
+	// tests can supply a fake in place of shelling out to the helper binary.
+	runner importRunner
+}
+
+// NewLanguage returns a new GALA Gazelle language extension. This is the entry
+// point referenced by gazelle_binary's generated main.
+func NewLanguage() language.Language {
+	return &galaLang{runner: execRunner}
+}
+
+var (
+	_ language.Language           = (*galaLang)(nil)
+	_ config.Configurer           = (*galaLang)(nil)
+	_ language.FinishableLanguage = (*galaLang)(nil)
+)
+
+// Name implements resolve.Resolver / language.Language.
+func (*galaLang) Name() string { return languageName }
+
+// Kinds implements language.Language. It describes how each managed rule kind
+// is matched and merged.
+func (*galaLang) Kinds() map[string]rule.KindInfo {
+	srcsMergeable := map[string]bool{"srcs": true}
+	depsResolvable := map[string]bool{"deps": true, "gala_deps": true}
+	return map[string]rule.KindInfo{
+		"gala_library": {
+			MatchAttrs:    []string{"importpath"},
+			NonEmptyAttrs: map[string]bool{"srcs": true, "src": true},
+			MergeableAttrs: map[string]bool{
+				"srcs":       true,
+				"src":        true,
+				"importpath": true,
+			},
+			ResolveAttrs: depsResolvable,
+		},
+		"gala_binary": {
+			NonEmptyAttrs:  map[string]bool{"srcs": true, "src": true},
+			MergeableAttrs: srcsMergeable,
+			ResolveAttrs:   depsResolvable,
+		},
+		"gala_test": {
+			NonEmptyAttrs:  map[string]bool{"srcs": true, "src": true},
+			MergeableAttrs: srcsMergeable,
+			ResolveAttrs:   depsResolvable,
+		},
+		"gala_exec_test": {
+			NonEmptyAttrs:  map[string]bool{"src": true},
+			MergeableAttrs: map[string]bool{"src": true, "expected": true},
+			ResolveAttrs:   depsResolvable,
+		},
+	}
+}
+
+// Loads implements language.Language. Every managed kind loads from the same
+// rules_gala defs.bzl file.
+func (*galaLang) Loads() []rule.LoadInfo {
+	return []rule.LoadInfo{
+		{
+			Name: galaDefs,
+			Symbols: []string{
+				"gala_binary",
+				"gala_exec_test",
+				"gala_library",
+				"gala_test",
+			},
+		},
+	}
+}
+
+// Fix implements language.Language. GALA has no deprecated rule forms to repair.
+func (*galaLang) Fix(c *config.Config, f *rule.File) {}
+
+// DoneGeneratingRules implements language.FinishableLanguage. No background
+// resources are held, so this is a no-op.
+func (*galaLang) DoneGeneratingRules() {}

--- a/gazelle/gala/resolve.go
+++ b/gazelle/gala/resolve.go
@@ -1,0 +1,114 @@
+package gala
+
+import (
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/repo"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// Imports implements resolve.Resolver. A gala_library is indexed by its
+// importpath so other rules can resolve imports to it. gala_binary and
+// gala_test are not importable, so they are not indexed (return nil).
+func (*galaLang) Imports(c *config.Config, r *rule.Rule, f *rule.File) []resolve.ImportSpec {
+	if r.Kind() != "gala_library" {
+		return nil
+	}
+	importpath := r.AttrString("importpath")
+	if importpath == "" {
+		return nil
+	}
+	return []resolve.ImportSpec{{Lang: languageName, Imp: importpath}}
+}
+
+// Embeds implements resolve.Resolver. GALA rules do not embed one another.
+func (*galaLang) Embeds(r *rule.Rule, from label.Label) []label.Label { return nil }
+
+// Resolve implements resolve.Resolver. It translates each GALA import path in
+// the rule's payload into a Bazel label and writes the sorted set to "deps".
+func (*galaLang) Resolve(
+	c *config.Config,
+	ix *resolve.RuleIndex,
+	rc *repo.RemoteCache,
+	r *rule.Rule,
+	imports interface{},
+	from label.Label,
+) {
+	gi, ok := imports.(*galaImports)
+	if !ok || gi == nil {
+		return
+	}
+	gc := getGalaConfig(c)
+
+	deps := map[string]bool{}
+	for _, imp := range gi.imports {
+		if imp == gi.self {
+			continue
+		}
+		if gc.ImplicitDeps[imp] {
+			// Injected automatically by the gala_* macros (std, test).
+			continue
+		}
+		lbl, ok := resolveImport(gc, ix, imp, from)
+		if !ok {
+			continue
+		}
+		deps[lbl] = true
+	}
+
+	if len(deps) == 0 {
+		r.DelAttr("deps")
+		return
+	}
+	sorted := make([]string, 0, len(deps))
+	for d := range deps {
+		sorted = append(sorted, d)
+	}
+	sort.Strings(sorted)
+	r.SetAttr("deps", sorted)
+}
+
+// resolveImport maps a single GALA import path to a Bazel label string. It
+// reports ok=false for imports that need no GALA dependency (Go stdlib and
+// other non-GALA paths).
+func resolveImport(gc *galaConfig, ix *resolve.RuleIndex, imp string, from label.Label) (string, bool) {
+	// Prefer an in-repo library indexed under this importpath.
+	if matches := ix.FindRulesByImport(resolve.ImportSpec{Lang: languageName, Imp: imp}, languageName); len(matches) > 0 {
+		return matches[0].Label.Rel(from.Repo, from.Pkg).String(), true
+	}
+
+	// In-repo namespace: under the configured prefix → //<relpath>.
+	if rel, ok := relUnder(imp, gc.Prefix); ok && rel != "" {
+		lbl := label.New("", rel, path.Base(rel))
+		return lbl.Rel(from.Repo, from.Pkg).String(), true
+	}
+
+	// GALA stdlib namespace not present in-repo → @<repo>//<relpath>.
+	if rel, ok := relUnder(imp, gc.StdlibPrefix); ok && rel != "" {
+		lbl := label.New(gc.StdlibRepo, rel, path.Base(rel))
+		return lbl.String(), true
+	}
+
+	// Go stdlib / external Go imports: no GALA dependency.
+	return "", false
+}
+
+// relUnder returns the path of imp relative to ns ("" when imp == ns) and
+// whether imp lies within the ns namespace.
+func relUnder(imp, ns string) (string, bool) {
+	if ns == "" {
+		return "", false
+	}
+	if imp == ns {
+		return "", true
+	}
+	if strings.HasPrefix(imp, ns+"/") {
+		return strings.TrimPrefix(imp, ns+"/"), true
+	}
+	return "", false
+}

--- a/gazelle/gala/resolve_test.go
+++ b/gazelle/gala/resolve_test.go
@@ -1,0 +1,134 @@
+package gala
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// indexFromLibs builds a RuleIndex containing gala_library rules so Resolve can
+// translate in-repo imports to their labels.
+func indexFromLibs(c *config.Config, gl *galaLang, libs map[string]string) *resolve.RuleIndex {
+	ix := resolve.NewRuleIndex(func(r *rule.Rule, pkgRel string) resolve.Resolver { return gl })
+	for pkg, importpath := range libs {
+		name := pkg
+		if i := lastSlash(pkg); i >= 0 {
+			name = pkg[i+1:]
+		}
+		r := rule.NewRule("gala_library", name)
+		r.SetAttr("importpath", importpath)
+		f := rule.EmptyFile(pkg+"/BUILD.bazel", pkg)
+		r.Insert(f)
+		ix.AddRule(c, r, f)
+	}
+	ix.Finish()
+	return ix
+}
+
+func lastSlash(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '/' {
+			return i
+		}
+	}
+	return -1
+}
+
+func resolveDeps(t *testing.T, c *config.Config, gl *galaLang, ix *resolve.RuleIndex, kind, pkg string, gi *galaImports) []string {
+	t.Helper()
+	r := rule.NewRule(kind, "target")
+	from := label.New("", pkg, "target")
+	gl.Resolve(c, ix, nil, r, gi, from)
+	got := r.AttrStrings("deps")
+	sort.Strings(got)
+	return got
+}
+
+func TestResolveLibraryDeps(t *testing.T) {
+	gl := &galaLang{runner: fakeRunner}
+	c := testConfig()
+	ix := indexFromLibs(c, gl, map[string]string{
+		"collection_immutable": "martianoff/gala/collection_immutable",
+		"go_interop":           "martianoff/gala/go_interop",
+		"std":                  "martianoff/gala/std",
+	})
+	// regex library: imports regexp(skip), std(implicit/skip), collection_immutable, go_interop.
+	gi := &galaImports{
+		imports: []string{
+			"regexp",
+			"martianoff/gala/std",
+			"martianoff/gala/collection_immutable",
+			"martianoff/gala/go_interop",
+		},
+		self: "martianoff/gala/regex",
+	}
+	got := resolveDeps(t, c, gl, ix, "gala_library", "regex", gi)
+	want := []string{"//collection_immutable", "//go_interop"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("deps = %v, want %v", got, want)
+	}
+}
+
+func TestResolveTestDeps(t *testing.T) {
+	gl := &galaLang{runner: fakeRunner}
+	c := testConfig()
+	ix := indexFromLibs(c, gl, map[string]string{
+		"regex": "martianoff/gala/regex",
+	})
+	// test in regex/ imports test(implicit/skip) and the sibling regex library.
+	gi := &galaImports{
+		imports: []string{"martianoff/gala/test", "martianoff/gala/regex"},
+		self:    "",
+	}
+	got := resolveDeps(t, c, gl, ix, "gala_test", "regex", gi)
+	want := []string{":regex"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("deps = %v, want %v", got, want)
+	}
+}
+
+func TestResolveExternalStdlib(t *testing.T) {
+	gl := &galaLang{runner: fakeRunner}
+	c := testConfig()
+	// Consumer repo: prefix differs from the stdlib namespace, and the stdlib
+	// packages are not in-repo, so they map to @gala//<pkg>.
+	gc := getGalaConfig(c)
+	gc.Prefix = "github.com/me/app"
+	ix := resolve.NewRuleIndex(func(r *rule.Rule, pkgRel string) resolve.Resolver { return gl })
+	ix.Finish()
+	gi := &galaImports{
+		imports: []string{
+			"fmt",
+			"martianoff/gala/std", // implicit, skipped
+			"martianoff/gala/collection_immutable",
+			"github.com/me/app/util",
+		},
+		self: "github.com/me/app/widget",
+	}
+	got := resolveDeps(t, c, gl, ix, "gala_library", "widget", gi)
+	want := []string{"//util", "@gala//collection_immutable"}
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("deps = %v, want %v", got, want)
+	}
+}
+
+func TestImportsIndexing(t *testing.T) {
+	gl := &galaLang{}
+	lib := rule.NewRule("gala_library", "regex")
+	lib.SetAttr("importpath", "martianoff/gala/regex")
+	specs := gl.Imports(nil, lib, nil)
+	if len(specs) != 1 || specs[0].Lang != "gala" || specs[0].Imp != "martianoff/gala/regex" {
+		t.Errorf("Imports = %v", specs)
+	}
+	// binaries and tests are not importable.
+	bin := rule.NewRule("gala_binary", "app")
+	if specs := gl.Imports(nil, bin, nil); specs != nil {
+		t.Errorf("binary Imports = %v, want nil", specs)
+	}
+}

--- a/gazelle/gala/testdata/benchlike/coll.gala
+++ b/gazelle/gala/testdata/benchlike/coll.gala
@@ -1,0 +1,3 @@
+package coll
+
+func N() int = 1

--- a/gazelle/gala/testdata/benchlike/perf_test.gala
+++ b/gazelle/gala/testdata/benchlike/perf_test.gala
@@ -1,0 +1,7 @@
+package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    Println("bench")
+}

--- a/gazelle/gala/testdata/binlike/main.gala
+++ b/gazelle/gala/testdata/binlike/main.gala
@@ -1,0 +1,7 @@
+package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    Println("hi")
+}

--- a/gazelle/gala/testdata/mathlike/math.gala
+++ b/gazelle/gala/testdata/mathlike/math.gala
@@ -1,0 +1,3 @@
+package mathlib
+
+func Add(a int, b int) int = a + b

--- a/gazelle/gala/testdata/multitest/alpha_test.gala
+++ b/gazelle/gala/testdata/multitest/alpha_test.gala
@@ -1,0 +1,8 @@
+package main
+
+import (
+    . "martianoff/gala/test"
+    "martianoff/gala/multitest"
+)
+
+func TestAlpha(t T) T = IsTrue(t, true)

--- a/gazelle/gala/testdata/multitest/beta_test.gala
+++ b/gazelle/gala/testdata/multitest/beta_test.gala
@@ -1,0 +1,8 @@
+package main
+
+import (
+    . "martianoff/gala/test"
+    . "martianoff/gala/collection_immutable"
+)
+
+func TestBeta(t T) T = IsTrue(t, true)

--- a/gazelle/gala/testdata/multitest/core.gala
+++ b/gazelle/gala/testdata/multitest/core.gala
@@ -1,0 +1,3 @@
+package core
+
+func Core() int = 1

--- a/gazelle/gala/testdata/regexlike/regex.gala
+++ b/gazelle/gala/testdata/regexlike/regex.gala
@@ -1,0 +1,12 @@
+package regex
+
+import (
+    "regexp"
+    . "martianoff/gala/std"
+    . "martianoff/gala/collection_immutable"
+    "martianoff/gala/go_interop"
+)
+
+type Regex struct {
+    Pattern string
+}

--- a/gazelle/gala/testdata/regexlike/regex_test.gala
+++ b/gazelle/gala/testdata/regexlike/regex_test.gala
@@ -1,0 +1,10 @@
+package main
+
+import (
+    . "martianoff/gala/test"
+    "martianoff/gala/regex"
+)
+
+func TestX(t T) T {
+    return IsTrue(t, true)
+}

--- a/gazelle/go.mod
+++ b/gazelle/go.mod
@@ -1,0 +1,12 @@
+module martianoff/gala/gazelle
+
+go 1.23.0
+
+require github.com/bazelbuild/bazel-gazelle v0.47.0
+
+require (
+	github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52 // indirect
+	golang.org/x/mod v0.20.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
+	golang.org/x/tools/go/vcs v0.1.0-deprecated // indirect
+)

--- a/gazelle/go.sum
+++ b/gazelle/go.sum
@@ -1,0 +1,14 @@
+github.com/bazelbuild/bazel-gazelle v0.47.0 h1:g3Rr1ZbkC1Pk20aOgBITxSD/efS1WbaSty5jC786Z3Q=
+github.com/bazelbuild/bazel-gazelle v0.47.0/go.mod h1:8Ozf20jhv+in87nCUHdmUPPcVGTfKg/gotZ/hce3T+w=
+github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52 h1:njQAmjTv/YHRm/0Lfv9DXHFZ4MdT2IA/RKHTnqZkgDw=
+github.com/bazelbuild/buildtools v0.0.0-20250930140053-2eb4fccefb52/go.mod h1:PLNUetjLa77TCCziPsz0EI8a6CUxgC+1jgmWv0H25tg=
+github.com/bazelbuild/rules_go v0.53.0 h1:u160DT+RRb+Xb2aSO4piN8xhs4aZvWz2UDXCq48F4ao=
+github.com/bazelbuild/rules_go v0.53.0/go.mod h1:xB1jfsYHWlnZyPPxzlOSst4q2ZAwS251Mp9Iw6TPuBc=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=
+golang.org/x/mod v0.20.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/tools/go/vcs v0.1.0-deprecated h1:cOIJqWBl99H1dH5LWizPa+0ImeeJq3t3cJjaeOWUAL4=
+golang.org/x/tools/go/vcs v0.1.0-deprecated/go.mod h1:zUrvATBAvEI9535oC0yWYsLsHIV4Z7g63sNPVMtuBy8=


### PR DESCRIPTION
Add a Gazelle language extension for GALA so `gala_library` / `gala_binary` / `gala_test` BUILD files can be generated and kept in sync automatically, instead of being hand-written.

## What
- **New `gala imports` CLI subcommand** — a parse-only import/package extractor. `gala imports --json <files...>` emits, per file, the declared package and its imports (path + alias + dot-import flag), e.g.:
  ```json
  [{"file":"regex/regex.gala","package":"regex","imports":[
     {"path":"regexp","alias":"","dot":false},
     {"path":"martianoff/gala/collection_immutable","alias":"","dot":true}],"error":""}]
  ```
  It uses the existing ANTLR parser only — no transpilation, no Go SDK — so it runs in well under a second. Files that fail to parse get a per-file `error` and are skipped; the process still exits 0. Usage errors exit 1.
- **New nested Bazel module `gazelle/` (`gala_gazelle`)** implementing `language.Language`:
  - Generates one `gala_library` per directory (importpath = configurable prefix + relative path), a `gala_binary` for `package main` + `main()`, and **one `gala_test` per `*_test.gala` file** (matching the repo's established per-file convention). `package main` benchmark files (e.g. `perf_test.gala`) are deliberately left to their hand-wired `gala_binary` rather than minting a colliding test rule.
  - Resolves GALA imports to Bazel labels: in-repo imports → `//relpath`, stdlib → in-repo target or `@gala//x`, Go stdlib imports skipped, macro-injected `std`/`test` excluded.
  - Extracts imports via the **helper-binary model** — it shells out to `gala imports --json` rather than re-implementing the parser. Helper path is configurable (`# gazelle:gala_helper`, default `gala` on `PATH`).
  - Rule kinds load from `@rules_gala//gala:defs.bzl` with no build dependency on `rules_gala`.
- **Directives:** `gala_prefix`, `gala_helper`, `gala_stdlib_prefix`, `gala_stdlib_repo`, `gala_implicit_dep`, plus `-gala_prefix` / `-gala_helper` flags.
- **Dogfood wiring:** a `gazelle_binary` + `gazelle` target in the repo root, and a `gazelle/README.md` documenting consumer setup, generation rules, and the directive table.

## Why
BUILD files for every GALA package are currently hand-maintained — `srcs`, `importpath`, and `deps` all written and updated by hand, which drifts and is error-prone as packages grow. This is the standard Gazelle workflow that Go (and rules_python, rules_js, etc.) already enjoy. Shipping it as a standalone Bazel module follows the rules_python plugin model, so external GALA projects can adopt it via a single `bazel_dep`.

## Verification
- `bazel build //...` green; `bazel test //...` plus the nested module tests → 347/347 pass.
- End-to-end: the real `gala imports` driving the real extension in diff mode reproduces the hand-written targets for `regex/`, `fs/`, `collection_immutable/`, and `collection_mutable/` — including correct per-file test rules with no collisions, orphans, or duplicates.
- The only differences from hand-written BUILDs are two intentional normalizations: `src=` → `srcs=[...]` (both accepted by the macro), and pruning manually-added transitive deps to direct-imports-only. The pruned deps were confirmed empirically to still build and pass (they're supplied transitively).

## Follow-ups
- The nested module ships a small stand-in import-scanner (`gazelle/cmd/galaimports`) that was used for development before the `gala imports` subcommand existed. It is no longer used by default and can be removed in a cleanup PR.
- `gazelle/go.mod` pins `go 1.23.0` (not 1.25.5) to work around an incomplete host Go toolchain on the build machine; Bazel builds/tests use the rules_go 1.25.5 SDK regardless. Bump once a complete host toolchain is available.
- A real consumer's `gazelle_binary` should list both `@gala_gazelle//gala` and the Go language; the in-repo dogfood binary bundles only GALA, which produces a benign `unknown directive: gazelle:prefix` warning on Go directives.
- Blank imports (`import _ "x"`) currently surface as a named alias of `_`; if the extension ever needs to distinguish them, a `blank` flag can be added to the contract.

---
🍎 orchestrated by [Gala Team](https://github.com/martianoff/gala-team)