### PR TITLE
fix(transpiler): resolve third-party Go module types from source

### DIFF
--- a/cmd/gala/commands/worker.go
+++ b/cmd/gala/commands/worker.go
@@ -260,6 +260,34 @@ var (
 	analyzerCache   = map[string]*analyzerCacheEntry{}
 )
 
+// parseGoSrc parses the --go-src flag into an import-path -> source-dir map.
+// The value is a comma-separated list of "importpath=dir" entries (Go import
+// paths never contain '=' or ',', so the split is unambiguous). The Bazel
+// gala rules emit one entry per Go dependency, pointing at the staged .go
+// source so the analyzer can resolve third-party Go module types that
+// go/importer's source mode cannot find in the sandbox. Returns nil for an
+// empty flag.
+func parseGoSrc(s string) map[string]string {
+	if s == "" {
+		return nil
+	}
+	dirs := make(map[string]string)
+	for _, entry := range strings.Split(s, ",") {
+		if entry == "" {
+			continue
+		}
+		eq := strings.IndexByte(entry, '=')
+		if eq <= 0 {
+			continue
+		}
+		dirs[entry[:eq]] = entry[eq+1:]
+	}
+	if len(dirs) == 0 {
+		return nil
+	}
+	return dirs
+}
+
 func cacheKey(searchPaths []string, goroot, projectRoot string) string {
 	h := sha256.New()
 	for _, p := range searchPaths {
@@ -313,11 +341,13 @@ func runWorkerTranspilePackage(argv []string, out io.Writer) int {
 		outputs string
 		search  string
 		goroot  string
+		goSrc   string
 	)
 	fs.StringVar(&inputs, "inputs", "", "")
 	fs.StringVar(&outputs, "outputs", "", "")
 	fs.StringVar(&search, "search", ".", "")
 	fs.StringVar(&goroot, "goroot", "", "")
+	fs.StringVar(&goSrc, "go-src", "", "")
 	if err := fs.Parse(argv); err != nil {
 		fmt.Fprintf(out, "transpile-package: parse flags: %v\n", err)
 		return 1
@@ -347,6 +377,9 @@ func runWorkerTranspilePackage(argv []string, out io.Writer) int {
 	projectRoot := findGalaModDir(filepath.Dir(mustAbs(inList[0])))
 
 	parser, batch := getBatchAnalyzer(paths, goroot, projectRoot)
+	if dirs := parseGoSrc(goSrc); dirs != nil {
+		batch.SetGoSrcDirs(dirs)
+	}
 
 	hasError := false
 	for i, inputPath := range inList {
@@ -411,12 +444,14 @@ func runWorkerTranspile(argv []string, out io.Writer) int {
 		search       string
 		packageFiles string
 		goroot       string
+		goSrc        string
 	)
 	fs.StringVar(&input, "input", "", "")
 	fs.StringVar(&output, "output", "", "")
 	fs.StringVar(&search, "search", ".", "")
 	fs.StringVar(&packageFiles, "package-files", "", "")
 	fs.StringVar(&goroot, "goroot", "", "")
+	fs.StringVar(&goSrc, "go-src", "", "")
 	if err := fs.Parse(argv); err != nil {
 		fmt.Fprintf(out, "transpile: parse flags: %v\n", err)
 		return 1
@@ -448,6 +483,9 @@ func runWorkerTranspile(argv []string, out io.Writer) int {
 	projectRoot := findGalaModDir(filepath.Dir(mustAbs(input)))
 
 	parser, batch := getBatchAnalyzer(paths, goroot, projectRoot)
+	if dirs := parseGoSrc(goSrc); dirs != nil {
+		batch.SetGoSrcDirs(dirs)
+	}
 
 	var pkgFiles []string
 	if packageFiles != "" {

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -270,6 +270,88 @@ func (b *Builder) effectiveDepDir(req mod.Require) string {
 	return resolveEffectiveDepDir(b.config, b.galaMod, b.workspace.ProjectDir, req)
 }
 
+// goModuleSrcDirs maps each Go (`// go`) dependency's module path to the
+// on-disk directory holding its .go source, so the analyzer can resolve
+// third-party Go types module-aware (go/importer's source mode can't — see
+// analyzer.goSrcDirs). The source is parsed, not compiled, so either cache
+// works: GALA's own dep cache (populated by `gala mod add --go` / auto-fetch,
+// source-only) or the Go module cache (populated by `go build`). We prefer the
+// GALA cache because it is available at transpile time, which runs before the
+// `go build` step that fills GOMODCACHE. Returns nil when there are no Go deps
+// or none are cached yet (the analyzer then leaves Go resolution to the
+// importer, which is correct for stdlib-only code).
+func (b *Builder) goModuleSrcDirs() map[string]string {
+	reqs := b.galaMod.GoRequires()
+	if len(reqs) == 0 {
+		return nil
+	}
+	dirs := make(map[string]string, len(reqs))
+	for _, req := range reqs {
+		// GALA dep cache stores the module path verbatim; the Go module
+		// cache case-escapes it (uppercase letter c -> "!"+lower(c)).
+		galaCand := filepath.Join(b.config.GalaPkgDir, filepath.FromSlash(req.Path)+"@"+req.Version)
+		goCand := filepath.Join(b.config.GoPkgDir, filepath.FromSlash(escapeGoModulePath(req.Path))+"@"+req.Version)
+		for _, cand := range []string{galaCand, goCand} {
+			if dirHasGoFiles(cand) {
+				dirs[req.Path] = cand
+				break
+			}
+		}
+	}
+	if len(dirs) == 0 {
+		return nil
+	}
+	return dirs
+}
+
+// escapeGoModulePath applies the Go module cache path escaping: every
+// uppercase ASCII letter is replaced with "!" followed by its lowercase form
+// (e.g. github.com/BurntSushi/toml -> github.com/!burnt!sushi/toml). This
+// mirrors golang.org/x/mod/module.EscapePath for the common case without
+// taking on the dependency.
+func escapeGoModulePath(p string) string {
+	hasUpper := false
+	for i := 0; i < len(p); i++ {
+		if p[i] >= 'A' && p[i] <= 'Z' {
+			hasUpper = true
+			break
+		}
+	}
+	if !hasUpper {
+		return p
+	}
+	var sb strings.Builder
+	for i := 0; i < len(p); i++ {
+		c := p[i]
+		if c >= 'A' && c <= 'Z' {
+			sb.WriteByte('!')
+			sb.WriteByte(c + ('a' - 'A'))
+		} else {
+			sb.WriteByte(c)
+		}
+	}
+	return sb.String()
+}
+
+// dirHasGoFiles reports whether dir exists and contains at least one
+// non-test, non-generated .go source file.
+func dirHasGoFiles(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(name, ".go") && !strings.HasSuffix(name, "_test.go") && !strings.HasSuffix(name, ".gen.go") {
+			return true
+		}
+	}
+	return false
+}
+
 // ensureStdlib extracts the stdlib to the versioned cache if not present.
 func (b *Builder) ensureStdlib() error {
 	stdlibDir := b.config.StdlibVersionDir(b.stdlibVersion)
@@ -382,6 +464,7 @@ func (b *Builder) transpile() error {
 	// Use BatchAnalyzer to share analyzed package cache across all files.
 	// This avoids redundant re-analysis of imports (std, collection_immutable, etc.).
 	batchAnalyzer := analyzer.NewBatchAnalyzer(p, searchPaths, b.workspace.ProjectDir)
+	batchAnalyzer.SetGoSrcDirs(b.goModuleSrcDirs())
 
 	// Group files by their parent directory so sibling-based type resolution
 	// only sees files that actually share a Go package. A root-level file is
@@ -535,6 +618,7 @@ func (b *Builder) transpileWithSourceDir() error {
 		libFilesByDir[filepath.Dir(f)] = append(libFilesByDir[filepath.Dir(f)], f)
 	}
 	libBatch := analyzer.NewBatchAnalyzer(p, searchPaths, b.workspace.ProjectDir)
+	libBatch.SetGoSrcDirs(b.goModuleSrcDirs())
 	for _, galaFile := range libFiles {
 		content, err := os.ReadFile(galaFile)
 		if err != nil {
@@ -1798,6 +1882,7 @@ func (b *Builder) transpileFilesToDir(files []string, allSiblings []string, outD
 	tr := transformer.NewGalaASTTransformer()
 	g := generator.NewGoCodeGenerator()
 	batchAnalyzer := analyzer.NewBatchAnalyzer(p, searchPaths, b.workspace.ProjectDir)
+	batchAnalyzer.SetGoSrcDirs(b.goModuleSrcDirs())
 
 	// Group sibling candidates by source directory so we can cheaply look up
 	// "other .gala files in my own package" without re-scanning allSiblings on

--- a/internal/transpiler/analyzer/BUILD.bazel
+++ b/internal/transpiler/analyzer/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "cache_codec_test.go",
         "cache_e2e_test.go",
         "cache_test.go",
+        "go_src_dirs_test.go",
         "go_types_debug_test.go",
         "go_types_test.go",
         "multipackage_panic_test.go",

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -112,6 +112,20 @@ type galaAnalyzer struct {
 	// dead work in LSP context and contends heavily under parallel analyzers
 	// on Windows.
 	skipTranspileToDisk bool
+
+	// goSrcDirs maps a Go import-path prefix (a module path, or an exact
+	// package path) to the on-disk directory holding that package's .go
+	// source. It is the module-aware escape hatch for third-party Go
+	// interop: go/importer's "source" mode (AnalyzeGoPackage) is
+	// GOPATH/GOROOT-based and cannot resolve a versioned module from the
+	// module cache (CLI) or Bazel's external tree, so it returns nothing for
+	// e.g. github.com/google/uuid. When the importer comes up empty, the
+	// analyzer falls back to parsing the package's real .go sources from the
+	// directory resolved here (the same code path that already resolves
+	// hand-written local .go files). Populated by the builder (from gala.mod
+	// + GOMODCACHE) and by the worker's --go-src flag (from the Bazel rule).
+	// Nil when no Go module sources are wired in (stdlib-only projects).
+	goSrcDirs map[string]string
 }
 
 // siblingCacheEntry is the value stored in galaAnalyzer.siblingTreeCache.
@@ -275,9 +289,49 @@ func (b *BatchAnalyzer) SetPackageFiles(files []string) {
 	b.inner.checkedDirs = make(map[string]bool)
 }
 
+// SetGoSrcDirs wires module-aware Go source directories into the inner
+// analyzer (see galaAnalyzer.goSrcDirs). Idempotent and invariant for a build,
+// so callers set it once after construction.
+func (b *BatchAnalyzer) SetGoSrcDirs(dirs map[string]string) {
+	b.inner.goSrcDirs = dirs
+}
+
 // Analyze delegates to the inner analyzer, sharing the package cache.
 func (b *BatchAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.RichAST, error) {
 	return b.inner.Analyze(tree, filePath)
+}
+
+// SetGoSrcDirs wires module-aware Go source directories into the analyzer
+// (see galaAnalyzer.goSrcDirs). Used by the single-file/LSP analyzers that
+// are not BatchAnalyzers.
+func (a *galaAnalyzer) SetGoSrcDirs(dirs map[string]string) {
+	a.goSrcDirs = dirs
+}
+
+// resolveGoSrcDir maps a Go import path to its on-disk .go source directory
+// using the wired goSrcDirs table. It first tries an exact match, then the
+// longest registered import-path prefix (a module path), appending the
+// remaining package subpath. Returns ("", false) when nothing is wired or
+// no prefix matches — in which case the caller leaves Go type resolution to
+// go/importer (correct for stdlib, which is always on GOROOT).
+func (a *galaAnalyzer) resolveGoSrcDir(importPath string) (string, bool) {
+	if len(a.goSrcDirs) == 0 {
+		return "", false
+	}
+	if dir, ok := a.goSrcDirs[importPath]; ok {
+		return dir, true
+	}
+	bestKey := ""
+	for k := range a.goSrcDirs {
+		if len(k) > len(bestKey) && strings.HasPrefix(importPath, k+"/") {
+			bestKey = k
+		}
+	}
+	if bestKey == "" {
+		return "", false
+	}
+	rel := strings.TrimPrefix(importPath, bestKey+"/")
+	return filepath.Join(a.goSrcDirs[bestKey], filepath.FromSlash(rel)), true
 }
 
 // Analyze walk the ANTLR tree and collects metadata for RichAST.
@@ -601,9 +655,25 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 				continue // Already handled above
 			}
 
-			// This is a Go package — analyze it for type info
+			// This is a Go package — analyze it for type info.
 			goInfo := AnalyzeGoPackage(path)
-			if len(goInfo.Functions) > 0 || len(goInfo.Types) > 0 || len(goInfo.Variables) > 0 || len(goInfo.TypeAliases) > 0 {
+			// go/importer "source" mode resolves Go stdlib (always on
+			// GOROOT/src) but cannot find a versioned third-party module in
+			// the module cache or Bazel's external tree, so it returns
+			// nothing for e.g. github.com/google/uuid. When that happens and
+			// the package's real .go source directory has been wired in (CLI
+			// builder from gala.mod+GOMODCACHE, or the worker's --go-src flag
+			// under Bazel), parse it directly — the same path that already
+			// resolves hand-written local .go files, yielding concrete types
+			// instead of falling back to `any`.
+			if !goTypeInfoNonEmpty(goInfo) {
+				if dir, ok := a.resolveGoSrcDir(path); ok {
+					if srcInfo := AnalyzeGoFiles(dir); goTypeInfoNonEmpty(srcInfo) {
+						goInfo = srcInfo
+					}
+				}
+			}
+			if goTypeInfoNonEmpty(goInfo) {
 				if richAST.GoTypeInfo == nil {
 					richAST.GoTypeInfo = transpiler.NewGoTypeInfo()
 				}

--- a/internal/transpiler/analyzer/go_src_dirs_test.go
+++ b/internal/transpiler/analyzer/go_src_dirs_test.go
@@ -1,0 +1,127 @@
+package analyzer_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeSyntheticGoModule writes a tiny, import-free Go package to a fresh
+// directory and returns it. Import-free is deliberate: AnalyzeGoFiles
+// type-checks the package with the (possibly unavailable) go/importer, but a
+// package that imports nothing never invokes the importer, so the fixture
+// resolves identically inside and outside the Bazel sandbox — no Go SDK
+// needed, fully hermetic.
+func writeSyntheticGoModule(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := `package widget
+
+type Widget struct {
+	Name string
+}
+
+func New(name string) Widget { return Widget{Name: name} }
+
+func Parse(s string) (Widget, error) { return Widget{Name: s}, nil }
+
+func (w Widget) Label() string { return w.Name }
+`
+	if err := os.WriteFile(filepath.Join(dir, "widget.go"), []byte(src), 0644); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	return dir
+}
+
+// TestGoSrcDirs_ThirdPartyModuleResolvesConcreteTypes is the regression test
+// for third-party Go MODULE interop. go/importer's "source" mode (used by
+// AnalyzeGoPackage) is GOPATH/GOROOT-based and cannot resolve a versioned
+// module from the module cache or Bazel's external tree, so a direct import
+// of e.g. github.com/google/uuid used to collapse to `any` and produce
+// uncompilable Go. With the package's real .go source directory wired in via
+// SetGoSrcDirs, the analyzer parses it directly and recovers concrete types.
+func TestGoSrcDirs_ThirdPartyModuleResolvesConcreteTypes(t *testing.T) {
+	dir := writeSyntheticGoModule(t)
+
+	p := transpiler.NewAntlrGalaParser()
+	batch := analyzer.NewBatchAnalyzer(p, getStdSearchPath(), t.TempDir())
+	batch.SetGoSrcDirs(map[string]string{"example.test/widget": dir})
+
+	input := `package main
+
+import "example.test/widget"
+
+func main() {
+}
+`
+	tree, err := p.Parse(input)
+	require.NoError(t, err)
+
+	richAST, err := batch.Analyze(tree, "")
+	require.NoError(t, err)
+	require.NotNil(t, richAST)
+	require.NotNil(t, richAST.GoTypeInfo, "Go type info should be populated from the wired source dir")
+
+	// widget.New returns a concrete widget.Widget — not `any`.
+	retType := richAST.GoTypeInfo.GetFuncReturnType("widget.New")
+	require.NotNil(t, retType, "widget.New should resolve")
+	assert.Equal(t, "widget.Widget", retType.String())
+
+	// widget.Parse returns (widget.Widget, error) — the (T, error) shape that
+	// the transpiler auto-wraps into Try[widget.Widget].
+	sig := richAST.GoTypeInfo.GetFuncSignature("widget.Parse")
+	require.NotNil(t, sig, "widget.Parse should resolve")
+	require.Len(t, sig.Returns, 2)
+	assert.Equal(t, "widget.Widget", sig.Returns[0].String())
+	assert.Equal(t, "error", sig.Returns[1].String())
+
+	// The Widget type and its method are visible, so w.Label() resolves to a
+	// concrete string instead of failing on `any`.
+	retType = richAST.GoTypeInfo.GetMethodReturnType("widget.Widget", "Label")
+	require.NotNil(t, retType, "Widget.Label should resolve")
+	assert.Equal(t, "string", retType.String())
+}
+
+// TestGoSrcDirs_LongestPrefixSubpackage verifies that a registered module-path
+// prefix resolves a subpackage import by appending the remaining path segment,
+// mirroring how the CLI builder registers one entry per module root while user
+// code may import a nested package.
+func TestGoSrcDirs_LongestPrefixSubpackage(t *testing.T) {
+	moduleRoot := t.TempDir()
+	subDir := filepath.Join(moduleRoot, "sub")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+	src := `package sub
+
+func Tag() string { return "tag" }
+`
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "sub.go"), []byte(src), 0644))
+
+	p := transpiler.NewAntlrGalaParser()
+	batch := analyzer.NewBatchAnalyzer(p, getStdSearchPath(), t.TempDir())
+	// Register only the module root; the import is a subpackage of it.
+	batch.SetGoSrcDirs(map[string]string{"example.test/mod": moduleRoot})
+
+	input := `package main
+
+import "example.test/mod/sub"
+
+func main() {
+}
+`
+	tree, err := p.Parse(input)
+	require.NoError(t, err)
+
+	richAST, err := batch.Analyze(tree, "")
+	require.NoError(t, err)
+	require.NotNil(t, richAST.GoTypeInfo)
+
+	retType := richAST.GoTypeInfo.GetFuncReturnType("sub.Tag")
+	require.NotNil(t, retType, "sub.Tag should resolve via longest-prefix module root match")
+	assert.Equal(t, "string", retType.String())
+}

--- a/internal/transpiler/analyzer/go_types.go
+++ b/internal/transpiler/analyzer/go_types.go
@@ -166,6 +166,16 @@ var goPackageCache = struct {
 	cache map[string]*transpiler.GoTypeInfo
 }{cache: make(map[string]*transpiler.GoTypeInfo)}
 
+// goTypeInfoNonEmpty reports whether a GoTypeInfo carries any usable type
+// data. Used to decide whether go/importer resolved a package or whether the
+// analyzer should fall back to parsing the package's .go source directly.
+func goTypeInfoNonEmpty(info *transpiler.GoTypeInfo) bool {
+	if info == nil {
+		return false
+	}
+	return len(info.Functions) > 0 || len(info.Types) > 0 || len(info.Variables) > 0 || len(info.TypeAliases) > 0
+}
+
 // AnalyzeGoPackage loads type information for a Go package by import path.
 // Uses go/importer to resolve installed packages (stdlib and third-party).
 // Returns empty GoTypeInfo if Go SDK is not available (e.g., Bazel sandbox).

--- a/website/features/go-interop.md
+++ b/website/features/go-interop.md
@@ -79,6 +79,50 @@ val dir = result.GetOrElse("/tmp")
 
 ---
 
+## Third-Party Go Modules
+
+Third-party modules work exactly like the standard library — not just stdlib.
+Add the module as a Go dependency, import it, and call it directly. GALA reads
+the module's source to infer concrete types (return types, struct fields,
+methods), so you get `uuid.UUID`, never `any`.
+
+Add the dependency with `--go` so GALA tracks it as a Go (not GALA) package:
+
+```bash
+gala mod add github.com/google/uuid@v1.6.0 --go
+```
+
+Then use it like any other package:
+
+```gala
+import "github.com/google/uuid"
+
+func main() {
+    val id = uuid.New()
+    Println(s"id: ${id.String()}")
+}
+```
+
+A function returning `(T, error)` — like `uuid.Parse(string) (uuid.UUID, error)`
+— is consumed exactly like a stdlib error pair: as a multi-return, or wrapped in
+`Try` for pattern matching:
+
+```gala
+import "github.com/google/uuid"
+
+func describe(s string) string = Try(() => uuid.Parse(s)) match {
+    case Success(id) => s"valid: ${id.String()}"
+    case Failure(_)  => s"invalid: $s"
+}
+```
+
+Both the plain CLI (`gala build` / `gala run`) and Bazel builds resolve these
+types from the dependency's source. See
+[Dependency Management](/docs/dependency-management/) for adding and pinning Go
+modules.
+
+---
+
 ## Using Go Types
 
 Define and use Go struct types with GALA syntax:


### PR DESCRIPTION
﻿## Problem

A fresh project that imports a third-party Go **module** (e.g. `github.com/google/uuid`) and uses it directly in GALA code failed to compile in both `gala run` and `bazel build`: `uuid.New()`/`uuid.Parse()` resolved to `any`, so `.String()` was "undefined (type any)" and the `(T,error)?Try` wrap emitted a malformed call.

**Root cause:** the analyzer resolved every Go import via `go/importer`'s "source" mode, which is GOPATH/GOROOT-based and cannot find a versioned module in the module cache or Bazel's `external/...+go_deps+...` tree. Go stdlib worked (it lives in `GOROOT/src`); third-party modules did not. This contradicted the README's "Full Go third-party module interop" claim.

## Fix

Wire each Go dependency's on-disk `.go` source directory into the analyzer and fall back to the existing `AnalyzeGoFiles` source-parsing path (already used for local hand-written `.go`) when the importer is empty ? yielding concrete types instead of `any`.

- **analyzer**: `goSrcDirs` map + `SetGoSrcDirs` + `resolveGoSrcDir` (exact then longest-prefix match, appends subpath); `goTypeInfoNonEmpty` helper.
- **builder**: map each `// go` dep to its cached source dir (prefer the GALA pkg cache, available at transpile time, then GOMODCACHE) with inline module-path escaping.
- **worker**: `--go-src` flag (comma-separated `importpath=dir`) for the Bazel transpile worker.

The Bazel half is completed by martianoff/rules-gala (companion PR) staging Go dep sources and passing `--go-src`.

## Verification

- New hermetic regression test `go_src_dirs_test.go` (synthetic, import-free Go module ? no network/SDK).
- `bazel test //...` ? **347/347 pass**, no regressions.
- End-to-end: `gala run` and `bazel build //:hello` of a fresh uuid project both compile and print real UUIDs (Try + `uuid.New`/`uuid.Parse` + pattern matching).

?? Generated with [Claude Code](https://claude.com/claude-code)
