### PR TITLE
fix(release): bump version files to 0.56.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ module(
     # release-script tag and gala.mod so `bazel_dep(name = "gala",
     # version = X)` always matches the published binary the registry
     # serves for that version.
-    version = "0.56.0",
+    version = "0.56.1",
 )
 
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/gala.mod
+++ b/gala.mod
@@ -1,3 +1,3 @@
 module martianoff/gala
 
-gala 0.56.0
+gala 0.56.1


### PR DESCRIPTION
Bumps `MODULE.bazel` and `gala.mod` to **0.56.1** in lockstep ahead of cutting the `0.56.1` release tag.

This is a patch release carrying the IDE-sync fix from #379 (LSP/IntelliJ plugin sync with newer GALA prelude types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)