### PR TITLE
fix(release): bump version files to 0.56.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ module(
     # release-script tag and gala.mod so `bazel_dep(name = "gala",
     # version = X)` always matches the published binary the registry
     # serves for that version.
-    version = "0.55.0",
+    version = "0.56.0",
 )
 
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/gala.mod
+++ b/gala.mod
@@ -1,3 +1,3 @@
 module martianoff/gala
 
-gala 0.55.0
+gala 0.56.0


### PR DESCRIPTION
Bumps `MODULE.bazel` and `gala.mod` to **0.56.0** ahead of cutting the release tag, so the tagged tree's module version matches `bazel_dep(name = "gala", version = "0.56.0")` served by the registry.

Release contents (0.55.0...0.56.0):
- #376 — fix(module): resolve absolute replace paths verbatim
- #377 — fix(transpiler): zero-field struct ctor and chained FlatMap type args

🤖 Generated with [Claude Code](https://claude.com/claude-code)