### PR TITLE
fix(build): resolve dep go.mod Go imports to module roots (BUG-1)

### DIFF
--- a/internal/build/deptranspiler.go
+++ b/internal/build/deptranspiler.go
@@ -281,8 +281,10 @@ func (dt *DepTranspiler) generateDepGoMod(dep mod.Require, outDir string, transp
 	// depInternalPaths maps requirePath -> internalModulePath for the dep's GALA dependencies
 	depInternalPaths := make(map[string]string)
 	var depGalaReqs []mod.Require
+	var depGoReqs []mod.Require
 	if depMod, parseErr := mod.ParseFile(depGalaModPath); parseErr == nil {
 		depGalaReqs = depMod.GalaRequires()
+		depGoReqs = depMod.GoRequires()
 		for _, depReq := range depGalaReqs {
 			internalPath := dt.resolveInternalModulePath(depReq)
 			if internalPath != depReq.Path {
@@ -298,7 +300,12 @@ func (dt *DepTranspiler) generateDepGoMod(dep mod.Require, outDir string, transp
 		importPath string // the internal module path used in Go imports
 	}
 	var galaDepReqs []galaDepEntry
-	var goReqs []string
+	// goReqs maps a resolved Go *module* path -> its required version. A scanned
+	// import is a *package* path; its module may be a proper prefix of it (e.g.
+	// the package golang.org/x/sys/windows belongs to module golang.org/x/sys).
+	// Keying by module path also dedupes multiple imported subpackages of the
+	// same module.
+	goReqs := make(map[string]string)
 
 	for _, imp := range imports {
 		if IsGoStdlibImport(imp) {
@@ -327,13 +334,30 @@ func (dt *DepTranspiler) generateDepGoMod(dep mod.Require, outDir string, transp
 				break
 			}
 		}
-		if !found {
-			goReqs = append(goReqs, imp)
+		if found {
+			continue
+		}
+		// Plain Go import. Resolve it to the module that provides it using the
+		// dep's declared `// go` requires (longest module-path prefix), and
+		// require THAT module at its declared version. Emitting the full import
+		// path as a module at a fake v0.0.0 makes `go build` try to download a
+		// nonexistent module (e.g. golang.org/x/sys/windows v0.0.0). Imports
+		// with no declared module prefix are left out entirely — the workspace's
+		// `go mod tidy` resolves their real versions across the whole graph.
+		if goModPath, version, ok := resolveGoModuleForImport(imp, depGoReqs); ok {
+			goReqs[goModPath] = version
 		}
 	}
 
+	// Stable, deduped ordering for the generated require block.
+	goReqPaths := make([]string, 0, len(goReqs))
+	for p := range goReqs {
+		goReqPaths = append(goReqPaths, p)
+	}
+	sort.Strings(goReqPaths)
+
 	// Write require block
-	if len(stdlibReqs) > 0 || len(galaDepReqs) > 0 || len(goReqs) > 0 {
+	if len(stdlibReqs) > 0 || len(galaDepReqs) > 0 || len(goReqPaths) > 0 {
 		sb.WriteString("require (\n")
 		for _, imp := range stdlibReqs {
 			sb.WriteString(fmt.Sprintf("\t%s v0.0.0\n", imp))
@@ -341,8 +365,8 @@ func (dt *DepTranspiler) generateDepGoMod(dep mod.Require, outDir string, transp
 		for _, entry := range galaDepReqs {
 			sb.WriteString(fmt.Sprintf("\t%s v0.0.0\n", entry.importPath))
 		}
-		for _, imp := range goReqs {
-			sb.WriteString(fmt.Sprintf("\t%s v0.0.0\n", imp))
+		for _, goModPath := range goReqPaths {
+			sb.WriteString(fmt.Sprintf("\t%s %s\n", goModPath, goReqs[goModPath]))
 		}
 		sb.WriteString(")\n\n")
 	}
@@ -376,6 +400,31 @@ func (dt *DepTranspiler) generateDepGoMod(dep mod.Require, outDir string, transp
 
 	goModPath := filepath.Join(outDir, "go.mod")
 	return os.WriteFile(goModPath, []byte(sb.String()), 0644)
+}
+
+// resolveGoModuleForImport maps a scanned Go import (a package path) to the
+// declared Go module that provides it. A module path can be a proper prefix of
+// the import path — e.g. the package "golang.org/x/sys/windows" is provided by
+// module "golang.org/x/sys". It matches against the dep's declared `// go`
+// requires, choosing the longest module-path prefix (the same rule Go uses),
+// and returns that module's path, its declared version, and whether a match was
+// found. Imports with no declared module prefix return ok=false so the caller
+// can omit them and let the workspace's `go mod tidy` resolve them globally.
+func resolveGoModuleForImport(importPath string, goReqs []mod.Require) (string, string, bool) {
+	bestPath := ""
+	bestVersion := ""
+	for _, r := range goReqs {
+		if importPath == r.Path || strings.HasPrefix(importPath, r.Path+"/") {
+			if len(r.Path) > len(bestPath) {
+				bestPath = r.Path
+				bestVersion = r.Version
+			}
+		}
+	}
+	if bestPath == "" {
+		return "", "", false
+	}
+	return bestPath, bestVersion, true
 }
 
 // copyNonGalaFiles copies non-.gala files and subdirectories from srcDir to dstDir.

--- a/internal/build/deptranspiler_test.go
+++ b/internal/build/deptranspiler_test.go
@@ -6,9 +6,82 @@ import (
 	"strings"
 	"testing"
 
+	"martianoff/gala/internal/depman/mod"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestResolveGoModuleForImport(t *testing.T) {
+	// A dependency (e.g. gala-tui) that declares golang.org/x/term but imports
+	// the package golang.org/x/sys/windows (provided by module golang.org/x/sys,
+	// which it does NOT declare).
+	goReqs := []mod.Require{
+		{Path: "golang.org/x/term", Version: "v0.25.0", Go: true},
+		{Path: "golang.org/x/sys", Version: "v0.26.0", Go: true},
+		{Path: "github.com/foo/bar", Version: "v1.2.3", Go: true},
+	}
+
+	tests := []struct {
+		name        string
+		importPath  string
+		wantModule  string
+		wantVersion string
+		wantOK      bool
+	}{
+		{
+			name:        "import path is the module root",
+			importPath:  "golang.org/x/term",
+			wantModule:  "golang.org/x/term",
+			wantVersion: "v0.25.0",
+			wantOK:      true,
+		},
+		{
+			name:        "package path resolves to module prefix (BUG-1)",
+			importPath:  "golang.org/x/sys/windows",
+			wantModule:  "golang.org/x/sys",
+			wantVersion: "v0.26.0",
+			wantOK:      true,
+		},
+		{
+			name:        "nested subpackage resolves to declared module",
+			importPath:  "github.com/foo/bar/baz/qux",
+			wantModule:  "github.com/foo/bar",
+			wantVersion: "v1.2.3",
+			wantOK:      true,
+		},
+		{
+			name:       "no declared module prefix is omitted",
+			importPath: "golang.org/x/sys/windows",
+			wantOK:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqs := goReqs
+			if tt.name == "no declared module prefix is omitted" {
+				// Drop the golang.org/x/sys declaration so the import has no
+				// declared prefix and must be omitted (resolved by `go mod tidy`).
+				reqs = []mod.Require{{Path: "golang.org/x/term", Version: "v0.25.0", Go: true}}
+			}
+			gotModule, gotVersion, gotOK := resolveGoModuleForImport(tt.importPath, reqs)
+			assert.Equal(t, tt.wantOK, gotOK)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantModule, gotModule)
+				assert.Equal(t, tt.wantVersion, gotVersion)
+			}
+		})
+	}
+}
+
+func TestResolveGoModuleForImport_PrefixBoundary(t *testing.T) {
+	// A module path must match on a path boundary: golang.org/x/term must NOT
+	// match the import golang.org/x/terminal.
+	goReqs := []mod.Require{{Path: "golang.org/x/term", Version: "v0.25.0", Go: true}}
+	_, _, ok := resolveGoModuleForImport("golang.org/x/terminal", goReqs)
+	assert.False(t, ok, "golang.org/x/term must not match golang.org/x/terminal")
+}
 
 func TestCopyNonGalaFiles(t *testing.T) {
 	// Create source directory structure simulating a GALA module with Go subpackages


### PR DESCRIPTION
## Summary

Fixes **BUG-1**: `gala build` / `gala test` fail before compiling any project code with `go: downloading golang.org/x/sys/windows v0.0.0` → `Build failed: go build: exit status 1`.

**Category**: TRANSPILER_BUG (build system — Go `go.mod` generation for transpiled deps)
**Priority**: P0 (blocks all builds/tests of any project that pulls in such a dependency)
**Found in**: gala-assimilator (dependency `github.com/martianoff/gala-tui@v0.9.2`)

## Root Cause

`generateDepGoMod` (`internal/build/deptranspiler.go`) wrote each scanned Go **import path** verbatim into a transpiled dependency's `go.mod` as a module require at `v0.0.0`. `golang.org/x/sys/windows` is a *package*, not a module, so `go build` tried to download a nonexistent `golang.org/x/sys/windows v0.0.0`. (`golang.org/x/term` only worked by accident because the import path happens to equal its module root and the workspace pins a real version that wins MVS.)

## Changes

- `internal/build/deptranspiler.go`:
  - New `resolveGoModuleForImport` maps a scanned import to its **module root** via the longest declared `// go` module-path prefix (the same rule `go mod` uses) and requires that module at its **declared version**.
  - Imports with no declared module prefix are **omitted** — the workspace's `go mod tidy` resolves their real versions across the whole module graph (e.g. it already lands `golang.org/x/sys v0.26.0 // indirect`).
  - Go requires are now keyed by module path (dedupes imported subpackages) and emitted in sorted order.
- `internal/build/deptranspiler_test.go`: `TestResolveGoModuleForImport` (+ a path-boundary guard test).

## Verification

- `TestResolveGoModuleForImport`: package→module-prefix resolution (the BUG-1 case), module-root imports, nested subpackages, omit-when-undeclared, and `x/term` must-not-match `x/terminal`.
- Code is gofmt-clean.
- ⚠️ `bazel build //...` / `bazel test //...` were **not run in the authoring session** due to a corrupted local Go 1.25.5 toolchain / blocked SDK fetch. Please confirm the gates in CI / a working shell before merging.

## Repro (before fix)

gala-tui's `gala.mod` declares only `golang.org/x/term`, but it imports `golang.org/x/sys/windows`. The generated dep `go.mod` emitted:

```
require (
	golang.org/x/sys/windows v0.0.0   // wrong: module is golang.org/x/sys
	golang.org/x/term v0.0.0
)
```

After the fix, `golang.org/x/sys/windows` is omitted (resolved globally by `go mod tidy`) and `golang.org/x/term` is required at its declared `v0.25.0`.

## Dependencies

None — independent, can be reviewed and merged directly to `master`.

## Battle Test Report Reference

Originally reported as BUG-1 in gala-assimilator's private bug log.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)