### PR TITLE
release: bump version files to 0.55.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ module(
     # release-script tag and gala.mod so `bazel_dep(name = "gala",
     # version = X)` always matches the published binary the registry
     # serves for that version.
-    version = "0.54.0",
+    version = "0.55.0",
 )
 
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/gala.mod
+++ b/gala.mod
@@ -1,3 +1,3 @@
 module martianoff/gala
 
-gala 0.54.0
+gala 0.55.0


### PR DESCRIPTION
Bumps `MODULE.bazel` and `gala.mod` to `0.55.0` ahead of cutting the `0.55.0` release.

Follows the same pattern as the 0.54.0 bump (#371).

🤖 Generated with [Claude Code](https://claude.com/claude-code)