### PR TITLE
fix(transpiler): statement-position match dispatch and guarded wildcard before default

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -589,6 +589,36 @@ val msg = animal match {
 }
 ```
 
+A **guarded** wildcard (`case _ if cond`) is conditional, not a catch-all:
+control falls through to later cases when the guard is false. So a guarded
+wildcard may precede a real `case _` default without conflicting with it — only
+an *unguarded* `case _` counts as the default:
+
+```gala
+val label = n match {
+    case 0           => "zero"
+    case _ if n < 10 => "small"   // conditional — not the default
+    case _           => "large"   // the actual default
+}
+```
+
+#### Match in statement position (side-effect dispatch)
+When a `match` is used as a statement — its value is discarded — the arms are
+pure side-effect dispatch and need not produce a common type. This lets each
+arm call a different function whose result is ignored:
+
+```gala
+// value discarded: arms may return different types (string, bool, void)
+c match {
+    case '"' => { readString() }   // returns string
+    case 't' => { readBool() }     // returns bool
+    case _   => { skipOther() }    // returns nothing
+}
+```
+
+When the match's value *is* used (assigned to a `val`, returned, passed as an
+argument), all arms must still unify to one type.
+
 #### Standard Library Sealed Types
 The `std` package defines `Option[T]`, `Either[A, B]`, and `Try[T]` as sealed types. See [Standard Library Types](#9-standard-library-types) for details.
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1827,6 +1827,13 @@ gala_exec_test(
     expected = "block_lambda_match.out",
 )
 
+# Verification: statement-position match dispatch + guarded wildcard before default
+gala_exec_test(
+    name = "match_stmt_guard_dispatch",
+    src = "match_stmt_guard_dispatch.gala",
+    expected = "match_stmt_guard_dispatch.out",
+)
+
 # Verification: bare None() infers its element type from context
 gala_exec_test(
     name = "none_downward_inference",

--- a/examples/match_stmt_guard_dispatch.gala
+++ b/examples/match_stmt_guard_dispatch.gala
@@ -1,0 +1,28 @@
+package main
+
+// A statement-position match (its value is discarded) dispatches purely for
+// side effects, so its arms may call functions with different return types.
+func record(c int) {
+    c match {
+        case 1 => { Println("one") }
+        case 2 => { Println(s"two=${2}") }
+        case _ => { Println("many") }
+    }
+}
+
+// A guarded wildcard `case _ if g` is conditional, so it can precede a real
+// `case _` default without being treated as a duplicate default.
+func size(n int) string = n match {
+    case 0          => "empty"
+    case _ if n < 10 => "small"
+    case _          => "large"
+}
+
+func main() {
+    record(1)
+    record(2)
+    record(9)
+    Println(size(0))
+    Println(size(5))
+    Println(size(42))
+}

--- a/examples/match_stmt_guard_dispatch.out
+++ b/examples/match_stmt_guard_dispatch.out
@@ -1,0 +1,6 @@
+one
+two=2
+many
+empty
+small
+large

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -79,6 +79,7 @@ go_test(
         "match_in_lambda_void_test.go",
         "match_return_statement_test.go",
         "match_return_type_test.go",
+        "match_stmt_dispatch_test.go",
         "match_test.go",
         "match_void_dispatch_test.go",
         "methods_test.go",

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -1151,8 +1151,9 @@ func (t *galaASTTransformer) transformPartialFunctionLiteral(ctx *grammar.Partia
 		}
 	}
 
-	// Infer common inner result type T from all branches
-	innerResultType, err := t.inferCommonResultType(resultTypes, casePatterns, ctx)
+	// Infer common inner result type T from all branches. A match used as a
+	// lambda's value is value-producing, so arms must unify (discardValue=false).
+	innerResultType, err := t.inferCommonResultType(resultTypes, casePatterns, ctx, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/transpiler/transformer/match.go
+++ b/internal/transpiler/transformer/match.go
@@ -37,7 +37,7 @@ func (t *galaASTTransformer) transformMatchExpression(ctx grammar.IExpressionCon
 	t.matchInStatementPos = false
 	defer func() { t.matchInStatementPos = stmtPosition }()
 
-	clauses, defaultBody, resultType, err := t.transformMatchClauses(ctx, paramName, matchedType)
+	clauses, defaultBody, resultType, err := t.transformMatchClauses(ctx, paramName, matchedType, stmtPosition)
 	if err != nil {
 		return nil, err
 	}
@@ -700,18 +700,21 @@ func (t *galaASTTransformer) lookupCompanion(name string) *transpiler.CompanionO
 }
 
 // transformMatchClauses processes all case clauses and infers the common result type.
-func (t *galaASTTransformer) transformMatchClauses(ctx grammar.IExpressionContext, paramName string, matchedType transpiler.Type) ([]ast.Stmt, []ast.Stmt, transpiler.Type, error) {
+func (t *galaASTTransformer) transformMatchClauses(ctx grammar.IExpressionContext, paramName string, matchedType transpiler.Type, discardValue bool) ([]ast.Stmt, []ast.Stmt, transpiler.Type, error) {
 	var clauses []ast.Stmt
 	var defaultBody []ast.Stmt
 	foundDefault := false
 	var resultTypes []transpiler.Type
 	var casePatterns []string
 
-	// Pre-scan: check if there's an explicit wildcard `_` case.
+	// Pre-scan: check if there's an explicit, UNGUARDED wildcard `_` case.
+	// A guarded wildcard (`case _ if g`) is conditional — it can fall through
+	// to later cases — so it is not a catch-all and must not suppress a binding
+	// pattern acting as the default.
 	hasExplicitWildcard := false
 	for i := 3; i < ctx.GetChildCount()-1; i++ {
 		ccCtx, ok := ctx.GetChild(i).(*grammar.CaseClauseContext)
-		if ok && isWildcard(ccCtx.Pattern().GetText()) {
+		if ok && isWildcard(ccCtx.Pattern().GetText()) && ccCtx.GetGuard() == nil {
 			hasExplicitWildcard = true
 			break
 		}
@@ -725,8 +728,12 @@ func (t *galaASTTransformer) transformMatchClauses(ctx grammar.IExpressionContex
 
 		patCtx := ccCtx.Pattern()
 		patternText := patCtx.GetText()
-		treatAsDefault := isWildcard(patternText) ||
-			(!hasExplicitWildcard && isBindingPattern(patternText))
+		// A guarded clause is conditional and never a default, even when its
+		// pattern is a wildcard or binding — control can fall through to a
+		// later case when the guard is false.
+		treatAsDefault := ccCtx.GetGuard() == nil &&
+			(isWildcard(patternText) ||
+				(!hasExplicitWildcard && isBindingPattern(patternText)))
 
 		if treatAsDefault {
 			if foundDefault {
@@ -825,7 +832,8 @@ func (t *galaASTTransformer) transformMatchClauses(ctx grammar.IExpressionContex
 			if !ok {
 				continue
 			}
-			if isBindingPattern(ccCtx.Pattern().GetText()) {
+			// A guarded binding pattern is conditional, not a catch-all default.
+			if isBindingPattern(ccCtx.Pattern().GetText()) && ccCtx.GetGuard() == nil {
 				hasDefault = true
 				break
 			}
@@ -861,7 +869,7 @@ func (t *galaASTTransformer) transformMatchClauses(ctx grammar.IExpressionContex
 	if pc, ok := ctx.(antlr.ParserRuleContext); ok {
 		matchCtx = pc
 	}
-	resultType, err := t.inferCommonResultType(resultTypes, casePatterns, matchCtx)
+	resultType, err := t.inferCommonResultType(resultTypes, casePatterns, matchCtx, discardValue)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1032,13 +1040,29 @@ func (t *galaASTTransformer) isKnownMultiReturnFunction(pkgName, funcName string
 
 // inferCommonResultType checks that all result types are compatible and returns the common type.
 // ctx is optional and used for position info in error messages.
-func (t *galaASTTransformer) inferCommonResultType(types []transpiler.Type, patterns []string, ctx antlr.ParserRuleContext) (transpiler.Type, error) {
+//
+// discardValue is set when the match is in statement position — its value is
+// discarded by the enclosing block, so the arms are pure side-effect dispatch
+// and their result types need not unify. In that case the match lowers to a
+// void IIFE (the result type is overwritten with VoidType by the caller), so a
+// mismatch among arm types (e.g. one arm calling a string-returning method,
+// another a bool-returning one) is not an error. Skipping the unification here
+// is what lets `c match { case '"' => readString(); case 't' => readBool() }`
+// stand as a statement.
+func (t *galaASTTransformer) inferCommonResultType(types []transpiler.Type, patterns []string, ctx antlr.ParserRuleContext, discardValue bool) (transpiler.Type, error) {
 	if len(types) == 0 {
 		line, col := t.lastLine, t.lastCol
 		if ctx != nil && ctx.GetStart() != nil {
 			line, col = ctx.GetStart().GetLine(), ctx.GetStart().GetColumn()
 		}
 		return nil, galaerr.NewSemanticErrorAt(line, col, "match expression has no case branches")
+	}
+
+	// Value-discarding (statement-position) match: arms are side-effect
+	// dispatch, so they need not share a type. Caller forces the lowered IIFE
+	// to void.
+	if discardValue {
+		return transpiler.VoidType{}, nil
 	}
 
 	// Check if all branches are void (side-effect only, like fmt.Printf calls)

--- a/internal/transpiler/transformer/match_stmt_dispatch_test.go
+++ b/internal/transpiler/transformer/match_stmt_dispatch_test.go
@@ -1,0 +1,125 @@
+package transformer_test
+
+import (
+	"strings"
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMatchDispatchTranspiler() *transpiler.GalaToGoTranspiler {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	return transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+}
+
+// TestStatementPositionMatchHeterogeneousArms covers the fix for a
+// statement-position (value-discarded) match whose arms call methods with
+// different return types. Because the match's value is discarded, the arms are
+// pure side-effect dispatch and their result types need not unify — the match
+// lowers to a void IIFE. Before the fix the transpiler ran arm-type
+// unification unconditionally and rejected the match with "type mismatch in
+// match expression ... All branches must return the same type", even though no
+// value was ever consumed. This is the shape used by hand-written pull-parsers
+// (e.g. a `Skip()` that dispatches on the next byte to `readString()` →
+// string, `readBool()` → bool, etc.).
+func TestStatementPositionMatchHeterogeneousArms(t *testing.T) {
+	trans := newMatchDispatchTranspiler()
+
+	input := `package main
+
+func si() string = "x"
+func bi() bool = true
+func vi() { Println("v") }
+
+func dispatch(c int) {
+    c match {
+        case 1 => { si() }
+        case 2 => { bi() }
+        case 3 => { vi() }
+        case _ => { Println("other") }
+    }
+}
+
+func main() { dispatch(1) }`
+
+	out, err := trans.Transpile(input, "stmt_match_test.gala")
+	require.NoError(t, err, "statement-position match with heterogeneous arm types must transpile")
+	// The discarded arm values must NOT be wrapped in `return ...` (Go rejects
+	// `return vi()` for a void call), i.e. the match lowered as a void IIFE.
+	assert.NotContains(t, out, "return si()")
+	assert.NotContains(t, out, "return bi()")
+}
+
+// Note on scope: discard position is recognized for a match that is itself a
+// statement (the json pull-parser's flat `Skip()`/`writeEscapedJsonString`
+// dispatch). A *nested* match whose value flows up through an enclosing arm
+// block to a discarded outer match is still treated as value-producing (the
+// outer match resets the statement-position marker for its arm bodies), so its
+// arms must still unify. Threading discard-ness through block-value chains is a
+// possible future extension.
+
+// TestGuardedWildcardBeforeDefault covers the fix for a guarded wildcard
+// (`case _ if g`) followed by a real default (`case _`). A guarded wildcard is
+// conditional — control falls through to later cases when the guard is false —
+// so it is NOT a catch-all default. Before the fix the transpiler counted the
+// guarded `case _` as a default and rejected the following `case _` with
+// GALA-E0006 "multiple default cases".
+func TestGuardedWildcardBeforeDefault(t *testing.T) {
+	trans := newMatchDispatchTranspiler()
+
+	input := `package main
+
+func classify(c int) string {
+    var out = ""
+    c match {
+        case 0 => { out = "zero" }
+        case _ if c < 10 => { out = "small" }
+        case _ => { out = "big" }
+    }
+    return out
+}
+
+func main() {
+    Println(classify(0))
+    Println(classify(5))
+    Println(classify(99))
+}`
+
+	out, err := trans.Transpile(input, "guarded_wildcard_test.gala")
+	require.NoError(t, err, "guarded wildcard before a default must transpile")
+	// The guard must lower to a real conditional on the guard expression.
+	assert.True(t, strings.Contains(out, "c < 10"),
+		"guarded wildcard arm must emit its guard condition; got:\n%s", out)
+}
+
+// TestGuardedBindingNotDefault verifies a guarded binding pattern
+// (`case x if g`) is likewise conditional, so a following unguarded default is
+// allowed rather than rejected as a duplicate default.
+func TestGuardedBindingNotDefault(t *testing.T) {
+	trans := newMatchDispatchTranspiler()
+
+	input := `package main
+
+func label(n int) string {
+    var out = ""
+    n match {
+        case v if v < 0 => { out = "neg" }
+        case _ => { out = "nonneg" }
+    }
+    return out
+}
+
+func main() { Println(label(-1)) }`
+
+	_, err := trans.Transpile(input, "guarded_binding_test.gala")
+	require.NoError(t, err, "guarded binding pattern before a default must transpile")
+}

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -486,12 +486,14 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 		}
 	}
 
-	// Pre-scan: check if there's an explicit wildcard `_` case.
+	// Pre-scan: check if there's an explicit, UNGUARDED wildcard `_` case.
 	// If there is, binding patterns are regular clauses. If not, the last
-	// binding pattern acts as the default (catch-all) case.
+	// binding pattern acts as the default (catch-all) case. A guarded wildcard
+	// (`case _ if g`) is conditional, not a catch-all, so it does not count.
 	hasExplicitWildcard := false
 	for _, cc := range caseClauses {
-		if isWildcard(cc.(*grammar.CaseClauseContext).Pattern().GetText()) {
+		ccCtx := cc.(*grammar.CaseClauseContext)
+		if isWildcard(ccCtx.Pattern().GetText()) && ccCtx.GetGuard() == nil {
 			hasExplicitWildcard = true
 			break
 		}
@@ -503,9 +505,12 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 		patCtx := ccCtx.Pattern()
 		patternText := patCtx.GetText()
 		// Treat as default: explicit wildcard `_` always, OR binding pattern when
-		// there's no explicit wildcard elsewhere (binding acts as catch-all).
-		treatAsDefault := isWildcard(patternText) ||
-			(!hasExplicitWildcard && isBindingPattern(patternText))
+		// there's no explicit wildcard elsewhere (binding acts as catch-all). A
+		// guarded clause is conditional and never a default — control can fall
+		// through to a later case when the guard is false.
+		treatAsDefault := ccCtx.GetGuard() == nil &&
+			(isWildcard(patternText) ||
+				(!hasExplicitWildcard && isBindingPattern(patternText)))
 
 		if treatAsDefault {
 			if foundDefault {
@@ -577,8 +582,9 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 		}
 	}
 
-	// Infer common result type from all branches
-	resultType, err := t.inferCommonResultType(resultTypes, casePatterns, ctx)
+	// Infer common result type from all branches. In statement position the
+	// value is discarded, so arms need not unify (see inferCommonResultType).
+	resultType, err := t.inferCommonResultType(resultTypes, casePatterns, ctx, stmtPosition)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Fixes two match-handling limitations that rejected valid GALA. Both surfaced while converting if-chains to `match` in stdlib cleanup.

### 1. Statement-position match dispatch
A `match` used as a statement (its value discarded) ran arm-type unification unconditionally, so arms calling methods with different return types were rejected with *"type mismatch in match expression … All branches must return the same type"* — even though no value is consumed. This is the natural shape for side-effect dispatch:

```gala
c match {
    case '"' => { readString() }   // string
    case 't' => { readBool() }     // bool
    case _   => { skipOther() }    // void
}
```

`inferCommonResultType` now takes a `discardValue` flag; in statement position it short-circuits to `VoidType` (the IIFE lowers to void), so arms need not unify. When the match value **is** used (`val`/return/argument), unification still applies.

### 2. Guarded wildcard before a default
A guarded wildcard `case _ if g` was counted as a default, so a following real `case _` was rejected as `GALA-E0006` "multiple default cases":

```gala
n match {
    case 0           => "zero"
    case _ if n < 10 => "small"   // conditional — not a default
    case _           => "large"   // the actual default
}
```

A guarded clause is conditional (control falls through when the guard is false), so it's never a default. Default detection now excludes any clause carrying a guard — in both match-lowering paths (`match.go`, `postfix.go`), including the explicit-wildcard pre-scan and the exhaustiveness fallback.

## Scope note
Discard position is recognized for a match that is itself a statement (the flat dispatch shape). A *nested* match whose value flows up through an enclosing arm block to a discarded outer match is still treated as value-producing; threading discard-ness through block-value chains is a possible future extension.

## Tests & docs
- `match_stmt_dispatch_test.go` — statement-position heterogeneous arms, guarded wildcard before default, guarded binding before default.
- `examples/match_stmt_guard_dispatch.gala` — runnable verification.
- `docs/GALA.MD` — documents both patterns.

`bazel build //...`, `bazel test //...` (355 tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)