### PR TITLE
fix(transpiler): infer None() type from context for qualified variants

### DIFF
--- a/.claude/skills/gala-lint/SKILL.md
+++ b/.claude/skills/gala-lint/SKILL.md
@@ -352,6 +352,7 @@ func createServer(host string, port int = 8080, tls bool = true, maxConnections 
 |-------|-----------------|-----------------|
 | Redundant variable type | `val x int = 42` | `val x = 42` |
 | Redundant generic params on helpers | `Some[int](42)` | `Some(42)` |
+| Redundant type arg on `None[T]()` in inferable context | `func parse() Option[int] = None[int]()` | `func parse() Option[int] = None()` (type pinned by the return type) |
 | Redundant collection types | `ListOf[int](1, 2, 3)` | `ListOf(1, 2, 3)` |
 | Redundant single-param struct constructor | `Box[int](Value = 42)` | `Box(Value = 42)` (type inferred from named field value) |
 | Redundant generic function call type params | `Try[int](() => { return 1 })` | `Try(() => { return 1 })` (type inferred from lambda return) |
@@ -366,9 +367,18 @@ func createServer(host string, port int = 8080, tls bool = true, maxConnections 
 - **Single-type-param generic struct constructors**: `Box[int](Value = 42)` → `Box(Value = 42)` — Go infers the single type param from the named field value
 - **Single-type-param generic function calls**: `Try[int](f)`, `NewCons[int](head, tail)` — argument types determine the type param
 - **Helper constructors**: `Some[int](42)`, `ListOf[int](1, 2, 3)` — element values determine type params
+- **Zero-arg sealed-variant constructors in an inferable context**: `None[T]()` (and other zero-field cases of a generic sealed type) when the surrounding context pins the type. A zero-field variant has no argument to infer from, but the transpiler propagates an **expected type** downward and injects the type arg, so the explicit `[T]` is redundant. Flag `None[T]()` → `None()` when it appears as any of:
+  - a function body or `return` whose declared return type is `Option[T]` — `func f() Option[T] = None[T]()`
+  - the RHS of a `val`/`var` with an explicit `Option[T]` type — `val x Option[T] = None[T]()`
+  - an argument to a function/constructor whose parameter type is `Option[T]`
+  - an element of a typed container — `ArrayOf[Option[T]](None[T]())`
+  - a `match` arm whose result type is externally pinned (e.g. the match is the body of a function returning `Option[T]`)
+  - an `if`/`else` branch whose sibling branch is a `Some(...)` of known type — `if (c) Some(x) else None[int]()`
+
+  Do NOT flag (explicit typing is still required) when none of the above pins the type — most commonly a bare `None[T]()` inside a lambda whose result type is unconstrained, e.g. `arr.Map((x) => None[int]())`: the element-result type is free, so removing `[int]` makes the type undeterminable and the transpiler reports GALA-E0018.
 
 **Exception**: Explicit types ARE required for:
-- `None[T]()`, `Left[L, R]()`, `Right[L, R]()` — no value arguments to infer from
+- `Left[L, R]()`, `Right[L, R]()` — no value arguments to infer from (and Either carries two params)
 - Empty collections: `EmptyArray[T]()`, `EmptyList[T]()`, `EmptyHashMap[K, V]()`, `Empty[T]()` — no elements to infer from
 - **Multi-type-param generic struct constructors**: `Pair[string, int]("a", 1)` — Go cannot infer when there are 2+ type params on struct instantiation
 - **Generic struct constructors inside generic method bodies**: `Pair[C, B](First = ...)` — abstract type params from enclosing method must be explicit

--- a/docs/GALA_BEST_PRACTICES.MD
+++ b/docs/GALA_BEST_PRACTICES.MD
@@ -28,7 +28,8 @@ A scannable rule list for writing idiomatic GALA — useful as both a learning c
 - **No variable types** — `val x = 42`, not `val x int = 42`.
 - **No method type params** — `list.Map((x) => x * 2)`, not `list.Map[int](...)`.
 - **No FoldLeft accumulator type** — `list.FoldLeft(0, (acc, x) => acc + x)`.
-- **Annotate only when there's nothing to infer from**: `None[int]()`, `Left[string, int]("err")`, empty collections, standalone lambdas.
+- **No type arg on `None()`** when the context pins the type — `func f() Option[int] = None()`, `val x Option[int] = None()`, or a `None()` arm of a match returning `Option[int]`. The type flows down from the return/annotation, so `None[int]()` is redundant there.
+- **Annotate only when there's nothing to infer from**: `None[int]()` *only* where no context pins it (e.g. a bare `None[int]()` in a lambda whose result type is unconstrained), `Left[string, int]("err")`, empty collections, standalone lambdas.
 
 ---
 

--- a/docs/TYPE_INFERENCE.MD
+++ b/docs/TYPE_INFERENCE.MD
@@ -393,10 +393,20 @@ Five contexts feed the expected type:
   across siblings.
 - For the **zero-arg call** path (`NoCmd()` with empty parens),
   `applyCallSuffix` peeks the top hint after `inferZeroArgTypeParams`
-  (which already covered the match-subject and enclosing-return
-  fallbacks for `None()` / `Some()`), and rewrites the receiver via
+  (which covers the enclosing-return and match-subject fallbacks for
+  `None()` / `Some()`), and rewrites the receiver via
   `injectSealedVariantTypeArgs`. On a successful rewrite it consumes
   the hint so deeper sub-expressions cannot pick it up.
+  `inferZeroArgTypeParams` consults `currentFuncReturnType` **before**
+  `currentMatchSubjectType`: in value position the arm body's type is
+  the match *result* type, which the declared return pins, while the
+  subject is only a proxy that coincides with the result when the match
+  maps `Option[T]` to `Option[T]`. The two diverge in e.g.
+  `v.AsObject() match { case Some(fields) => …; case None() => None() }`
+  inside `func firstName(v) Option[string]` — the subject is
+  `Option[Array[JField]]` but the result must be `Option[string]`, so
+  the return type wins and the subject stays a fallback for the
+  no-return-type case.
 - For the **non-zero-arg call** path, `transformCallWithArgsCtx`
   consumes the top hint at dispatcher entry and invokes the same
   rewrite.
@@ -418,7 +428,17 @@ is a sealed variant of a generic parent, the transpiler fails fast
 with [`GALA-E0018`](errors/GALA-E0018.md) at the offending call — it
 does **not** silently emit an untyped `Variant{}` literal that Go
 would later reject with an obscure deduction error far from the
-source.
+source. The sealed-variant gate (`isSealedVariantTypeName`) splits any
+package qualifier off the name and passes it as the lookup scope: the
+zero-arg path derives the name from `getBaseTypeName`, which keeps the
+selector for dot-imported / std variants (`std.None`), while
+sealed-variant metadata is registered under the bare case name.
+Matching the qualified `std.None` against the unqualified metadata
+names found nothing, so the guard never fired for `std.None()` and an
+uninstantiated `std.None{}.Apply()` (invalid Go) was emitted instead of
+the diagnostic. Passing the qualifier as scope (rather than searching
+every package) also keeps the check precise when two packages declare
+a sealed case of the same name.
 
 ### Limitations
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1827,6 +1827,14 @@ gala_exec_test(
     expected = "block_lambda_match.out",
 )
 
+# Verification: bare None() infers its element type from context
+gala_exec_test(
+    name = "none_downward_inference",
+    src = "none_downward_inference.gala",
+    expected = "none_downward_inference.out",
+    deps = ["//collection_immutable"],
+)
+
 # Repro: Try match extractor values typed as any
 gala_exec_test(
     name = "try_match_extractor_any_types",

--- a/examples/none_downward_inference.gala
+++ b/examples/none_downward_inference.gala
@@ -1,0 +1,39 @@
+package main
+
+import . "martianoff/gala/std"
+import . "martianoff/gala/collection_immutable"
+
+// A bare `None()` infers its element type from context, so callers never need
+// to spell out `None[Array[JField]]()` when the type is predictable.
+
+sealed type JField {
+    case JF(Name string)
+}
+
+sealed type JsonValue {
+    case JObj(Fields Array[JField])
+    case JNull()
+}
+
+// Match arm: `Some(fields)` pins the element type; the `None()` arm inherits it
+// via the method's declared return type.
+func (v JsonValue) AsObject() Option[Array[JField]] = v match {
+    case JObj(fields) => Some(fields)
+    case _ => None()
+}
+
+// Plain function return type pins the element type directly.
+func firstName(v JsonValue) Option[string] = v.AsObject() match {
+    case Some(fields) => fields.HeadOption().Map((f) => f.Name)
+    case None() => None()
+}
+
+func main() {
+    val obj = JObj(ArrayOf(JF("id"), JF("name")))
+    val empty = JNull()
+
+    Println(obj.AsObject().IsDefined())
+    Println(empty.AsObject().IsDefined())
+    Println(firstName(obj).GetOrElse("<none>"))
+    Println(firstName(empty).GetOrElse("<none>"))
+}

--- a/examples/none_downward_inference.out
+++ b/examples/none_downward_inference.out
@@ -1,0 +1,4 @@
+true
+false
+id
+<none>

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -85,6 +85,7 @@ go_test(
         "multi_file_some_none_test.go",
         "multi_var_test.go",
         "nested_success_typearg_test.go",
+        "none_qualified_downward_inference_test.go",
         "option_test.go",
         "panic_audit_test.go",
         "phantom_reexport_funconly_test.go",

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -105,11 +105,12 @@ func (t *galaASTTransformer) applyCallSuffix(base ast.Expr, suffix *grammar.Post
 							if receiverType == base && baseExpr == base && len(typeMeta.TypeParams) > 0 {
 								if t.isSealedVariantTypeName(typeName) {
 									line, col := suffix.GetStart().GetLine(), suffix.GetStart().GetColumn()
+									bareName := stripPackagePrefix(typeName)
 									return nil, galaerr.NewCodedSemanticError(
 										galaerr.CodeSealedVariantUninferred,
 										line, col,
-										fmt.Sprintf("cannot infer type parameter for sealed variant constructor %q", typeName+"()"),
-										fmt.Sprintf("annotate the binding (e.g. `val x: ParentType[Int] = %s()`) or pass type args explicitly (`%s[Int]()`)", typeName, typeName),
+										fmt.Sprintf("cannot infer type parameter for sealed variant constructor %q", bareName+"()"),
+										fmt.Sprintf("annotate the binding (e.g. `val x: ParentType[Int] = %s()`) or pass type args explicitly (`%s[Int]()`)", bareName, bareName),
 									)
 								}
 							}
@@ -1716,10 +1717,7 @@ func (t *galaASTTransformer) handleNamedArgsCall(fun ast.Expr, args []ast.Expr, 
 			// segment before the last "." is the package the variant came
 			// from — using it prevents a same-named variant in another
 			// package from shadowing the local one via map-iteration order.
-			variantPkg := ""
-			if idx := strings.LastIndex(resolvedTypeName, "."); idx != -1 {
-				variantPkg = resolvedTypeName[:idx]
-			}
+			variantPkg, _ := splitPackageQualifier(resolvedTypeName)
 			variantFieldNames, found, ferr := t.findSealedVariantFields(typeName, variantPkg, line, col)
 			if ferr != nil {
 				return nil, ferr
@@ -2182,22 +2180,20 @@ func (t *galaASTTransformer) findSealedVariantFields(variantName, pkgQualifier s
 	}
 }
 
-// isSealedVariantTypeName reports whether `typeName` (an unqualified variant
-// name in the current package) is a registered sealed variant. Used by the
-// B6 fail-loud check to limit the GALA-E0018 diagnostic to sealed variants —
-// other generic types still fall through to Go's deduction.
+// isSealedVariantTypeName reports whether `typeName` (qualified `std.None` or
+// bare `None`) is a registered sealed variant, gating the GALA-E0018
+// diagnostic; other generic types fall through to Go's deduction.
 //
-// The empty pkgQualifier passed to findSealedParentForVariant is deliberate:
-// this is purely an existence check ("does any loaded sealed type expose a
-// case with this name?") used to gate a more specific error message. It is
-// NOT a codegen path, so the cross-package map walk that the codegen-side
-// lookups (findSealedVariant, findSealedVariantFields) had to package-scope
-// for determinism would only reduce diagnostic coverage here. A false
-// positive (the name exists in some package, but not the one the user
-// meant) still produces the correct user-visible error — pointing at an
-// uninferable sealed-variant constructor — so the looser scope is safe.
+// The zero-arg call path derives the name from `getBaseTypeName`, which keeps
+// the package selector for dot-imported / std variants, but metadata is keyed
+// by the bare case name — so the qualifier is split off and passed as the
+// lookup scope (see findSealedParentForVariant, which also resolves import
+// aliases against it). Comparing the qualified `std.None` directly never
+// matched, so the guard previously missed `std.None()` and the transpiler
+// emitted an uninstantiated `std.None{}.Apply()` (invalid Go) instead.
 func (t *galaASTTransformer) isSealedVariantTypeName(typeName string) bool {
-	return t.findSealedParentForVariant(typeName, "") != nil
+	pkgQualifier, bareName := splitPackageQualifier(typeName)
+	return t.findSealedParentForVariant(bareName, pkgQualifier) != nil
 }
 
 // findSealedParentForVariant returns the parent sealed type's metadata for a
@@ -2940,10 +2936,19 @@ func (t *galaASTTransformer) lambdaActualFuncType(expr ast.Expr) transpiler.Type
 // Returns a typed AST expression (e.g., None[User]) or nil if inference fails.
 //
 // Context sources tried, in order:
-//  1. currentMatchSubjectType — `x match { case _ => None() }` where the subject is
-//     Option[T]. (Companion match required.)
-//  2. currentFuncReturnType — gap #11: `func find(id int) Option[User] { ... None() ... }`
-//     widens the zero-arg constructor from the enclosing function's return type.
+//  1. currentFuncReturnType — the enclosing function's return type (or the
+//     expected-result type promoted onto it by val/arg/match-arm contexts).
+//     Authoritative for a constructor in *value* position: the arm body's type
+//     is the match *result* type, not the subject type.
+//  2. currentMatchSubjectType — `x match { case _ => None() }` where the subject
+//     is Option[T] and no result type is in scope (e.g. inside a lambda whose
+//     result type is unconstrained). Only a proxy: it equals the result type
+//     when the match maps Option[T] to Option[T].
+//
+// Return type is tried first because subject and result can diverge (a match on
+// Option[A] whose arm returns Option[B]); see the worked example under
+// "Downward Inference for Generic Sealed-Type Case Constructors" in
+// docs/TYPE_INFERENCE.MD.
 func (t *galaASTTransformer) inferZeroArgTypeParams(typeName string, typeMeta *transpiler.TypeMetadata) ast.Expr {
 	// Look up companion relationship for this type
 	companion := t.lookupCompanion(typeName)
@@ -2952,9 +2957,10 @@ func (t *galaASTTransformer) inferZeroArgTypeParams(typeName string, typeMeta *t
 	}
 	targetBaseName := stripPackagePrefix(companion.TargetType)
 
-	// Try each context source in priority order: match subject first (most
-	// specific), then enclosing function return type (gap #11 widening).
-	sources := []transpiler.Type{t.currentMatchSubjectType, t.currentFuncReturnType}
+	// Try each context source in priority order: enclosing function return type
+	// first (authoritative for value position), then match subject (proxy
+	// fallback when no return type pins the result).
+	sources := []transpiler.Type{t.currentFuncReturnType, t.currentMatchSubjectType}
 	for _, src := range sources {
 		if transpiler.IsUnusable(src) {
 			continue

--- a/internal/transpiler/transformer/error_codes_test.go
+++ b/internal/transpiler/transformer/error_codes_test.go
@@ -230,6 +230,32 @@ func main() {
 			expectContains: "cannot infer type parameter",
 		},
 		{
+			// B6, qualified-variant path: a bare `None()` (a std.Option case,
+			// so the call target lowers to the package-qualified `std.None`)
+			// with no inference signal must also surface as GALA-E0018. The
+			// guard's sealed-variant check previously compared the qualified
+			// name `std.None` against the unqualified variant names in
+			// metadata, never matched, and let the transpiler emit an
+			// uninstantiated `std.None{}.Apply()` — invalid Go reported far
+			// from the source. Here the lambda's result type is unconstrained
+			// (Array.Map's element-result type), so no context pins T.
+			name: "GALA-E0018 qualified None() uninferred in lambda",
+			input: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+func f(arr Array[int]) bool {
+    val mapped = arr.Map((x) => None())
+    return mapped.Size() > 0
+}
+
+func main() {
+    Println(f(ArrayOf(1, 2, 3)))
+}`,
+			expectCode:     galaerr.CodeSealedVariantUninferred,
+			expectContains: `constructor "None()"`,
+		},
+		{
 			// Empty parenthesized expression `()` (the unit-shorthand the
 			// grammar admits but the transpiler has no Go lowering for)
 			// must surface as GALA-E0019 with a real source span instead

--- a/internal/transpiler/transformer/none_qualified_downward_inference_test.go
+++ b/internal/transpiler/transformer/none_qualified_downward_inference_test.go
@@ -1,0 +1,126 @@
+package transformer_test
+
+import (
+	"strings"
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNoneQualifiedDownwardInference verifies that a bare `None()` (a std.Option
+// case, whose call target lowers to the package-qualified `std.None`) has its
+// vestigial type parameter inferred from the surrounding context, so callers
+// never need to write `None[Array[JField]]()` when the type is predictable.
+//
+// The motivating shape is a method whose declared return type is `Option[X]`
+// with a match body — `Some(...)` pins the element type and the `None()` arm
+// inherits it via the match's externally-pinned result type:
+//
+//	func (v JsonValue) AsObject() Option[Array[JField]] = v match {
+//	    case JObj(fields) => Some(fields)
+//	    case _            => None()
+//	}
+//
+// Before the fix this already worked for `None()` via `inferZeroArgTypeParams`
+// (match subject + enclosing return). The companion negative case
+// (`TestErrorPathAssertions/GALA-E0018 qualified None() uninferred in lambda`)
+// covers the qualified-name guard that previously misfired.
+func TestNoneQualifiedDownwardInference(t *testing.T) {
+	newTranspiler := func() *transpiler.GalaToGoTranspiler {
+		p := transpiler.NewAntlrGalaParser()
+		a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+		tr := transformer.NewGalaASTTransformer()
+		g := generator.NewGoCodeGenerator()
+		return transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+	}
+
+	cases := []struct {
+		name string
+		// expectInjected is the Go fragment proving the type arg was injected
+		// onto the zero-arg variant (so Go can instantiate it).
+		expectInjected string
+		input          string
+	}{
+		{
+			name:           "method match return over generic element",
+			expectInjected: "std.None[Array[JField]]{}.Apply()",
+			input: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+sealed type JField {
+    case JF(Name string)
+}
+
+sealed type JsonValue {
+    case JObj(Fields Array[JField])
+    case JNull()
+}
+
+func (v JsonValue) AsObject() Option[Array[JField]] = v match {
+    case JObj(fields) => Some(fields)
+    case _ => None()
+}
+
+func main() {
+    val v = JObj(ArrayOf[JField]())
+    Println(v.AsObject().IsDefined())
+}`,
+		},
+		{
+			name:           "plain function return type",
+			expectInjected: "std.None[int]{}.Apply()",
+			input: `package main
+
+func f() Option[int] = None()
+
+func main() {
+    Println(f().IsDefined())
+}`,
+		},
+		{
+			name:           "val with explicit option type",
+			expectInjected: "std.None[string]{}.Apply()",
+			input: `package main
+
+func f() bool {
+    val x Option[string] = None()
+    return x.IsDefined()
+}
+
+func main() {
+    Println(f())
+}`,
+		},
+		{
+			name:           "if-expression sibling pins the type",
+			expectInjected: "std.None[int]{}.Apply()",
+			input: `package main
+
+func pick(b bool) Option[int] = if (b) Some(1) else None()
+
+func main() {
+    Println(pick(true).IsDefined())
+}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := newTranspiler().Transpile(tc.input, "none_inference_test.gala")
+			require.NoError(t, err)
+			assert.Contains(t, out, tc.expectInjected,
+				"expected the zero-arg None() to be instantiated with the inferred type arg")
+			// Guard against the pre-fix regression: an uninstantiated
+			// `std.None{}` (no type args) is invalid Go.
+			assert.False(t, strings.Contains(out, "std.None{}"),
+				"must not emit an uninstantiated std.None{}; got:\n%s", out)
+		})
+	}
+}

--- a/internal/transpiler/transformer/patterns.go
+++ b/internal/transpiler/transformer/patterns.go
@@ -1425,14 +1425,23 @@ func (t *galaASTTransformer) inferExtractorTypeParams(extractorMeta *transpiler.
 // stripPackagePrefix removes package prefixes from type names for comparison.
 // For example, "std.Either" becomes "Either", "main.User" becomes "User".
 func stripPackagePrefix(name string) string {
-	if idx := len(name) - 1; idx >= 0 {
-		for i := idx; i >= 0; i-- {
-			if name[i] == '.' {
-				return name[i+1:]
-			}
+	_, bare := splitPackageQualifier(name)
+	return bare
+}
+
+// splitPackageQualifier splits a possibly-qualified type name at its last "."
+// into its package qualifier and bare name: "std.None" → ("std", "None"),
+// "User" → ("", "User"). Sealed-variant lookups follow the last-dot convention
+// (the bare case name is the metadata key, the prefix is the package scope), so
+// callers that need both halves should use this rather than re-deriving the
+// split inline.
+func splitPackageQualifier(name string) (pkg, bare string) {
+	for i := len(name) - 1; i >= 0; i-- {
+		if name[i] == '.' {
+			return name[:i], name[i+1:]
 		}
 	}
-	return name
+	return "", name
 }
 
 // unifyTypes attempts to unify two types and extract type parameter substitutions.

--- a/website/features/type-inference.md
+++ b/website/features/type-inference.md
@@ -172,6 +172,32 @@ val c = Circle(5.0)          // Shape, no type annotation needed
 val r = Rectangle(3.0, 4.0)  // Shape
 ```
 
+### Zero-field variants of a generic sealed type
+
+A zero-field case of a *generic* sealed type — `None()` for `Option[T]`, or
+any `case Empty()`-style variant — has no argument to infer its type parameter
+from. GALA fills it in by **downward inference**: the type flows in from the
+surrounding context, so you write `None()`, not `None[T]()`, whenever the
+context pins the type.
+
+```gala
+// Return type pins the element type
+func parseObject(v JsonValue) Option[Array[JField]] = v match {
+    case JObj(fields) => Some(fields)
+    case _            => None()        // inferred as Option[Array[JField]]
+}
+
+// A val annotation pins it
+val empty Option[int] = None()         // inferred as Option[int]
+
+// An if/else sibling pins it
+func pick(b bool) Option[int] = if (b) Some(1) else None()
+```
+
+When **no** context pins the type — for example a bare `None()` inside a lambda
+whose result type is unconstrained — the type genuinely cannot be determined,
+and GALA asks you to annotate it explicitly (`None[int]()`) rather than guess.
+
 ---
 
 ## What Is NOT Inferred


### PR DESCRIPTION
## Summary

Makes the bare zero-arg sealed-variant constructor `None()` (a case of generic `Option[T]`, and any zero-field case of a generic sealed type) reliably infer its type parameter from the surrounding context, and fixes two defects in that path that previously emitted invalid Go or mis-inferred the type.

```gala
func (v JsonValue) AsObject() Option[Array[JField]] = v match {
    case JObj(fields) => Some(fields)
    case _            => None()   // inferred as Option[Array[JField]] — no None[Array[JField]]() needed
}
```

## What changed

1. **Qualified-variant guard bug.** The fail-loud `GALA-E0018` guard never fired for package-qualified variant names. `getBaseTypeName` keeps the package selector for dot-imported / std variants (`std.None`), but the sealed-variant gate compared that qualified name against the *unqualified* case names in metadata, never matched, and let the transpiler emit an uninstantiated `std.None{}.Apply()` — invalid Go reported far from the source — instead of the diagnostic. The gate now splits the qualifier off and passes it as the lookup **scope**, so it both fires for qualified names and stays precise when two packages declare a sealed case of the same name.

2. **Inference priority bug.** `inferZeroArgTypeParams` tried the match *subject* type before the enclosing *return* type. For a match on `Option[A]` whose arm returns `Option[B]` (e.g. a method returning `Option[string]` matching on `Option[Array[JField]]`), this mis-injected the subject's type arg and the match failed its branch-type check. The return type (authoritative in value position) is now tried first; the subject remains a fallback when no result type is in scope.

3. **DRY cleanup.** Extracted a shared `splitPackageQualifier(name) (pkg, bare)` helper, replacing the open-coded last-dot split duplicated across the sealed-variant lookups.

When no context pins the type (e.g. a bare `None()` in a lambda whose result type is unconstrained), the type genuinely cannot be determined and the transpiler now reports `GALA-E0018` asking for explicit `None[T]()`, rather than emitting broken Go.

## Tests & docs

- Positive transpile test (`none_qualified_downward_inference_test.go`) covering method-match-return, plain return, val annotation, and if/else sibling contexts.
- `GALA-E0018` negative test for the qualified uninferable lambda case.
- Verification example `examples/none_downward_inference.gala`.
- Updated `docs/GALA_BEST_PRACTICES.MD`, `docs/TYPE_INFERENCE.MD`, `website/features/type-inference.md`, and the `gala-lint` rule (flag redundant `None[T]()` only where the context pins the type).

`bazel build //...`, `bazel test //...` (353 tests pass), gazelle, and the examples all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)