### PR TITLE
refactor(stdlib): GALA best-practice cleanups across the standard library

### DIFF
--- a/.claude/skills/gala-lint/SKILL.md
+++ b/.claude/skills/gala-lint/SKILL.md
@@ -367,15 +367,19 @@ func createServer(host string, port int = 8080, tls bool = true, maxConnections 
 - **Single-type-param generic struct constructors**: `Box[int](Value = 42)` → `Box(Value = 42)` — Go infers the single type param from the named field value
 - **Single-type-param generic function calls**: `Try[int](f)`, `NewCons[int](head, tail)` — argument types determine the type param
 - **Helper constructors**: `Some[int](42)`, `ListOf[int](1, 2, 3)` — element values determine type params
-- **Zero-arg sealed-variant constructors in an inferable context**: `None[T]()` (and other zero-field cases of a generic sealed type) when the surrounding context pins the type. A zero-field variant has no argument to infer from, but the transpiler propagates an **expected type** downward and injects the type arg, so the explicit `[T]` is redundant. Flag `None[T]()` → `None()` when it appears as any of:
-  - a function body or `return` whose declared return type is `Option[T]` — `func f() Option[T] = None[T]()`
-  - the RHS of a `val`/`var` with an explicit `Option[T]` type — `val x Option[T] = None[T]()`
-  - an argument to a function/constructor whose parameter type is `Option[T]`
-  - an element of a typed container — `ArrayOf[Option[T]](None[T]())`
-  - a `match` arm whose result type is externally pinned (e.g. the match is the body of a function returning `Option[T]`)
-  - an `if`/`else` branch whose sibling branch is a `Some(...)` of known type — `if (c) Some(x) else None[int]()`
+- **Zero-arg sealed-variant constructors when the context pins a CONCRETE type**: `None[int]()` (and other zero-field cases of a generic sealed type) when the surrounding context supplies a **concrete** type argument. A zero-field variant has no argument to infer from, but the transpiler propagates an **expected type** downward and injects the type arg, so the explicit `[…]` is redundant. Flag `None[Concrete]()` → `None()` when it appears as any of:
+  - a function body or `return` whose declared return type is a concrete `Option[Concrete]` — `func parse() Option[int] = None[int]()` → `None()`
+  - the RHS of a `val`/`var` with an explicit concrete `Option[Concrete]` type — `val x Option[string] = None[string]()` → `None()`
+  - an argument to a function/constructor whose parameter type is a concrete `Option[Concrete]`
+  - an element of a typed container — `ArrayOf[Option[int]](None[int]())` → `ArrayOf[Option[int]](None())`
+  - a `match` arm whose result type is externally pinned to a concrete `Option[Concrete]` (e.g. the match is the body of a function returning `Option[int]`)
+  - an `if`/`else` branch whose sibling branch is a `Some(...)` of known concrete type — `if (c) Some(x) else None[int]()`
 
-  Do NOT flag (explicit typing is still required) when none of the above pins the type — most commonly a bare `None[T]()` inside a lambda whose result type is unconstrained, e.g. `arr.Map((x) => None[int]())`: the element-result type is free, so removing `[int]` makes the type undeterminable and the transpiler reports GALA-E0018.
+  Do NOT flag (explicit typing is still REQUIRED) when:
+  - the pinning type is an **abstract type parameter** of the enclosing generic function/method, e.g. `func (a Array[T]) HeadOption() Option[T] = … None[T]()` or `func (o Option[T]) OrElse(...) = … None[T]()`. The transpiler cannot infer an unresolved `T` from context and rejects bare `None()` with `GALA-E0018`. Keep `None[T]()`. (This is the common case inside the collection/std library — do not flag those.)
+  - no context pins the type at all — most commonly a bare `None[int]()` inside a lambda whose result type is unconstrained, e.g. `arr.Map((x) => None[int]())`: removing `[int]` makes the type undeterminable (`GALA-E0018`). Keep it.
+
+  Rule of thumb: only flag when the type argument you would remove is a **concrete** type (`int`, `string`, `Array[JField]`, …), never when it is an in-scope abstract type parameter.
 
 **Exception**: Explicit types ARE required for:
 - `Left[L, R]()`, `Right[L, R]()` — no value arguments to infer from (and Either carries two params)

--- a/collection_immutable/array.gala
+++ b/collection_immutable/array.gala
@@ -1,7 +1,6 @@
 package collection_immutable
 
 import (
-    "fmt"
     . "martianoff/gala/std"
     "martianoff/gala/go_interop"
 )
@@ -312,7 +311,7 @@ func getFromNode[T any](node *arrayNode[T], index int, depth int) T {
 // Panics if index is out of bounds.
 func (a Array[T]) Get(index int) T {
     if (index < 0) || (index >= a.length) {
-        panic(fmt.Sprintf("Array.Get: index %d out of bounds [0, %d)", index, a.length))
+        panic(f"Array.Get: index $index out of bounds [0, ${a.length})")
     }
 
     // Check if index is in prefix (prefix is stored in forward order)
@@ -385,7 +384,7 @@ func updateInNode[T any](node *arrayNode[T], index int, value T, depth int) *arr
 // Updated returns a new array with the element at index replaced. O(log32 n).
 func (a Array[T]) Updated(index int, value T) Array[T] {
     if (index < 0) || (index >= a.length) {
-        panic(fmt.Sprintf("Array.Updated: index %d out of bounds [0, %d)", index, a.length))
+        panic(f"Array.Updated: index $index out of bounds [0, ${a.length})")
     }
 
     var prefixLen = len(a.prefix)
@@ -1012,7 +1011,7 @@ func (a Array[T]) String() string {
         if i > 0 {
             result = result + ", "
         }
-        result = result + fmt.Sprintf("%v", a.Get(i))
+        result = result + s"${a.Get(i)}"
     }
     return result + ")"
 }
@@ -1027,7 +1026,7 @@ func (a Array[T]) MkString(sep string) string {
         if i > 0 {
             result = result + sep
         }
-        result = result + fmt.Sprintf("%v", a.Get(i))
+        result = result + s"${a.Get(i)}"
     }
     return result
 }

--- a/collection_immutable/array_test.gala
+++ b/collection_immutable/array_test.gala
@@ -8,128 +8,128 @@ import (
 // === Array Creation Tests ===
 
 func TestEmptyArray(t T) T {
-    var arr = EmptyArray[int]()
-    var t1 = IsTrue(t, arr.IsEmpty())
+    val arr = EmptyArray[int]()
+    val t1 = IsTrue(t, arr.IsEmpty())
     return Eq[int](t1, arr.Length(), 0)
 }
 
 func TestArrayOf(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
-    var t1 = IsFalse(t, arr.IsEmpty())
+    val arr = ArrayOf(1, 2, 3)
+    val t1 = IsFalse(t, arr.IsEmpty())
     return Eq[int](t1, arr.Length(), 3)
 }
 
 func TestArrayToGoSlice(t T) T {
-    var arr = ArrayOf[int](10, 20, 30)
-    var slice = arr.ToGoSlice()
-    var t1 = Eq[int](t, len(slice), 3)
+    val arr = ArrayOf(10, 20, 30)
+    val slice = arr.ToGoSlice()
+    val t1 = Eq[int](t, len(slice), 3)
     return Eq[int](t1, slice[0], 10)
 }
 
 // === Array Access Tests ===
 
 func TestArrayGet(t T) T {
-    var arr = ArrayOf[int](10, 20, 30)
-    var t1 = Eq[int](t, arr.Get(0), 10)
-    var t2 = Eq[int](t1, arr.Get(1), 20)
+    val arr = ArrayOf(10, 20, 30)
+    val t1 = Eq[int](t, arr.Get(0), 10)
+    val t2 = Eq[int](t1, arr.Get(1), 20)
     return Eq[int](t2, arr.Get(2), 30)
 }
 
 func TestArrayHead(t T) T {
-    var arr = ArrayOf[string]("first", "second", "third")
+    val arr = ArrayOf("first", "second", "third")
     return Eq[string](t, arr.Head(), "first")
 }
 
 func TestArrayLast(t T) T {
-    var arr = ArrayOf[string]("first", "second", "third")
+    val arr = ArrayOf("first", "second", "third")
     return Eq[string](t, arr.Last(), "third")
 }
 
 func TestArrayHeadOption(t T) T {
-    var arr = ArrayOf[int](42)
-    var opt = arr.HeadOption()
-    var t1 = IsSome(t, opt)
+    val arr = ArrayOf(42)
+    val opt = arr.HeadOption()
+    val t1 = IsSome(t, opt)
     return Eq[int](t1, opt.Get(), 42)
 }
 
 func TestArrayHeadOptionEmpty(t T) T {
-    var arr = EmptyArray[int]()
-    var opt = arr.HeadOption()
+    val arr = EmptyArray[int]()
+    val opt = arr.HeadOption()
     return IsNone(t, opt)
 }
 
 // === Array Modification Tests ===
 
 func TestArrayAppend(t T) T {
-    var arr = ArrayOf[int](1, 2)
-    var newArr = arr.Append(3)
-    var t1 = Eq[int](t, arr.Length(), 2)
-    var t2 = Eq[int](t1, newArr.Length(), 3)
+    val arr = ArrayOf(1, 2)
+    val newArr = arr.Append(3)
+    val t1 = Eq[int](t, arr.Length(), 2)
+    val t2 = Eq[int](t1, newArr.Length(), 3)
     return Eq[int](t2, newArr.Get(2), 3)
 }
 
 func TestArrayPrepend(t T) T {
-    var arr = ArrayOf[int](2, 3)
-    var newArr = arr.Prepend(1)
-    var t1 = Eq[int](t, newArr.Length(), 3)
+    val arr = ArrayOf(2, 3)
+    val newArr = arr.Prepend(1)
+    val t1 = Eq[int](t, newArr.Length(), 3)
     return Eq[int](t1, newArr.Head(), 1)
 }
 
 func TestArrayUpdated(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
-    var newArr = arr.Updated(1, 99)
-    var t1 = Eq[int](t, arr.Get(1), 2)
+    val arr = ArrayOf(1, 2, 3)
+    val newArr = arr.Updated(1, 99)
+    val t1 = Eq[int](t, arr.Get(1), 2)
     return Eq[int](t1, newArr.Get(1), 99)
 }
 
 func TestArrayTail(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
-    var tail = arr.Tail()
-    var t1 = Eq[int](t, tail.Length(), 2)
+    val arr = ArrayOf(1, 2, 3)
+    val tail = arr.Tail()
+    val t1 = Eq[int](t, tail.Length(), 2)
     return Eq[int](t1, tail.Head(), 2)
 }
 
 func TestArrayTake(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4, 5)
-    var taken = arr.Take(3)
-    var t1 = Eq[int](t, taken.Length(), 3)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val taken = arr.Take(3)
+    val t1 = Eq[int](t, taken.Length(), 3)
     return Eq[int](t1, taken.Last(), 3)
 }
 
 func TestArrayDrop(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4, 5)
-    var dropped = arr.Drop(2)
-    var t1 = Eq[int](t, dropped.Length(), 3)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val dropped = arr.Drop(2)
+    val t1 = Eq[int](t, dropped.Length(), 3)
     return Eq[int](t1, dropped.Head(), 3)
 }
 
 func TestArraySlice(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4, 5)
-    var sliced = arr.Slice(1, 4)
-    var t1 = Eq[int](t, sliced.Length(), 3)
-    var t2 = Eq[int](t1, sliced.Head(), 2)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val sliced = arr.Slice(1, 4)
+    val t1 = Eq[int](t, sliced.Length(), 3)
+    val t2 = Eq[int](t1, sliced.Head(), 2)
     return Eq[int](t2, sliced.Last(), 4)
 }
 
 func TestArrayReverse(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
-    var reversed = arr.Reverse()
-    var t1 = Eq[int](t, reversed.Get(0), 3)
-    var t2 = Eq[int](t1, reversed.Get(1), 2)
+    val arr = ArrayOf(1, 2, 3)
+    val reversed = arr.Reverse()
+    val t1 = Eq[int](t, reversed.Get(0), 3)
+    val t2 = Eq[int](t1, reversed.Get(1), 2)
     return Eq[int](t2, reversed.Get(2), 1)
 }
 
 // === Array Search Tests ===
 
 func TestArrayContains(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
-    var t1 = IsTrue(t, arr.Contains(2))
+    val arr = ArrayOf(1, 2, 3)
+    val t1 = IsTrue(t, arr.Contains(2))
     return IsFalse(t1, arr.Contains(5))
 }
 
 func TestArrayIndexOf(t T) T {
-    var arr = ArrayOf[string]("a", "b", "c")
-    var t1 = Eq[int](t, arr.IndexOf("b"), 1)
+    val arr = ArrayOf("a", "b", "c")
+    val t1 = Eq[int](t, arr.IndexOf("b"), 1)
     return Eq[int](t1, arr.IndexOf("z"), -1)
 }
 
@@ -140,10 +140,10 @@ func doubleValue(x int) int {
 }
 
 func TestArrayMap(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
-    var mapped = arr.Map[int](doubleValue)
-    var t1 = Eq[int](t, mapped.Get(0), 2)
-    var t2 = Eq[int](t1, mapped.Get(1), 4)
+    val arr = ArrayOf(1, 2, 3)
+    val mapped = arr.Map(doubleValue)
+    val t1 = Eq[int](t, mapped.Get(0), 2)
+    val t2 = Eq[int](t1, mapped.Get(1), 4)
     return Eq[int](t2, mapped.Get(2), 6)
 }
 
@@ -152,10 +152,10 @@ func isEven(x int) bool {
 }
 
 func TestArrayFilter(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4, 5)
-    var filtered = arr.Filter(isEven)
-    var t1 = Eq[int](t, filtered.Length(), 2)
-    var t2 = Eq[int](t1, filtered.Get(0), 2)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val filtered = arr.Filter(isEven)
+    val t1 = Eq[int](t, filtered.Length(), 2)
+    val t2 = Eq[int](t1, filtered.Get(0), 2)
     return Eq[int](t2, filtered.Get(1), 4)
 }
 
@@ -164,8 +164,8 @@ func sum(acc int, x int) int {
 }
 
 func TestArrayFoldLeft(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4)
-    var result = arr.FoldLeft[int](0, sum)
+    val arr = ArrayOf(1, 2, 3, 4)
+    val result = arr.FoldLeft(0, sum)
     return Eq[int](t, result, 10)
 }
 
@@ -176,14 +176,14 @@ func isGreaterThanZero(x int) bool {
 }
 
 func TestArrayExists(t T) T {
-    var arr = ArrayOf[int](-1, 0, 1, 2)
+    val arr = ArrayOf(-1, 0, 1, 2)
     return IsTrue(t, arr.Exists(isGreaterThanZero))
 }
 
 func TestArrayForAll(t T) T {
-    var arr1 = ArrayOf[int](1, 2, 3)
-    var arr2 = ArrayOf[int](-1, 0, 1)
-    var t1 = IsTrue(t, arr1.ForAll(isGreaterThanZero))
+    val arr1 = ArrayOf(1, 2, 3)
+    val arr2 = ArrayOf(-1, 0, 1)
+    val t1 = IsTrue(t, arr1.ForAll(isGreaterThanZero))
     return IsFalse(t1, arr2.ForAll(isGreaterThanZero))
 }
 
@@ -192,56 +192,56 @@ func isGreaterThanTen(x int) bool {
 }
 
 func TestArrayFind(t T) T {
-    var arr = ArrayOf[int](5, 15, 25)
-    var found = arr.Find(isGreaterThanTen)
-    var t1 = IsSome(t, found)
+    val arr = ArrayOf(5, 15, 25)
+    val found = arr.Find(isGreaterThanTen)
+    val t1 = IsSome(t, found)
     return Eq[int](t1, found.Get(), 15)
 }
 
 func TestArrayFindNone(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
-    var found = arr.Find(isGreaterThanTen)
+    val arr = ArrayOf(1, 2, 3)
+    val found = arr.Find(isGreaterThanTen)
     return IsNone(t, found)
 }
 
 func TestArrayCount(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4, 5)
-    var count = arr.Count(isEven)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val count = arr.Count(isEven)
     return Eq[int](t, count, 2)
 }
 
 // === Array Utility Tests ===
 
 func TestArrayDistinct(t T) T {
-    var arr = ArrayOf[int](1, 2, 2, 3, 3, 3)
-    var distinct = arr.Distinct()
+    val arr = ArrayOf(1, 2, 2, 3, 3, 3)
+    val distinct = arr.Distinct()
     return Eq[int](t, distinct.Length(), 3)
 }
 
 func TestArrayGrouped(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4, 5)
-    var grouped = arr.Grouped(2)
-    var t1 = Eq[int](t, grouped.Length(), 3)
-    var t2 = Eq[int](t1, grouped.Get(0).Length(), 2)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val grouped = arr.Grouped(2)
+    val t1 = Eq[int](t, grouped.Length(), 3)
+    val t2 = Eq[int](t1, grouped.Get(0).Length(), 2)
     return Eq[int](t2, grouped.Get(2).Length(), 1)
 }
 
 func TestArrayAppendAll(t T) T {
-    var arr1 = ArrayOf[int](1, 2)
-    var arr2 = ArrayOf[int](3, 4)
-    var combined = arr1.AppendAll(arr2)
-    var t1 = Eq[int](t, combined.Length(), 4)
-    var t2 = Eq[int](t1, combined.Get(0), 1)
+    val arr1 = ArrayOf(1, 2)
+    val arr2 = ArrayOf(3, 4)
+    val combined = arr1.AppendAll(arr2)
+    val t1 = Eq[int](t, combined.Length(), 4)
+    val t2 = Eq[int](t1, combined.Get(0), 1)
     return Eq[int](t2, combined.Get(3), 4)
 }
 
 func TestArrayString(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
+    val arr = ArrayOf(1, 2, 3)
     return Eq[string](t, arr.String(), "Array(1, 2, 3)")
 }
 
 func TestEmptyArrayString(t T) T {
-    var arr = EmptyArray[int]()
+    val arr = EmptyArray[int]()
     return Eq[string](t, arr.String(), "Array()")
 }
 
@@ -249,39 +249,39 @@ func TestEmptyArrayString(t T) T {
 
 // Test using HeadOption with GetOrElse (functional pattern)
 func TestArrayPatternMatchHeadOption(t T) T {
-    var empty = EmptyArray[int]()
-    var nonEmpty = ArrayOf[int](42, 2, 3)
+    val empty = EmptyArray[int]()
+    val nonEmpty = ArrayOf(42, 2, 3)
     // GetOrElse is the functional way to handle Option
-    var t1 = Eq[int](t, empty.HeadOption().GetOrElse(-1), -1)
+    val t1 = Eq[int](t, empty.HeadOption().GetOrElse(-1), -1)
     return Eq[int](t1, nonEmpty.HeadOption().GetOrElse(-1), 42)
 }
 
 // Test using GetOption with GetOrElse for safe access
 func TestArrayPatternMatchGetOption(t T) T {
-    var arr = ArrayOf[int](10, 20, 30)
-    var t1 = Eq[int](t, arr.GetOption(0).GetOrElse(0), 10)
-    var t2 = Eq[int](t1, arr.GetOption(1).GetOrElse(0), 20)
-    var t3 = Eq[int](t2, arr.GetOption(2).GetOrElse(0), 30)
+    val arr = ArrayOf(10, 20, 30)
+    val t1 = Eq[int](t, arr.GetOption(0).GetOrElse(0), 10)
+    val t2 = Eq[int](t1, arr.GetOption(1).GetOrElse(0), 20)
+    val t3 = Eq[int](t2, arr.GetOption(2).GetOrElse(0), 30)
     return Eq[int](t3, arr.GetOption(99).GetOrElse(0), 0)
 }
 
 // Test processing array with isEmpty check (functional pattern)
 func TestArrayEmptyNonEmptyCheck(t T) T {
-    var empty = EmptyArray[int]()
-    var nonEmpty = ArrayOf[int](1, 2, 3)
-    var t1 = IsTrue(t, empty.IsEmpty())
-    var t2 = IsFalse(t1, nonEmpty.IsEmpty())
-    var t3 = IsFalse(t2, empty.NonEmpty())
+    val empty = EmptyArray[int]()
+    val nonEmpty = ArrayOf(1, 2, 3)
+    val t1 = IsTrue(t, empty.IsEmpty())
+    val t2 = IsFalse(t1, nonEmpty.IsEmpty())
+    val t3 = IsFalse(t2, empty.NonEmpty())
     return IsTrue(t3, nonEmpty.NonEmpty())
 }
 
 // Test Find with pattern matching behavior
 func TestArrayFindPattern(t T) T {
-    var arr = ArrayOf[int](1, 5, 10, 15)
-    var found = arr.Find(isGreaterThanTen)
-    var notFound = arr.Find((x int) => x > 100)
-    var t1 = IsSome(t, found)
-    var t2 = Eq[int](t1, found.GetOrElse(0), 15)
+    val arr = ArrayOf(1, 5, 10, 15)
+    val found = arr.Find(isGreaterThanTen)
+    val notFound = arr.Find((x) => x > 100)
+    val t1 = IsSome(t, found)
+    val t2 = Eq[int](t1, found.GetOrElse(0), 15)
     return IsNone(t2, notFound)
 }
 
@@ -289,94 +289,94 @@ func TestArrayFindPattern(t T) T {
 
 func TestArrayAppendImmutability(t T) T {
     // Original array should remain unchanged after append
-    var original = ArrayOf[int](1, 2, 3)
-    var modified = original.Append(4)
-    var t1 = Eq[int](t, original.Length(), 3)
-    var t2 = Eq[int](t1, modified.Length(), 4)
-    var t3 = Eq[int](t2, original.Get(0), 1)
-    var t4 = Eq[int](t3, original.Get(1), 2)
+    val original = ArrayOf(1, 2, 3)
+    val modified = original.Append(4)
+    val t1 = Eq[int](t, original.Length(), 3)
+    val t2 = Eq[int](t1, modified.Length(), 4)
+    val t3 = Eq[int](t2, original.Get(0), 1)
+    val t4 = Eq[int](t3, original.Get(1), 2)
     return Eq[int](t4, original.Get(2), 3)
 }
 
 func TestArrayPrependImmutability(t T) T {
     // Original array should remain unchanged after prepend
-    var original = ArrayOf[int](2, 3, 4)
-    var modified = original.Prepend(1)
-    var t1 = Eq[int](t, original.Length(), 3)
-    var t2 = Eq[int](t1, modified.Length(), 4)
-    var t3 = Eq[int](t2, original.Head(), 2)
+    val original = ArrayOf(2, 3, 4)
+    val modified = original.Prepend(1)
+    val t1 = Eq[int](t, original.Length(), 3)
+    val t2 = Eq[int](t1, modified.Length(), 4)
+    val t3 = Eq[int](t2, original.Head(), 2)
     return Eq[int](t3, modified.Head(), 1)
 }
 
 func TestArrayUpdatedImmutability(t T) T {
     // Original array should remain unchanged after update
-    var original = ArrayOf[int](1, 2, 3)
-    var modified = original.Updated(1, 99)
-    var t1 = Eq[int](t, original.Get(1), 2)
-    var t2 = Eq[int](t1, modified.Get(1), 99)
+    val original = ArrayOf(1, 2, 3)
+    val modified = original.Updated(1, 99)
+    val t1 = Eq[int](t, original.Get(1), 2)
+    val t2 = Eq[int](t1, modified.Get(1), 99)
     // Verify other elements unchanged
-    var t3 = Eq[int](t2, original.Get(0), 1)
+    val t3 = Eq[int](t2, original.Get(0), 1)
     return Eq[int](t3, original.Get(2), 3)
 }
 
 func TestArrayTailImmutability(t T) T {
     // Original array should remain unchanged after tail
-    var original = ArrayOf[int](1, 2, 3)
-    var tail = original.Tail()
-    var t1 = Eq[int](t, original.Length(), 3)
-    var t2 = Eq[int](t1, tail.Length(), 2)
+    val original = ArrayOf(1, 2, 3)
+    val tail = original.Tail()
+    val t1 = Eq[int](t, original.Length(), 3)
+    val t2 = Eq[int](t1, tail.Length(), 2)
     return Eq[int](t2, original.Head(), 1)
 }
 
 func TestArrayFilterImmutability(t T) T {
     // Original array should remain unchanged after filter
-    var original = ArrayOf[int](1, 2, 3, 4, 5)
-    var filtered = original.Filter(isEven)
-    var t1 = Eq[int](t, original.Length(), 5)
-    var t2 = Eq[int](t1, filtered.Length(), 2)
+    val original = ArrayOf(1, 2, 3, 4, 5)
+    val filtered = original.Filter(isEven)
+    val t1 = Eq[int](t, original.Length(), 5)
+    val t2 = Eq[int](t1, filtered.Length(), 2)
     // Original still has all elements
-    var t3 = Eq[int](t2, original.Get(0), 1)
+    val t3 = Eq[int](t2, original.Get(0), 1)
     return Eq[int](t3, original.Get(4), 5)
 }
 
 func TestArrayMapImmutability(t T) T {
     // Original array should remain unchanged after map
-    var original = ArrayOf[int](1, 2, 3)
-    var mapped = original.Map[int](doubleValue)
-    var t1 = Eq[int](t, original.Get(0), 1)
-    var t2 = Eq[int](t1, original.Get(1), 2)
-    var t3 = Eq[int](t2, original.Get(2), 3)
-    var t4 = Eq[int](t3, mapped.Get(0), 2)
+    val original = ArrayOf(1, 2, 3)
+    val mapped = original.Map(doubleValue)
+    val t1 = Eq[int](t, original.Get(0), 1)
+    val t2 = Eq[int](t1, original.Get(1), 2)
+    val t3 = Eq[int](t2, original.Get(2), 3)
+    val t4 = Eq[int](t3, mapped.Get(0), 2)
     return Eq[int](t4, mapped.Get(1), 4)
 }
 
 func TestArrayReverseImmutability(t T) T {
     // Original array should remain unchanged after reverse
-    var original = ArrayOf[int](1, 2, 3)
-    var reversed = original.Reverse()
-    var t1 = Eq[int](t, original.Get(0), 1)
-    var t2 = Eq[int](t1, original.Get(2), 3)
-    var t3 = Eq[int](t2, reversed.Get(0), 3)
+    val original = ArrayOf(1, 2, 3)
+    val reversed = original.Reverse()
+    val t1 = Eq[int](t, original.Get(0), 1)
+    val t2 = Eq[int](t1, original.Get(2), 3)
+    val t3 = Eq[int](t2, reversed.Get(0), 3)
     return Eq[int](t3, reversed.Get(2), 1)
 }
 
 func TestArrayMultipleModificationsImmutability(t T) T {
     // Chain of operations should not affect original
-    var original = ArrayOf[int](1, 2, 3)
-    var step1 = original.Append(4)
-    var step2 = step1.Prepend(0)
-    var step3 = step2.Updated(2, 99)
+    val original = ArrayOf(1, 2, 3)
+    val step1 = original.Append(4)
+    val step2 = step1.Prepend(0)
+    val step3 = step2.Updated(2, 99)
     // Original unchanged
-    var t1 = Eq[int](t, original.Length(), 3)
-    var t2 = Eq[int](t1, original.Get(0), 1)
+    val t1 = Eq[int](t, original.Length(), 3)
+    val t2 = Eq[int](t1, original.Get(0), 1)
     // step1 unchanged
-    var t3 = Eq[int](t2, step1.Length(), 4)
-    var t4 = Eq[int](t3, step1.Get(0), 1)
+    val t3 = Eq[int](t2, step1.Length(), 4)
+    val t4 = Eq[int](t3, step1.Get(0), 1)
     // step2 unchanged
-    var t5 = Eq[int](t4, step2.Length(), 5)
-    var t6 = Eq[int](t5, step2.Get(0), 0)
+    val t5 = Eq[int](t4, step2.Length(), 5)
+    val t6 = Eq[int](t5, step2.Get(0), 0)
     // step3 has all modifications
-    var t7 = Eq[int](t6, step3.Length(), 5)
+    val t7 = Eq[int](t6, step3.Length(), 5)
     return Eq[int](t7, step3.Get(2), 99)
 }
 
@@ -392,10 +392,10 @@ func TestArrayAppendBeyondBranchingFactor(t T) T {
         arr = arr.Append(i)
     }
     // Verify length
-    var t1 = Eq[int](t, arr.Length(), 100)
+    val t1 = Eq[int](t, arr.Length(), 100)
     // Verify first, middle, and last elements
-    var t2 = Eq[int](t1, arr.Get(0), 0)
-    var t3 = Eq[int](t2, arr.Get(50), 50)
+    val t2 = Eq[int](t1, arr.Get(0), 0)
+    val t3 = Eq[int](t2, arr.Get(50), 50)
     return Eq[int](t3, arr.Get(99), 99)
 }
 
@@ -406,9 +406,9 @@ func TestArrayOfLarge(t T) T {
     for i := 0; i < 50; i++ {
         arr = arr.Append(i * 2)
     }
-    var t1 = Eq[int](t, arr.Length(), 50)
-    var t2 = Eq[int](t1, arr.Get(0), 0)
-    var t3 = Eq[int](t2, arr.Get(25), 50)
+    val t1 = Eq[int](t, arr.Length(), 50)
+    val t2 = Eq[int](t1, arr.Get(0), 0)
+    val t3 = Eq[int](t2, arr.Get(25), 50)
     return Eq[int](t3, arr.Get(49), 98)
 }
 
@@ -419,11 +419,11 @@ func TestArrayFromSliceLarge(t T) T {
     for i := 0; i < 100; i++ {
         slice = append(slice, i)
     }
-    var arr = ArrayFromSlice[int](slice)
-    var t1 = Eq[int](t, arr.Length(), 100)
-    var t2 = Eq[int](t1, arr.Get(0), 0)
-    var t3 = Eq[int](t2, arr.Get(32), 32)  // First element in second node
-    var t4 = Eq[int](t3, arr.Get(64), 64)  // First element in third node
+    val arr = ArrayFromSlice[int](slice)
+    val t1 = Eq[int](t, arr.Length(), 100)
+    val t2 = Eq[int](t1, arr.Get(0), 0)
+    val t3 = Eq[int](t2, arr.Get(32), 32)  // First element in second node
+    val t4 = Eq[int](t3, arr.Get(64), 64)  // First element in third node
     return Eq[int](t4, arr.Get(99), 99)
 }
 
@@ -434,10 +434,10 @@ func TestArrayUpdatedLarge(t T) T {
         arr = arr.Append(i)
     }
     // Update element at position 33 (in second node)
-    var updated = arr.Updated(33, 999)
-    var t1 = Eq[int](t, arr.Get(33), 33)      // Original unchanged
-    var t2 = Eq[int](t1, updated.Get(33), 999) // Updated has new value
-    var t3 = Eq[int](t2, updated.Get(32), 32)  // Adjacent unchanged
+    val updated = arr.Updated(33, 999)
+    val t1 = Eq[int](t, arr.Get(33), 33)      // Original unchanged
+    val t2 = Eq[int](t1, updated.Get(33), 999) // Updated has new value
+    val t3 = Eq[int](t2, updated.Get(32), 32)  // Adjacent unchanged
     return Eq[int](t3, updated.Get(34), 34)    // Adjacent unchanged
 }
 
@@ -445,45 +445,45 @@ func TestArrayUpdatedLarge(t T) T {
 
 // Test multiple prepends that stay within the prefix buffer (< 32)
 func TestArrayPrependMultiple(t T) T {
-    var arr = ArrayOf[int](100, 200, 300)
+    var arr = ArrayOf(100, 200, 300)
     // Prepend 5 elements - should all stay in prefix buffer
     arr = arr.Prepend(5)
     arr = arr.Prepend(4)
     arr = arr.Prepend(3)
     arr = arr.Prepend(2)
     arr = arr.Prepend(1)
-    var t1 = Eq[int](t, arr.Length(), 8)
-    var t2 = Eq[int](t1, arr.Get(0), 1)  // First prepended (most recent at logical 0)
-    var t3 = Eq[int](t2, arr.Get(4), 5)  // Last prepended
-    var t4 = Eq[int](t3, arr.Get(5), 100) // Original first element
+    val t1 = Eq[int](t, arr.Length(), 8)
+    val t2 = Eq[int](t1, arr.Get(0), 1)  // First prepended (most recent at logical 0)
+    val t3 = Eq[int](t2, arr.Get(4), 5)  // Last prepended
+    val t4 = Eq[int](t3, arr.Get(5), 100) // Original first element
     return Eq[int](t4, arr.Get(7), 300) // Original last element
 }
 
 // Test prepend that triggers consolidation (32+ prepends)
 func TestArrayPrependConsolidation(t T) T {
-    var arr = ArrayOf[int](999)
+    var arr = ArrayOf(999)
     // Prepend 35 elements - should trigger consolidation at 32
     for i := 35; i >= 1; i-- {
         arr = arr.Prepend(i)
     }
-    var t1 = Eq[int](t, arr.Length(), 36)
-    var t2 = Eq[int](t1, arr.Get(0), 1)   // First prepended
-    var t3 = Eq[int](t2, arr.Get(34), 35) // Last prepended
+    val t1 = Eq[int](t, arr.Length(), 36)
+    val t2 = Eq[int](t1, arr.Get(0), 1)   // First prepended
+    val t3 = Eq[int](t2, arr.Get(34), 35) // Last prepended
     return Eq[int](t3, arr.Get(35), 999)  // Original element
 }
 
 // Test mixed prepend and append operations
 func TestArrayPrependAndAppendMixed(t T) T {
-    var arr = ArrayOf[int](50)
+    var arr = ArrayOf(50)
     arr = arr.Prepend(25)  // Add to front
     arr = arr.Append(75)   // Add to back
     arr = arr.Prepend(10)  // Add to front again
     arr = arr.Append(90)   // Add to back again
-    var t1 = Eq[int](t, arr.Length(), 5)
-    var t2 = Eq[int](t1, arr.Get(0), 10)  // First (most recent prepend)
-    var t3 = Eq[int](t2, arr.Get(1), 25)  // Second prepend
-    var t4 = Eq[int](t3, arr.Get(2), 50)  // Original
-    var t5 = Eq[int](t4, arr.Get(3), 75)  // First append
+    val t1 = Eq[int](t, arr.Length(), 5)
+    val t2 = Eq[int](t1, arr.Get(0), 10)  // First (most recent prepend)
+    val t3 = Eq[int](t2, arr.Get(1), 25)  // Second prepend
+    val t4 = Eq[int](t3, arr.Get(2), 50)  // Original
+    val t5 = Eq[int](t4, arr.Get(3), 75)  // First append
     return Eq[int](t5, arr.Get(4), 90)    // Second append
 }
 
@@ -491,7 +491,7 @@ func TestArrayPrependAndAppendMixed(t T) T {
 func TestArrayPrependEmpty(t T) T {
     var arr = EmptyArray[int]()
     arr = arr.Prepend(42)
-    var t1 = Eq[int](t, arr.Length(), 1)
+    val t1 = Eq[int](t, arr.Length(), 1)
     return Eq[int](t1, arr.Get(0), 42)
 }
 
@@ -500,41 +500,41 @@ func TestArrayPrependChain(t T) T {
     var arr = EmptyArray[int]()
     // Build array by prepending: result should be 1, 2, 3, 4, 5
     arr = arr.Prepend(5).Prepend(4).Prepend(3).Prepend(2).Prepend(1)
-    var t1 = Eq[int](t, arr.Length(), 5)
-    var t2 = Eq[int](t1, arr.Get(0), 1)
-    var t3 = Eq[int](t2, arr.Get(2), 3)
+    val t1 = Eq[int](t, arr.Length(), 5)
+    val t2 = Eq[int](t1, arr.Get(0), 1)
+    val t3 = Eq[int](t2, arr.Get(2), 3)
     return Eq[int](t3, arr.Get(4), 5)
 }
 
 // Test Updated on array with prefix
 func TestArrayUpdatedWithPrefix(t T) T {
-    var arr = ArrayOf[int](100, 200, 300)
+    var arr = ArrayOf(100, 200, 300)
     arr = arr.Prepend(50)
     arr = arr.Prepend(25)
     // Array is now: [25, 50, 100, 200, 300]
     // Update in prefix (index 0)
-    var updated1 = arr.Updated(0, 999)
-    var t1 = Eq[int](t, updated1.Get(0), 999)
-    var t2 = Eq[int](t1, updated1.Get(1), 50) // Other prefix element unchanged
+    val updated1 = arr.Updated(0, 999)
+    val t1 = Eq[int](t, updated1.Get(0), 999)
+    val t2 = Eq[int](t1, updated1.Get(1), 50) // Other prefix element unchanged
     // Update in tree (index 3)
-    var updated2 = arr.Updated(3, 888)
-    var t3 = Eq[int](t2, updated2.Get(3), 888)
-    var t4 = Eq[int](t3, updated2.Get(0), 25) // Prefix unchanged
+    val updated2 = arr.Updated(3, 888)
+    val t3 = Eq[int](t2, updated2.Get(3), 888)
+    val t4 = Eq[int](t3, updated2.Get(0), 25) // Prefix unchanged
     // Original unchanged
     return Eq[int](t4, arr.Get(0), 25)
 }
 
 // Test that prepend maintains immutability
 func TestArrayPrependImmutabilityDeep(t T) T {
-    var arr1 = ArrayOf[int](100, 200)
-    var arr2 = arr1.Prepend(50)
-    var arr3 = arr2.Prepend(25)
+    val arr1 = ArrayOf(100, 200)
+    val arr2 = arr1.Prepend(50)
+    val arr3 = arr2.Prepend(25)
     // All arrays should be independent
-    var t1 = Eq[int](t, arr1.Length(), 2)
-    var t2 = Eq[int](t1, arr2.Length(), 3)
-    var t3 = Eq[int](t2, arr3.Length(), 4)
-    var t4 = Eq[int](t3, arr1.Get(0), 100) // arr1 unchanged
-    var t5 = Eq[int](t4, arr2.Get(0), 50)  // arr2 has its own state
+    val t1 = Eq[int](t, arr1.Length(), 2)
+    val t2 = Eq[int](t1, arr2.Length(), 3)
+    val t3 = Eq[int](t2, arr3.Length(), 4)
+    val t4 = Eq[int](t3, arr1.Get(0), 100) // arr1 unchanged
+    val t5 = Eq[int](t4, arr2.Get(0), 50)  // arr2 has its own state
     return Eq[int](t5, arr3.Get(0), 25)    // arr3 has its own state
 }
 
@@ -545,8 +545,8 @@ func TestArrayPrependLargeAccess(t T) T {
     for i := 50; i >= 1; i-- {
         arr = arr.Prepend(i)
     }
-    var t1 = Eq[int](t, arr.Length(), 50)
-    var t2 = Eq[int](t1, arr.Get(0), 1)
-    var t3 = Eq[int](t2, arr.Get(24), 25)
+    val t1 = Eq[int](t, arr.Length(), 50)
+    val t2 = Eq[int](t1, arr.Get(0), 1)
+    val t3 = Eq[int](t2, arr.Get(24), 25)
     return Eq[int](t3, arr.Get(49), 50)
 }

--- a/collection_immutable/hashmap.gala
+++ b/collection_immutable/hashmap.gala
@@ -170,11 +170,10 @@ func (m HashMap[K, V]) GetOrElse(key K, defaultValue V) V {
 
 // Apply returns the value for a key. Panics if key not found. O(eC).
 func (m HashMap[K, V]) Apply(key K) V {
-    val opt = m.Get(key)
-    if opt.IsEmpty() {
-        panic(fmt.Sprintf("HashMap: key not found: %v", key))
+    return m.Get(key) match {
+        case Some(v) => v
+        case None() => panic(s"HashMap: key not found: $key")
     }
-    return opt.Get()
 }
 
 // Put adds or updates a key-value pair. Returns a new map. O(eC).
@@ -612,11 +611,10 @@ func (m HashMap[K, V]) PutAll(other HashMap[K, V]) HashMap[K, V] {
 // Merge merges another map with a combining function for duplicate keys.
 func (m HashMap[K, V]) Merge(other HashMap[K, V], f func(V, V) V) HashMap[K, V] {
     return other.FoldLeftKV[HashMap[K, V]](m, (acc HashMap[K, V], k K, v V) => {
-        val existing = acc.Get(k)
-        if existing.IsDefined() {
-            return acc.Put(k, f(existing.Get(), v))
+        return acc.Get(k) match {
+            case Some(existing) => acc.Put(k, f(existing, v))
+            case None() => acc.Put(k, v)
         }
-        return acc.Put(k, v)
     })
 }
 
@@ -647,7 +645,7 @@ func (m HashMap[K, V]) String() string {
         if !first {
             result = result + ", "
         }
-        result = result + fmt.Sprintf("%v -> %v", k, v)
+        result = result + s"$k -> $v"
         first = false
     })
     return result + ")"
@@ -664,7 +662,7 @@ func (m HashMap[K, V]) MkString(sep string) string {
         if !first {
             result = result + sep
         }
-        result = result + fmt.Sprintf("%v -> %v", k, v)
+        result = result + s"$k -> $v"
         first = false
     })
     return result
@@ -698,11 +696,10 @@ func (m HashMap[K, V]) Find(p func(K, V) bool) Option[Tuple[K, V]] {
 
 // Head returns the first entry. Panics if empty.
 func (m HashMap[K, V]) Head() Tuple[K, V] {
-    val opt = m.HeadOption()
-    if opt.IsEmpty() {
-        panic("HashMap: head of empty map")
+    return m.HeadOption() match {
+        case Some(v) => v
+        case None() => panic("HashMap: head of empty map")
     }
-    return opt.Get()
 }
 
 // HeadOption returns the first entry as Option.

--- a/collection_immutable/hashmap_test.gala
+++ b/collection_immutable/hashmap_test.gala
@@ -12,8 +12,8 @@ import (
 
 func TestHashMapEmpty(t T) T {
     val m = EmptyHashMap[string, int]()
-    var t1 = IsTrue(t, m.IsEmpty())
-    var t2 = IsFalse(t1, m.NonEmpty())
+    val t1 = IsTrue(t, m.IsEmpty())
+    val t2 = IsFalse(t1, m.NonEmpty())
     return Eq[int](t2, m.Size(), 0)
 }
 
@@ -23,9 +23,9 @@ func TestHashMapPut(t T) T {
     val m2 = m1.Put("b", 2)
     val m3 = m2.Put("c", 3)
 
-    var t1 = Eq[int](t, m.Size(), 0)
-    var t2 = Eq[int](t1, m1.Size(), 1)
-    var t3 = Eq[int](t2, m2.Size(), 2)
+    val t1 = Eq[int](t, m.Size(), 0)
+    val t2 = Eq[int](t1, m1.Size(), 1)
+    val t3 = Eq[int](t2, m2.Size(), 2)
     return Eq[int](t3, m3.Size(), 3)
 }
 
@@ -34,40 +34,40 @@ func TestHashMapPutUpdate(t T) T {
     val m1 = m.Put("a", 1)
     val m2 = m1.Put("a", 2)
 
-    var t1 = Eq[int](t, m2.Size(), 1)
+    val t1 = Eq[int](t, m2.Size(), 1)
     return Eq[int](t1, m2.GetOrElse("a", 0), 2)
 }
 
 func TestHashMapOf(t T) T {
     val m = HashMapOf[string, int](
-        Tuple[string, int](V1 = "a", V2 = 1),
-        Tuple[string, int](V1 = "b", V2 = 2),
-        Tuple[string, int](V1 = "c", V2 = 3)
+        ("a", 1),
+        ("b", 2),
+        ("c", 3)
     )
-    var t1 = Eq[int](t, m.Size(), 3)
-    var t2 = IsTrue(t1, m.Contains("a"))
-    var t3 = IsTrue(t2, m.Contains("b"))
+    val t1 = Eq[int](t, m.Size(), 3)
+    val t2 = IsTrue(t1, m.Contains("a"))
+    val t3 = IsTrue(t2, m.Contains("b"))
     return IsTrue(t3, m.Contains("c"))
 }
 
 func TestHashMapContains(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2)
-    var t1 = IsTrue(t, m.Contains("a"))
-    var t2 = IsTrue(t1, m.Contains("b"))
+    val t1 = IsTrue(t, m.Contains("a"))
+    val t2 = IsTrue(t1, m.Contains("b"))
     return IsFalse(t2, m.Contains("c"))
 }
 
 func TestHashMapGet(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2)
-    var t1 = IsSome(t, m.Get("a"))
-    var t2 = Eq[int](t1, m.Get("a").Get(), 1)
-    var t3 = Eq[int](t2, m.Get("b").Get(), 2)
+    val t1 = IsSome(t, m.Get("a"))
+    val t2 = Eq[int](t1, m.Get("a").Get(), 1)
+    val t3 = Eq[int](t2, m.Get("b").Get(), 2)
     return IsNone(t3, m.Get("c"))
 }
 
 func TestHashMapGetOrElse(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1)
-    var t1 = Eq[int](t, m.GetOrElse("a", 0), 1)
+    val t1 = Eq[int](t, m.GetOrElse("a", 0), 1)
     return Eq[int](t1, m.GetOrElse("b", 42), 42)
 }
 
@@ -75,9 +75,9 @@ func TestHashMapRemove(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
     val m2 = m.Remove("b")
 
-    var t1 = Eq[int](t, m2.Size(), 2)
-    var t2 = IsTrue(t1, m2.Contains("a"))
-    var t3 = IsFalse(t2, m2.Contains("b"))
+    val t1 = Eq[int](t, m2.Size(), 2)
+    val t2 = IsTrue(t1, m2.Contains("a"))
+    val t3 = IsFalse(t2, m2.Contains("b"))
     return IsTrue(t3, m2.Contains("c"))
 }
 
@@ -91,9 +91,9 @@ func TestHashMapRemoveNonExistent(t T) T {
 
 func TestHashMapIntKeys(t T) T {
     val m = EmptyHashMap[int, string]().Put(1, "one").Put(2, "two").Put(3, "three")
-    var t1 = Eq[int](t, m.Size(), 3)
-    var t2 = Eq[string](t1, m.GetOrElse(1, ""), "one")
-    var t3 = Eq[string](t2, m.GetOrElse(2, ""), "two")
+    val t1 = Eq[int](t, m.Size(), 3)
+    val t2 = Eq[string](t1, m.GetOrElse(1, ""), "one")
+    val t3 = Eq[string](t2, m.GetOrElse(2, ""), "two")
     return Eq[string](t3, m.GetOrElse(3, ""), "three")
 }
 
@@ -104,20 +104,20 @@ func TestHashMapPutAll(t T) T {
     val m2 = EmptyHashMap[string, int]().Put("c", 3).Put("d", 4)
     val merged = m1.PutAll(m2)
 
-    var t1 = Eq[int](t, merged.Size(), 4)
-    var t2 = IsTrue(t1, merged.Contains("a"))
-    var t3 = IsTrue(t2, merged.Contains("c"))
+    val t1 = Eq[int](t, merged.Size(), 4)
+    val t2 = IsTrue(t1, merged.Contains("a"))
+    val t3 = IsTrue(t2, merged.Contains("c"))
     return IsTrue(t3, merged.Contains("d"))
 }
 
 func TestHashMapMerge(t T) T {
     val m1 = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2)
     val m2 = EmptyHashMap[string, int]().Put("b", 3).Put("c", 4)
-    val merged = m1.Merge(m2, (v1 int, v2 int) => v1 + v2)
+    val merged = m1.Merge(m2, (v1, v2) => v1 + v2)
 
-    var t1 = Eq[int](t, merged.Size(), 3)
-    var t2 = Eq[int](t1, merged.GetOrElse("a", 0), 1)
-    var t3 = Eq[int](t2, merged.GetOrElse("b", 0), 5)
+    val t1 = Eq[int](t, merged.Size(), 3)
+    val t2 = Eq[int](t1, merged.GetOrElse("a", 0), 1)
+    val t3 = Eq[int](t2, merged.GetOrElse("b", 0), 5)
     return Eq[int](t3, merged.GetOrElse("c", 0), 4)
 }
 
@@ -125,48 +125,48 @@ func TestHashMapMerge(t T) T {
 
 func TestHashMapFilter(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3).Put("d", 4)
-    val filtered = m.Filter((k string, v int) => v > 2)
+    val filtered = m.Filter((k, v) => v > 2)
 
-    var t1 = Eq[int](t, filtered.Size(), 2)
-    var t2 = IsFalse(t1, filtered.Contains("a"))
-    var t3 = IsFalse(t2, filtered.Contains("b"))
-    var t4 = IsTrue(t3, filtered.Contains("c"))
+    val t1 = Eq[int](t, filtered.Size(), 2)
+    val t2 = IsFalse(t1, filtered.Contains("a"))
+    val t3 = IsFalse(t2, filtered.Contains("b"))
+    val t4 = IsTrue(t3, filtered.Contains("c"))
     return IsTrue(t4, filtered.Contains("d"))
 }
 
 func TestHashMapFilterKeys(t T) T {
     val m = EmptyHashMap[string, int]().Put("apple", 1).Put("banana", 2).Put("cherry", 3)
-    val filtered = m.FilterKeys((k string) => len(k) > 5)
+    val filtered = m.FilterKeys((k) => len(k) > 5)
 
-    var t1 = Eq[int](t, filtered.Size(), 2)
-    var t2 = IsFalse(t1, filtered.Contains("apple"))
+    val t1 = Eq[int](t, filtered.Size(), 2)
+    val t2 = IsFalse(t1, filtered.Contains("apple"))
     return IsTrue(t2, filtered.Contains("banana"))
 }
 
 func TestHashMapFilterValues(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
-    val filtered = m.FilterValues((v int) => v % 2 == 0)
+    val filtered = m.FilterValues((v) => v % 2 == 0)
 
-    var t1 = Eq[int](t, filtered.Size(), 1)
+    val t1 = Eq[int](t, filtered.Size(), 1)
     return IsTrue(t1, filtered.Contains("b"))
 }
 
 func TestHashMapMapValues(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
-    val doubled = m.MapValues[int]((v int) => v * 2)
+    val doubled = m.MapValues((v) => v * 2)
 
-    var t1 = Eq[int](t, doubled.GetOrElse("a", 0), 2)
-    var t2 = Eq[int](t1, doubled.GetOrElse("b", 0), 4)
+    val t1 = Eq[int](t, doubled.GetOrElse("a", 0), 2)
+    val t2 = Eq[int](t1, doubled.GetOrElse("b", 0), 4)
     return Eq[int](t2, doubled.GetOrElse("c", 0), 6)
 }
 
 func TestHashMapPartition(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3).Put("d", 4)
-    val result = m.Partition((k string, v int) => v % 2 == 0)
+    val result = m.Partition((k, v) => v % 2 == 0)
     val even = result.V1
     val odd = result.V2
 
-    var t1 = Eq[int](t, even.Size(), 2)
+    val t1 = Eq[int](t, even.Size(), 2)
     return Eq[int](t1, odd.Size(), 2)
 }
 
@@ -174,7 +174,7 @@ func TestHashMapPartition(t T) T {
 
 func TestHashMapFoldLeft(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
-    val sum = m.FoldLeftKV[int](0, (acc int, k string, v int) => acc + v)
+    val sum = m.FoldLeftKV(0, (acc, k, v) => acc + v)
     return Eq[int](t, sum, 6)
 }
 
@@ -182,32 +182,32 @@ func TestHashMapFoldLeft(t T) T {
 
 func TestHashMapExists(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
-    var t1 = IsTrue(t, m.Exists((k string, v int) => v > 2))
-    return IsFalse(t1, m.Exists((k string, v int) => v > 10))
+    val t1 = IsTrue(t, m.Exists((k, v) => v > 2))
+    return IsFalse(t1, m.Exists((k, v) => v > 10))
 }
 
 func TestHashMapForAll(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 2).Put("b", 4).Put("c", 6)
-    var t1 = IsTrue(t, m.ForAll((k string, v int) => v % 2 == 0))
-    return IsFalse(t1, m.ForAll((k string, v int) => v < 5))
+    val t1 = IsTrue(t, m.ForAll((k, v) => v % 2 == 0))
+    return IsFalse(t1, m.ForAll((k, v) => v < 5))
 }
 
 func TestHashMapFind(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
-    val found = m.Find((k string, v int) => v == 2)
-    var t1 = IsSome(t, found)
+    val found = m.Find((k, v) => v == 2)
+    val t1 = IsSome(t, found)
     return Eq[string](t1, found.Get().V1, "b")
 }
 
 func TestHashMapCount(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3).Put("d", 4)
-    return Eq[int](t, m.Count((k string, v int) => v > 2), 2)
+    return Eq[int](t, m.Count((k, v) => v > 2), 2)
 }
 
 func TestHashMapCollect(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
     // Collect values > 1 as formatted strings
-    val result = m.Collect((k string, v int) => {
+    val result = m.Collect((k, v) => {
         if v > 1 {
             return Some(fmt.Sprintf("%s:%d", k, v))
         }
@@ -222,9 +222,9 @@ func TestHashMapCollect(t T) T {
 func TestHashMapKeys(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
     val keys = m.Keys()
-    var t1 = Eq[int](t, keys.Size(), 3)
-    var t2 = IsTrue(t1, keys.Contains("a"))
-    var t3 = IsTrue(t2, keys.Contains("b"))
+    val t1 = Eq[int](t, keys.Size(), 3)
+    val t2 = IsTrue(t1, keys.Contains("a"))
+    val t3 = IsTrue(t2, keys.Contains("b"))
     return IsTrue(t3, keys.Contains("c"))
 }
 
@@ -244,7 +244,7 @@ func TestHashMapHeadOption(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1)
     val empty = EmptyHashMap[string, int]()
 
-    var t1 = IsSome(t, m.HeadOption())
+    val t1 = IsSome(t, m.HeadOption())
     return IsNone(t1, empty.HeadOption())
 }
 
@@ -259,7 +259,7 @@ func TestHashMapToArray(t T) T {
 func TestHashMapToGoMap(t T) T {
     val m = EmptyHashMap[string, int]().Put("a", 1).Put("b", 2)
     val goMap = m.ToGoMap()
-    var t1 = Eq[int](t, len(goMap), 2)
+    val t1 = Eq[int](t, len(goMap), 2)
     return Eq[int](t1, goMap["a"], 1)
 }
 
@@ -271,14 +271,14 @@ func TestHashMapToList(t T) T {
 
 func TestHashMapFromSlice(t T) T {
     val entries = go_interop.SliceOf[Tuple[string, int]](
-        Tuple[string, int](V1 = "a", V2 = 1),
-        Tuple[string, int](V1 = "b", V2 = 2),
-        Tuple[string, int](V1 = "c", V2 = 3)
+        ("a", 1),
+        ("b", 2),
+        ("c", 3)
     )
 
     val m = HashMapFromSlice[string, int](entries)
-    var t1 = Eq[int](t, m.Size(), 3)
-    var t2 = Eq[int](t1, m.GetOrElse("a", 0), 1)
+    val t1 = Eq[int](t, m.Size(), 3)
+    val t2 = Eq[int](t1, m.GetOrElse("a", 0), 1)
     return Eq[int](t2, m.GetOrElse("b", 0), 2)
 }
 
@@ -289,9 +289,9 @@ func TestHashMapLarge(t T) T {
     for i := 0; i < 1000; i++ {
         m = m.Put(i, i * 2)
     }
-    var t1 = Eq[int](t, m.Size(), 1000)
-    var t2 = Eq[int](t1, m.GetOrElse(0, -1), 0)
-    var t3 = Eq[int](t2, m.GetOrElse(500, -1), 1000)
+    val t1 = Eq[int](t, m.Size(), 1000)
+    val t2 = Eq[int](t1, m.GetOrElse(0, -1), 0)
+    val t3 = Eq[int](t2, m.GetOrElse(500, -1), 1000)
     return Eq[int](t3, m.GetOrElse(999, -1), 1998)
 }
 
@@ -316,8 +316,8 @@ func TestHashMapWithHashableKey(t T) T {
     val m1 = m.Put(p1, "Engineer")
     val m2 = m1.Put(p2, "Designer")
 
-    var t1 = Eq[int](t, m2.Size(), 2)
-    var t2 = Eq[string](t1, m2.GetOrElse(p1, ""), "Engineer")
+    val t1 = Eq[int](t, m2.Size(), 2)
+    val t2 = Eq[string](t1, m2.GetOrElse(p1, ""), "Engineer")
     return Eq[string](t2, m2.GetOrElse(p2, ""), "Designer")
 }
 
@@ -328,7 +328,7 @@ func TestHashMapHashableKeyUpdate(t T) T {
     val m = EmptyHashMap[PersonKey, string]().Put(p1, "Engineer")
     val m2 = m.Put(p1copy, "Senior Engineer")
 
-    var t1 = Eq[int](t, m2.Size(), 1)
+    val t1 = Eq[int](t, m2.Size(), 1)
     return Eq[string](t1, m2.GetOrElse(p1, ""), "Senior Engineer")
 }
 
@@ -336,7 +336,7 @@ func TestHashMapHashableKeyUpdate(t T) T {
 
 func TestHashMapString(t T) T {
     val empty = EmptyHashMap[string, int]()
-    var t1 = Eq[string](t, empty.String(), "HashMap()")
+    val t1 = Eq[string](t, empty.String(), "HashMap()")
 
     val m = EmptyHashMap[string, int]().Put("a", 1)
     return IsTrue(t1, len(m.String()) > 10)
@@ -349,8 +349,8 @@ func TestHashMapImmutability(t T) T {
     val m2 = m1.Put("b", 2)
     val m3 = m1.Remove("a")
 
-    var t1 = Eq[int](t, m1.Size(), 1)
-    var t2 = Eq[int](t1, m2.Size(), 2)
-    var t3 = Eq[int](t2, m3.Size(), 0)
+    val t1 = Eq[int](t, m1.Size(), 1)
+    val t2 = Eq[int](t1, m2.Size(), 2)
+    val t3 = Eq[int](t2, m3.Size(), 0)
     return IsTrue(t3, m1.Contains("a"))
 }

--- a/collection_immutable/hashset.gala
+++ b/collection_immutable/hashset.gala
@@ -591,7 +591,7 @@ func (s HashSet[T]) String() string {
         if !first {
             result = result + ", "
         }
-        result = result + fmt.Sprintf("%v", elem)
+        result = result + s"${elem}"
         first = false
     })
     return result + ")"
@@ -608,7 +608,7 @@ func (s HashSet[T]) MkString(sep string) string {
         if !first {
             result = result + sep
         }
-        result = result + fmt.Sprintf("%v", elem)
+        result = result + s"${elem}"
         first = false
     })
     return result

--- a/collection_immutable/hashset_test.gala
+++ b/collection_immutable/hashset_test.gala
@@ -9,15 +9,15 @@ import (
 // Basic operations tests
 func TestHashSetEmpty(t T) T {
     val s = EmptyHashSet[int]()
-    var t1 = IsTrue(t, s.IsEmpty())
-    var t2 = IsFalse(t1, s.NonEmpty())
+    val t1 = IsTrue(t, s.IsEmpty())
+    val t2 = IsFalse(t1, s.NonEmpty())
     return Eq[int](t2, s.Size(), 0)
 }
 
 func TestHashSetOf(t T) T {
     val s = HashSetOf[int](1, 2, 3, 4, 5)
-    var t1 = IsFalse(t, s.IsEmpty())
-    var t2 = IsTrue(t1, s.NonEmpty())
+    val t1 = IsFalse(t, s.IsEmpty())
+    val t2 = IsTrue(t1, s.NonEmpty())
     return Eq[int](t2, s.Size(), 5)
 }
 
@@ -39,12 +39,12 @@ func TestHashSetAdd(t T) T {
     val s2 = s1.Add(2)
     val s3 = s2.Add(3)
 
-    var t1 = Eq[int](t, s.Size(), 0)
-    var t2 = Eq[int](t1, s1.Size(), 1)
-    var t3 = Eq[int](t2, s2.Size(), 2)
-    var t4 = Eq[int](t3, s3.Size(), 3)
-    var t5 = IsTrue(t4, s3.Contains(1))
-    var t6 = IsTrue(t5, s3.Contains(2))
+    val t1 = Eq[int](t, s.Size(), 0)
+    val t2 = Eq[int](t1, s1.Size(), 1)
+    val t3 = Eq[int](t2, s2.Size(), 2)
+    val t4 = Eq[int](t3, s3.Size(), 3)
+    val t5 = IsTrue(t4, s3.Contains(1))
+    val t6 = IsTrue(t5, s3.Contains(2))
     return IsTrue(t6, s3.Contains(3))
 }
 
@@ -58,9 +58,9 @@ func TestHashSetRemove(t T) T {
     val s = HashSetOf[int](1, 2, 3, 4, 5)
     val s2 = s.Remove(3)
 
-    var t1 = Eq[int](t, s2.Size(), 4)
-    var t2 = IsFalse(t1, s2.Contains(3))
-    var t3 = IsTrue(t2, s2.Contains(1))
+    val t1 = Eq[int](t, s2.Size(), 4)
+    val t2 = IsFalse(t1, s2.Contains(3))
+    val t3 = IsTrue(t2, s2.Contains(1))
     return IsTrue(t3, s2.Contains(5))
 }
 
@@ -76,9 +76,9 @@ func TestHashSetUnion(t T) T {
     val s2 = HashSetOf[int](3, 4, 5)
     val union = s1.Union(s2)
 
-    var t1 = Eq[int](t, union.Size(), 5)
-    var t2 = IsTrue(t1, union.Contains(1))
-    var t3 = IsTrue(t2, union.Contains(3))
+    val t1 = Eq[int](t, union.Size(), 5)
+    val t2 = IsTrue(t1, union.Contains(1))
+    val t3 = IsTrue(t2, union.Contains(3))
     return IsTrue(t3, union.Contains(5))
 }
 
@@ -87,8 +87,8 @@ func TestHashSetIntersect(t T) T {
     val s2 = HashSetOf[int](3, 4, 5, 6)
     val intersect = s1.Intersect(s2)
 
-    var t1 = Eq[int](t, intersect.Size(), 2)
-    var t2 = IsTrue(t1, intersect.Contains(3))
+    val t1 = Eq[int](t, intersect.Size(), 2)
+    val t2 = IsTrue(t1, intersect.Contains(3))
     return IsTrue(t2, intersect.Contains(4))
 }
 
@@ -97,10 +97,10 @@ func TestHashSetDiff(t T) T {
     val s2 = HashSetOf[int](3, 4, 5, 6)
     val diff = s1.Diff(s2)
 
-    var t1 = Eq[int](t, diff.Size(), 2)
-    var t2 = IsTrue(t1, diff.Contains(1))
-    var t3 = IsTrue(t2, diff.Contains(2))
-    var t4 = IsFalse(t3, diff.Contains(3))
+    val t1 = Eq[int](t, diff.Size(), 2)
+    val t2 = IsTrue(t1, diff.Contains(1))
+    val t3 = IsTrue(t2, diff.Contains(2))
+    val t4 = IsFalse(t3, diff.Contains(3))
     return IsFalse(t4, diff.Contains(4))
 }
 
@@ -109,59 +109,59 @@ func TestHashSetSubsetOf(t T) T {
     val s2 = HashSetOf[int](1, 2, 3, 4, 5)
     val s3 = HashSetOf[int](1, 2, 6)
 
-    var t1 = IsTrue(t, s1.SubsetOf(s2))
+    val t1 = IsTrue(t, s1.SubsetOf(s2))
     return IsFalse(t1, s3.SubsetOf(s2))
 }
 
 // Transformation tests
 func TestHashSetFilter(t T) T {
     val s = HashSetOf[int](1, 2, 3, 4, 5, 6)
-    val even = s.Filter((x int) => x % 2 == 0)
+    val even = s.Filter((x) => x % 2 == 0)
 
-    var t1 = Eq[int](t, even.Size(), 3)
-    var t2 = IsTrue(t1, even.Contains(2))
-    var t3 = IsTrue(t2, even.Contains(4))
-    var t4 = IsTrue(t3, even.Contains(6))
+    val t1 = Eq[int](t, even.Size(), 3)
+    val t2 = IsTrue(t1, even.Contains(2))
+    val t3 = IsTrue(t2, even.Contains(4))
+    val t4 = IsTrue(t3, even.Contains(6))
     return IsFalse(t4, even.Contains(1))
 }
 
 func TestHashSetMap(t T) T {
     val s = HashSetOf[int](1, 2, 3)
-    val doubled = MapHashSet[int, int](s, (x int) => x * 2)
+    val doubled = MapHashSet[int, int](s, (x) => x * 2)
 
-    var t1 = Eq[int](t, doubled.Size(), 3)
-    var t2 = IsTrue(t1, doubled.Contains(2))
-    var t3 = IsTrue(t2, doubled.Contains(4))
+    val t1 = Eq[int](t, doubled.Size(), 3)
+    val t2 = IsTrue(t1, doubled.Contains(2))
+    val t3 = IsTrue(t2, doubled.Contains(4))
     return IsTrue(t3, doubled.Contains(6))
 }
 
 func TestHashSetFoldLeft(t T) T {
     val s = HashSetOf[int](1, 2, 3, 4, 5)
-    val sum = s.FoldLeft[int](0, (acc int, x int) => acc + x)
+    val sum = s.FoldLeft(0, (acc, x) => acc + x)
     return Eq[int](t, sum, 15)
 }
 
 // Predicate tests
 func TestHashSetExists(t T) T {
     val s = HashSetOf[int](1, 2, 3, 4, 5)
-    var t1 = IsTrue(t, s.Exists((x int) => x > 4))
-    return IsFalse(t1, s.Exists((x int) => x > 5))
+    val t1 = IsTrue(t, s.Exists((x) => x > 4))
+    return IsFalse(t1, s.Exists((x) => x > 5))
 }
 
 func TestHashSetForAll(t T) T {
     val s = HashSetOf[int](2, 4, 6, 8)
-    var t1 = IsTrue(t, s.ForAll((x int) => x % 2 == 0))
-    return IsFalse(t1, s.ForAll((x int) => x < 5))
+    val t1 = IsTrue(t, s.ForAll((x) => x % 2 == 0))
+    return IsFalse(t1, s.ForAll((x) => x < 5))
 }
 
 func TestHashSetCount(t T) T {
     val s = HashSetOf[int](1, 2, 3, 4, 5, 6)
-    return Eq[int](t, s.Count((x int) => x > 3), 3)
+    return Eq[int](t, s.Count((x) => x > 3), 3)
 }
 
 func TestHashSetFind(t T) T {
     val s = HashSetOf[int](1, 2, 3, 4, 5)
-    val found = s.Find((x int) => x > 3)
+    val found = s.Find((x) => x > 3)
     return IsSome(t, found)
 }
 
@@ -187,7 +187,7 @@ func TestHashSetToArray(t T) T {
 func TestHashSetCollect(t T) T {
     val s = HashSetOf[int](1, 2, 3, 4, 5)
     // Collect even numbers doubled
-    val result = s.Collect((x int) => {
+    val result = s.Collect((x) => {
         if x % 2 == 0 {
             return Some(x * 2)
         }
@@ -200,9 +200,9 @@ func TestHashSetCollect(t T) T {
 // String tests
 func TestHashSetStrings(t T) T {
     val s = HashSetOf[string]("apple", "banana", "cherry")
-    var t1 = Eq[int](t, s.Size(), 3)
-    var t2 = IsTrue(t1, s.Contains("apple"))
-    var t3 = IsTrue(t2, s.Contains("banana"))
+    val t1 = Eq[int](t, s.Size(), 3)
+    val t2 = IsTrue(t1, s.Contains("apple"))
+    val t3 = IsTrue(t2, s.Contains("banana"))
     return IsTrue(t3, s.Contains("cherry"))
 }
 
@@ -212,9 +212,9 @@ func TestHashSetLarge(t T) T {
     for i := 0; i < 1000; i++ {
         s = s.Add(i)
     }
-    var t1 = Eq[int](t, s.Size(), 1000)
-    var t2 = IsTrue(t1, s.Contains(0))
-    var t3 = IsTrue(t2, s.Contains(500))
+    val t1 = Eq[int](t, s.Size(), 1000)
+    val t2 = IsTrue(t1, s.Contains(0))
+    val t3 = IsTrue(t2, s.Contains(500))
     return IsTrue(t3, s.Contains(999))
 }
 
@@ -229,25 +229,25 @@ func TestHashSetHeadOption(t T) T {
     val s = HashSetOf[int](1, 2, 3)
     val empty = EmptyHashSet[int]()
 
-    var t1 = IsSome(t, s.HeadOption())
+    val t1 = IsSome(t, s.HeadOption())
     return IsNone(t1, empty.HeadOption())
 }
 
 // Partition test
 func TestHashSetPartition(t T) T {
     val s = HashSetOf[int](1, 2, 3, 4, 5, 6)
-    val result = s.Partition((x int) => x % 2 == 0)
+    val result = s.Partition((x) => x % 2 == 0)
     val even = result.V1
     val odd = result.V2
 
-    var t1 = Eq[int](t, even.Size(), 3)
+    val t1 = Eq[int](t, even.Size(), 3)
     return Eq[int](t1, odd.Size(), 3)
 }
 
 // Reduce tests
 func TestHashSetReduce(t T) T {
     val s = HashSetOf[int](1, 2, 3, 4, 5)
-    val sum = s.Reduce((a int, b int) => a + b)
+    val sum = s.Reduce((a, b) => a + b)
     return Eq[int](t, sum, 15)
 }
 
@@ -255,8 +255,8 @@ func TestHashSetReduceOption(t T) T {
     val s = HashSetOf[int](1, 2, 3)
     val empty = EmptyHashSet[int]()
 
-    var t1 = IsSome(t, s.ReduceOption((a int, b int) => a + b))
-    return IsNone(t1, empty.ReduceOption((a int, b int) => a + b))
+    val t1 = IsSome(t, s.ReduceOption((a, b) => a + b))
+    return IsNone(t1, empty.ReduceOption((a, b) => a + b))
 }
 
 // ============ Hashable Interface Tests ============
@@ -282,9 +282,9 @@ func TestHashSetWithHashable(t T) T {
     val s2 = s1.Add(p2)
     val s3 = s2.Add(p3)
 
-    var t1 = Eq[int](t, s3.Size(), 3)
-    var t2 = IsTrue(t1, s3.Contains(p1))
-    var t3 = IsTrue(t2, s3.Contains(p2))
+    val t1 = Eq[int](t, s3.Size(), 3)
+    val t2 = IsTrue(t1, s3.Contains(p1))
+    val t3 = IsTrue(t2, s3.Contains(p2))
     return IsTrue(t3, s3.Contains(p3))
 }
 
@@ -306,8 +306,8 @@ func TestHashSetHashableRemove(t T) T {
     val s = HashSetOf[Person](p1, p2)
     val s2 = s.Remove(p1)
 
-    var t1 = Eq[int](t, s2.Size(), 1)
-    var t2 = IsFalse(t1, s2.Contains(p1))
+    val t1 = Eq[int](t, s2.Size(), 1)
+    val t2 = IsFalse(t1, s2.Contains(p1))
     return IsTrue(t2, s2.Contains(p2))
 }
 
@@ -316,17 +316,17 @@ func TestHashFunctions(t T) T {
     // HashInt should produce consistent results
     val h1 = HashInt(int64(42))
     val h2 = HashInt(int64(42))
-    var t1 = Eq[uint32](t, h1, h2)
+    val t1 = Eq[uint32](t, h1, h2)
 
     // HashString should produce consistent results
     val h3 = HashString("hello")
     val h4 = HashString("hello")
-    var t2 = Eq[uint32](t1, h3, h4)
+    val t2 = Eq[uint32](t1, h3, h4)
 
     // Different values should (usually) produce different hashes
     val h5 = HashInt(int64(1))
     val h6 = HashInt(int64(2))
-    var t3 = IsTrue(t2, h5 != h6)
+    val t3 = IsTrue(t2, h5 != h6)
 
     // HashCombine should work
     val combined = HashCombine(h1, h3)

--- a/collection_immutable/inference_test.gala
+++ b/collection_immutable/inference_test.gala
@@ -10,31 +10,31 @@ import (
 // Test if ArrayOf can infer type from elements
 func TestArrayImplicitType(t T) T {
     // Try creating array without explicit type parameter
-    var arr = ArrayOf(1, 2, 3)
-    var t1 = Eq[int](t, arr.Length(), 3)
-    var t2 = Eq[int](t1, arr.Get(0), 1)
+    val arr = ArrayOf(1, 2, 3)
+    val t1 = Eq[int](t, arr.Length(), 3)
+    val t2 = Eq[int](t1, arr.Get(0), 1)
     return Eq[int](t2, arr.Get(2), 3)
 }
 
 // Test if ListOf can infer type from elements
 func TestListImplicitType(t T) T {
     // Try creating list without explicit type parameter
-    var list = ListOf(1, 2, 3)
-    var t1 = Eq[int](t, list.Length(), 3)
-    var t2 = Eq[int](t1, list.Head(), 1)
+    val list = ListOf(1, 2, 3)
+    val t1 = Eq[int](t, list.Length(), 3)
+    val t2 = Eq[int](t1, list.Head(), 1)
     return Eq[int](t2, list.Last(), 3)
 }
 
 // Test implicit type with strings
 func TestArrayImplicitTypeString(t T) T {
-    var arr = ArrayOf("a", "b", "c")
-    var t1 = Eq[int](t, arr.Length(), 3)
+    val arr = ArrayOf("a", "b", "c")
+    val t1 = Eq[int](t, arr.Length(), 3)
     return Eq[string](t1, arr.Head(), "a")
 }
 
 func TestListImplicitTypeString(t T) T {
-    var list = ListOf("x", "y", "z")
-    var t1 = Eq[int](t, list.Length(), 3)
+    val list = ListOf("x", "y", "z")
+    val t1 = Eq[int](t, list.Length(), 3)
     return Eq[string](t1, list.Head(), "x")
 }
 
@@ -44,46 +44,46 @@ func TestListImplicitTypeString(t T) T {
 
 // Test functional pattern matching - List to (head, tail) via methods
 func TestListToHeadTail(t T) T {
-    var list = ListOf(1, 2, 3)
+    val list = ListOf(1, 2, 3)
     // Extract head and tail functionally
-    var head = list.Head()
-    var tail = list.Tail()
-    var t1 = Eq[int](t, head, 1)
-    var t2 = Eq[int](t1, tail.Head(), 2)
+    val head = list.Head()
+    val tail = list.Tail()
+    val t1 = Eq[int](t, head, 1)
+    val t2 = Eq[int](t1, tail.Head(), 2)
     return Eq[int](t2, tail.Length(), 2)
 }
 
 // Test pattern matching with IsEmpty/NonEmpty checks
 func TestListIsEmptyPatternMatch(t T) T {
-    var empty = EmptyList[int]()
-    var nonEmpty = ListOf(42, 2, 3)
-    var t1 = IsTrue(t, empty.IsEmpty())
+    val empty = EmptyList[int]()
+    val nonEmpty = ListOf(42, 2, 3)
+    val t1 = IsTrue(t, empty.IsEmpty())
     return IsFalse(t1, nonEmpty.IsEmpty())
 }
 
 // Test extracting head and tail via HeadOption/TailOption (safe pattern)
 func TestListHeadTailOption(t T) T {
-    var list = ListOf(10, 20, 30)
-    var headOpt = list.HeadOption()
-    var tailOpt = list.TailOption()
-    var t1 = Eq[int](t, headOpt.GetOrElse(-1), 10)
-    var t2 = IsFalse(t1, tailOpt.IsEmpty())
+    val list = ListOf(10, 20, 30)
+    val headOpt = list.HeadOption()
+    val tailOpt = list.TailOption()
+    val t1 = Eq[int](t, headOpt.GetOrElse(-1), 10)
+    val t2 = IsFalse(t1, tailOpt.IsEmpty())
     // Access tail's head
-    var tail = list.Tail()
+    val tail = list.Tail()
     return Eq[int](t2, tail.Head(), 20)
 }
 
 // Test empty list returns None for HeadOption/TailOption
 func TestEmptyListOptions(t T) T {
-    var empty = EmptyList[int]()
-    var t1 = IsTrue(t, empty.HeadOption().IsEmpty())
+    val empty = EmptyList[int]()
+    val t1 = IsTrue(t, empty.HeadOption().IsEmpty())
     return IsTrue(t1, empty.TailOption().IsEmpty())
 }
 
 // Test recursive list processing pattern - sum via FoldLeft
 func TestListFunctionalPattern(t T) T {
-    var list = ListOf(1, 2, 3, 4, 5)
-    var sum = list.FoldLeft[int](0, (acc int, x int) => acc + x)
+    val list = ListOf(1, 2, 3, 4, 5)
+    val sum = list.FoldLeft(0, (acc, x) => acc + x)
     return Eq[int](t, sum, 15)
 }
 
@@ -92,46 +92,46 @@ func TestListFunctionalPattern(t T) T {
 
 // Test extracting Array(a, b, c) elements via Get
 func TestArrayElementExtraction(t T) T {
-    var arr = ArrayOf(10, 20, 30)
+    val arr = ArrayOf(10, 20, 30)
     // Extract elements by position - simulates Array(a, b, c) pattern
-    var a = arr.Get(0)
-    var b = arr.Get(1)
-    var c = arr.Get(2)
-    var t1 = Eq[int](t, a, 10)
-    var t2 = Eq[int](t1, b, 20)
+    val a = arr.Get(0)
+    val b = arr.Get(1)
+    val c = arr.Get(2)
+    val t1 = Eq[int](t, a, 10)
+    val t2 = Eq[int](t1, b, 20)
     return Eq[int](t2, c, 30)
 }
 
 // Test safe element extraction with GetOption
 func TestArraySafeExtraction(t T) T {
-    var arr = ArrayOf(1, 2, 3)
-    var first = arr.GetOption(0).GetOrElse(-1)
-    var outOfBounds = arr.GetOption(99).GetOrElse(-1)
-    var t1 = Eq[int](t, first, 1)
+    val arr = ArrayOf(1, 2, 3)
+    val first = arr.GetOption(0).GetOrElse(-1)
+    val outOfBounds = arr.GetOption(99).GetOrElse(-1)
+    val t1 = Eq[int](t, first, 1)
     return Eq[int](t1, outOfBounds, -1)
 }
 
 // Test Array IsEmpty/NonEmpty pattern
 func TestArrayIsEmptyPattern(t T) T {
-    var empty = EmptyArray[int]()
-    var nonEmpty = ArrayOf(42)
-    var t1 = IsTrue(t, empty.IsEmpty())
+    val empty = EmptyArray[int]()
+    val nonEmpty = ArrayOf(42)
+    val t1 = IsTrue(t, empty.IsEmpty())
     return IsFalse(t1, nonEmpty.IsEmpty())
 }
 
 // Test Array head and tail extraction
 func TestArrayHeadTail(t T) T {
-    var arr = ArrayOf(10, 20, 30)
-    var head = arr.Head()
-    var tail = arr.Tail()
-    var t1 = Eq[int](t, head, 10)
-    var t2 = Eq[int](t1, tail.Head(), 20)
+    val arr = ArrayOf(10, 20, 30)
+    val head = arr.Head()
+    val tail = arr.Tail()
+    val t1 = Eq[int](t, head, 10)
+    val t2 = Eq[int](t1, tail.Head(), 20)
     return Eq[int](t2, tail.Length(), 2)
 }
 
 // Test Array functional pattern - sum via FoldLeft
 func TestArrayFunctionalPattern(t T) T {
-    var arr = ArrayOf(1, 2, 3, 4, 5)
-    var sum = arr.FoldLeft[int](0, (acc int, x int) => acc + x)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val sum = arr.FoldLeft(0, (acc, x) => acc + x)
     return Eq[int](t, sum, 15)
 }

--- a/collection_immutable/list.gala
+++ b/collection_immutable/list.gala
@@ -1,7 +1,6 @@
 package collection_immutable
 
 import (
-    "fmt"
     . "martianoff/gala/std"
     "martianoff/gala/go_interop"
 )
@@ -174,7 +173,7 @@ func (l List[T]) AppendAll(other List[T]) List[T] {
 // Panics if index is out of bounds.
 func (l List[T]) Get(index int) T {
     if (index < 0) || (index >= l.length) {
-        panic(fmt.Sprintf("List.Get: index %d out of bounds [0, %d)", index, l.length))
+        panic(f"List.Get: index $index out of bounds [0, ${l.length})")
     }
     var current = l
     for i := 0; i < index; i++ {
@@ -194,7 +193,7 @@ func (l List[T]) GetOption(index int) Option[T] {
 // Updated returns a new list with element at index replaced. O(n).
 func (l List[T]) Updated(index int, elem T) List[T] {
     if (index < 0) || (index >= l.length) {
-        panic(fmt.Sprintf("List.Updated: index %d out of bounds [0, %d)", index, l.length))
+        panic(f"List.Updated: index $index out of bounds [0, ${l.length})")
     }
     if index == 0 {
         return consList[T](elem, *l.tail)
@@ -336,11 +335,10 @@ func (l List[T]) Collect[U any](pf func(T) Option[U]) List[U] {
         return emptyList[U]()
     }
     val tail = *l.tail
-    val opt = pf(l.head)
-    if opt.IsDefined() {
-        return consList[U](opt.Get(), tail.Collect[U](pf))
+    return pf(l.head) match {
+        case Some(v) => consList[U](v, tail.Collect[U](pf))
+        case None() => tail.Collect[U](pf)
     }
-    return tail.Collect[U](pf)
 }
 
 // Concat returns a new list containing all elements of this list followed by
@@ -651,7 +649,7 @@ func (l List[T]) String() string {
         if !first {
             result = result + ", "
         }
-        result = result + fmt.Sprintf("%v", current.head)
+        result = result + s"${current.head}"
         current = *current.tail
         first = false
     }
@@ -670,7 +668,7 @@ func (l List[T]) MkString(sep string) string {
         if !first {
             result = result + sep
         }
-        result = result + fmt.Sprintf("%v", current.head)
+        result = result + s"${current.head}"
         current = *current.tail
         first = false
     }

--- a/collection_immutable/list_test.gala
+++ b/collection_immutable/list_test.gala
@@ -8,127 +8,127 @@ import (
 // === List Creation Tests ===
 
 func TestEmptyList(t T) T {
-    var list = EmptyList[int]()
-    var t1 = IsTrue(t, list.IsEmpty())
+    val list = EmptyList[int]()
+    val t1 = IsTrue(t, list.IsEmpty())
     return Eq[int](t1, list.Length(), 0)
 }
 
 func TestListOf(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var t1 = IsFalse(t, list.IsEmpty())
+    val list = ListOf(1, 2, 3)
+    val t1 = IsFalse(t, list.IsEmpty())
     return Eq[int](t1, list.Length(), 3)
 }
 
 func TestListToGoSlice(t T) T {
-    var list = ListOf[int](10, 20, 30)
-    var slice = list.ToGoSlice()
-    var t1 = Eq[int](t, len(slice), 3)
+    val list = ListOf(10, 20, 30)
+    val slice = list.ToGoSlice()
+    val t1 = Eq[int](t, len(slice), 3)
     return Eq[int](t1, slice[0], 10)
 }
 
 // === List Access Tests ===
 
 func TestListHead(t T) T {
-    var list = ListOf[string]("first", "second", "third")
+    val list = ListOf("first", "second", "third")
     return Eq[string](t, list.Head(), "first")
 }
 
 func TestListTail(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var tail = list.Tail()
-    var t1 = Eq[int](t, tail.Length(), 2)
+    val list = ListOf(1, 2, 3)
+    val tail = list.Tail()
+    val t1 = Eq[int](t, tail.Length(), 2)
     return Eq[int](t1, tail.Head(), 2)
 }
 
 func TestListLast(t T) T {
-    var list = ListOf[string]("first", "second", "third")
+    val list = ListOf("first", "second", "third")
     return Eq[string](t, list.Last(), "third")
 }
 
 func TestListGet(t T) T {
-    var list = ListOf[int](10, 20, 30)
-    var t1 = Eq[int](t, list.Get(0), 10)
-    var t2 = Eq[int](t1, list.Get(1), 20)
+    val list = ListOf(10, 20, 30)
+    val t1 = Eq[int](t, list.Get(0), 10)
+    val t2 = Eq[int](t1, list.Get(1), 20)
     return Eq[int](t2, list.Get(2), 30)
 }
 
 func TestListHeadOption(t T) T {
-    var list = ListOf[int](42)
-    var opt = list.HeadOption()
-    var t1 = IsSome(t, opt)
+    val list = ListOf(42)
+    val opt = list.HeadOption()
+    val t1 = IsSome(t, opt)
     return Eq[int](t1, opt.Get(), 42)
 }
 
 func TestListHeadOptionEmpty(t T) T {
-    var list = EmptyList[int]()
-    var opt = list.HeadOption()
+    val list = EmptyList[int]()
+    val opt = list.HeadOption()
     return IsNone(t, opt)
 }
 
 // === List Modification Tests ===
 
 func TestListPrepend(t T) T {
-    var list = ListOf[int](2, 3)
-    var newList = list.Prepend(1)
-    var t1 = Eq[int](t, newList.Length(), 3)
+    val list = ListOf(2, 3)
+    val newList = list.Prepend(1)
+    val t1 = Eq[int](t, newList.Length(), 3)
     return Eq[int](t1, newList.Head(), 1)
 }
 
 func TestListAppend(t T) T {
-    var list = ListOf[int](1, 2)
-    var newList = list.Append(3)
-    var t1 = Eq[int](t, list.Length(), 2)
-    var t2 = Eq[int](t1, newList.Length(), 3)
+    val list = ListOf(1, 2)
+    val newList = list.Append(3)
+    val t1 = Eq[int](t, list.Length(), 2)
+    val t2 = Eq[int](t1, newList.Length(), 3)
     return Eq[int](t2, newList.Last(), 3)
 }
 
 func TestListUpdated(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var newList = list.Updated(1, 99)
-    var t1 = Eq[int](t, list.Get(1), 2)
+    val list = ListOf(1, 2, 3)
+    val newList = list.Updated(1, 99)
+    val t1 = Eq[int](t, list.Get(1), 2)
     return Eq[int](t1, newList.Get(1), 99)
 }
 
 func TestListTake(t T) T {
-    var list = ListOf[int](1, 2, 3, 4, 5)
-    var taken = list.Take(3)
-    var t1 = Eq[int](t, taken.Length(), 3)
+    val list = ListOf(1, 2, 3, 4, 5)
+    val taken = list.Take(3)
+    val t1 = Eq[int](t, taken.Length(), 3)
     return Eq[int](t1, taken.Last(), 3)
 }
 
 func TestListDrop(t T) T {
-    var list = ListOf[int](1, 2, 3, 4, 5)
-    var dropped = list.Drop(2)
-    var t1 = Eq[int](t, dropped.Length(), 3)
+    val list = ListOf(1, 2, 3, 4, 5)
+    val dropped = list.Drop(2)
+    val t1 = Eq[int](t, dropped.Length(), 3)
     return Eq[int](t1, dropped.Head(), 3)
 }
 
 func TestListReverse(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var reversed = list.Reverse()
-    var t1 = Eq[int](t, reversed.Get(0), 3)
-    var t2 = Eq[int](t1, reversed.Get(1), 2)
+    val list = ListOf(1, 2, 3)
+    val reversed = list.Reverse()
+    val t1 = Eq[int](t, reversed.Get(0), 3)
+    val t2 = Eq[int](t1, reversed.Get(1), 2)
     return Eq[int](t2, reversed.Get(2), 1)
 }
 
 func TestListInit(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var init = list.Init()
-    var t1 = Eq[int](t, init.Length(), 2)
+    val list = ListOf(1, 2, 3)
+    val init = list.Init()
+    val t1 = Eq[int](t, init.Length(), 2)
     return Eq[int](t1, init.Last(), 2)
 }
 
 // === List Search Tests ===
 
 func TestListContains(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var t1 = IsTrue(t, list.Contains(2))
+    val list = ListOf(1, 2, 3)
+    val t1 = IsTrue(t, list.Contains(2))
     return IsFalse(t1, list.Contains(5))
 }
 
 func TestListIndexOf(t T) T {
-    var list = ListOf[string]("a", "b", "c")
-    var t1 = Eq[int](t, list.IndexOf("b"), 1)
+    val list = ListOf("a", "b", "c")
+    val t1 = Eq[int](t, list.IndexOf("b"), 1)
     return Eq[int](t1, list.IndexOf("z"), -1)
 }
 
@@ -139,10 +139,10 @@ func doubleValue(x int) int {
 }
 
 func TestListMap(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var mapped = list.Map[int](doubleValue)
-    var t1 = Eq[int](t, mapped.Get(0), 2)
-    var t2 = Eq[int](t1, mapped.Get(1), 4)
+    val list = ListOf(1, 2, 3)
+    val mapped = list.Map(doubleValue)
+    val t1 = Eq[int](t, mapped.Get(0), 2)
+    val t2 = Eq[int](t1, mapped.Get(1), 4)
     return Eq[int](t2, mapped.Get(2), 6)
 }
 
@@ -151,10 +151,10 @@ func isEven(x int) bool {
 }
 
 func TestListFilter(t T) T {
-    var list = ListOf[int](1, 2, 3, 4, 5)
-    var filtered = list.Filter(isEven)
-    var t1 = Eq[int](t, filtered.Length(), 2)
-    var t2 = Eq[int](t1, filtered.Get(0), 2)
+    val list = ListOf(1, 2, 3, 4, 5)
+    val filtered = list.Filter(isEven)
+    val t1 = Eq[int](t, filtered.Length(), 2)
+    val t2 = Eq[int](t1, filtered.Get(0), 2)
     return Eq[int](t2, filtered.Get(1), 4)
 }
 
@@ -163,8 +163,8 @@ func sum(acc int, x int) int {
 }
 
 func TestListFoldLeft(t T) T {
-    var list = ListOf[int](1, 2, 3, 4)
-    var result = list.FoldLeft[int](0, sum)
+    val list = ListOf(1, 2, 3, 4)
+    val result = list.FoldLeft(0, sum)
     return Eq[int](t, result, 10)
 }
 
@@ -173,8 +173,8 @@ func multiply(x int, acc int) int {
 }
 
 func TestListFoldRight(t T) T {
-    var list = ListOf[int](1, 2, 3, 4)
-    var result = list.FoldRight[int](1, multiply)
+    val list = ListOf(1, 2, 3, 4)
+    val result = list.FoldRight(1, multiply)
     return Eq[int](t, result, 24)
 }
 
@@ -185,14 +185,14 @@ func isGreaterThanZero(x int) bool {
 }
 
 func TestListExists(t T) T {
-    var list = ListOf[int](-1, 0, 1, 2)
+    val list = ListOf(-1, 0, 1, 2)
     return IsTrue(t, list.Exists(isGreaterThanZero))
 }
 
 func TestListForAll(t T) T {
-    var list1 = ListOf[int](1, 2, 3)
-    var list2 = ListOf[int](-1, 0, 1)
-    var t1 = IsTrue(t, list1.ForAll(isGreaterThanZero))
+    val list1 = ListOf(1, 2, 3)
+    val list2 = ListOf(-1, 0, 1)
+    val t1 = IsTrue(t, list1.ForAll(isGreaterThanZero))
     return IsFalse(t1, list2.ForAll(isGreaterThanZero))
 }
 
@@ -201,56 +201,56 @@ func isGreaterThanTen(x int) bool {
 }
 
 func TestListFind(t T) T {
-    var list = ListOf[int](5, 15, 25)
-    var found = list.Find(isGreaterThanTen)
-    var t1 = IsSome(t, found)
+    val list = ListOf(5, 15, 25)
+    val found = list.Find(isGreaterThanTen)
+    val t1 = IsSome(t, found)
     return Eq[int](t1, found.Get(), 15)
 }
 
 func TestListFindNone(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var found = list.Find(isGreaterThanTen)
+    val list = ListOf(1, 2, 3)
+    val found = list.Find(isGreaterThanTen)
     return IsNone(t, found)
 }
 
 func TestListCount(t T) T {
-    var list = ListOf[int](1, 2, 3, 4, 5)
-    var count = list.Count(isEven)
+    val list = ListOf(1, 2, 3, 4, 5)
+    val count = list.Count(isEven)
     return Eq[int](t, count, 2)
 }
 
 // === List Utility Tests ===
 
 func TestListDistinct(t T) T {
-    var list = ListOf[int](1, 2, 2, 3, 3, 3)
-    var distinct = list.Distinct()
+    val list = ListOf(1, 2, 2, 3, 3, 3)
+    val distinct = list.Distinct()
     return Eq[int](t, distinct.Length(), 3)
 }
 
 func TestListAppendAll(t T) T {
-    var list1 = ListOf[int](1, 2)
-    var list2 = ListOf[int](3, 4)
-    var combined = list1.AppendAll(list2)
-    var t1 = Eq[int](t, combined.Length(), 4)
-    var t2 = Eq[int](t1, combined.Get(0), 1)
+    val list1 = ListOf(1, 2)
+    val list2 = ListOf(3, 4)
+    val combined = list1.AppendAll(list2)
+    val t1 = Eq[int](t, combined.Length(), 4)
+    val t2 = Eq[int](t1, combined.Get(0), 1)
     return Eq[int](t2, combined.Get(3), 4)
 }
 
 func TestListPrependAll(t T) T {
-    var list1 = ListOf[int](3, 4)
-    var list2 = ListOf[int](1, 2)
-    var combined = list1.PrependAll(list2)
-    var t1 = Eq[int](t, combined.Length(), 4)
+    val list1 = ListOf(3, 4)
+    val list2 = ListOf(1, 2)
+    val combined = list1.PrependAll(list2)
+    val t1 = Eq[int](t, combined.Length(), 4)
     return Eq[int](t1, combined.Head(), 1)
 }
 
 func TestListString(t T) T {
-    var list = ListOf[int](1, 2, 3)
+    val list = ListOf(1, 2, 3)
     return Eq[string](t, list.String(), "List(1, 2, 3)")
 }
 
 func TestEmptyListString(t T) T {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     return Eq[string](t, list.String(), "List()")
 }
 
@@ -259,16 +259,16 @@ func lessThanThree(x int) bool {
 }
 
 func TestListTakeWhile(t T) T {
-    var list = ListOf[int](1, 2, 3, 4, 5)
-    var taken = list.TakeWhile(lessThanThree)
-    var t1 = Eq[int](t, taken.Length(), 2)
+    val list = ListOf(1, 2, 3, 4, 5)
+    val taken = list.TakeWhile(lessThanThree)
+    val t1 = Eq[int](t, taken.Length(), 2)
     return Eq[int](t1, taken.Last(), 2)
 }
 
 func TestListDropWhile(t T) T {
-    var list = ListOf[int](1, 2, 3, 4, 5)
-    var dropped = list.DropWhile(lessThanThree)
-    var t1 = Eq[int](t, dropped.Length(), 3)
+    val list = ListOf(1, 2, 3, 4, 5)
+    val dropped = list.DropWhile(lessThanThree)
+    val t1 = Eq[int](t, dropped.Length(), 3)
     return Eq[int](t1, dropped.Head(), 3)
 }
 
@@ -276,39 +276,39 @@ func TestListDropWhile(t T) T {
 
 // Test using HeadOption with GetOrElse (functional pattern)
 func TestListPatternMatchHeadOption(t T) T {
-    var empty = EmptyList[int]()
-    var nonEmpty = ListOf[int](42, 2, 3)
+    val empty = EmptyList[int]()
+    val nonEmpty = ListOf(42, 2, 3)
     // GetOrElse is the functional way to handle Option
-    var t1 = Eq[int](t, empty.HeadOption().GetOrElse(-1), -1)
+    val t1 = Eq[int](t, empty.HeadOption().GetOrElse(-1), -1)
     return Eq[int](t1, nonEmpty.HeadOption().GetOrElse(-1), 42)
 }
 
 // Test using GetOption with GetOrElse for safe access
 func TestListPatternMatchGetOption(t T) T {
-    var list = ListOf[int](10, 20, 30)
-    var t1 = Eq[int](t, list.GetOption(0).GetOrElse(0), 10)
-    var t2 = Eq[int](t1, list.GetOption(1).GetOrElse(0), 20)
-    var t3 = Eq[int](t2, list.GetOption(2).GetOrElse(0), 30)
+    val list = ListOf(10, 20, 30)
+    val t1 = Eq[int](t, list.GetOption(0).GetOrElse(0), 10)
+    val t2 = Eq[int](t1, list.GetOption(1).GetOrElse(0), 20)
+    val t3 = Eq[int](t2, list.GetOption(2).GetOrElse(0), 30)
     return Eq[int](t3, list.GetOption(99).GetOrElse(0), 0)
 }
 
 // Test processing list with isEmpty check (functional pattern)
 func TestListEmptyNonEmptyCheck(t T) T {
-    var empty = EmptyList[int]()
-    var nonEmpty = ListOf[int](1, 2, 3)
-    var t1 = IsTrue(t, empty.IsEmpty())
-    var t2 = IsFalse(t1, nonEmpty.IsEmpty())
-    var t3 = IsFalse(t2, empty.NonEmpty())
+    val empty = EmptyList[int]()
+    val nonEmpty = ListOf(1, 2, 3)
+    val t1 = IsTrue(t, empty.IsEmpty())
+    val t2 = IsFalse(t1, nonEmpty.IsEmpty())
+    val t3 = IsFalse(t2, empty.NonEmpty())
     return IsTrue(t3, nonEmpty.NonEmpty())
 }
 
 // Test Find with pattern matching behavior
 func TestListFindPattern(t T) T {
-    var list = ListOf[int](1, 5, 10, 15)
-    var found = list.Find(isGreaterThanTen)
-    var notFound = list.Find((x int) => x > 100)
-    var t1 = IsSome(t, found)
-    var t2 = Eq[int](t1, found.GetOrElse(0), 15)
+    val list = ListOf(1, 5, 10, 15)
+    val found = list.Find(isGreaterThanTen)
+    val notFound = list.Find((x) => x > 100)
+    val t1 = IsSome(t, found)
+    val t2 = Eq[int](t1, found.GetOrElse(0), 15)
     return IsNone(t2, notFound)
 }
 
@@ -316,105 +316,105 @@ func TestListFindPattern(t T) T {
 
 func TestListPrependImmutability(t T) T {
     // Original list should remain unchanged after prepend
-    var original = ListOf[int](2, 3, 4)
-    var modified = original.Prepend(1)
-    var t1 = Eq[int](t, original.Length(), 3)
-    var t2 = Eq[int](t1, modified.Length(), 4)
-    var t3 = Eq[int](t2, original.Head(), 2)
+    val original = ListOf(2, 3, 4)
+    val modified = original.Prepend(1)
+    val t1 = Eq[int](t, original.Length(), 3)
+    val t2 = Eq[int](t1, modified.Length(), 4)
+    val t3 = Eq[int](t2, original.Head(), 2)
     return Eq[int](t3, modified.Head(), 1)
 }
 
 func TestListAppendImmutability(t T) T {
     // Original list should remain unchanged after append
-    var original = ListOf[int](1, 2, 3)
-    var modified = original.Append(4)
-    var t1 = Eq[int](t, original.Length(), 3)
-    var t2 = Eq[int](t1, modified.Length(), 4)
-    var t3 = Eq[int](t2, original.Last(), 3)
+    val original = ListOf(1, 2, 3)
+    val modified = original.Append(4)
+    val t1 = Eq[int](t, original.Length(), 3)
+    val t2 = Eq[int](t1, modified.Length(), 4)
+    val t3 = Eq[int](t2, original.Last(), 3)
     return Eq[int](t3, modified.Last(), 4)
 }
 
 func TestListUpdatedImmutability(t T) T {
     // Original list should remain unchanged after update
-    var original = ListOf[int](1, 2, 3)
-    var modified = original.Updated(1, 99)
-    var t1 = Eq[int](t, original.Get(1), 2)
-    var t2 = Eq[int](t1, modified.Get(1), 99)
+    val original = ListOf(1, 2, 3)
+    val modified = original.Updated(1, 99)
+    val t1 = Eq[int](t, original.Get(1), 2)
+    val t2 = Eq[int](t1, modified.Get(1), 99)
     // Verify other elements unchanged
-    var t3 = Eq[int](t2, original.Get(0), 1)
+    val t3 = Eq[int](t2, original.Get(0), 1)
     return Eq[int](t3, original.Get(2), 3)
 }
 
 func TestListTailImmutability(t T) T {
     // Original list should remain unchanged after tail
-    var original = ListOf[int](1, 2, 3)
-    var tail = original.Tail()
-    var t1 = Eq[int](t, original.Length(), 3)
-    var t2 = Eq[int](t1, tail.Length(), 2)
+    val original = ListOf(1, 2, 3)
+    val tail = original.Tail()
+    val t1 = Eq[int](t, original.Length(), 3)
+    val t2 = Eq[int](t1, tail.Length(), 2)
     return Eq[int](t2, original.Head(), 1)
 }
 
 func TestListFilterImmutability(t T) T {
     // Original list should remain unchanged after filter
-    var original = ListOf[int](1, 2, 3, 4, 5)
-    var filtered = original.Filter(isEven)
-    var t1 = Eq[int](t, original.Length(), 5)
-    var t2 = Eq[int](t1, filtered.Length(), 2)
+    val original = ListOf(1, 2, 3, 4, 5)
+    val filtered = original.Filter(isEven)
+    val t1 = Eq[int](t, original.Length(), 5)
+    val t2 = Eq[int](t1, filtered.Length(), 2)
     // Original still has all elements
-    var t3 = Eq[int](t2, original.Get(0), 1)
+    val t3 = Eq[int](t2, original.Get(0), 1)
     return Eq[int](t3, original.Get(4), 5)
 }
 
 func TestListMapImmutability(t T) T {
     // Original list should remain unchanged after map
-    var original = ListOf[int](1, 2, 3)
-    var mapped = original.Map[int](doubleValue)
-    var t1 = Eq[int](t, original.Get(0), 1)
-    var t2 = Eq[int](t1, original.Get(1), 2)
-    var t3 = Eq[int](t2, original.Get(2), 3)
-    var t4 = Eq[int](t3, mapped.Get(0), 2)
+    val original = ListOf(1, 2, 3)
+    val mapped = original.Map(doubleValue)
+    val t1 = Eq[int](t, original.Get(0), 1)
+    val t2 = Eq[int](t1, original.Get(1), 2)
+    val t3 = Eq[int](t2, original.Get(2), 3)
+    val t4 = Eq[int](t3, mapped.Get(0), 2)
     return Eq[int](t4, mapped.Get(1), 4)
 }
 
 func TestListReverseImmutability(t T) T {
     // Original list should remain unchanged after reverse
-    var original = ListOf[int](1, 2, 3)
-    var reversed = original.Reverse()
-    var t1 = Eq[int](t, original.Get(0), 1)
-    var t2 = Eq[int](t1, original.Get(2), 3)
-    var t3 = Eq[int](t2, reversed.Get(0), 3)
+    val original = ListOf(1, 2, 3)
+    val reversed = original.Reverse()
+    val t1 = Eq[int](t, original.Get(0), 1)
+    val t2 = Eq[int](t1, original.Get(2), 3)
+    val t3 = Eq[int](t2, reversed.Get(0), 3)
     return Eq[int](t3, reversed.Get(2), 1)
 }
 
 func TestListMultipleModificationsImmutability(t T) T {
     // Chain of operations should not affect original
-    var original = ListOf[int](1, 2, 3)
-    var step1 = original.Append(4)
-    var step2 = step1.Prepend(0)
-    var step3 = step2.Updated(2, 99)
+    val original = ListOf(1, 2, 3)
+    val step1 = original.Append(4)
+    val step2 = step1.Prepend(0)
+    val step3 = step2.Updated(2, 99)
     // Original unchanged
-    var t1 = Eq[int](t, original.Length(), 3)
-    var t2 = Eq[int](t1, original.Get(0), 1)
+    val t1 = Eq[int](t, original.Length(), 3)
+    val t2 = Eq[int](t1, original.Get(0), 1)
     // step1 unchanged
-    var t3 = Eq[int](t2, step1.Length(), 4)
-    var t4 = Eq[int](t3, step1.Get(0), 1)
+    val t3 = Eq[int](t2, step1.Length(), 4)
+    val t4 = Eq[int](t3, step1.Get(0), 1)
     // step2 unchanged
-    var t5 = Eq[int](t4, step2.Length(), 5)
-    var t6 = Eq[int](t5, step2.Get(0), 0)
+    val t5 = Eq[int](t4, step2.Length(), 5)
+    val t6 = Eq[int](t5, step2.Get(0), 0)
     // step3 has all modifications
-    var t7 = Eq[int](t6, step3.Length(), 5)
+    val t7 = Eq[int](t6, step3.Length(), 5)
     return Eq[int](t7, step3.Get(2), 99)
 }
 
 // List shares structure with prepended elements
 func TestListStructuralSharing(t T) T {
-    var base = ListOf[int](2, 3, 4)
-    var extended1 = base.Prepend(1)
-    var extended2 = base.Prepend(0)
+    val base = ListOf(2, 3, 4)
+    val extended1 = base.Prepend(1)
+    val extended2 = base.Prepend(0)
     // Both extended lists share the same tail (base)
-    var t1 = Eq[int](t, extended1.Tail().Head(), 2)
-    var t2 = Eq[int](t1, extended2.Tail().Head(), 2)
+    val t1 = Eq[int](t, extended1.Tail().Head(), 2)
+    val t2 = Eq[int](t1, extended2.Tail().Head(), 2)
     // But have different heads
-    var t3 = Eq[int](t2, extended1.Head(), 1)
+    val t3 = Eq[int](t2, extended1.Head(), 1)
     return Eq[int](t3, extended2.Head(), 0)
 }

--- a/collection_immutable/perf_test.gala
+++ b/collection_immutable/perf_test.gala
@@ -8,11 +8,11 @@ import (
 
 // Performance test utilities
 func measureNs(iterations int, f func()) int64 {
-    var start = time.Now()
+    val start = time.Now()
     for i := 0; i < iterations; i++ {
         f()
     }
-    var elapsed = time.Since(start)
+    val elapsed = time.Since(start)
     return elapsed.Nanoseconds() / int64(iterations)
 }
 
@@ -24,7 +24,7 @@ func printResult(name string, nsPerOp int64) {
 
 // List creation benchmark - small
 func benchListCreation100() {
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var list = EmptyList[int]()
         for i := 0; i < 100; i++ {
             list = list.Prepend(i)
@@ -35,7 +35,7 @@ func benchListCreation100() {
 
 // List creation benchmark - medium
 func benchListCreation10000() {
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var list = EmptyList[int]()
         for i := 0; i < 10000; i++ {
             list = list.Prepend(i)
@@ -46,7 +46,7 @@ func benchListCreation10000() {
 
 // List creation benchmark - large
 func benchListCreation100000() {
-    var ns = measureNs(10, () => {
+    val ns = measureNs(10, () => {
         var list = EmptyList[int]()
         for i := 0; i < 100000; i++ {
             list = list.Prepend(i)
@@ -61,7 +61,7 @@ func benchListPrepend() {
     for i := 0; i < 10000; i++ {
         list = list.Prepend(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = list.Prepend(999)
     })
     printResult("List.Prepend (size=10000)", ns)
@@ -73,7 +73,7 @@ func benchListHead() {
     for i := 0; i < 10000; i++ {
         list = list.Prepend(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = list.Head()
     })
     printResult("List.Head (size=10000)", ns)
@@ -85,7 +85,7 @@ func benchListGetFirst() {
     for i := 0; i < 10000; i++ {
         list = list.Prepend(i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = list.Get(0)
     })
     printResult("List.Get(0) (size=10000)", ns)
@@ -97,7 +97,7 @@ func benchListGetMiddle() {
     for i := 0; i < 10000; i++ {
         list = list.Prepend(i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = list.Get(5000)
     })
     printResult("List.Get(5000) (size=10000)", ns)
@@ -109,8 +109,8 @@ func benchListFilter() {
     for i := 0; i < 10000; i++ {
         list = list.Prepend(i)
     }
-    var ns = measureNs(100, () => {
-        var _ = list.Filter((x int) => x % 2 == 0)
+    val ns = measureNs(100, () => {
+        var _ = list.Filter((x) => x % 2 == 0)
     })
     printResult("List.Filter (size=10000)", ns)
 }
@@ -121,8 +121,8 @@ func benchListMap() {
     for i := 0; i < 10000; i++ {
         list = list.Prepend(i)
     }
-    var ns = measureNs(100, () => {
-        var _ = list.Map((x int) => x * 2)
+    val ns = measureNs(100, () => {
+        var _ = list.Map((x) => x * 2)
     })
     printResult("List.Map (size=10000)", ns)
 }
@@ -133,7 +133,7 @@ func benchListFoldLeft() {
     for i := 0; i < 10000; i++ {
         list = list.Prepend(i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = List_FoldLeft[int](list, 0, (acc int, x int) => acc + x)
     })
     printResult("List.FoldLeft (size=10000)", ns)
@@ -143,7 +143,7 @@ func benchListFoldLeft() {
 
 // Array creation benchmark - small
 func benchArrayCreation100() {
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var arr = EmptyArray[int]()
         for i := 0; i < 100; i++ {
             arr = arr.Append(i)
@@ -154,7 +154,7 @@ func benchArrayCreation100() {
 
 // Array creation benchmark - medium
 func benchArrayCreation10000() {
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var arr = EmptyArray[int]()
         for i := 0; i < 10000; i++ {
             arr = arr.Append(i)
@@ -165,7 +165,7 @@ func benchArrayCreation10000() {
 
 // Array creation benchmark - large
 func benchArrayCreation100000() {
-    var ns = measureNs(10, () => {
+    val ns = measureNs(10, () => {
         var arr = EmptyArray[int]()
         for i := 0; i < 100000; i++ {
             arr = arr.Append(i)
@@ -180,7 +180,7 @@ func benchArrayAppend() {
     for i := 0; i < 10000; i++ {
         arr = arr.Append(i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = arr.Append(999)
     })
     printResult("Array.Append (size=10000)", ns)
@@ -192,7 +192,7 @@ func benchArrayPrepend() {
     for i := 0; i < 10000; i++ {
         arr = arr.Append(i)
     }
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var _ = arr.Prepend(999)
     })
     printResult("Array.Prepend (size=10000)", ns)
@@ -204,7 +204,7 @@ func benchArrayHead() {
     for i := 0; i < 10000; i++ {
         arr = arr.Append(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = arr.Head()
     })
     printResult("Array.Head (size=10000)", ns)
@@ -216,7 +216,7 @@ func benchArrayGetFirst() {
     for i := 0; i < 10000; i++ {
         arr = arr.Append(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = arr.Get(0)
     })
     printResult("Array.Get(0) (size=10000)", ns)
@@ -228,7 +228,7 @@ func benchArrayGetMiddle() {
     for i := 0; i < 10000; i++ {
         arr = arr.Append(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = arr.Get(5000)
     })
     printResult("Array.Get(5000) (size=10000)", ns)
@@ -240,7 +240,7 @@ func benchArrayGetLast() {
     for i := 0; i < 10000; i++ {
         arr = arr.Append(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = arr.Get(9999)
     })
     printResult("Array.Get(9999) (size=10000)", ns)
@@ -252,7 +252,7 @@ func benchArrayUpdate() {
     for i := 0; i < 10000; i++ {
         arr = arr.Append(i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = arr.Updated(5000, 999)
     })
     printResult("Array.Updated(5000) (size=10000)", ns)
@@ -264,8 +264,8 @@ func benchArrayFilter() {
     for i := 0; i < 10000; i++ {
         arr = arr.Append(i)
     }
-    var ns = measureNs(100, () => {
-        var _ = arr.Filter((x int) => x % 2 == 0)
+    val ns = measureNs(100, () => {
+        var _ = arr.Filter((x) => x % 2 == 0)
     })
     printResult("Array.Filter (size=10000)", ns)
 }
@@ -276,8 +276,8 @@ func benchArrayMap() {
     for i := 0; i < 10000; i++ {
         arr = arr.Append(i)
     }
-    var ns = measureNs(100, () => {
-        var _ = arr.Map((x int) => x * 2)
+    val ns = measureNs(100, () => {
+        var _ = arr.Map((x) => x * 2)
     })
     printResult("Array.Map (size=10000)", ns)
 }
@@ -288,7 +288,7 @@ func benchArrayFoldLeft() {
     for i := 0; i < 10000; i++ {
         arr = arr.Append(i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = Array_FoldLeft[int](arr, 0, (acc int, x int) => acc + x)
     })
     printResult("Array.FoldLeft (size=10000)", ns)
@@ -300,7 +300,7 @@ func benchArrayTake() {
     for i := 0; i < 10000; i++ {
         arr = arr.Append(i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = arr.Take(5000)
     })
     printResult("Array.Take(5000) (size=10000)", ns)
@@ -312,7 +312,7 @@ func benchArrayDrop() {
     for i := 0; i < 10000; i++ {
         arr = arr.Append(i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = arr.Drop(5000)
     })
     printResult("Array.Drop(5000) (size=10000)", ns)
@@ -322,7 +322,7 @@ func benchArrayDrop() {
 
 // HashSet creation benchmark - small
 func benchHashSetCreation100() {
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var set = EmptyHashSet[int]()
         for i := 0; i < 100; i++ {
             set = set.Add(i)
@@ -333,7 +333,7 @@ func benchHashSetCreation100() {
 
 // HashSet creation benchmark - medium
 func benchHashSetCreation10000() {
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var set = EmptyHashSet[int]()
         for i := 0; i < 10000; i++ {
             set = set.Add(i)
@@ -344,7 +344,7 @@ func benchHashSetCreation10000() {
 
 // HashSet creation benchmark - large
 func benchHashSetCreation100000() {
-    var ns = measureNs(10, () => {
+    val ns = measureNs(10, () => {
         var set = EmptyHashSet[int]()
         for i := 0; i < 100000; i++ {
             set = set.Add(i)
@@ -359,7 +359,7 @@ func benchHashSetAdd() {
     for i := 0; i < 10000; i++ {
         set = set.Add(i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = set.Add(99999)
     })
     printResult("HashSet.Add (size=10000)", ns)
@@ -371,7 +371,7 @@ func benchHashSetContainsHit() {
     for i := 0; i < 10000; i++ {
         set = set.Add(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = set.Contains(5000)
     })
     printResult("HashSet.Contains (hit, size=10000)", ns)
@@ -383,7 +383,7 @@ func benchHashSetContainsMiss() {
     for i := 0; i < 10000; i++ {
         set = set.Add(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = set.Contains(20000)
     })
     printResult("HashSet.Contains (miss, size=10000)", ns)
@@ -395,7 +395,7 @@ func benchHashSetRemove() {
     for i := 0; i < 10000; i++ {
         set = set.Add(i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = set.Remove(5000)
     })
     printResult("HashSet.Remove (size=10000)", ns)
@@ -407,8 +407,8 @@ func benchHashSetFilter() {
     for i := 0; i < 10000; i++ {
         set = set.Add(i)
     }
-    var ns = measureNs(100, () => {
-        var _ = set.Filter((x int) => x % 2 == 0)
+    val ns = measureNs(100, () => {
+        var _ = set.Filter((x) => x % 2 == 0)
     })
     printResult("HashSet.Filter (size=10000)", ns)
 }
@@ -421,7 +421,7 @@ func benchHashSetUnion() {
         set1 = set1.Add(i)
         set2 = set2.Add(i + 500)
     }
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var _ = set1.Union(set2)
     })
     printResult("HashSet.Union (2x1000)", ns)
@@ -435,7 +435,7 @@ func benchHashSetIntersect() {
         set1 = set1.Add(i)
         set2 = set2.Add(i + 500)
     }
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var _ = set1.Intersect(set2)
     })
     printResult("HashSet.Intersect (2x1000)", ns)
@@ -445,7 +445,7 @@ func benchHashSetIntersect() {
 
 // TreeSet creation benchmark - small
 func benchTreeSetCreation100() {
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var set = EmptyTreeSet[int]()
         for i := 0; i < 100; i++ {
             set = set.Add(i)
@@ -456,7 +456,7 @@ func benchTreeSetCreation100() {
 
 // TreeSet creation benchmark - medium
 func benchTreeSetCreation10000() {
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var set = EmptyTreeSet[int]()
         for i := 0; i < 10000; i++ {
             set = set.Add(i)
@@ -467,7 +467,7 @@ func benchTreeSetCreation10000() {
 
 // TreeSet creation benchmark - large
 func benchTreeSetCreation100000() {
-    var ns = measureNs(10, () => {
+    val ns = measureNs(10, () => {
         var set = EmptyTreeSet[int]()
         for i := 0; i < 100000; i++ {
             set = set.Add(i)
@@ -482,7 +482,7 @@ func benchTreeSetAdd() {
     for i := 0; i < 10000; i++ {
         set = set.Add(i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = set.Add(99999)
     })
     printResult("TreeSet.Add (size=10000)", ns)
@@ -494,7 +494,7 @@ func benchTreeSetContainsHit() {
     for i := 0; i < 10000; i++ {
         set = set.Add(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = set.Contains(5000)
     })
     printResult("TreeSet.Contains (hit, size=10000)", ns)
@@ -506,7 +506,7 @@ func benchTreeSetContainsMiss() {
     for i := 0; i < 10000; i++ {
         set = set.Add(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = set.Contains(20000)
     })
     printResult("TreeSet.Contains (miss, size=10000)", ns)
@@ -518,7 +518,7 @@ func benchTreeSetRemove() {
     for i := 0; i < 10000; i++ {
         set = set.Add(i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = set.Remove(5000)
     })
     printResult("TreeSet.Remove (size=10000)", ns)
@@ -530,7 +530,7 @@ func benchTreeSetMin() {
     for i := 0; i < 10000; i++ {
         set = set.Add(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = set.Min()
     })
     printResult("TreeSet.Min (size=10000)", ns)
@@ -542,7 +542,7 @@ func benchTreeSetMax() {
     for i := 0; i < 10000; i++ {
         set = set.Add(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = set.Max()
     })
     printResult("TreeSet.Max (size=10000)", ns)
@@ -554,8 +554,8 @@ func benchTreeSetFilter() {
     for i := 0; i < 10000; i++ {
         set = set.Add(i)
     }
-    var ns = measureNs(100, () => {
-        var _ = set.Filter((x int) => x % 2 == 0)
+    val ns = measureNs(100, () => {
+        var _ = set.Filter((x) => x % 2 == 0)
     })
     printResult("TreeSet.Filter (size=10000)", ns)
 }
@@ -568,7 +568,7 @@ func benchTreeSetUnion() {
         set1 = set1.Add(i)
         set2 = set2.Add(i + 500)
     }
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var _ = set1.Union(set2)
     })
     printResult("TreeSet.Union (2x1000)", ns)
@@ -582,7 +582,7 @@ func benchTreeSetIntersect() {
         set1 = set1.Add(i)
         set2 = set2.Add(i + 500)
     }
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var _ = set1.Intersect(set2)
     })
     printResult("TreeSet.Intersect (2x1000)", ns)
@@ -594,7 +594,7 @@ func benchTreeSetRange() {
     for i := 0; i < 10000; i++ {
         set = set.Add(i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = set.Range(2500, 7500)
     })
     printResult("TreeSet.Range (size=10000)", ns)
@@ -604,7 +604,7 @@ func benchTreeSetRange() {
 
 // HashMap creation benchmark - small
 func benchHashMapCreation100() {
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var m = EmptyHashMap[int, int]()
         for i := 0; i < 100; i++ {
             m = m.Put(i, i)
@@ -615,7 +615,7 @@ func benchHashMapCreation100() {
 
 // HashMap creation benchmark - medium
 func benchHashMapCreation10000() {
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var m = EmptyHashMap[int, int]()
         for i := 0; i < 10000; i++ {
             m = m.Put(i, i)
@@ -626,7 +626,7 @@ func benchHashMapCreation10000() {
 
 // HashMap creation benchmark - large
 func benchHashMapCreation100000() {
-    var ns = measureNs(10, () => {
+    val ns = measureNs(10, () => {
         var m = EmptyHashMap[int, int]()
         for i := 0; i < 100000; i++ {
             m = m.Put(i, i)
@@ -641,7 +641,7 @@ func benchHashMapPut() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = m.Put(99999, 99999)
     })
     printResult("HashMap.Put (size=10000)", ns)
@@ -653,7 +653,7 @@ func benchHashMapGetHit() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.Get(5000)
     })
     printResult("HashMap.Get hit (size=10000)", ns)
@@ -665,7 +665,7 @@ func benchHashMapGetMiss() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.Get(99999)
     })
     printResult("HashMap.Get miss (size=10000)", ns)
@@ -677,7 +677,7 @@ func benchHashMapContainsHit() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.Contains(5000)
     })
     printResult("HashMap.Contains (hit, size=10000)", ns)
@@ -689,7 +689,7 @@ func benchHashMapContainsMiss() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.Contains(20000)
     })
     printResult("HashMap.Contains (miss, size=10000)", ns)
@@ -701,7 +701,7 @@ func benchHashMapRemove() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = m.Remove(5000)
     })
     printResult("HashMap.Remove (size=10000)", ns)
@@ -713,8 +713,8 @@ func benchHashMapFilter() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(100, () => {
-        var _ = m.Filter((k int, v int) => v % 2 == 0)
+    val ns = measureNs(100, () => {
+        var _ = m.Filter((k, v) => v % 2 == 0)
     })
     printResult("HashMap.Filter (size=10000)", ns)
 }
@@ -725,8 +725,8 @@ func benchHashMapMapValues() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(100, () => {
-        var _ = m.MapValues[int]((v int) => v * 2)
+    val ns = measureNs(100, () => {
+        var _ = m.MapValues[int]((v) => v * 2)
     })
     printResult("HashMap.MapValues (size=10000)", ns)
 }
@@ -739,7 +739,7 @@ func benchHashMapPutAll() {
         m1 = m1.Put(i, i)
         m2 = m2.Put(i + 500, i + 500)
     }
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var _ = m1.PutAll(m2)
     })
     printResult("HashMap.PutAll (2x1000)", ns)
@@ -750,11 +750,11 @@ func benchHashMapStringKeys() {
     var m = EmptyHashMap[string, int]()
     var keys []string
     for i := 0; i < 10000; i++ {
-        var key = "key" + string(rune(i%26+65)) + string(rune((i/26)%26+65))
+        val key = "key" + string(rune(i%26+65)) + string(rune((i/26)%26+65))
         keys = append(keys, key)
         m = m.Put(key, i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = m.Get(keys[5000])
     })
     printResult("HashMap.Get string key (size=10000)", ns)
@@ -764,7 +764,7 @@ func benchHashMapStringKeys() {
 
 // TreeMap creation benchmark - small
 func benchTreeMapCreation100() {
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var m = EmptyTreeMap[int, int]()
         for i := 0; i < 100; i++ {
             m = m.Put(i, i)
@@ -775,7 +775,7 @@ func benchTreeMapCreation100() {
 
 // TreeMap creation benchmark - medium
 func benchTreeMapCreation10000() {
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var m = EmptyTreeMap[int, int]()
         for i := 0; i < 10000; i++ {
             m = m.Put(i, i)
@@ -786,7 +786,7 @@ func benchTreeMapCreation10000() {
 
 // TreeMap creation benchmark - large
 func benchTreeMapCreation100000() {
-    var ns = measureNs(10, () => {
+    val ns = measureNs(10, () => {
         var m = EmptyTreeMap[int, int]()
         for i := 0; i < 100000; i++ {
             m = m.Put(i, i)
@@ -801,7 +801,7 @@ func benchTreeMapPut() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = m.Put(99999, 99999)
     })
     printResult("TreeMap.Put (size=10000)", ns)
@@ -813,7 +813,7 @@ func benchTreeMapGetHit() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.Get(5000)
     })
     printResult("TreeMap.Get hit (size=10000)", ns)
@@ -825,7 +825,7 @@ func benchTreeMapGetMiss() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.Get(99999)
     })
     printResult("TreeMap.Get miss (size=10000)", ns)
@@ -837,7 +837,7 @@ func benchTreeMapContainsHit() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.Contains(5000)
     })
     printResult("TreeMap.Contains (hit, size=10000)", ns)
@@ -849,7 +849,7 @@ func benchTreeMapContainsMiss() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.Contains(20000)
     })
     printResult("TreeMap.Contains (miss, size=10000)", ns)
@@ -861,7 +861,7 @@ func benchTreeMapRemove() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = m.Remove(5000)
     })
     printResult("TreeMap.Remove (size=10000)", ns)
@@ -873,7 +873,7 @@ func benchTreeMapMinKey() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.MinKey()
     })
     printResult("TreeMap.MinKey (size=10000)", ns)
@@ -885,7 +885,7 @@ func benchTreeMapMaxKey() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.MaxKey()
     })
     printResult("TreeMap.MaxKey (size=10000)", ns)
@@ -897,7 +897,7 @@ func benchTreeMapRange() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = m.Range(2500, 7500)
     })
     printResult("TreeMap.Range (size=10000)", ns)
@@ -909,8 +909,8 @@ func benchTreeMapFilter() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(100, () => {
-        var _ = m.Filter((k int, v int) => v % 2 == 0)
+    val ns = measureNs(100, () => {
+        var _ = m.Filter((k, v) => v % 2 == 0)
     })
     printResult("TreeMap.Filter (size=10000)", ns)
 }
@@ -921,8 +921,8 @@ func benchTreeMapMapValues() {
     for i := 0; i < 10000; i++ {
         m = m.Put(i, i)
     }
-    var ns = measureNs(100, () => {
-        var _ = m.MapValues[int]((v int) => v * 2)
+    val ns = measureNs(100, () => {
+        var _ = m.MapValues[int]((v) => v * 2)
     })
     printResult("TreeMap.MapValues (size=10000)", ns)
 }
@@ -935,7 +935,7 @@ func benchTreeMapPutAll() {
         m1 = m1.Put(i, i)
         m2 = m2.Put(i + 500, i + 500)
     }
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var _ = m1.PutAll(m2)
     })
     printResult("TreeMap.PutAll (2x1000)", ns)

--- a/collection_immutable/treemap.gala
+++ b/collection_immutable/treemap.gala
@@ -270,11 +270,10 @@ func (m TreeMap[K, V]) GetOrElse(key K, defaultValue V) V {
 
 // Apply returns the value for a key. Panics if key not found. O(log n).
 func (m TreeMap[K, V]) Apply(key K) V {
-    val opt = m.Get(key)
-    if opt.IsEmpty() {
-        panic(fmt.Sprintf("TreeMap: key not found: %v", key))
+    return m.Get(key) match {
+        case Some(v) => v
+        case None() => panic(s"TreeMap: key not found: $key")
     }
-    return opt.Get()
 }
 
 // === Mutating Operations (return new TreeMap) ===
@@ -762,11 +761,10 @@ func (m TreeMap[K, V]) PutAll(other TreeMap[K, V]) TreeMap[K, V] {
 // Merge merges another map with a combining function for duplicate keys.
 func (m TreeMap[K, V]) Merge(other TreeMap[K, V], f func(V, V) V) TreeMap[K, V] {
     return other.FoldLeftKV[TreeMap[K, V]](m, (acc TreeMap[K, V], k K, v V) => {
-        val existing = acc.Get(k)
-        if existing.IsDefined() {
-            return acc.Put(k, f(existing.Get(), v))
+        return acc.Get(k) match {
+            case Some(existing) => acc.Put(k, f(existing, v))
+            case None() => acc.Put(k, v)
         }
-        return acc.Put(k, v)
     })
 }
 
@@ -814,7 +812,7 @@ func (m TreeMap[K, V]) String() string {
         if !first {
             result = result + ", "
         }
-        result = result + fmt.Sprintf("%v -> %v", k, v)
+        result = result + s"$k -> $v"
         first = false
     })
     return result + ")"
@@ -831,7 +829,7 @@ func (m TreeMap[K, V]) MkString(sep string) string {
         if !first {
             result = result + sep
         }
-        result = result + fmt.Sprintf("%v -> %v", k, v)
+        result = result + s"$k -> $v"
         first = false
     })
     return result

--- a/collection_immutable/treemap_test.gala
+++ b/collection_immutable/treemap_test.gala
@@ -12,8 +12,8 @@ import (
 
 func TestTreeMapEmpty(t T) T {
     val m = EmptyTreeMap[string, int]()
-    var t1 = IsTrue(t, m.IsEmpty())
-    var t2 = IsFalse(t1, m.NonEmpty())
+    val t1 = IsTrue(t, m.IsEmpty())
+    val t2 = IsFalse(t1, m.NonEmpty())
     return Eq[int](t2, m.Size(), 0)
 }
 
@@ -23,9 +23,9 @@ func TestTreeMapPut(t T) T {
     val m2 = m1.Put("a", 1)
     val m3 = m2.Put("b", 2)
 
-    var t1 = Eq[int](t, m.Size(), 0)
-    var t2 = Eq[int](t1, m1.Size(), 1)
-    var t3 = Eq[int](t2, m2.Size(), 2)
+    val t1 = Eq[int](t, m.Size(), 0)
+    val t2 = Eq[int](t1, m1.Size(), 1)
+    val t3 = Eq[int](t2, m2.Size(), 2)
     return Eq[int](t3, m3.Size(), 3)
 }
 
@@ -34,40 +34,40 @@ func TestTreeMapPutUpdate(t T) T {
     val m1 = m.Put("a", 1)
     val m2 = m1.Put("a", 2)
 
-    var t1 = Eq[int](t, m2.Size(), 1)
+    val t1 = Eq[int](t, m2.Size(), 1)
     return Eq[int](t1, m2.GetOrElse("a", 0), 2)
 }
 
 func TestTreeMapOf(t T) T {
     val m = TreeMapOf[string, int](
-        Tuple[string, int](V1 = "a", V2 = 1),
-        Tuple[string, int](V1 = "b", V2 = 2),
-        Tuple[string, int](V1 = "c", V2 = 3)
+        ("a", 1),
+        ("b", 2),
+        ("c", 3)
     )
-    var t1 = Eq[int](t, m.Size(), 3)
-    var t2 = IsTrue(t1, m.Contains("a"))
-    var t3 = IsTrue(t2, m.Contains("b"))
+    val t1 = Eq[int](t, m.Size(), 3)
+    val t2 = IsTrue(t1, m.Contains("a"))
+    val t3 = IsTrue(t2, m.Contains("b"))
     return IsTrue(t3, m.Contains("c"))
 }
 
 func TestTreeMapContains(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2)
-    var t1 = IsTrue(t, m.Contains("a"))
-    var t2 = IsTrue(t1, m.Contains("b"))
+    val t1 = IsTrue(t, m.Contains("a"))
+    val t2 = IsTrue(t1, m.Contains("b"))
     return IsFalse(t2, m.Contains("c"))
 }
 
 func TestTreeMapGet(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2)
-    var t1 = IsSome(t, m.Get("a"))
-    var t2 = Eq[int](t1, m.Get("a").Get(), 1)
-    var t3 = Eq[int](t2, m.Get("b").Get(), 2)
+    val t1 = IsSome(t, m.Get("a"))
+    val t2 = Eq[int](t1, m.Get("a").Get(), 1)
+    val t3 = Eq[int](t2, m.Get("b").Get(), 2)
     return IsNone(t3, m.Get("c"))
 }
 
 func TestTreeMapGetOrElse(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1)
-    var t1 = Eq[int](t, m.GetOrElse("a", 0), 1)
+    val t1 = Eq[int](t, m.GetOrElse("a", 0), 1)
     return Eq[int](t1, m.GetOrElse("b", 42), 42)
 }
 
@@ -75,9 +75,9 @@ func TestTreeMapRemove(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
     val m2 = m.Remove("b")
 
-    var t1 = Eq[int](t, m2.Size(), 2)
-    var t2 = IsTrue(t1, m2.Contains("a"))
-    var t3 = IsFalse(t2, m2.Contains("b"))
+    val t1 = Eq[int](t, m2.Size(), 2)
+    val t2 = IsTrue(t1, m2.Contains("a"))
+    val t3 = IsFalse(t2, m2.Contains("b"))
     return IsTrue(t3, m2.Contains("c"))
 }
 
@@ -92,15 +92,15 @@ func TestTreeMapRemoveNonExistent(t T) T {
 func TestTreeMapSortedOrder(t T) T {
     val m = EmptyTreeMap[int, string]().Put(5, "e").Put(3, "c").Put(1, "a").Put(4, "d").Put(2, "b")
     var keys []int
-    m.ForEachKV((k int, v string) => {
+    m.ForEachKV((k, v) => {
         keys = append(keys, k)
     })
 
-    var t1 = Eq[int](t, len(keys), 5)
-    var t2 = Eq[int](t1, keys[0], 1)
-    var t3 = Eq[int](t2, keys[1], 2)
-    var t4 = Eq[int](t3, keys[2], 3)
-    var t5 = Eq[int](t4, keys[3], 4)
+    val t1 = Eq[int](t, len(keys), 5)
+    val t2 = Eq[int](t1, keys[0], 1)
+    val t3 = Eq[int](t2, keys[1], 2)
+    val t4 = Eq[int](t3, keys[2], 3)
+    val t5 = Eq[int](t4, keys[3], 4)
     return Eq[int](t5, keys[4], 5)
 }
 
@@ -120,8 +120,8 @@ func TestTreeMapMinKeyOption(t T) T {
     val m = EmptyTreeMap[int, string]().Put(5, "e").Put(3, "c")
     val empty = EmptyTreeMap[int, string]()
 
-    var t1 = IsSome(t, m.MinKeyOption())
-    var t2 = Eq[int](t1, m.MinKeyOption().GetOrElse(0), 3)
+    val t1 = IsSome(t, m.MinKeyOption())
+    val t2 = Eq[int](t1, m.MinKeyOption().GetOrElse(0), 3)
     return IsNone(t2, empty.MinKeyOption())
 }
 
@@ -129,22 +129,22 @@ func TestTreeMapMaxKeyOption(t T) T {
     val m = EmptyTreeMap[int, string]().Put(5, "e").Put(3, "c")
     val empty = EmptyTreeMap[int, string]()
 
-    var t1 = IsSome(t, m.MaxKeyOption())
-    var t2 = Eq[int](t1, m.MaxKeyOption().GetOrElse(0), 5)
+    val t1 = IsSome(t, m.MaxKeyOption())
+    val t2 = Eq[int](t1, m.MaxKeyOption().GetOrElse(0), 5)
     return IsNone(t2, empty.MaxKeyOption())
 }
 
 func TestTreeMapMinEntry(t T) T {
     val m = EmptyTreeMap[int, string]().Put(5, "e").Put(3, "c").Put(1, "a")
     val entry = m.MinEntry()
-    var t1 = Eq[int](t, entry.V1, 1)
+    val t1 = Eq[int](t, entry.V1, 1)
     return Eq[string](t1, entry.V2, "a")
 }
 
 func TestTreeMapMaxEntry(t T) T {
     val m = EmptyTreeMap[int, string]().Put(5, "e").Put(3, "c").Put(1, "a")
     val entry = m.MaxEntry()
-    var t1 = Eq[int](t, entry.V1, 5)
+    val t1 = Eq[int](t, entry.V1, 5)
     return Eq[string](t1, entry.V2, "e")
 }
 
@@ -157,11 +157,11 @@ func TestTreeMapRange(t T) T {
     }
     val rangeMap = m.Range(3, 7)
 
-    var t1 = Eq[int](t, rangeMap.Size(), 5)
-    var t2 = IsTrue(t1, rangeMap.Contains(3))
-    var t3 = IsTrue(t2, rangeMap.Contains(5))
-    var t4 = IsTrue(t3, rangeMap.Contains(7))
-    var t5 = IsFalse(t4, rangeMap.Contains(2))
+    val t1 = Eq[int](t, rangeMap.Size(), 5)
+    val t2 = IsTrue(t1, rangeMap.Contains(3))
+    val t3 = IsTrue(t2, rangeMap.Contains(5))
+    val t4 = IsTrue(t3, rangeMap.Contains(7))
+    val t5 = IsFalse(t4, rangeMap.Contains(2))
     return IsFalse(t5, rangeMap.Contains(8))
 }
 
@@ -172,10 +172,10 @@ func TestTreeMapRangeFrom(t T) T {
     }
     val rangeMap = m.RangeFrom(3)
 
-    var t1 = Eq[int](t, rangeMap.Size(), 3)
-    var t2 = IsTrue(t1, rangeMap.Contains(3))
-    var t3 = IsTrue(t2, rangeMap.Contains(4))
-    var t4 = IsTrue(t3, rangeMap.Contains(5))
+    val t1 = Eq[int](t, rangeMap.Size(), 3)
+    val t2 = IsTrue(t1, rangeMap.Contains(3))
+    val t3 = IsTrue(t2, rangeMap.Contains(4))
+    val t4 = IsTrue(t3, rangeMap.Contains(5))
     return IsFalse(t4, rangeMap.Contains(2))
 }
 
@@ -186,10 +186,10 @@ func TestTreeMapRangeTo(t T) T {
     }
     val rangeMap = m.RangeTo(3)
 
-    var t1 = Eq[int](t, rangeMap.Size(), 3)
-    var t2 = IsTrue(t1, rangeMap.Contains(1))
-    var t3 = IsTrue(t2, rangeMap.Contains(2))
-    var t4 = IsTrue(t3, rangeMap.Contains(3))
+    val t1 = Eq[int](t, rangeMap.Size(), 3)
+    val t2 = IsTrue(t1, rangeMap.Contains(1))
+    val t3 = IsTrue(t2, rangeMap.Contains(2))
+    val t4 = IsTrue(t3, rangeMap.Contains(3))
     return IsFalse(t4, rangeMap.Contains(4))
 }
 
@@ -197,48 +197,48 @@ func TestTreeMapRangeTo(t T) T {
 
 func TestTreeMapFilter(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3).Put("d", 4)
-    val filtered = m.Filter((k string, v int) => v > 2)
+    val filtered = m.Filter((k, v) => v > 2)
 
-    var t1 = Eq[int](t, filtered.Size(), 2)
-    var t2 = IsFalse(t1, filtered.Contains("a"))
-    var t3 = IsFalse(t2, filtered.Contains("b"))
-    var t4 = IsTrue(t3, filtered.Contains("c"))
+    val t1 = Eq[int](t, filtered.Size(), 2)
+    val t2 = IsFalse(t1, filtered.Contains("a"))
+    val t3 = IsFalse(t2, filtered.Contains("b"))
+    val t4 = IsTrue(t3, filtered.Contains("c"))
     return IsTrue(t4, filtered.Contains("d"))
 }
 
 func TestTreeMapFilterKeys(t T) T {
     val m = EmptyTreeMap[string, int]().Put("apple", 1).Put("banana", 2).Put("cherry", 3)
-    val filtered = m.FilterKeys((k string) => len(k) > 5)
+    val filtered = m.FilterKeys((k) => len(k) > 5)
 
-    var t1 = Eq[int](t, filtered.Size(), 2)
-    var t2 = IsFalse(t1, filtered.Contains("apple"))
+    val t1 = Eq[int](t, filtered.Size(), 2)
+    val t2 = IsFalse(t1, filtered.Contains("apple"))
     return IsTrue(t2, filtered.Contains("banana"))
 }
 
 func TestTreeMapFilterValues(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
-    val filtered = m.FilterValues((v int) => v % 2 == 0)
+    val filtered = m.FilterValues((v) => v % 2 == 0)
 
-    var t1 = Eq[int](t, filtered.Size(), 1)
+    val t1 = Eq[int](t, filtered.Size(), 1)
     return IsTrue(t1, filtered.Contains("b"))
 }
 
 func TestTreeMapMapValues(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
-    val doubled = m.MapValues[int]((v int) => v * 2)
+    val doubled = m.MapValues((v) => v * 2)
 
-    var t1 = Eq[int](t, doubled.GetOrElse("a", 0), 2)
-    var t2 = Eq[int](t1, doubled.GetOrElse("b", 0), 4)
+    val t1 = Eq[int](t, doubled.GetOrElse("a", 0), 2)
+    val t2 = Eq[int](t1, doubled.GetOrElse("b", 0), 4)
     return Eq[int](t2, doubled.GetOrElse("c", 0), 6)
 }
 
 func TestTreeMapPartition(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3).Put("d", 4)
-    val result = m.Partition((k string, v int) => v % 2 == 0)
+    val result = m.Partition((k, v) => v % 2 == 0)
     val even = result.V1
     val odd = result.V2
 
-    var t1 = Eq[int](t, even.Size(), 2)
+    val t1 = Eq[int](t, even.Size(), 2)
     return Eq[int](t1, odd.Size(), 2)
 }
 
@@ -246,7 +246,7 @@ func TestTreeMapPartition(t T) T {
 
 func TestTreeMapFoldLeftKV(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
-    val sum = m.FoldLeftKV[int](0, (acc int, k string, v int) => acc + v)
+    val sum = m.FoldLeftKV(0, (acc, k, v) => acc + v)
     return Eq[int](t, sum, 6)
 }
 
@@ -254,31 +254,31 @@ func TestTreeMapFoldLeftKV(t T) T {
 
 func TestTreeMapExists(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
-    var t1 = IsTrue(t, m.Exists((k string, v int) => v > 2))
-    return IsFalse(t1, m.Exists((k string, v int) => v > 10))
+    val t1 = IsTrue(t, m.Exists((k, v) => v > 2))
+    return IsFalse(t1, m.Exists((k, v) => v > 10))
 }
 
 func TestTreeMapForAll(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 2).Put("b", 4).Put("c", 6)
-    var t1 = IsTrue(t, m.ForAll((k string, v int) => v % 2 == 0))
-    return IsFalse(t1, m.ForAll((k string, v int) => v < 5))
+    val t1 = IsTrue(t, m.ForAll((k, v) => v % 2 == 0))
+    return IsFalse(t1, m.ForAll((k, v) => v < 5))
 }
 
 func TestTreeMapFind(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
-    val found = m.Find((k string, v int) => v == 2)
-    var t1 = IsSome(t, found)
+    val found = m.Find((k, v) => v == 2)
+    val t1 = IsSome(t, found)
     return Eq[string](t1, found.Get().V1, "b")
 }
 
 func TestTreeMapCount(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3).Put("d", 4)
-    return Eq[int](t, m.Count((k string, v int) => v > 2), 2)
+    return Eq[int](t, m.Count((k, v) => v > 2), 2)
 }
 
 func TestTreeMapCollect(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
-    val result = m.Collect((k string, v int) => {
+    val result = m.Collect((k, v) => {
         if v > 1 {
             return Some(fmt.Sprintf("%s:%d", k, v))
         }
@@ -294,20 +294,20 @@ func TestTreeMapPutAll(t T) T {
     val m2 = EmptyTreeMap[string, int]().Put("c", 3).Put("d", 4)
     val merged = m1.PutAll(m2)
 
-    var t1 = Eq[int](t, merged.Size(), 4)
-    var t2 = IsTrue(t1, merged.Contains("a"))
-    var t3 = IsTrue(t2, merged.Contains("c"))
+    val t1 = Eq[int](t, merged.Size(), 4)
+    val t2 = IsTrue(t1, merged.Contains("a"))
+    val t3 = IsTrue(t2, merged.Contains("c"))
     return IsTrue(t3, merged.Contains("d"))
 }
 
 func TestTreeMapMerge(t T) T {
     val m1 = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2)
     val m2 = EmptyTreeMap[string, int]().Put("b", 3).Put("c", 4)
-    val merged = m1.Merge(m2, (v1 int, v2 int) => v1 + v2)
+    val merged = m1.Merge(m2, (v1, v2) => v1 + v2)
 
-    var t1 = Eq[int](t, merged.Size(), 3)
-    var t2 = Eq[int](t1, merged.GetOrElse("a", 0), 1)
-    var t3 = Eq[int](t2, merged.GetOrElse("b", 0), 5)
+    val t1 = Eq[int](t, merged.Size(), 3)
+    val t2 = Eq[int](t1, merged.GetOrElse("a", 0), 1)
+    val t3 = Eq[int](t2, merged.GetOrElse("b", 0), 5)
     return Eq[int](t3, merged.GetOrElse("c", 0), 4)
 }
 
@@ -316,9 +316,9 @@ func TestTreeMapMerge(t T) T {
 func TestTreeMapKeys(t T) T {
     val m = EmptyTreeMap[string, int]().Put("c", 3).Put("a", 1).Put("b", 2)
     val keys = m.Keys()
-    var t1 = Eq[int](t, keys.Size(), 3)
-    var t2 = IsTrue(t1, keys.Contains("a"))
-    var t3 = IsTrue(t2, keys.Contains("b"))
+    val t1 = Eq[int](t, keys.Size(), 3)
+    val t2 = IsTrue(t1, keys.Contains("a"))
+    val t3 = IsTrue(t2, keys.Contains("b"))
     return IsTrue(t3, keys.Contains("c"))
 }
 
@@ -331,7 +331,7 @@ func TestTreeMapValues(t T) T {
 func TestTreeMapHead(t T) T {
     val m = EmptyTreeMap[int, string]().Put(3, "c").Put(1, "a").Put(2, "b")
     val head = m.Head()
-    var t1 = Eq[int](t, head.V1, 1)
+    val t1 = Eq[int](t, head.V1, 1)
     return Eq[string](t1, head.V2, "a")
 }
 
@@ -339,14 +339,14 @@ func TestTreeMapHeadOption(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1)
     val empty = EmptyTreeMap[string, int]()
 
-    var t1 = IsSome(t, m.HeadOption())
+    val t1 = IsSome(t, m.HeadOption())
     return IsNone(t1, empty.HeadOption())
 }
 
 func TestTreeMapLast(t T) T {
     val m = EmptyTreeMap[int, string]().Put(3, "c").Put(1, "a").Put(2, "b")
     val last = m.Last()
-    var t1 = Eq[int](t, last.V1, 3)
+    val t1 = Eq[int](t, last.V1, 3)
     return Eq[string](t1, last.V2, "c")
 }
 
@@ -354,7 +354,7 @@ func TestTreeMapLastOption(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1)
     val empty = EmptyTreeMap[string, int]()
 
-    var t1 = IsSome(t, m.LastOption())
+    val t1 = IsSome(t, m.LastOption())
     return IsNone(t1, empty.LastOption())
 }
 
@@ -363,24 +363,24 @@ func TestTreeMapLastOption(t T) T {
 func TestTreeMapToArray(t T) T {
     val m = EmptyTreeMap[int, string]().Put(3, "c").Put(1, "a").Put(2, "b")
     val arr = m.ToArray()
-    var t1 = Eq[int](t, arr.Size(), 3)
+    val t1 = Eq[int](t, arr.Size(), 3)
     // Should be in sorted key order
-    var t2 = Eq[int](t1, arr.Get(0).V1, 1)
-    var t3 = Eq[int](t2, arr.Get(1).V1, 2)
+    val t2 = Eq[int](t1, arr.Get(0).V1, 1)
+    val t3 = Eq[int](t2, arr.Get(1).V1, 2)
     return Eq[int](t3, arr.Get(2).V1, 3)
 }
 
 func TestTreeMapToGoMap(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2)
     val goMap = m.ToGoMap()
-    var t1 = Eq[int](t, len(goMap), 2)
+    val t1 = Eq[int](t, len(goMap), 2)
     return Eq[int](t1, goMap["a"], 1)
 }
 
 func TestTreeMapToList(t T) T {
     val m = EmptyTreeMap[int, string]().Put(3, "c").Put(1, "a").Put(2, "b")
     val list = m.ToList()
-    var t1 = Eq[int](t, list.Size(), 3)
+    val t1 = Eq[int](t, list.Size(), 3)
     // Head should be the min-key entry
     return Eq[int](t1, list.Head().V1, 1)
 }
@@ -388,21 +388,21 @@ func TestTreeMapToList(t T) T {
 func TestTreeMapToHashMap(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 1).Put("b", 2).Put("c", 3)
     val hm = m.ToHashMap()
-    var t1 = Eq[int](t, hm.Size(), 3)
-    var t2 = Eq[int](t1, hm.GetOrElse("a", 0), 1)
+    val t1 = Eq[int](t, hm.Size(), 3)
+    val t2 = Eq[int](t1, hm.GetOrElse("a", 0), 1)
     return Eq[int](t2, hm.GetOrElse("c", 0), 3)
 }
 
 func TestTreeMapFromSlice(t T) T {
     val entries = go_interop.SliceOf[Tuple[string, int]](
-        Tuple[string, int](V1 = "a", V2 = 1),
-        Tuple[string, int](V1 = "b", V2 = 2),
-        Tuple[string, int](V1 = "c", V2 = 3)
+        ("a", 1),
+        ("b", 2),
+        ("c", 3)
     )
 
     val m = TreeMapFromSlice[string, int](entries)
-    var t1 = Eq[int](t, m.Size(), 3)
-    var t2 = Eq[int](t1, m.GetOrElse("a", 0), 1)
+    val t1 = Eq[int](t, m.Size(), 3)
+    val t2 = Eq[int](t1, m.GetOrElse("a", 0), 1)
     return Eq[int](t2, m.GetOrElse("b", 0), 2)
 }
 
@@ -410,7 +410,7 @@ func TestTreeMapFromSlice(t T) T {
 
 func TestTreeMapString(t T) T {
     val empty = EmptyTreeMap[string, int]()
-    var t1 = Eq[string](t, empty.String(), "TreeMap()")
+    val t1 = Eq[string](t, empty.String(), "TreeMap()")
 
     val m = EmptyTreeMap[int, string]().Put(2, "b").Put(1, "a").Put(3, "c")
     // Should be in sorted key order
@@ -424,11 +424,11 @@ func TestTreeMapLarge(t T) T {
     for i := 0; i < 1000; i++ {
         m = m.Put(i, i * 2)
     }
-    var t1 = Eq[int](t, m.Size(), 1000)
-    var t2 = Eq[int](t1, m.GetOrElse(0, -1), 0)
-    var t3 = Eq[int](t2, m.GetOrElse(500, -1), 1000)
-    var t4 = Eq[int](t3, m.GetOrElse(999, -1), 1998)
-    var t5 = Eq[int](t4, m.MinKey(), 0)
+    val t1 = Eq[int](t, m.Size(), 1000)
+    val t2 = Eq[int](t1, m.GetOrElse(0, -1), 0)
+    val t3 = Eq[int](t2, m.GetOrElse(500, -1), 1000)
+    val t4 = Eq[int](t3, m.GetOrElse(999, -1), 1998)
+    val t5 = Eq[int](t4, m.MinKey(), 0)
     return Eq[int](t5, m.MaxKey(), 999)
 }
 
@@ -439,9 +439,9 @@ func TestTreeMapImmutability(t T) T {
     val m2 = m1.Put("b", 2)
     val m3 = m1.Remove("a")
 
-    var t1 = Eq[int](t, m1.Size(), 1)
-    var t2 = Eq[int](t1, m2.Size(), 2)
-    var t3 = Eq[int](t2, m3.Size(), 0)
+    val t1 = Eq[int](t, m1.Size(), 1)
+    val t2 = Eq[int](t1, m2.Size(), 2)
+    val t3 = Eq[int](t2, m3.Size(), 0)
     return IsTrue(t3, m1.Contains("a"))
 }
 
@@ -450,30 +450,30 @@ func TestTreeMapImmutability(t T) T {
 func TestTreeMapSorted(t T) T {
     val m = EmptyTreeMap[int, string]().Put(3, "c").Put(1, "a").Put(2, "b")
     val sorted = m.Sorted()
-    var t1 = Eq[int](t, sorted.Size(), 3)
+    val t1 = Eq[int](t, sorted.Size(), 3)
     // Already in sorted key order
-    var t2 = Eq[int](t1, sorted.Get(0).V1, 1)
-    var t3 = Eq[int](t2, sorted.Get(1).V1, 2)
+    val t2 = Eq[int](t1, sorted.Get(0).V1, 1)
+    val t3 = Eq[int](t2, sorted.Get(1).V1, 2)
     return Eq[int](t3, sorted.Get(2).V1, 3)
 }
 
 func TestTreeMapSortWith(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 3).Put("b", 1).Put("c", 2)
     // Sort by value instead of key
-    val sorted = m.SortWith((a Tuple[string, int], b Tuple[string, int]) => a.V2 < b.V2)
-    var t1 = Eq[int](t, sorted.Size(), 3)
-    var t2 = Eq[string](t1, sorted.Get(0).V1, "b")
-    var t3 = Eq[string](t2, sorted.Get(1).V1, "c")
+    val sorted = m.SortWith((a, b) => a.V2 < b.V2)
+    val t1 = Eq[int](t, sorted.Size(), 3)
+    val t2 = Eq[string](t1, sorted.Get(0).V1, "b")
+    val t3 = Eq[string](t2, sorted.Get(1).V1, "c")
     return Eq[string](t3, sorted.Get(2).V1, "a")
 }
 
 func TestTreeMapSortBy(t T) T {
     val m = EmptyTreeMap[string, int]().Put("a", 30).Put("b", 10).Put("c", 20)
     // Sort by value
-    val sorted = m.SortBy[int]((entry Tuple[string, int]) => entry.V2)
-    var t1 = Eq[int](t, sorted.Size(), 3)
-    var t2 = Eq[string](t1, sorted.Get(0).V1, "b")
-    var t3 = Eq[string](t2, sorted.Get(1).V1, "c")
+    val sorted = m.SortBy((entry) => entry.V2)
+    val t1 = Eq[int](t, sorted.Size(), 3)
+    val t2 = Eq[string](t1, sorted.Get(0).V1, "b")
+    val t3 = Eq[string](t2, sorted.Get(1).V1, "c")
     return Eq[string](t3, sorted.Get(2).V1, "a")
 }
 
@@ -498,9 +498,9 @@ func TestTreeMapCustomOrderedKey(t T) T {
     val k3 = OrderedKey(Priority = 1, Name = "gamma")
 
     val m = EmptyTreeMap[OrderedKey, string]().Put(k2, "second").Put(k1, "first").Put(k3, "third")
-    var t1 = Eq[int](t, m.Size(), 3)
+    val t1 = Eq[int](t, m.Size(), 3)
     // Min should be k1 (priority=1, name=alpha)
-    var t2 = Eq[string](t1, m.MinEntry().V2, "first")
+    val t2 = Eq[string](t1, m.MinEntry().V2, "first")
     // Max should be k2 (priority=2)
     return Eq[string](t2, m.MaxEntry().V2, "second")
 }

--- a/collection_immutable/treeset.gala
+++ b/collection_immutable/treeset.gala
@@ -775,7 +775,7 @@ func (s TreeSet[T]) String() string {
         if !first {
             result = result + ", "
         }
-        result = result + fmt.Sprintf("%v", elem)
+        result = result + s"${elem}"
         first = false
     })
     return result + ")"
@@ -792,7 +792,7 @@ func (s TreeSet[T]) MkString(sep string) string {
         if !first {
             result = result + sep
         }
-        result = result + fmt.Sprintf("%v", elem)
+        result = result + s"${elem}"
         first = false
     })
     return result

--- a/collection_immutable/treeset_test.gala
+++ b/collection_immutable/treeset_test.gala
@@ -11,15 +11,15 @@ import (
 // Basic operations tests
 func TestTreeSetEmpty(t T) T {
     val s = EmptyTreeSet[int]()
-    var t1 = IsTrue(t, s.IsEmpty())
-    var t2 = IsFalse(t1, s.NonEmpty())
+    val t1 = IsTrue(t, s.IsEmpty())
+    val t2 = IsFalse(t1, s.NonEmpty())
     return Eq[int](t2, s.Size(), 0)
 }
 
 func TestTreeSetOf(t T) T {
     val s = TreeSetOf(1, 2, 3, 4, 5)
-    var t1 = IsFalse(t, s.IsEmpty())
-    var t2 = IsTrue(t1, s.NonEmpty())
+    val t1 = IsFalse(t, s.IsEmpty())
+    val t2 = IsTrue(t1, s.NonEmpty())
     return Eq[int](t2, s.Size(), 5)
 }
 
@@ -41,12 +41,12 @@ func TestTreeSetAdd(t T) T {
     val s2 = s1.Add(2)
     val s3 = s2.Add(3)
 
-    var t1 = Eq[int](t, s.Size(), 0)
-    var t2 = Eq[int](t1, s1.Size(), 1)
-    var t3 = Eq[int](t2, s2.Size(), 2)
-    var t4 = Eq[int](t3, s3.Size(), 3)
-    var t5 = IsTrue(t4, s3.Contains(1))
-    var t6 = IsTrue(t5, s3.Contains(2))
+    val t1 = Eq[int](t, s.Size(), 0)
+    val t2 = Eq[int](t1, s1.Size(), 1)
+    val t3 = Eq[int](t2, s2.Size(), 2)
+    val t4 = Eq[int](t3, s3.Size(), 3)
+    val t5 = IsTrue(t4, s3.Contains(1))
+    val t6 = IsTrue(t5, s3.Contains(2))
     return IsTrue(t6, s3.Contains(3))
 }
 
@@ -60,9 +60,9 @@ func TestTreeSetRemove(t T) T {
     val s = TreeSetOf(1, 2, 3, 4, 5)
     val s2 = s.Remove(3)
 
-    var t1 = Eq[int](t, s2.Size(), 4)
-    var t2 = IsFalse(t1, s2.Contains(3))
-    var t3 = IsTrue(t2, s2.Contains(1))
+    val t1 = Eq[int](t, s2.Size(), 4)
+    val t2 = IsFalse(t1, s2.Contains(3))
+    val t3 = IsTrue(t2, s2.Contains(1))
     return IsTrue(t3, s2.Contains(5))
 }
 
@@ -77,11 +77,11 @@ func TestTreeSetSortedOrder(t T) T {
     val s = TreeSetOf(5, 3, 1, 4, 2)
     val slice = s.ToGoSlice()
 
-    var t1 = Eq[int](t, len(slice), 5)
-    var t2 = Eq[int](t1, slice[0], 1)
-    var t3 = Eq[int](t2, slice[1], 2)
-    var t4 = Eq[int](t3, slice[2], 3)
-    var t5 = Eq[int](t4, slice[3], 4)
+    val t1 = Eq[int](t, len(slice), 5)
+    val t2 = Eq[int](t1, slice[0], 1)
+    val t3 = Eq[int](t2, slice[1], 2)
+    val t4 = Eq[int](t3, slice[2], 3)
+    val t5 = Eq[int](t4, slice[3], 4)
     return Eq[int](t5, slice[4], 5)
 }
 
@@ -99,8 +99,8 @@ func TestTreeSetMinOption(t T) T {
     val s = TreeSetOf(5, 3, 1)
     val empty = EmptyTreeSet[int]()
 
-    var t1 = IsSome(t, s.MinOption())
-    var t2 = Eq[int](t1, s.MinOption().GetOrElse(0), 1)
+    val t1 = IsSome(t, s.MinOption())
+    val t2 = Eq[int](t1, s.MinOption().GetOrElse(0), 1)
     return IsNone(t2, empty.MinOption())
 }
 
@@ -108,8 +108,8 @@ func TestTreeSetMaxOption(t T) T {
     val s = TreeSetOf(5, 3, 1)
     val empty = EmptyTreeSet[int]()
 
-    var t1 = IsSome(t, s.MaxOption())
-    var t2 = Eq[int](t1, s.MaxOption().GetOrElse(0), 5)
+    val t1 = IsSome(t, s.MaxOption())
+    val t2 = Eq[int](t1, s.MaxOption().GetOrElse(0), 5)
     return IsNone(t2, empty.MaxOption())
 }
 
@@ -118,11 +118,11 @@ func TestTreeSetRange(t T) T {
     val s = TreeSetOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
     val rangeSet = s.Range(3, 7)
 
-    var t1 = Eq[int](t, rangeSet.Size(), 5)
-    var t2 = IsTrue(t1, rangeSet.Contains(3))
-    var t3 = IsTrue(t2, rangeSet.Contains(5))
-    var t4 = IsTrue(t3, rangeSet.Contains(7))
-    var t5 = IsFalse(t4, rangeSet.Contains(2))
+    val t1 = Eq[int](t, rangeSet.Size(), 5)
+    val t2 = IsTrue(t1, rangeSet.Contains(3))
+    val t3 = IsTrue(t2, rangeSet.Contains(5))
+    val t4 = IsTrue(t3, rangeSet.Contains(7))
+    val t5 = IsFalse(t4, rangeSet.Contains(2))
     return IsFalse(t5, rangeSet.Contains(8))
 }
 
@@ -130,10 +130,10 @@ func TestTreeSetRangeFrom(t T) T {
     val s = TreeSetOf(1, 2, 3, 4, 5)
     val rangeSet = s.RangeFrom(3)
 
-    var t1 = Eq[int](t, rangeSet.Size(), 3)
-    var t2 = IsTrue(t1, rangeSet.Contains(3))
-    var t3 = IsTrue(t2, rangeSet.Contains(4))
-    var t4 = IsTrue(t3, rangeSet.Contains(5))
+    val t1 = Eq[int](t, rangeSet.Size(), 3)
+    val t2 = IsTrue(t1, rangeSet.Contains(3))
+    val t3 = IsTrue(t2, rangeSet.Contains(4))
+    val t4 = IsTrue(t3, rangeSet.Contains(5))
     return IsFalse(t4, rangeSet.Contains(2))
 }
 
@@ -141,10 +141,10 @@ func TestTreeSetRangeTo(t T) T {
     val s = TreeSetOf(1, 2, 3, 4, 5)
     val rangeSet = s.RangeTo(3)
 
-    var t1 = Eq[int](t, rangeSet.Size(), 3)
-    var t2 = IsTrue(t1, rangeSet.Contains(1))
-    var t3 = IsTrue(t2, rangeSet.Contains(2))
-    var t4 = IsTrue(t3, rangeSet.Contains(3))
+    val t1 = Eq[int](t, rangeSet.Size(), 3)
+    val t2 = IsTrue(t1, rangeSet.Contains(1))
+    val t3 = IsTrue(t2, rangeSet.Contains(2))
+    val t4 = IsTrue(t3, rangeSet.Contains(3))
     return IsFalse(t4, rangeSet.Contains(4))
 }
 
@@ -154,9 +154,9 @@ func TestTreeSetUnion(t T) T {
     val s2 = TreeSetOf(3, 4, 5)
     val union = s1.Union(s2)
 
-    var t1 = Eq[int](t, union.Size(), 5)
-    var t2 = IsTrue(t1, union.Contains(1))
-    var t3 = IsTrue(t2, union.Contains(3))
+    val t1 = Eq[int](t, union.Size(), 5)
+    val t2 = IsTrue(t1, union.Contains(1))
+    val t3 = IsTrue(t2, union.Contains(3))
     return IsTrue(t3, union.Contains(5))
 }
 
@@ -165,8 +165,8 @@ func TestTreeSetIntersect(t T) T {
     val s2 = TreeSetOf(3, 4, 5, 6)
     val intersect = s1.Intersect(s2)
 
-    var t1 = Eq[int](t, intersect.Size(), 2)
-    var t2 = IsTrue(t1, intersect.Contains(3))
+    val t1 = Eq[int](t, intersect.Size(), 2)
+    val t2 = IsTrue(t1, intersect.Contains(3))
     return IsTrue(t2, intersect.Contains(4))
 }
 
@@ -175,10 +175,10 @@ func TestTreeSetDiff(t T) T {
     val s2 = TreeSetOf(3, 4, 5, 6)
     val diff = s1.Diff(s2)
 
-    var t1 = Eq[int](t, diff.Size(), 2)
-    var t2 = IsTrue(t1, diff.Contains(1))
-    var t3 = IsTrue(t2, diff.Contains(2))
-    var t4 = IsFalse(t3, diff.Contains(3))
+    val t1 = Eq[int](t, diff.Size(), 2)
+    val t2 = IsTrue(t1, diff.Contains(1))
+    val t3 = IsTrue(t2, diff.Contains(2))
+    val t4 = IsFalse(t3, diff.Contains(3))
     return IsFalse(t4, diff.Contains(4))
 }
 
@@ -187,60 +187,60 @@ func TestTreeSetSubsetOf(t T) T {
     val s2 = TreeSetOf(1, 2, 3, 4, 5)
     val s3 = TreeSetOf(1, 2, 6)
 
-    var t1 = IsTrue(t, s1.SubsetOf(s2))
+    val t1 = IsTrue(t, s1.SubsetOf(s2))
     return IsFalse(t1, s3.SubsetOf(s2))
 }
 
 // Transformation tests
 func TestTreeSetFilter(t T) T {
     val s = TreeSetOf(1, 2, 3, 4, 5, 6)
-    val even = s.Filter((x int) => x % 2 == 0)
+    val even = s.Filter((x) => x % 2 == 0)
 
-    var t1 = Eq[int](t, even.Size(), 3)
-    var t2 = IsTrue(t1, even.Contains(2))
-    var t3 = IsTrue(t2, even.Contains(4))
-    var t4 = IsTrue(t3, even.Contains(6))
+    val t1 = Eq[int](t, even.Size(), 3)
+    val t2 = IsTrue(t1, even.Contains(2))
+    val t3 = IsTrue(t2, even.Contains(4))
+    val t4 = IsTrue(t3, even.Contains(6))
     return IsFalse(t4, even.Contains(1))
 }
 
 func TestTreeSetMap(t T) T {
     val s = TreeSetOf(1, 2, 3)
-    val doubled = MapTreeSet(s, (x int) => x * 2)
+    val doubled = MapTreeSet[int, int](s, (x) => x * 2)
 
-    var t1 = Eq[int](t, doubled.Size(), 3)
-    var t2 = IsTrue(t1, doubled.Contains(2))
-    var t3 = IsTrue(t2, doubled.Contains(4))
+    val t1 = Eq[int](t, doubled.Size(), 3)
+    val t2 = IsTrue(t1, doubled.Contains(2))
+    val t3 = IsTrue(t2, doubled.Contains(4))
     return IsTrue(t3, doubled.Contains(6))
 }
 
 func TestTreeSetFoldLeft(t T) T {
     val s = TreeSetOf(1, 2, 3, 4, 5)
-    val sum = s.FoldLeft[int](0, (acc int, x int) => acc + x)
+    val sum = s.FoldLeft(0, (acc, x) => acc + x)
     return Eq[int](t, sum, 15)
 }
 
 // Predicate tests
 func TestTreeSetExists(t T) T {
     val s = TreeSetOf(1, 2, 3, 4, 5)
-    var t1 = IsTrue(t, s.Exists((x int) => x > 4))
-    return IsFalse(t1, s.Exists((x int) => x > 5))
+    val t1 = IsTrue(t, s.Exists((x) => x > 4))
+    return IsFalse(t1, s.Exists((x) => x > 5))
 }
 
 func TestTreeSetForAll(t T) T {
     val s = TreeSetOf(2, 4, 6, 8)
-    var t1 = IsTrue(t, s.ForAll((x int) => x % 2 == 0))
-    return IsFalse(t1, s.ForAll((x int) => x < 5))
+    val t1 = IsTrue(t, s.ForAll((x) => x % 2 == 0))
+    return IsFalse(t1, s.ForAll((x) => x < 5))
 }
 
 func TestTreeSetCount(t T) T {
     val s = TreeSetOf(1, 2, 3, 4, 5, 6)
-    return Eq[int](t, s.Count((x int) => x > 3), 3)
+    return Eq[int](t, s.Count((x) => x > 3), 3)
 }
 
 func TestTreeSetFind(t T) T {
     val s = TreeSetOf(1, 2, 3, 4, 5)
-    val found = s.Find((x int) => x > 3)
-    var t1 = IsSome(t, found)
+    val found = s.Find((x) => x > 3)
+    val t1 = IsSome(t, found)
     // Find returns first in sorted order, so should be 4
     return Eq[int](t1, found.GetOrElse(0), 4)
 }
@@ -249,35 +249,35 @@ func TestTreeSetFind(t T) T {
 func TestTreeSetToGoSlice(t T) T {
     val s = TreeSetOf(3, 1, 2)
     val slice = s.ToGoSlice()
-    var t1 = Eq[int](t, len(slice), 3)
+    val t1 = Eq[int](t, len(slice), 3)
     // Should be in sorted order
-    var t2 = Eq[int](t1, slice[0], 1)
-    var t3 = Eq[int](t2, slice[1], 2)
+    val t2 = Eq[int](t1, slice[0], 1)
+    val t3 = Eq[int](t2, slice[1], 2)
     return Eq[int](t3, slice[2], 3)
 }
 
 func TestTreeSetToList(t T) T {
     val s = TreeSetOf(3, 1, 2)
     val list = s.ToList()
-    var t1 = Eq[int](t, list.Size(), 3)
+    val t1 = Eq[int](t, list.Size(), 3)
     // Should be in sorted order
-    var t2 = Eq[int](t1, list.Head(), 1)
+    val t2 = Eq[int](t1, list.Head(), 1)
     return Eq[int](t2, list.Get(2), 3)
 }
 
 func TestTreeSetToArray(t T) T {
     val s = TreeSetOf(3, 1, 2)
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Size(), 3)
+    val t1 = Eq[int](t, arr.Size(), 3)
     // Should be in sorted order
-    var t2 = Eq[int](t1, arr.Get(0), 1)
+    val t2 = Eq[int](t1, arr.Get(0), 1)
     return Eq[int](t2, arr.Get(2), 3)
 }
 
 func TestTreeSetCollect(t T) T {
     val s = TreeSetOf(1, 2, 3, 4, 5)
     // Collect odd numbers as strings
-    val result = s.Collect((x int) => {
+    val result = s.Collect((x) => {
         if x % 2 == 1 {
             return Some(fmt.Sprintf("%d", x))
         }
@@ -290,19 +290,19 @@ func TestTreeSetCollect(t T) T {
 func TestTreeSetToHashSet(t T) T {
     val s = TreeSetOf(1, 2, 3)
     val hashSet = s.ToHashSet()
-    var t1 = Eq[int](t, hashSet.Size(), 3)
-    var t2 = IsTrue(t1, hashSet.Contains(1))
-    var t3 = IsTrue(t2, hashSet.Contains(2))
+    val t1 = Eq[int](t, hashSet.Size(), 3)
+    val t2 = IsTrue(t1, hashSet.Contains(1))
+    val t3 = IsTrue(t2, hashSet.Contains(2))
     return IsTrue(t3, hashSet.Contains(3))
 }
 
 // String tests
 func TestTreeSetStrings(t T) T {
     val s = TreeSetOf("cherry", "apple", "banana")
-    var t1 = Eq[int](t, s.Size(), 3)
-    var t2 = IsTrue(t1, s.Contains("apple"))
-    var t3 = IsTrue(t2, s.Contains("banana"))
-    var t4 = IsTrue(t3, s.Contains("cherry"))
+    val t1 = Eq[int](t, s.Size(), 3)
+    val t2 = IsTrue(t1, s.Contains("apple"))
+    val t3 = IsTrue(t2, s.Contains("banana"))
+    val t4 = IsTrue(t3, s.Contains("cherry"))
     // Should be sorted alphabetically
     return Eq[string](t4, s.Min(), "apple")
 }
@@ -313,11 +313,11 @@ func TestTreeSetLarge(t T) T {
     for i := 0; i < 1000; i++ {
         s = s.Add(i)
     }
-    var t1 = Eq[int](t, s.Size(), 1000)
-    var t2 = IsTrue(t1, s.Contains(0))
-    var t3 = IsTrue(t2, s.Contains(500))
-    var t4 = IsTrue(t3, s.Contains(999))
-    var t5 = Eq[int](t4, s.Min(), 0)
+    val t1 = Eq[int](t, s.Size(), 1000)
+    val t2 = IsTrue(t1, s.Contains(0))
+    val t3 = IsTrue(t2, s.Contains(500))
+    val t4 = IsTrue(t3, s.Contains(999))
+    val t5 = Eq[int](t4, s.Min(), 0)
     return Eq[int](t5, s.Max(), 999)
 }
 
@@ -338,7 +338,7 @@ func TestTreeSetHeadOption(t T) T {
     val s = TreeSetOf(5, 3, 1)
     val empty = EmptyTreeSet[int]()
 
-    var t1 = IsSome(t, s.HeadOption())
+    val t1 = IsSome(t, s.HeadOption())
     return IsNone(t1, empty.HeadOption())
 }
 
@@ -346,25 +346,25 @@ func TestTreeSetLastOption(t T) T {
     val s = TreeSetOf(5, 3, 1)
     val empty = EmptyTreeSet[int]()
 
-    var t1 = IsSome(t, s.LastOption())
+    val t1 = IsSome(t, s.LastOption())
     return IsNone(t1, empty.LastOption())
 }
 
 // Partition test
 func TestTreeSetPartition(t T) T {
     val s = TreeSetOf(1, 2, 3, 4, 5, 6)
-    val result = s.Partition((x int) => x % 2 == 0)
+    val result = s.Partition((x) => x % 2 == 0)
     val even = result.V1
     val odd = result.V2
 
-    var t1 = Eq[int](t, even.Size(), 3)
+    val t1 = Eq[int](t, even.Size(), 3)
     return Eq[int](t1, odd.Size(), 3)
 }
 
 // Reduce tests
 func TestTreeSetReduce(t T) T {
     val s = TreeSetOf(1, 2, 3, 4, 5)
-    val sum = s.Reduce((a int, b int) => a + b)
+    val sum = s.Reduce((a, b) => a + b)
     return Eq[int](t, sum, 15)
 }
 
@@ -372,8 +372,8 @@ func TestTreeSetReduceOption(t T) T {
     val s = TreeSetOf(1, 2, 3)
     val empty = EmptyTreeSet[int]()
 
-    var t1 = IsSome(t, s.ReduceOption((a int, b int) => a + b))
-    return IsNone(t1, empty.ReduceOption((a int, b int) => a + b))
+    val t1 = IsSome(t, s.ReduceOption((a, b) => a + b))
+    return IsNone(t1, empty.ReduceOption((a, b) => a + b))
 }
 
 // Balance test - ensure tree stays balanced after many insertions
@@ -383,11 +383,11 @@ func TestTreeSetBalance(t T) T {
     for i := 0; i < 100; i++ {
         s = s.Add(i)
     }
-    var t1 = Eq[int](t, s.Size(), 100)
-    var t2 = Eq[int](t1, s.Min(), 0)
-    var t3 = Eq[int](t2, s.Max(), 99)
+    val t1 = Eq[int](t, s.Size(), 100)
+    val t2 = Eq[int](t1, s.Min(), 0)
+    val t3 = Eq[int](t2, s.Max(), 99)
     // All elements should be present
-    var t4 = IsTrue(t3, s.Contains(50))
+    val t4 = IsTrue(t3, s.Contains(50))
     return IsTrue(t4, s.Contains(75))
 }
 
@@ -397,8 +397,8 @@ func TestTreeSetReverseInsertion(t T) T {
     for i := 99; i >= 0; i-- {
         s = s.Add(i)
     }
-    var t1 = Eq[int](t, s.Size(), 100)
-    var t2 = Eq[int](t1, s.Min(), 0)
+    val t1 = Eq[int](t, s.Size(), 100)
+    val t2 = Eq[int](t1, s.Min(), 0)
     return Eq[int](t2, s.Max(), 99)
 }
 
@@ -409,7 +409,7 @@ func TestTreeSetRandomInsertion(t T) T {
     for i := 0; i < len(values); i++ {
         s = s.Add(values[i])
     }
-    var t1 = Eq[int](t, s.Size(), 15)
-    var t2 = Eq[int](t1, s.Min(), 6)
+    val t1 = Eq[int](t, s.Size(), 15)
+    val t2 = Eq[int](t1, s.Min(), 6)
     return Eq[int](t2, s.Max(), 93)
 }

--- a/collection_immutable/validation_test.gala
+++ b/collection_immutable/validation_test.gala
@@ -18,7 +18,7 @@ func TestArrayLargeScale(t T) T {
     }
 
     // Verify all elements are correct
-    var t1 = Eq[int](t, arr.Length(), 10000)
+    val t1 = Eq[int](t, arr.Length(), 10000)
     var allCorrect = true
     for i := 0; i < 10000; i++ {
         if arr.Get(i) != i {
@@ -36,7 +36,7 @@ func TestArrayPrependStress(t T) T {
         arr = arr.Prepend(i)
     }
 
-    var t1 = Eq[int](t, arr.Length(), 100)
+    val t1 = Eq[int](t, arr.Length(), 100)
     // Verify order is correct (1, 2, 3, ..., 100)
     var allCorrect = true
     for i := 0; i < 100; i++ {
@@ -58,7 +58,7 @@ func TestArrayMixedOperationsIntegrity(t T) T {
     }
 
     // Should have 100 elements: 0-49 (prepended) then 100-149 (appended)
-    var t1 = Eq[int](t, arr.Length(), 100)
+    val t1 = Eq[int](t, arr.Length(), 100)
 
     // Check first half (prepended in reverse, so 0-49)
     var firstHalfCorrect = true
@@ -76,7 +76,7 @@ func TestArrayMixedOperationsIntegrity(t T) T {
         }
     }
 
-    var t2 = IsTrue(t1, firstHalfCorrect)
+    val t2 = IsTrue(t1, firstHalfCorrect)
     return IsTrue(t2, secondHalfCorrect)
 }
 
@@ -94,14 +94,14 @@ func TestArrayUpdateAcrossTree(t T) T {
     updated = updated.Updated(63, 1063)   // Last of second leaf
     updated = updated.Updated(99, 1099)   // Last element
 
-    var t1 = Eq[int](t, updated.Get(0), 1000)
-    var t2 = Eq[int](t1, updated.Get(31), 1031)
-    var t3 = Eq[int](t2, updated.Get(32), 1032)
-    var t4 = Eq[int](t3, updated.Get(63), 1063)
-    var t5 = Eq[int](t4, updated.Get(99), 1099)
+    val t1 = Eq[int](t, updated.Get(0), 1000)
+    val t2 = Eq[int](t1, updated.Get(31), 1031)
+    val t3 = Eq[int](t2, updated.Get(32), 1032)
+    val t4 = Eq[int](t3, updated.Get(63), 1063)
+    val t5 = Eq[int](t4, updated.Get(99), 1099)
 
     // Original unchanged
-    var t6 = Eq[int](t5, arr.Get(0), 0)
+    val t6 = Eq[int](t5, arr.Get(0), 0)
     return Eq[int](t6, arr.Get(99), 99)
 }
 
@@ -112,11 +112,11 @@ func TestArrayTakeDropDataIntegrity(t T) T {
         arr = arr.Append(i * 2)
     }
 
-    var taken = arr.Take(50)
-    var dropped = arr.Drop(50)
+    val taken = arr.Take(50)
+    val dropped = arr.Drop(50)
 
     // Verify taken has first 50 elements
-    var t1 = Eq[int](t, taken.Length(), 50)
+    val t1 = Eq[int](t, taken.Length(), 50)
     var takenCorrect = true
     for i := 0; i < 50; i++ {
         if taken.Get(i) != (i * 2) {
@@ -125,7 +125,7 @@ func TestArrayTakeDropDataIntegrity(t T) T {
     }
 
     // Verify dropped has last 50 elements
-    var t2 = Eq[int](t1, dropped.Length(), 50)
+    val t2 = Eq[int](t1, dropped.Length(), 50)
     var droppedCorrect = true
     for i := 0; i < 50; i++ {
         if dropped.Get(i) != ((50 + i) * 2) {
@@ -133,7 +133,7 @@ func TestArrayTakeDropDataIntegrity(t T) T {
         }
     }
 
-    var t3 = IsTrue(t2, takenCorrect)
+    val t3 = IsTrue(t2, takenCorrect)
     return IsTrue(t3, droppedCorrect)
 }
 
@@ -144,11 +144,11 @@ func TestArrayMapDataIntegrity(t T) T {
         arr = arr.Append(i)
     }
 
-    var doubled = arr.Map[int]((x int) => x * 2)
-    var squared = arr.Map[int]((x int) => x * x)
+    val doubled = arr.Map((x) => x * 2)
+    val squared = arr.Map((x) => x * x)
 
-    var t1 = Eq[int](t, doubled.Length(), 100)
-    var t2 = Eq[int](t1, squared.Length(), 100)
+    val t1 = Eq[int](t, doubled.Length(), 100)
+    val t2 = Eq[int](t1, squared.Length(), 100)
 
     var doubledCorrect = true
     var squaredCorrect = true
@@ -161,7 +161,7 @@ func TestArrayMapDataIntegrity(t T) T {
         }
     }
 
-    var t3 = IsTrue(t2, doubledCorrect)
+    val t3 = IsTrue(t2, doubledCorrect)
     return IsTrue(t3, squaredCorrect)
 }
 
@@ -172,11 +172,11 @@ func TestArrayFilterDataIntegrity(t T) T {
         arr = arr.Append(i)
     }
 
-    var evens = arr.Filter((x int) => x % 2 == 0)
-    var multiplesOf10 = arr.Filter((x int) => x % 10 == 0)
+    val evens = arr.Filter((x) => x % 2 == 0)
+    val multiplesOf10 = arr.Filter((x) => x % 10 == 0)
 
-    var t1 = Eq[int](t, evens.Length(), 50)
-    var t2 = Eq[int](t1, multiplesOf10.Length(), 10)
+    val t1 = Eq[int](t, evens.Length(), 50)
+    val t2 = Eq[int](t1, multiplesOf10.Length(), 10)
 
     // Verify evens are actually even
     var evensCorrect = true
@@ -194,7 +194,7 @@ func TestArrayFilterDataIntegrity(t T) T {
         }
     }
 
-    var t3 = IsTrue(t2, evensCorrect)
+    val t3 = IsTrue(t2, evensCorrect)
     return IsTrue(t3, multiplesCorrect)
 }
 
@@ -206,12 +206,12 @@ func TestArrayFoldDataIntegrity(t T) T {
     }
 
     // Sum 1 to 100 = 5050
-    var sum = arr.FoldLeft[int](0, (acc int, x int) => acc + x)
-    var t1 = Eq[int](t, sum, 5050)
+    val sum = arr.FoldLeft(0, (acc, x) => acc + x)
+    val t1 = Eq[int](t, sum, 5050)
 
     // Product of first 5: 1*2*3*4*5 = 120
-    var first5 = arr.Take(5)
-    var product = first5.FoldLeft[int](1, (acc int, x int) => acc * x)
+    val first5 = arr.Take(5)
+    val product = first5.FoldLeft(1, (acc, x) => acc * x)
     return Eq[int](t1, product, 120)
 }
 
@@ -222,8 +222,8 @@ func TestArrayReverseDataIntegrity(t T) T {
         arr = arr.Append(i)
     }
 
-    var reversed = arr.Reverse()
-    var t1 = Eq[int](t, reversed.Length(), 100)
+    val reversed = arr.Reverse()
+    val t1 = Eq[int](t, reversed.Length(), 100)
 
     var allCorrect = true
     for i := 0; i < 100; i++ {
@@ -241,8 +241,8 @@ func TestArraySliceDataIntegrity(t T) T {
         arr = arr.Append(i)
     }
 
-    var slice1 = arr.Slice(25, 75)
-    var t1 = Eq[int](t, slice1.Length(), 50)
+    val slice1 = arr.Slice(25, 75)
+    val t1 = Eq[int](t, slice1.Length(), 50)
 
     var allCorrect = true
     for i := 0; i < 50; i++ {
@@ -264,7 +264,7 @@ func TestListLargeScale(t T) T {
         list = list.Prepend(i)
     }
 
-    var t1 = Eq[int](t, list.Length(), 1000)
+    val t1 = Eq[int](t, list.Length(), 1000)
     var allCorrect = true
     for i := 0; i < 1000; i++ {
         if list.Get(i) != i {
@@ -276,7 +276,7 @@ func TestListLargeScale(t T) T {
 
 // Test List structural integrity through many tail operations
 func TestListTailChainIntegrity(t T) T {
-    var list = ListOf[int](1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    val list = ListOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 
     var lengths []int
     var heads []int
@@ -288,7 +288,7 @@ func TestListTailChainIntegrity(t T) T {
     }
 
     // Should have 10 iterations
-    var t1 = Eq[int](t, len(lengths), 10)
+    val t1 = Eq[int](t, len(lengths), 10)
 
     // Each tail should have decreasing length
     var lengthsCorrect = true
@@ -306,7 +306,7 @@ func TestListTailChainIntegrity(t T) T {
         }
     }
 
-    var t2 = IsTrue(t1, lengthsCorrect)
+    val t2 = IsTrue(t1, lengthsCorrect)
     return IsTrue(t2, headsCorrect)
 }
 
@@ -317,9 +317,9 @@ func TestListMapDataIntegrity(t T) T {
         list = list.Prepend(i)
     }
 
-    var doubled = list.Map[int]((x int) => x * 2)
+    val doubled = list.Map((x) => x * 2)
 
-    var t1 = Eq[int](t, doubled.Length(), 100)
+    val t1 = Eq[int](t, doubled.Length(), 100)
     var allCorrect = true
     for i := 0; i < 100; i++ {
         if doubled.Get(i) != (i * 2) {
@@ -336,9 +336,9 @@ func TestListFilterDataIntegrity(t T) T {
         list = list.Prepend(i)
     }
 
-    var evens = list.Filter((x int) => x % 2 == 0)
+    val evens = list.Filter((x) => x % 2 == 0)
 
-    var t1 = Eq[int](t, evens.Length(), 50)
+    val t1 = Eq[int](t, evens.Length(), 50)
     var allEven = true
     for i := 0; i < evens.Length(); i++ {
         if evens.Get(i) % 2 != 0 {
@@ -356,12 +356,12 @@ func TestListFoldDataIntegrity(t T) T {
     }
 
     // Sum 1 to 100 = 5050
-    var sum = list.FoldLeft[int](0, (acc int, x int) => acc + x)
-    var t1 = Eq[int](t, sum, 5050)
+    val sum = list.FoldLeft(0, (acc, x) => acc + x)
+    val t1 = Eq[int](t, sum, 5050)
 
     // Product of first 5: 1*2*3*4*5 = 120
-    var first5 = list.Take(5)
-    var product = first5.FoldLeft[int](1, (acc int, x int) => acc * x)
+    val first5 = list.Take(5)
+    val product = first5.FoldLeft(1, (acc, x) => acc * x)
     return Eq[int](t1, product, 120)
 }
 
@@ -372,8 +372,8 @@ func TestListReverseDataIntegrity(t T) T {
         list = list.Prepend(i)
     }
 
-    var reversed = list.Reverse()
-    var t1 = Eq[int](t, reversed.Length(), 100)
+    val reversed = list.Reverse()
+    val t1 = Eq[int](t, reversed.Length(), 100)
 
     var allCorrect = true
     for i := 0; i < 100; i++ {
@@ -396,31 +396,31 @@ func TestArrayImmutabilityChain(t T) T {
     }
 
     // Create multiple derived arrays
-    var appended = original.Append(999)
-    var prepended = original.Prepend(-1)
-    var updated = original.Updated(25, 999)
-    var taken = original.Take(25)
-    var dropped = original.Drop(25)
-    var mapped = original.Map[int]((x int) => x * 2)
-    var filtered = original.Filter((x int) => x % 2 == 0)
+    val appended = original.Append(999)
+    val prepended = original.Prepend(-1)
+    val updated = original.Updated(25, 999)
+    val taken = original.Take(25)
+    val dropped = original.Drop(25)
+    val mapped = original.Map((x) => x * 2)
+    val filtered = original.Filter((x) => x % 2 == 0)
 
     // Original must be unchanged
-    var t1 = Eq[int](t, original.Length(), 50)
-    var t2 = Eq[int](t1, original.Get(0), 0)
-    var t3 = Eq[int](t2, original.Get(25), 25)
-    var t4 = Eq[int](t3, original.Get(49), 49)
+    val t1 = Eq[int](t, original.Length(), 50)
+    val t2 = Eq[int](t1, original.Get(0), 0)
+    val t3 = Eq[int](t2, original.Get(25), 25)
+    val t4 = Eq[int](t3, original.Get(49), 49)
 
     // Derived arrays have expected values
-    var t5 = Eq[int](t4, appended.Length(), 51)
-    var t6 = Eq[int](t5, appended.Get(50), 999)
+    val t5 = Eq[int](t4, appended.Length(), 51)
+    val t6 = Eq[int](t5, appended.Get(50), 999)
 
-    var t7 = Eq[int](t6, prepended.Length(), 51)
-    var t8 = Eq[int](t7, prepended.Get(0), -1)
+    val t7 = Eq[int](t6, prepended.Length(), 51)
+    val t8 = Eq[int](t7, prepended.Get(0), -1)
 
-    var t9 = Eq[int](t8, updated.Get(25), 999)
-    var t10 = Eq[int](t9, taken.Length(), 25)
-    var t11 = Eq[int](t10, dropped.Length(), 25)
-    var t12 = Eq[int](t11, mapped.Get(10), 20)
+    val t9 = Eq[int](t8, updated.Get(25), 999)
+    val t10 = Eq[int](t9, taken.Length(), 25)
+    val t11 = Eq[int](t10, dropped.Length(), 25)
+    val t12 = Eq[int](t11, mapped.Get(10), 20)
     return Eq[int](t12, filtered.Length(), 25)
 }
 
@@ -432,29 +432,29 @@ func TestListImmutabilityChain(t T) T {
     }
 
     // Create multiple derived lists
-    var appended = original.Append(999)
-    var prepended = original.Prepend(-1)
-    var taken = original.Take(25)
-    var dropped = original.Drop(25)
-    var mapped = original.Map[int]((x int) => x * 2)
-    var filtered = original.Filter((x int) => x % 2 == 0)
+    val appended = original.Append(999)
+    val prepended = original.Prepend(-1)
+    val taken = original.Take(25)
+    val dropped = original.Drop(25)
+    val mapped = original.Map((x) => x * 2)
+    val filtered = original.Filter((x) => x % 2 == 0)
 
     // Original must be unchanged
-    var t1 = Eq[int](t, original.Length(), 50)
-    var t2 = Eq[int](t1, original.Get(0), 0)
-    var t3 = Eq[int](t2, original.Get(25), 25)
-    var t4 = Eq[int](t3, original.Get(49), 49)
+    val t1 = Eq[int](t, original.Length(), 50)
+    val t2 = Eq[int](t1, original.Get(0), 0)
+    val t3 = Eq[int](t2, original.Get(25), 25)
+    val t4 = Eq[int](t3, original.Get(49), 49)
 
     // Derived lists have expected values
-    var t5 = Eq[int](t4, appended.Length(), 51)
-    var t6 = Eq[int](t5, appended.Last(), 999)
+    val t5 = Eq[int](t4, appended.Length(), 51)
+    val t6 = Eq[int](t5, appended.Last(), 999)
 
-    var t7 = Eq[int](t6, prepended.Length(), 51)
-    var t8 = Eq[int](t7, prepended.Get(0), -1)
+    val t7 = Eq[int](t6, prepended.Length(), 51)
+    val t8 = Eq[int](t7, prepended.Get(0), -1)
 
-    var t9 = Eq[int](t8, taken.Length(), 25)
-    var t10 = Eq[int](t9, dropped.Length(), 25)
-    var t11 = Eq[int](t10, mapped.Get(10), 20)
+    val t9 = Eq[int](t8, taken.Length(), 25)
+    val t10 = Eq[int](t9, dropped.Length(), 25)
+    val t11 = Eq[int](t10, mapped.Get(10), 20)
     return Eq[int](t11, filtered.Length(), 25)
 }
 
@@ -469,22 +469,22 @@ func TestArrayBranchingBoundary(t T) T {
     for i := 0; i < 32; i++ {
         arr32 = arr32.Append(i)
     }
-    var t1 = Eq[int](t, arr32.Length(), 32)
-    var t2 = Eq[int](t1, arr32.Get(0), 0)
-    var t3 = Eq[int](t2, arr32.Get(31), 31)
+    val t1 = Eq[int](t, arr32.Length(), 32)
+    val t2 = Eq[int](t1, arr32.Get(0), 0)
+    val t3 = Eq[int](t2, arr32.Get(31), 31)
 
     // Test at 33 elements (triggers second leaf)
-    var arr33 = arr32.Append(32)
-    var t4 = Eq[int](t3, arr33.Length(), 33)
-    var t5 = Eq[int](t4, arr33.Get(32), 32)
+    val arr33 = arr32.Append(32)
+    val t4 = Eq[int](t3, arr33.Length(), 33)
+    val t5 = Eq[int](t4, arr33.Get(32), 32)
 
     // Test at 64 elements (two full leaves)
     var arr64 = EmptyArray[int]()
     for i := 0; i < 64; i++ {
         arr64 = arr64.Append(i)
     }
-    var t6 = Eq[int](t5, arr64.Length(), 64)
-    var t7 = Eq[int](t6, arr64.Get(31), 31)
+    val t6 = Eq[int](t5, arr64.Length(), 64)
+    val t7 = Eq[int](t6, arr64.Get(31), 31)
     return Eq[int](t7, arr64.Get(32), 32)
 }
 
@@ -495,64 +495,64 @@ func TestArrayDepth3(t T) T {
         arr = arr.Append(i)
     }
 
-    var t1 = Eq[int](t, arr.Length(), 1024)
-    var t2 = Eq[int](t1, arr.Get(0), 0)
-    var t3 = Eq[int](t2, arr.Get(511), 511)
-    var t4 = Eq[int](t3, arr.Get(512), 512)
+    val t1 = Eq[int](t, arr.Length(), 1024)
+    val t2 = Eq[int](t1, arr.Get(0), 0)
+    val t3 = Eq[int](t2, arr.Get(511), 511)
+    val t4 = Eq[int](t3, arr.Get(512), 512)
     return Eq[int](t4, arr.Get(1023), 1023)
 }
 
 // Test empty collection operations don't panic
 func TestEmptyCollectionOperations(t T) T {
-    var emptyArr = EmptyArray[int]()
-    var emptyList = EmptyList[int]()
+    val emptyArr = EmptyArray[int]()
+    val emptyList = EmptyList[int]()
 
     // These should return empty results, not panic
-    var t1 = Eq[int](t, emptyArr.Take(10).Length(), 0)
-    var t2 = Eq[int](t1, emptyArr.Drop(10).Length(), 0)
-    var t3 = Eq[int](t2, emptyArr.Filter((x int) => true).Length(), 0)
-    var t4 = Eq[int](t3, emptyArr.Map[int]((x int) => x).Length(), 0)
+    val t1 = Eq[int](t, emptyArr.Take(10).Length(), 0)
+    val t2 = Eq[int](t1, emptyArr.Drop(10).Length(), 0)
+    val t3 = Eq[int](t2, emptyArr.Filter((x) => true).Length(), 0)
+    val t4 = Eq[int](t3, emptyArr.Map((x) => x).Length(), 0)
 
-    var t5 = Eq[int](t4, emptyList.Take(10).Length(), 0)
-    var t6 = Eq[int](t5, emptyList.Drop(10).Length(), 0)
-    var t7 = Eq[int](t6, emptyList.Filter((x int) => true).Length(), 0)
-    return Eq[int](t7, emptyList.Map[int]((x int) => x).Length(), 0)
+    val t5 = Eq[int](t4, emptyList.Take(10).Length(), 0)
+    val t6 = Eq[int](t5, emptyList.Drop(10).Length(), 0)
+    val t7 = Eq[int](t6, emptyList.Filter((x) => true).Length(), 0)
+    return Eq[int](t7, emptyList.Map((x) => x).Length(), 0)
 }
 
 // Test single element operations
 func TestSingleElementOperations(t T) T {
-    var arr = ArrayOf[int](42)
-    var list = ListOf[int](42)
+    val arr = ArrayOf(42)
+    val list = ListOf(42)
 
-    var t1 = Eq[int](t, arr.Head(), 42)
-    var t2 = Eq[int](t1, arr.Last(), 42)
-    var t3 = Eq[int](t2, arr.Tail().Length(), 0)
+    val t1 = Eq[int](t, arr.Head(), 42)
+    val t2 = Eq[int](t1, arr.Last(), 42)
+    val t3 = Eq[int](t2, arr.Tail().Length(), 0)
 
-    var t4 = Eq[int](t3, list.Head(), 42)
-    var t5 = Eq[int](t4, list.Last(), 42)
+    val t4 = Eq[int](t3, list.Head(), 42)
+    val t5 = Eq[int](t4, list.Last(), 42)
     return Eq[int](t5, list.Tail().Length(), 0)
 }
 
 // Test FlatMap data integrity
 func TestArrayFlatMapDataIntegrity(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
+    val arr = ArrayOf(1, 2, 3)
 
     // Each element becomes [x, x*10]
-    var flattened = arr.FlatMap[int]((x int) => ArrayOf[int](x, x * 10))
+    val flattened = arr.FlatMap((x) => ArrayOf(x, x * 10))
 
-    var t1 = Eq[int](t, flattened.Length(), 6)
-    var t2 = Eq[int](t1, flattened.Get(0), 1)
-    var t3 = Eq[int](t2, flattened.Get(1), 10)
-    var t4 = Eq[int](t3, flattened.Get(2), 2)
-    var t5 = Eq[int](t4, flattened.Get(3), 20)
-    var t6 = Eq[int](t5, flattened.Get(4), 3)
+    val t1 = Eq[int](t, flattened.Length(), 6)
+    val t2 = Eq[int](t1, flattened.Get(0), 1)
+    val t3 = Eq[int](t2, flattened.Get(1), 10)
+    val t4 = Eq[int](t3, flattened.Get(2), 2)
+    val t5 = Eq[int](t4, flattened.Get(3), 20)
+    val t6 = Eq[int](t5, flattened.Get(4), 3)
     return Eq[int](t6, flattened.Get(5), 30)
 }
 
 // Test Concat data integrity (using manual iteration since Array.Concat expects Iterable)
 func TestArrayConcatDataIntegrity(t T) T {
-    var arr1 = ArrayOf[int](1, 2, 3)
-    var arr2 = ArrayOf[int](4, 5, 6)
+    val arr1 = ArrayOf(1, 2, 3)
+    val arr2 = ArrayOf(4, 5, 6)
 
     // Manually concatenate since Array doesn't implement Iterable interface
     var concatenated = arr1
@@ -560,7 +560,7 @@ func TestArrayConcatDataIntegrity(t T) T {
         concatenated = concatenated.Append(arr2.Get(i))
     }
 
-    var t1 = Eq[int](t, concatenated.Length(), 6)
+    val t1 = Eq[int](t, concatenated.Length(), 6)
     var allCorrect = true
     for i := 0; i < 6; i++ {
         if concatenated.Get(i) != (i + 1) {
@@ -577,12 +577,12 @@ func TestArrayPartitionDataIntegrity(t T) T {
         arr = arr.Append(i)
     }
 
-    var partitioned = arr.Partition((x int) => x % 2 == 0)
-    var evens = partitioned.V1
-    var odds = partitioned.V2
+    val partitioned = arr.Partition((x) => x % 2 == 0)
+    val evens = partitioned.V1
+    val odds = partitioned.V2
 
-    var t1 = Eq[int](t, evens.Length(), 50)
-    var t2 = Eq[int](t1, odds.Length(), 50)
+    val t1 = Eq[int](t, evens.Length(), 50)
+    val t2 = Eq[int](t1, odds.Length(), 50)
 
     // Verify evens
     var evensCorrect = true
@@ -600,73 +600,73 @@ func TestArrayPartitionDataIntegrity(t T) T {
         }
     }
 
-    var t3 = IsTrue(t2, evensCorrect)
+    val t3 = IsTrue(t2, evensCorrect)
     return IsTrue(t3, oddsCorrect)
 }
 
 // Test Zip data integrity
 func TestArrayZipDataIntegrity(t T) T {
-    var arr1 = ArrayOf[int](1, 2, 3, 4, 5)
-    var arr2 = ArrayOf[string]("a", "b", "c", "d", "e")
-    var arr3 = ArrayOf[int](10, 20, 30)  // Shorter array
+    val arr1 = ArrayOf(1, 2, 3, 4, 5)
+    val arr2 = ArrayOf("a", "b", "c", "d", "e")
+    val arr3 = ArrayOf(10, 20, 30)  // Shorter array
 
     // Test basic zip
-    var zipped = arr1.Zip[string](arr2)
-    var t1 = Eq[int](t, zipped.Length(), 5)
+    val zipped = arr1.Zip[string](arr2)
+    val t1 = Eq[int](t, zipped.Length(), 5)
 
     // Test zip with different lengths (takes minimum)
-    var zippedShort = arr1.Zip[int](arr3)
-    var t2 = Eq[int](t1, zippedShort.Length(), 3)
+    val zippedShort = arr1.Zip[int](arr3)
+    val t2 = Eq[int](t1, zippedShort.Length(), 3)
 
     // Test empty arrays
-    var empty = EmptyArray[int]()
-    var zippedEmpty = empty.Zip[string](arr2)
-    var t3 = Eq[int](t2, zippedEmpty.Length(), 0)
+    val empty = EmptyArray[int]()
+    val zippedEmpty = empty.Zip[string](arr2)
+    val t3 = Eq[int](t2, zippedEmpty.Length(), 0)
 
     // Verify tuple contents by extracting and checking first element of each pair
-    var first0 = zippedShort.Get(0)
-    var first0V1 = first0.V1
-    var first1 = zippedShort.Get(1)
-    var first1V1 = first1.V1
-    var first2 = zippedShort.Get(2)
-    var first2V1 = first2.V1
+    val first0 = zippedShort.Get(0)
+    val first0V1 = first0.V1
+    val first1 = zippedShort.Get(1)
+    val first1V1 = first1.V1
+    val first2 = zippedShort.Get(2)
+    val first2V1 = first2.V1
 
-    var t4 = Eq[int](t3, first0V1, 1)
-    var t5 = Eq[int](t4, first1V1, 2)
+    val t4 = Eq[int](t3, first0V1, 1)
+    val t5 = Eq[int](t4, first1V1, 2)
     return Eq[int](t5, first2V1, 3)
 }
 
 // Test ZipWithIndex data integrity
 func TestArrayZipWithIndexDataIntegrity(t T) T {
-    var arr = ArrayOf[string]("a", "b", "c", "d", "e")
-    var zipped = arr.ZipWithIndex()
+    val arr = ArrayOf("a", "b", "c", "d", "e")
+    val zipped = arr.ZipWithIndex()
 
-    var t1 = Eq[int](t, zipped.Length(), 5)
+    val t1 = Eq[int](t, zipped.Length(), 5)
 
     // Test empty array
-    var empty = EmptyArray[string]()
-    var zippedEmpty = empty.ZipWithIndex()
-    var t2 = Eq[int](t1, zippedEmpty.Length(), 0)
+    val empty = EmptyArray[string]()
+    val zippedEmpty = empty.ZipWithIndex()
+    val t2 = Eq[int](t1, zippedEmpty.Length(), 0)
 
     // Verify tuple contents by extracting and checking index values
-    var elem0 = zipped.Get(0)
-    var elem0V2 = elem0.V2
-    var elem2 = zipped.Get(2)
-    var elem2V2 = elem2.V2
-    var elem4 = zipped.Get(4)
-    var elem4V2 = elem4.V2
+    val elem0 = zipped.Get(0)
+    val elem0V2 = elem0.V2
+    val elem2 = zipped.Get(2)
+    val elem2V2 = elem2.V2
+    val elem4 = zipped.Get(4)
+    val elem4V2 = elem4.V2
 
-    var t3 = Eq[int](t2, elem0V2, 0)
-    var t4 = Eq[int](t3, elem2V2, 2)
+    val t3 = Eq[int](t2, elem0V2, 0)
+    val t4 = Eq[int](t3, elem2V2, 2)
     return Eq[int](t4, elem4V2, 4)
 }
 
 // Test Distinct data integrity
 func TestArrayDistinctDataIntegrity(t T) T {
-    var arr = ArrayOf[int](1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5)
-    var distinct = arr.Distinct()
+    val arr = ArrayOf(1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5)
+    val distinct = arr.Distinct()
 
-    var t1 = Eq[int](t, distinct.Length(), 5)
+    val t1 = Eq[int](t, distinct.Length(), 5)
 
     var allCorrect = true
     for i := 0; i < 5; i++ {
@@ -684,28 +684,28 @@ func TestArrayGroupedDataIntegrity(t T) T {
         arr = arr.Append(i)
     }
 
-    var grouped = arr.Grouped(3)
-    var t1 = Eq[int](t, grouped.Length(), 4)
-    var t2 = Eq[int](t1, grouped.Get(0).Length(), 3)  // [1,2,3]
-    var t3 = Eq[int](t2, grouped.Get(1).Length(), 3)  // [4,5,6]
-    var t4 = Eq[int](t3, grouped.Get(2).Length(), 3)  // [7,8,9]
-    var t5 = Eq[int](t4, grouped.Get(3).Length(), 1)  // [10]
+    val grouped = arr.Grouped(3)
+    val t1 = Eq[int](t, grouped.Length(), 4)
+    val t2 = Eq[int](t1, grouped.Get(0).Length(), 3)  // [1,2,3]
+    val t3 = Eq[int](t2, grouped.Get(1).Length(), 3)  // [4,5,6]
+    val t4 = Eq[int](t3, grouped.Get(2).Length(), 3)  // [7,8,9]
+    val t5 = Eq[int](t4, grouped.Get(3).Length(), 1)  // [10]
 
-    var t6 = Eq[int](t5, grouped.Get(0).Get(0), 1)
+    val t6 = Eq[int](t5, grouped.Get(0).Get(0), 1)
     return Eq[int](t6, grouped.Get(3).Get(0), 10)
 }
 
 // Test Sliding window data integrity
 func TestArraySlidingDataIntegrity(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4, 5)
-    var windows = arr.Sliding(3)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val windows = arr.Sliding(3)
 
-    var t1 = Eq[int](t, windows.Length(), 3)  // [1,2,3], [2,3,4], [3,4,5]
+    val t1 = Eq[int](t, windows.Length(), 3)  // [1,2,3], [2,3,4], [3,4,5]
 
-    var t2 = Eq[int](t1, windows.Get(0).Get(0), 1)
-    var t3 = Eq[int](t2, windows.Get(0).Get(2), 3)
-    var t4 = Eq[int](t3, windows.Get(1).Get(0), 2)
-    var t5 = Eq[int](t4, windows.Get(2).Get(0), 3)
+    val t2 = Eq[int](t1, windows.Get(0).Get(0), 1)
+    val t3 = Eq[int](t2, windows.Get(0).Get(2), 3)
+    val t4 = Eq[int](t3, windows.Get(1).Get(0), 2)
+    val t5 = Eq[int](t4, windows.Get(2).Get(0), 3)
     return Eq[int](t5, windows.Get(2).Get(2), 5)
 }
 
@@ -717,7 +717,7 @@ func TestArrayMassivePrepend(t T) T {
         arr = arr.Prepend(i)
     }
 
-    var t1 = Eq[int](t, arr.Length(), 200)
+    val t1 = Eq[int](t, arr.Length(), 200)
     var allCorrect = true
     for i := 0; i < 200; i++ {
         if arr.Get(i) != (i + 1) {
@@ -729,7 +729,7 @@ func TestArrayMassivePrepend(t T) T {
 
 // Test interleaved prepend/append maintains order
 func TestArrayInterleavedPrependAppend(t T) T {
-    var arr = ArrayOf[int](50)
+    var arr = ArrayOf(50)
 
     // Interleave: prepend 49, append 51, prepend 48, append 52, ...
     for i := 1; i <= 49; i++ {
@@ -738,7 +738,7 @@ func TestArrayInterleavedPrependAppend(t T) T {
     }
 
     // Should have 99 elements: 1, 2, ..., 99
-    var t1 = Eq[int](t, arr.Length(), 99)
+    val t1 = Eq[int](t, arr.Length(), 99)
 
     var allCorrect = true
     for i := 0; i < 99; i++ {

--- a/collection_mutable/array.gala
+++ b/collection_mutable/array.gala
@@ -1,7 +1,6 @@
 package collection_mutable
 
 import (
-    "fmt"
     "sort"
     . "martianoff/gala/std"
     "martianoff/gala/go_interop"
@@ -105,7 +104,7 @@ func (a *Array[T]) Capacity() int = cap(a.elements)
 // Panics if index is out of bounds.
 func (a *Array[T]) Get(index int) T {
     if (index < 0) || (index >= len(a.elements)) {
-        panic(fmt.Sprintf("Array.Get: index %d out of bounds [0, %d)", index, len(a.elements)))
+        panic(f"Array.Get: index $index out of bounds [0, ${len(a.elements)})")
     }
     return a.elements[index]
 }
@@ -158,7 +157,7 @@ func (a *Array[T]) LastOption() Option[T] {
 // Panics if index is out of bounds.
 func (a *Array[T]) Set(index int, value T) {
     if (index < 0) || (index >= len(a.elements)) {
-        panic(fmt.Sprintf("Array.Set: index %d out of bounds [0, %d)", index, len(a.elements)))
+        panic(f"Array.Set: index $index out of bounds [0, ${len(a.elements)})")
     }
     a.elements[index] = value
 }
@@ -194,7 +193,7 @@ func (a *Array[T]) PrependAll(values []T) {
 // Panics if index is out of bounds (0 <= index <= length).
 func (a *Array[T]) Insert(index int, value T) {
     if (index < 0) || (index > len(a.elements)) {
-        panic(fmt.Sprintf("Array.Insert: index %d out of bounds [0, %d]", index, len(a.elements)))
+        panic(f"Array.Insert: index $index out of bounds [0, ${len(a.elements)}]")
     }
     a.elements = go_interop.SliceInsert(a.elements, index, value)
 }
@@ -203,7 +202,7 @@ func (a *Array[T]) Insert(index int, value T) {
 // Panics if index is out of bounds.
 func (a *Array[T]) RemoveAt(index int) {
     if (index < 0) || (index >= len(a.elements)) {
-        panic(fmt.Sprintf("Array.RemoveAt: index %d out of bounds [0, %d)", index, len(a.elements)))
+        panic(f"Array.RemoveAt: index $index out of bounds [0, ${len(a.elements)})")
     }
     a.elements = go_interop.SliceRemoveAt(a.elements, index)
 }
@@ -654,7 +653,7 @@ func (a *Array[T]) String() string {
         if i > 0 {
             result = result + ", "
         }
-        result = result + fmt.Sprintf("%v", a.elements[i])
+        result = result + s"${a.elements[i]}"
     }
     return result + ")"
 }
@@ -669,7 +668,7 @@ func (a *Array[T]) MkString(sep string) string {
         if i > 0 {
             result = result + sep
         }
-        result = result + fmt.Sprintf("%v", a.elements[i])
+        result = result + s"${a.elements[i]}"
     }
     return result
 }

--- a/collection_mutable/array_test.gala
+++ b/collection_mutable/array_test.gala
@@ -9,142 +9,142 @@ import (
 // === Array Creation Tests ===
 
 func TestEmpty(t T) T {
-    var arr = EmptyArray[int]()
-    var t1 = IsTrue(t, arr.IsEmpty())
+    val arr = EmptyArray[int]()
+    val t1 = IsTrue(t, arr.IsEmpty())
     return Eq[int](t1, arr.Length(), 0)
 }
 
 func TestArrayOf(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
-    var t1 = IsFalse(t, arr.IsEmpty())
+    val arr = ArrayOf(1, 2, 3)
+    val t1 = IsFalse(t, arr.IsEmpty())
     return Eq[int](t1, arr.Length(), 3)
 }
 
 func TestArrayFromSlice(t T) T {
-    var slice = go_interop.SliceOf(10, 20, 30)
-    var arr = ArrayFromSlice(slice)
-    var t1 = Eq[int](t, arr.Length(), 3)
+    val slice = go_interop.SliceOf(10, 20, 30)
+    val arr = ArrayFromSlice(slice)
+    val t1 = Eq[int](t, arr.Length(), 3)
     return Eq[int](t1, arr.Get(0), 10)
 }
 
 func TestArrayWithCapacity(t T) T {
-    var arr = ArrayWithCapacity[int](100)
-    var t1 = Eq[int](t, arr.Length(), 0)
+    val arr = ArrayWithCapacity[int](100)
+    val t1 = Eq[int](t, arr.Length(), 0)
     return IsTrue(t1, arr.Capacity() >= 100)
 }
 
 // === Array Access Tests ===
 
 func TestArrayGet(t T) T {
-    var arr = ArrayOf[int](10, 20, 30)
-    var t1 = Eq[int](t, arr.Get(0), 10)
-    var t2 = Eq[int](t1, arr.Get(1), 20)
+    val arr = ArrayOf(10, 20, 30)
+    val t1 = Eq[int](t, arr.Get(0), 10)
+    val t2 = Eq[int](t1, arr.Get(1), 20)
     return Eq[int](t2, arr.Get(2), 30)
 }
 
 func TestArrayHead(t T) T {
-    var arr = ArrayOf[string]("first", "second", "third")
+    val arr = ArrayOf("first", "second", "third")
     return Eq[string](t, arr.Head(), "first")
 }
 
 func TestArrayLast(t T) T {
-    var arr = ArrayOf[string]("first", "second", "third")
+    val arr = ArrayOf("first", "second", "third")
     return Eq[string](t, arr.Last(), "third")
 }
 
 func TestArrayHeadOption(t T) T {
-    var arr = ArrayOf[int](42)
-    var opt = arr.HeadOption()
-    var t1 = IsSome(t, opt)
+    val arr = ArrayOf(42)
+    val opt = arr.HeadOption()
+    val t1 = IsSome(t, opt)
     return Eq[int](t1, opt.Get(), 42)
 }
 
 func TestArrayHeadOptionEmpty(t T) T {
-    var arr = EmptyArray[int]()
-    var opt = arr.HeadOption()
+    val arr = EmptyArray[int]()
+    val opt = arr.HeadOption()
     return IsNone(t, opt)
 }
 
 // === Array Mutation Tests ===
 
 func TestArraySet(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
+    val arr = ArrayOf(1, 2, 3)
     arr.Set(1, 99)
     return Eq[int](t, arr.Get(1), 99)
 }
 
 func TestArrayAppend(t T) T {
-    var arr = ArrayOf[int](1, 2)
+    val arr = ArrayOf(1, 2)
     arr.Append(3)
-    var t1 = Eq[int](t, arr.Length(), 3)
+    val t1 = Eq[int](t, arr.Length(), 3)
     return Eq[int](t1, arr.Get(2), 3)
 }
 
 func TestArrayPrepend(t T) T {
-    var arr = ArrayOf[int](2, 3)
+    val arr = ArrayOf(2, 3)
     arr.Prepend(1)
-    var t1 = Eq[int](t, arr.Length(), 3)
+    val t1 = Eq[int](t, arr.Length(), 3)
     return Eq[int](t1, arr.Head(), 1)
 }
 
 func TestArrayInsert(t T) T {
-    var arr = ArrayOf[int](1, 3)
+    val arr = ArrayOf(1, 3)
     arr.Insert(1, 2)
-    var t1 = Eq[int](t, arr.Length(), 3)
-    var t2 = Eq[int](t1, arr.Get(0), 1)
-    var t3 = Eq[int](t2, arr.Get(1), 2)
+    val t1 = Eq[int](t, arr.Length(), 3)
+    val t2 = Eq[int](t1, arr.Get(0), 1)
+    val t3 = Eq[int](t2, arr.Get(1), 2)
     return Eq[int](t3, arr.Get(2), 3)
 }
 
 func TestArrayRemoveAt(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
+    val arr = ArrayOf(1, 2, 3)
     arr.RemoveAt(1)
-    var t1 = Eq[int](t, arr.Length(), 2)
-    var t2 = Eq[int](t1, arr.Get(0), 1)
+    val t1 = Eq[int](t, arr.Length(), 2)
+    val t2 = Eq[int](t1, arr.Get(0), 1)
     return Eq[int](t2, arr.Get(1), 3)
 }
 
 func TestArrayRemoveFirst(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
-    var removed = arr.RemoveFirst()
-    var t1 = Eq[int](t, removed, 1)
-    var t2 = Eq[int](t1, arr.Length(), 2)
+    val arr = ArrayOf(1, 2, 3)
+    val removed = arr.RemoveFirst()
+    val t1 = Eq[int](t, removed, 1)
+    val t2 = Eq[int](t1, arr.Length(), 2)
     return Eq[int](t2, arr.Head(), 2)
 }
 
 func TestArrayRemoveLast(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
-    var removed = arr.RemoveLast()
-    var t1 = Eq[int](t, removed, 3)
-    var t2 = Eq[int](t1, arr.Length(), 2)
+    val arr = ArrayOf(1, 2, 3)
+    val removed = arr.RemoveLast()
+    val t1 = Eq[int](t, removed, 3)
+    val t2 = Eq[int](t1, arr.Length(), 2)
     return Eq[int](t2, arr.Last(), 2)
 }
 
 func TestArrayClear(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
+    val arr = ArrayOf(1, 2, 3)
     arr.Clear()
     return IsTrue(t, arr.IsEmpty())
 }
 
 func TestArrayReverse(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
+    val arr = ArrayOf(1, 2, 3)
     arr.Reverse()
-    var t1 = Eq[int](t, arr.Get(0), 3)
-    var t2 = Eq[int](t1, arr.Get(1), 2)
+    val t1 = Eq[int](t, arr.Get(0), 3)
+    val t2 = Eq[int](t1, arr.Get(1), 2)
     return Eq[int](t2, arr.Get(2), 1)
 }
 
 // === Array Search Tests ===
 
 func TestArrayContains(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
-    var t1 = IsTrue(t, arr.Contains(2))
+    val arr = ArrayOf(1, 2, 3)
+    val t1 = IsTrue(t, arr.Contains(2))
     return IsFalse(t1, arr.Contains(5))
 }
 
 func TestArrayIndexOf(t T) T {
-    var arr = ArrayOf[string]("a", "b", "c")
-    var t1 = Eq[int](t, arr.IndexOf("b"), 1)
+    val arr = ArrayOf("a", "b", "c")
+    val t1 = Eq[int](t, arr.IndexOf("b"), 1)
     return Eq[int](t1, arr.IndexOf("z"), -1)
 }
 
@@ -153,28 +153,28 @@ func TestArrayIndexOf(t T) T {
 func doubleValue(x int) int = x * 2
 
 func TestArrayMap(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
-    var mapped = Array_Map[int, int](arr, doubleValue)
-    var t1 = Eq[int](t, mapped.Get(0), 2)
-    var t2 = Eq[int](t1, mapped.Get(1), 4)
+    val arr = ArrayOf(1, 2, 3)
+    val mapped = Array_Map[int, int](arr, doubleValue)
+    val t1 = Eq[int](t, mapped.Get(0), 2)
+    val t2 = Eq[int](t1, mapped.Get(1), 4)
     return Eq[int](t2, mapped.Get(2), 6)
 }
 
 func isEven(x int) bool = x % 2 == 0
 
 func TestArrayFilter(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4, 5)
-    var filtered = arr.Filter(isEven)
-    var t1 = Eq[int](t, filtered.Length(), 2)
-    var t2 = Eq[int](t1, filtered.Get(0), 2)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val filtered = arr.Filter(isEven)
+    val t1 = Eq[int](t, filtered.Length(), 2)
+    val t2 = Eq[int](t1, filtered.Get(0), 2)
     return Eq[int](t2, filtered.Get(1), 4)
 }
 
 func sum(acc int, x int) int = acc + x
 
 func TestArrayFoldLeft(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4)
-    var result = Array_FoldLeft[int](arr, 0, sum)
+    val arr = ArrayOf(1, 2, 3, 4)
+    val result = Array_FoldLeft[int](arr, 0, sum)
     return Eq[int](t, result, 10)
 }
 
@@ -183,133 +183,133 @@ func TestArrayFoldLeft(t T) T {
 func isGreaterThanZero(x int) bool = x > 0
 
 func TestArrayExists(t T) T {
-    var arr = ArrayOf[int](-1, 0, 1, 2)
+    val arr = ArrayOf(-1, 0, 1, 2)
     return IsTrue(t, arr.Exists(isGreaterThanZero))
 }
 
 func TestArrayForAll(t T) T {
-    var arr1 = ArrayOf[int](1, 2, 3)
-    var arr2 = ArrayOf[int](-1, 0, 1)
-    var t1 = IsTrue(t, arr1.ForAll(isGreaterThanZero))
+    val arr1 = ArrayOf(1, 2, 3)
+    val arr2 = ArrayOf(-1, 0, 1)
+    val t1 = IsTrue(t, arr1.ForAll(isGreaterThanZero))
     return IsFalse(t1, arr2.ForAll(isGreaterThanZero))
 }
 
 func isGreaterThanTen(x int) bool = x > 10
 
 func TestArrayFind(t T) T {
-    var arr = ArrayOf[int](5, 15, 25)
-    var found = arr.Find(isGreaterThanTen)
-    var t1 = IsSome(t, found)
+    val arr = ArrayOf(5, 15, 25)
+    val found = arr.Find(isGreaterThanTen)
+    val t1 = IsSome(t, found)
     return Eq[int](t1, found.Get(), 15)
 }
 
 func TestArrayCount(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4, 5)
-    var count = arr.Count(isEven)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val count = arr.Count(isEven)
     return Eq[int](t, count, 2)
 }
 
 // === Array Utility Tests ===
 
 func TestArrayTake(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4, 5)
-    var taken = arr.Take(3)
-    var t1 = Eq[int](t, taken.Length(), 3)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val taken = arr.Take(3)
+    val t1 = Eq[int](t, taken.Length(), 3)
     return Eq[int](t1, taken.Last(), 3)
 }
 
 func TestArrayDrop(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4, 5)
-    var dropped = arr.Drop(2)
-    var t1 = Eq[int](t, dropped.Length(), 3)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val dropped = arr.Drop(2)
+    val t1 = Eq[int](t, dropped.Length(), 3)
     return Eq[int](t1, dropped.Head(), 3)
 }
 
 func TestArraySlice(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4, 5)
-    var sliced = arr.Slice(1, 4)
-    var t1 = Eq[int](t, sliced.Length(), 3)
-    var t2 = Eq[int](t1, sliced.Head(), 2)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val sliced = arr.Slice(1, 4)
+    val t1 = Eq[int](t, sliced.Length(), 3)
+    val t2 = Eq[int](t1, sliced.Head(), 2)
     return Eq[int](t2, sliced.Last(), 4)
 }
 
 func TestArrayClone(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
-    var clone = arr.Clone()
+    val arr = ArrayOf(1, 2, 3)
+    val clone = arr.Clone()
     clone.Set(0, 99)
-    var t1 = Eq[int](t, arr.Get(0), 1)
+    val t1 = Eq[int](t, arr.Get(0), 1)
     return Eq[int](t1, clone.Get(0), 99)
 }
 
 func TestArrayDistinct(t T) T {
-    var arr = ArrayOf[int](1, 2, 2, 3, 3, 3)
-    var distinct = arr.Distinct()
+    val arr = ArrayOf(1, 2, 2, 3, 3, 3)
+    val distinct = arr.Distinct()
     return Eq[int](t, distinct.Length(), 3)
 }
 
 func TestArrayGrouped(t T) T {
-    var arr = ArrayOf[int](1, 2, 3, 4, 5)
-    var grouped = Array_Grouped[int](arr, 2)
-    var t1 = Eq[int](t, grouped.Length(), 3)
-    var t2 = Eq[int](t1, grouped.Get(0).Length(), 2)
+    val arr = ArrayOf(1, 2, 3, 4, 5)
+    val grouped = Array_Grouped[int](arr, 2)
+    val t1 = Eq[int](t, grouped.Length(), 3)
+    val t2 = Eq[int](t1, grouped.Get(0).Length(), 2)
     return Eq[int](t2, grouped.Get(2).Length(), 1)
 }
 
 func TestArrayString(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
+    val arr = ArrayOf(1, 2, 3)
     return Eq[string](t, arr.String(), "Array(1, 2, 3)")
 }
 
 func TestEmptyString(t T) T {
-    var arr = EmptyArray[int]()
+    val arr = EmptyArray[int]()
     return Eq[string](t, arr.String(), "Array()")
 }
 
 // === Array Mutability Tests ===
 
 func TestArrayMutability(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
+    val arr = ArrayOf(1, 2, 3)
     arr.Append(4)
     arr.Set(0, 10)
-    var t1 = Eq[int](t, arr.Length(), 4)
-    var t2 = Eq[int](t1, arr.Get(0), 10)
+    val t1 = Eq[int](t, arr.Length(), 4)
+    val t2 = Eq[int](t1, arr.Get(0), 10)
     return Eq[int](t2, arr.Get(3), 4)
 }
 
 func TestArrayMultipleMutations(t T) T {
-    var arr = ArrayOf[int](1, 2, 3)
+    val arr = ArrayOf(1, 2, 3)
     arr.Append(4)
     arr.Prepend(0)
     arr.Set(2, 99)
     arr.RemoveAt(3)
-    var t1 = Eq[int](t, arr.Length(), 4)
-    var t2 = Eq[int](t1, arr.Get(0), 0)
-    var t3 = Eq[int](t2, arr.Get(2), 99)
+    val t1 = Eq[int](t, arr.Length(), 4)
+    val t2 = Eq[int](t1, arr.Get(0), 0)
+    val t3 = Eq[int](t2, arr.Get(2), 99)
     return Eq[int](t3, arr.Get(3), 4)
 }
 
 // === Large Array Tests ===
 
 func TestArrayLarge(t T) T {
-    var arr = EmptyArray[int]()
+    val arr = EmptyArray[int]()
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
-    var t1 = Eq[int](t, arr.Length(), 10000)
-    var t2 = Eq[int](t1, arr.Get(0), 0)
-    var t3 = Eq[int](t2, arr.Get(5000), 5000)
+    val t1 = Eq[int](t, arr.Length(), 10000)
+    val t2 = Eq[int](t1, arr.Get(0), 0)
+    val t3 = Eq[int](t2, arr.Get(5000), 5000)
     return Eq[int](t3, arr.Get(9999), 9999)
 }
 
 func TestArrayLargeMutations(t T) T {
-    var arr = ArrayWithCapacity[int](10000)
+    val arr = ArrayWithCapacity[int](10000)
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
     for i := 0; i < 10000; i++ {
         arr.Set(i, i * 2)
     }
-    var t1 = Eq[int](t, arr.Get(0), 0)
-    var t2 = Eq[int](t1, arr.Get(5000), 10000)
+    val t1 = Eq[int](t, arr.Get(0), 0)
+    val t2 = Eq[int](t1, arr.Get(5000), 10000)
     return Eq[int](t2, arr.Get(9999), 19998)
 }

--- a/collection_mutable/hashmap.gala
+++ b/collection_mutable/hashmap.gala
@@ -259,11 +259,10 @@ func (m *HashMap[K, V]) GetOrElse(key K, defaultValue V) V {
 
 // Apply returns the value for a key. Panics if key not found.
 func (m *HashMap[K, V]) Apply(key K) V {
-    val opt = m.Get(key)
-    if opt.IsEmpty() {
-        panic(fmt.Sprintf("HashMap: key not found: %v", key))
+    return m.Get(key) match {
+        case Some(v) => v
+        case None() => panic(s"HashMap: key not found: $key")
     }
-    return opt.Get()
 }
 
 // ContainsAllKeys returns true if the map contains all keys from an Array.
@@ -525,7 +524,7 @@ func (m *HashMap[K, V]) String() string {
         if !first {
             result = result + ", "
         }
-        result = result + fmt.Sprintf("%v -> %v", k, v)
+        result = result + s"$k -> $v"
         first = false
     })
     return result + ")"
@@ -542,7 +541,7 @@ func (m *HashMap[K, V]) MkString(sep string) string {
         if !first {
             result = result + sep
         }
-        result = result + fmt.Sprintf("%v -> %v", k, v)
+        result = result + s"$k -> $v"
         first = false
     })
     return result
@@ -574,11 +573,9 @@ func (m *HashMap[K, V]) PutFrom(other *HashMap[K, V]) {
 // Merge merges another map, using a function for duplicate keys.
 func (m *HashMap[K, V]) Merge(other *HashMap[K, V], f func(V, V) V) {
     other.ForEachKV((k K, v V) => {
-        val existing = m.Get(k)
-        if existing.IsDefined() {
-            m.Put(k, f(existing.Get(), v))
-        } else {
-            m.Put(k, v)
+        m.Get(k) match {
+            case Some(e) => m.Put(k, f(e, v))
+            case None() => m.Put(k, v)
         }
     })
 }
@@ -604,11 +601,10 @@ func (m *HashMap[K, V]) Find(p func(K, V) bool) Option[Tuple[K, V]] {
 
 // Head returns the first entry. Panics if empty.
 func (m *HashMap[K, V]) Head() Tuple[K, V] {
-    val opt = m.HeadOption()
-    if opt.IsEmpty() {
-        panic("HashMap: head of empty map")
+    return m.HeadOption() match {
+        case Some(v) => v
+        case None() => panic("HashMap: head of empty map")
     }
-    return opt.Get()
 }
 
 // HeadOption returns the first entry as Option.

--- a/collection_mutable/hashmap_test.gala
+++ b/collection_mutable/hashmap_test.gala
@@ -12,43 +12,43 @@ import (
 
 func TestHashMapEmpty(t T) T {
     val m = EmptyHashMap[string, int]()
-    var t1 = IsTrue(t, m.IsEmpty())
-    var t2 = IsFalse(t1, m.NonEmpty())
+    val t1 = IsTrue(t, m.IsEmpty())
+    val t2 = IsFalse(t1, m.NonEmpty())
     return Eq[int](t2, m.Size(), 0)
 }
 
 func TestHashMapPut(t T) T {
     val m = EmptyHashMap[string, int]()
-    var added1 = m.Put("a", 1)
-    var added2 = m.Put("b", 2)
-    var added3 = m.Put("c", 3)
+    val added1 = m.Put("a", 1)
+    val added2 = m.Put("b", 2)
+    val added3 = m.Put("c", 3)
 
-    var t1 = IsTrue(t, added1)
-    var t2 = IsTrue(t1, added2)
-    var t3 = IsTrue(t2, added3)
+    val t1 = IsTrue(t, added1)
+    val t2 = IsTrue(t1, added2)
+    val t3 = IsTrue(t2, added3)
     return Eq[int](t3, m.Size(), 3)
 }
 
 func TestHashMapPutUpdate(t T) T {
     val m = EmptyHashMap[string, int]()
-    var added1 = m.Put("a", 1)
-    var added2 = m.Put("a", 2)
+    val added1 = m.Put("a", 1)
+    val added2 = m.Put("a", 2)
 
-    var t1 = IsTrue(t, added1)
-    var t2 = IsFalse(t1, added2)
-    var t3 = Eq[int](t2, m.Size(), 1)
+    val t1 = IsTrue(t, added1)
+    val t2 = IsFalse(t1, added2)
+    val t3 = Eq[int](t2, m.Size(), 1)
     return Eq[int](t3, m.GetOrElse("a", 0), 2)
 }
 
 func TestHashMapOf(t T) T {
     val m = HashMapOf[string, int](
-        Tuple[string, int](V1 = "a", V2 = 1),
-        Tuple[string, int](V1 = "b", V2 = 2),
-        Tuple[string, int](V1 = "c", V2 = 3)
+        ("a", 1),
+        ("b", 2),
+        ("c", 3)
     )
-    var t1 = Eq[int](t, m.Size(), 3)
-    var t2 = IsTrue(t1, m.Contains("a"))
-    var t3 = IsTrue(t2, m.Contains("b"))
+    val t1 = Eq[int](t, m.Size(), 3)
+    val t2 = IsTrue(t1, m.Contains("a"))
+    val t3 = IsTrue(t2, m.Contains("b"))
     return IsTrue(t3, m.Contains("c"))
 }
 
@@ -56,8 +56,8 @@ func TestHashMapContains(t T) T {
     val m = EmptyHashMap[string, int]()
     m.Put("a", 1)
     m.Put("b", 2)
-    var t1 = IsTrue(t, m.Contains("a"))
-    var t2 = IsTrue(t1, m.Contains("b"))
+    val t1 = IsTrue(t, m.Contains("a"))
+    val t2 = IsTrue(t1, m.Contains("b"))
     return IsFalse(t2, m.Contains("c"))
 }
 
@@ -65,16 +65,16 @@ func TestHashMapGet(t T) T {
     val m = EmptyHashMap[string, int]()
     m.Put("a", 1)
     m.Put("b", 2)
-    var t1 = IsSome(t, m.Get("a"))
-    var t2 = Eq[int](t1, m.Get("a").Get(), 1)
-    var t3 = Eq[int](t2, m.Get("b").Get(), 2)
+    val t1 = IsSome(t, m.Get("a"))
+    val t2 = Eq[int](t1, m.Get("a").Get(), 1)
+    val t3 = Eq[int](t2, m.Get("b").Get(), 2)
     return IsNone(t3, m.Get("c"))
 }
 
 func TestHashMapGetOrElse(t T) T {
     val m = EmptyHashMap[string, int]()
     m.Put("a", 1)
-    var t1 = Eq[int](t, m.GetOrElse("a", 0), 1)
+    val t1 = Eq[int](t, m.GetOrElse("a", 0), 1)
     return Eq[int](t1, m.GetOrElse("b", 42), 42)
 }
 
@@ -83,20 +83,20 @@ func TestHashMapRemove(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     m.Put("c", 3)
-    var removed = m.Remove("b")
+    val removed = m.Remove("b")
 
-    var t1 = IsTrue(t, removed)
-    var t2 = Eq[int](t1, m.Size(), 2)
-    var t3 = IsTrue(t2, m.Contains("a"))
-    var t4 = IsFalse(t3, m.Contains("b"))
+    val t1 = IsTrue(t, removed)
+    val t2 = Eq[int](t1, m.Size(), 2)
+    val t3 = IsTrue(t2, m.Contains("a"))
+    val t4 = IsFalse(t3, m.Contains("b"))
     return IsTrue(t4, m.Contains("c"))
 }
 
 func TestHashMapRemoveNonExistent(t T) T {
     val m = EmptyHashMap[string, int]()
     m.Put("a", 1)
-    var removed = m.Remove("b")
-    var t1 = IsFalse(t, removed)
+    val removed = m.Remove("b")
+    val t1 = IsFalse(t, removed)
     return Eq[int](t1, m.Size(), 1)
 }
 
@@ -105,7 +105,7 @@ func TestHashMapClear(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     m.Clear()
-    var t1 = Eq[int](t, m.Size(), 0)
+    val t1 = Eq[int](t, m.Size(), 0)
     return IsTrue(t1, m.IsEmpty())
 }
 
@@ -116,9 +116,9 @@ func TestHashMapIntKeys(t T) T {
     m.Put(1, "one")
     m.Put(2, "two")
     m.Put(3, "three")
-    var t1 = Eq[int](t, m.Size(), 3)
-    var t2 = Eq[string](t1, m.GetOrElse(1, ""), "one")
-    var t3 = Eq[string](t2, m.GetOrElse(2, ""), "two")
+    val t1 = Eq[int](t, m.Size(), 3)
+    val t2 = Eq[string](t1, m.GetOrElse(1, ""), "one")
+    val t3 = Eq[string](t2, m.GetOrElse(2, ""), "two")
     return Eq[string](t3, m.GetOrElse(3, ""), "three")
 }
 
@@ -127,12 +127,12 @@ func TestHashMapIntKeys(t T) T {
 func TestHashMapPutIfAbsent(t T) T {
     val m = EmptyHashMap[string, int]()
     m.Put("a", 1)
-    var added1 = m.PutIfAbsent("a", 2)
-    var added2 = m.PutIfAbsent("b", 2)
+    val added1 = m.PutIfAbsent("a", 2)
+    val added2 = m.PutIfAbsent("b", 2)
 
-    var t1 = IsFalse(t, added1)
-    var t2 = IsTrue(t1, added2)
-    var t3 = Eq[int](t2, m.GetOrElse("a", 0), 1)
+    val t1 = IsFalse(t, added1)
+    val t2 = IsTrue(t1, added2)
+    val t3 = Eq[int](t2, m.GetOrElse("a", 0), 1)
     return Eq[int](t3, m.GetOrElse("b", 0), 2)
 }
 
@@ -143,19 +143,19 @@ func TestHashMapGetOrElseUpdate(t T) T {
     val v1 = m.GetOrElseUpdate("a", () => 99)
     val v2 = m.GetOrElseUpdate("b", () => 42)
 
-    var t1 = Eq[int](t, v1, 1)
-    var t2 = Eq[int](t1, v2, 42)
+    val t1 = Eq[int](t, v1, 1)
+    val t2 = Eq[int](t1, v2, 42)
     return Eq[int](t2, m.GetOrElse("b", 0), 42)
 }
 
 func TestHashMapUpdate(t T) T {
     val m = EmptyHashMap[string, int]()
     m.Put("a", 1)
-    var updated = m.Update("a", (v int) => v * 2)
-    var notUpdated = m.Update("b", (v int) => v * 2)
+    val updated = m.Update("a", (v) => v * 2)
+    val notUpdated = m.Update("b", (v) => v * 2)
 
-    var t1 = IsTrue(t, updated)
-    var t2 = IsFalse(t1, notUpdated)
+    val t1 = IsTrue(t, updated)
+    val t2 = IsFalse(t1, notUpdated)
     return Eq[int](t2, m.GetOrElse("a", 0), 2)
 }
 
@@ -163,12 +163,12 @@ func TestHashMapPutAllEntries(t T) T {
     val m = EmptyHashMap[string, int]()
     m.Put("a", 1)
     val entries = ArrayOf[Tuple[string, int]](
-        Tuple[string, int](V1 = "b", V2 = 2),
-        Tuple[string, int](V1 = "c", V2 = 3)
+        ("b", 2),
+        ("c", 3)
     )
     m.PutAllEntries(entries)
 
-    var t1 = Eq[int](t, m.Size(), 3)
+    val t1 = Eq[int](t, m.Size(), 3)
     return IsTrue(t1, m.Contains("c"))
 }
 
@@ -190,11 +190,11 @@ func TestHashMapMerge(t T) T {
     val m2 = EmptyHashMap[string, int]()
     m2.Put("b", 3)
     m2.Put("c", 4)
-    m1.Merge(m2, (v1 int, v2 int) => v1 + v2)
+    m1.Merge(m2, (v1, v2) => v1 + v2)
 
-    var t1 = Eq[int](t, m1.Size(), 3)
-    var t2 = Eq[int](t1, m1.GetOrElse("a", 0), 1)
-    var t3 = Eq[int](t2, m1.GetOrElse("b", 0), 5)
+    val t1 = Eq[int](t, m1.Size(), 3)
+    val t2 = Eq[int](t1, m1.GetOrElse("a", 0), 1)
+    val t3 = Eq[int](t2, m1.GetOrElse("b", 0), 5)
     return Eq[int](t3, m1.GetOrElse("c", 0), 4)
 }
 
@@ -206,10 +206,10 @@ func TestHashMapFilter(t T) T {
     m.Put("b", 2)
     m.Put("c", 3)
     m.Put("d", 4)
-    val filtered = m.Filter((k string, v int) => v > 2)
+    val filtered = m.Filter((k, v) => v > 2)
 
-    var t1 = Eq[int](t, filtered.Size(), 2)
-    var t2 = IsFalse(t1, filtered.Contains("a"))
+    val t1 = Eq[int](t, filtered.Size(), 2)
+    val t2 = IsFalse(t1, filtered.Contains("a"))
     return IsTrue(t2, filtered.Contains("c"))
 }
 
@@ -219,7 +219,7 @@ func TestHashMapCollect(t T) T {
     m.Put("b", 2)
     m.Put("c", 3)
     // Collect values > 1 as formatted strings
-    var result = m.Collect((k string, v int) => {
+    val result = m.Collect((k, v) => {
         if v > 1 {
             return Some(fmt.Sprintf("%s:%d", k, v))
         }
@@ -234,9 +234,9 @@ func TestHashMapFilterKeys(t T) T {
     m.Put("apple", 1)
     m.Put("banana", 2)
     m.Put("cherry", 3)
-    val filtered = m.FilterKeys((k string) => len(k) > 5)
+    val filtered = m.FilterKeys((k) => len(k) > 5)
 
-    var t1 = Eq[int](t, filtered.Size(), 2)
+    val t1 = Eq[int](t, filtered.Size(), 2)
     return IsFalse(t1, filtered.Contains("apple"))
 }
 
@@ -245,9 +245,9 @@ func TestHashMapFilterValues(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     m.Put("c", 3)
-    val filtered = m.FilterValues((v int) => v % 2 == 0)
+    val filtered = m.FilterValues((v) => v % 2 == 0)
 
-    var t1 = Eq[int](t, filtered.Size(), 1)
+    val t1 = Eq[int](t, filtered.Size(), 1)
     return IsTrue(t1, filtered.Contains("b"))
 }
 
@@ -256,10 +256,10 @@ func TestHashMapMapValues(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     m.Put("c", 3)
-    val doubled = m.MapValues[int]((v int) => v * 2)
+    val doubled = m.MapValues[int]((v) => v * 2)
 
-    var t1 = Eq[int](t, doubled.GetOrElse("a", 0), 2)
-    var t2 = Eq[int](t1, doubled.GetOrElse("b", 0), 4)
+    val t1 = Eq[int](t, doubled.GetOrElse("a", 0), 2)
+    val t2 = Eq[int](t1, doubled.GetOrElse("b", 0), 4)
     return Eq[int](t2, doubled.GetOrElse("c", 0), 6)
 }
 
@@ -269,11 +269,11 @@ func TestHashMapPartition(t T) T {
     m.Put("b", 2)
     m.Put("c", 3)
     m.Put("d", 4)
-    val result = m.Partition((k string, v int) => v % 2 == 0)
+    val result = m.Partition((k, v) => v % 2 == 0)
     val even = result.V1
     val odd = result.V2
 
-    var t1 = Eq[int](t, even.Size(), 2)
+    val t1 = Eq[int](t, even.Size(), 2)
     return Eq[int](t1, odd.Size(), 2)
 }
 
@@ -285,9 +285,9 @@ func TestHashMapFilterInPlace(t T) T {
     m.Put("b", 2)
     m.Put("c", 3)
     m.Put("d", 4)
-    m.FilterInPlace((k string, v int) => v > 2)
+    m.FilterInPlace((k, v) => v > 2)
 
-    var t1 = Eq[int](t, m.Size(), 2)
+    val t1 = Eq[int](t, m.Size(), 2)
     return IsTrue(t1, m.Contains("c"))
 }
 
@@ -296,10 +296,10 @@ func TestHashMapUpdateAll(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     m.Put("c", 3)
-    m.UpdateAll((k string, v int) => v * 10)
+    m.UpdateAll((k, v) => v * 10)
 
-    var t1 = Eq[int](t, m.GetOrElse("a", 0), 10)
-    var t2 = Eq[int](t1, m.GetOrElse("b", 0), 20)
+    val t1 = Eq[int](t, m.GetOrElse("a", 0), 10)
+    val t2 = Eq[int](t1, m.GetOrElse("b", 0), 20)
     return Eq[int](t2, m.GetOrElse("c", 0), 30)
 }
 
@@ -310,7 +310,7 @@ func TestHashMapFoldLeft(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     m.Put("c", 3)
-    val sum = m.FoldLeftKV[int](0, (acc int, k string, v int) => acc + v)
+    val sum = m.FoldLeftKV[int](0, (acc, k, v) => acc + v)
     return Eq[int](t, sum, 6)
 }
 
@@ -321,8 +321,8 @@ func TestHashMapExists(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     m.Put("c", 3)
-    var t1 = IsTrue(t, m.Exists((k string, v int) => v > 2))
-    return IsFalse(t1, m.Exists((k string, v int) => v > 10))
+    val t1 = IsTrue(t, m.Exists((k, v) => v > 2))
+    return IsFalse(t1, m.Exists((k, v) => v > 10))
 }
 
 func TestHashMapForAll(t T) T {
@@ -330,8 +330,8 @@ func TestHashMapForAll(t T) T {
     m.Put("a", 2)
     m.Put("b", 4)
     m.Put("c", 6)
-    var t1 = IsTrue(t, m.ForAll((k string, v int) => v % 2 == 0))
-    return IsFalse(t1, m.ForAll((k string, v int) => v < 5))
+    val t1 = IsTrue(t, m.ForAll((k, v) => v % 2 == 0))
+    return IsFalse(t1, m.ForAll((k, v) => v < 5))
 }
 
 func TestHashMapFind(t T) T {
@@ -339,8 +339,8 @@ func TestHashMapFind(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     m.Put("c", 3)
-    val found = m.Find((k string, v int) => v == 2)
-    var t1 = IsSome(t, found)
+    val found = m.Find((k, v) => v == 2)
+    val t1 = IsSome(t, found)
     return Eq[string](t1, found.Get().V1, "b")
 }
 
@@ -350,7 +350,7 @@ func TestHashMapCount(t T) T {
     m.Put("b", 2)
     m.Put("c", 3)
     m.Put("d", 4)
-    return Eq[int](t, m.Count((k string, v int) => v > 2), 2)
+    return Eq[int](t, m.Count((k, v) => v > 2), 2)
 }
 
 // === Key/Value Access Tests ===
@@ -361,9 +361,9 @@ func TestHashMapKeys(t T) T {
     m.Put("b", 2)
     m.Put("c", 3)
     val keys = m.Keys()
-    var t1 = Eq[int](t, keys.Size(), 3)
-    var t2 = IsTrue(t1, keys.Contains("a"))
-    var t3 = IsTrue(t2, keys.Contains("b"))
+    val t1 = Eq[int](t, keys.Size(), 3)
+    val t2 = IsTrue(t1, keys.Contains("a"))
+    val t3 = IsTrue(t2, keys.Contains("b"))
     return IsTrue(t3, keys.Contains("c"))
 }
 
@@ -405,7 +405,7 @@ func TestHashMapHeadOption(t T) T {
     m.Put("a", 1)
     val empty = EmptyHashMap[string, int]()
 
-    var t1 = IsSome(t, m.HeadOption())
+    val t1 = IsSome(t, m.HeadOption())
     return IsNone(t1, empty.HeadOption())
 }
 
@@ -425,7 +425,7 @@ func TestHashMapToGoMap(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     val goMap = m.ToGoMap()
-    var t1 = Eq[int](t, len(goMap), 2)
+    val t1 = Eq[int](t, len(goMap), 2)
     return Eq[int](t1, goMap["a"], 1)
 }
 
@@ -444,20 +444,20 @@ func TestHashMapClone(t T) T {
     val clone = m.Clone()
 
     m.Put("c", 3)
-    var t1 = Eq[int](t, clone.Size(), 2)
+    val t1 = Eq[int](t, clone.Size(), 2)
     return Eq[int](t1, m.Size(), 3)
 }
 
 func TestHashMapFromSlice(t T) T {
     val entries = go_interop.SliceOf[Tuple[string, int]](
-        Tuple[string, int](V1 = "a", V2 = 1),
-        Tuple[string, int](V1 = "b", V2 = 2),
-        Tuple[string, int](V1 = "c", V2 = 3)
+        ("a", 1),
+        ("b", 2),
+        ("c", 3)
     )
 
     val m = HashMapFromSlice[string, int](entries)
-    var t1 = Eq[int](t, m.Size(), 3)
-    var t2 = Eq[int](t1, m.GetOrElse("a", 0), 1)
+    val t1 = Eq[int](t, m.Size(), 3)
+    val t2 = Eq[int](t1, m.GetOrElse("a", 0), 1)
     return Eq[int](t2, m.GetOrElse("b", 0), 2)
 }
 
@@ -468,9 +468,9 @@ func TestHashMapLarge(t T) T {
     for i := 0; i < 1000; i++ {
         m.Put(i, i * 2)
     }
-    var t1 = Eq[int](t, m.Size(), 1000)
-    var t2 = Eq[int](t1, m.GetOrElse(0, -1), 0)
-    var t3 = Eq[int](t2, m.GetOrElse(500, -1), 1000)
+    val t1 = Eq[int](t, m.Size(), 1000)
+    val t2 = Eq[int](t1, m.GetOrElse(0, -1), 0)
+    val t3 = Eq[int](t2, m.GetOrElse(500, -1), 1000)
     return Eq[int](t3, m.GetOrElse(999, -1), 1998)
 }
 
@@ -495,8 +495,8 @@ func TestHashMapWithHashableKey(t T) T {
     m.Put(p1, "Engineer")
     m.Put(p2, "Designer")
 
-    var t1 = Eq[int](t, m.Size(), 2)
-    var t2 = Eq[string](t1, m.GetOrElse(p1, ""), "Engineer")
+    val t1 = Eq[int](t, m.Size(), 2)
+    val t2 = Eq[string](t1, m.GetOrElse(p1, ""), "Engineer")
     return Eq[string](t2, m.GetOrElse(p2, ""), "Designer")
 }
 
@@ -508,7 +508,7 @@ func TestHashMapHashableKeyUpdate(t T) T {
     m.Put(p1, "Engineer")
     m.Put(p1copy, "Senior Engineer")
 
-    var t1 = Eq[int](t, m.Size(), 1)
+    val t1 = Eq[int](t, m.Size(), 1)
     return Eq[string](t1, m.GetOrElse(p1, ""), "Senior Engineer")
 }
 
@@ -516,7 +516,7 @@ func TestHashMapHashableKeyUpdate(t T) T {
 
 func TestHashMapString(t T) T {
     val empty = EmptyHashMap[string, int]()
-    var t1 = Eq[string](t, empty.String(), "HashMap()")
+    val t1 = Eq[string](t, empty.String(), "HashMap()")
 
     val m = EmptyHashMap[string, int]()
     m.Put("a", 1)
@@ -530,7 +530,7 @@ func TestHashMapResize(t T) T {
     for i := 0; i < 100; i++ {
         m.Put(i, i)
     }
-    var t1 = Eq[int](t, m.Size(), 100)
+    val t1 = Eq[int](t, m.Size(), 100)
     for i := 0; i < 100; i++ {
         if !m.Contains(i) {
             return t1.Error("Missing key after resize")

--- a/collection_mutable/hashset.gala
+++ b/collection_mutable/hashset.gala
@@ -554,7 +554,7 @@ func (s *HashSet[T]) String() string {
         if !first {
             result = result + ", "
         }
-        result = result + fmt.Sprintf("%v", elem)
+        result = result + s"$elem"
         first = false
     })
     return result + ")"
@@ -571,7 +571,7 @@ func (s *HashSet[T]) MkString(sep string) string {
         if !first {
             result = result + sep
         }
-        result = result + fmt.Sprintf("%v", elem)
+        result = result + s"$elem"
         first = false
     })
     return result

--- a/collection_mutable/hashset_test.gala
+++ b/collection_mutable/hashset_test.gala
@@ -10,64 +10,64 @@ import (
 // === HashSet Creation Tests ===
 
 func TestEmptyHashSet(t T) T {
-    var s = EmptyHashSet[int]()
-    var t1 = IsTrue(t, s.IsEmpty())
+    val s = EmptyHashSet[int]()
+    val t1 = IsTrue(t, s.IsEmpty())
     return Eq[int](t1, s.Size(), 0)
 }
 
 func TestHashSetOf(t T) T {
-    var s = HashSetOf[int](1, 2, 3)
-    var t1 = IsFalse(t, s.IsEmpty())
+    val s = HashSetOf[int](1, 2, 3)
+    val t1 = IsFalse(t, s.IsEmpty())
     return Eq[int](t1, s.Size(), 3)
 }
 
 func TestHashSetOfDuplicates(t T) T {
-    var s = HashSetOf[int](1, 2, 2, 3, 3, 3)
+    val s = HashSetOf[int](1, 2, 2, 3, 3, 3)
     return Eq[int](t, s.Size(), 3)
 }
 
 func TestHashSetFromSlice(t T) T {
-    var slice = go_interop.SliceOf(10, 20, 30)
-    var s = HashSetFromSlice(slice)
-    var t1 = Eq[int](t, s.Size(), 3)
-    var t2 = IsTrue(t1, s.Contains(10))
-    var t3 = IsTrue(t2, s.Contains(20))
+    val slice = go_interop.SliceOf(10, 20, 30)
+    val s = HashSetFromSlice(slice)
+    val t1 = Eq[int](t, s.Size(), 3)
+    val t2 = IsTrue(t1, s.Contains(10))
+    val t3 = IsTrue(t2, s.Contains(20))
     return IsTrue(t3, s.Contains(30))
 }
 
 // === HashSet Basic Operations Tests ===
 
 func TestHashSetAdd(t T) T {
-    var s = EmptyHashSet[int]()
-    var added1 = s.Add(1)
-    var added2 = s.Add(2)
-    var added3 = s.Add(1) // Duplicate
-    var t1 = IsTrue(t, added1)
-    var t2 = IsTrue(t1, added2)
-    var t3 = IsFalse(t2, added3)
+    val s = EmptyHashSet[int]()
+    val added1 = s.Add(1)
+    val added2 = s.Add(2)
+    val added3 = s.Add(1) // Duplicate
+    val t1 = IsTrue(t, added1)
+    val t2 = IsTrue(t1, added2)
+    val t3 = IsFalse(t2, added3)
     return Eq[int](t3, s.Size(), 2)
 }
 
 func TestHashSetRemove(t T) T {
-    var s = HashSetOf[int](1, 2, 3)
-    var removed1 = s.Remove(2)
-    var removed2 = s.Remove(5) // Not present
-    var t1 = IsTrue(t, removed1)
-    var t2 = IsFalse(t1, removed2)
-    var t3 = Eq[int](t2, s.Size(), 2)
+    val s = HashSetOf[int](1, 2, 3)
+    val removed1 = s.Remove(2)
+    val removed2 = s.Remove(5) // Not present
+    val t1 = IsTrue(t, removed1)
+    val t2 = IsFalse(t1, removed2)
+    val t3 = Eq[int](t2, s.Size(), 2)
     return IsFalse(t3, s.Contains(2))
 }
 
 func TestHashSetContains(t T) T {
-    var s = HashSetOf[int](1, 2, 3)
-    var t1 = IsTrue(t, s.Contains(1))
-    var t2 = IsTrue(t1, s.Contains(2))
-    var t3 = IsTrue(t2, s.Contains(3))
+    val s = HashSetOf[int](1, 2, 3)
+    val t1 = IsTrue(t, s.Contains(1))
+    val t2 = IsTrue(t1, s.Contains(2))
+    val t3 = IsTrue(t2, s.Contains(3))
     return IsFalse(t3, s.Contains(5))
 }
 
 func TestHashSetClear(t T) T {
-    var s = HashSetOf[int](1, 2, 3)
+    val s = HashSetOf[int](1, 2, 3)
     s.Clear()
     return IsTrue(t, s.IsEmpty())
 }
@@ -75,105 +75,105 @@ func TestHashSetClear(t T) T {
 // === HashSet String Type Tests ===
 
 func TestHashSetStrings(t T) T {
-    var s = HashSetOf[string]("apple", "banana", "cherry")
-    var t1 = Eq[int](t, s.Size(), 3)
-    var t2 = IsTrue(t1, s.Contains("apple"))
-    var t3 = IsTrue(t2, s.Contains("banana"))
+    val s = HashSetOf[string]("apple", "banana", "cherry")
+    val t1 = Eq[int](t, s.Size(), 3)
+    val t2 = IsTrue(t1, s.Contains("apple"))
+    val t3 = IsTrue(t2, s.Contains("banana"))
     return IsFalse(t3, s.Contains("orange"))
 }
 
 // === HashSet Operations Tests ===
 
 func TestHashSetUnion(t T) T {
-    var s1 = HashSetOf[int](1, 2, 3)
-    var s2 = HashSetOf[int](3, 4, 5)
-    var union = s1.Union(s2)
-    var t1 = Eq[int](t, union.Size(), 5)
-    var t2 = IsTrue(t1, union.Contains(1))
-    var t3 = IsTrue(t2, union.Contains(3))
+    val s1 = HashSetOf[int](1, 2, 3)
+    val s2 = HashSetOf[int](3, 4, 5)
+    val union = s1.Union(s2)
+    val t1 = Eq[int](t, union.Size(), 5)
+    val t2 = IsTrue(t1, union.Contains(1))
+    val t3 = IsTrue(t2, union.Contains(3))
     return IsTrue(t3, union.Contains(5))
 }
 
 func TestHashSetIntersect(t T) T {
-    var s1 = HashSetOf[int](1, 2, 3, 4)
-    var s2 = HashSetOf[int](3, 4, 5, 6)
-    var intersect = s1.Intersect(s2)
-    var t1 = Eq[int](t, intersect.Size(), 2)
-    var t2 = IsTrue(t1, intersect.Contains(3))
-    var t3 = IsTrue(t2, intersect.Contains(4))
-    var t4 = IsFalse(t3, intersect.Contains(1))
+    val s1 = HashSetOf[int](1, 2, 3, 4)
+    val s2 = HashSetOf[int](3, 4, 5, 6)
+    val intersect = s1.Intersect(s2)
+    val t1 = Eq[int](t, intersect.Size(), 2)
+    val t2 = IsTrue(t1, intersect.Contains(3))
+    val t3 = IsTrue(t2, intersect.Contains(4))
+    val t4 = IsFalse(t3, intersect.Contains(1))
     return IsFalse(t4, intersect.Contains(5))
 }
 
 func TestHashSetDiff(t T) T {
-    var s1 = HashSetOf[int](1, 2, 3, 4)
-    var s2 = HashSetOf[int](3, 4, 5, 6)
-    var diff = s1.Diff(s2)
-    var t1 = Eq[int](t, diff.Size(), 2)
-    var t2 = IsTrue(t1, diff.Contains(1))
-    var t3 = IsTrue(t2, diff.Contains(2))
+    val s1 = HashSetOf[int](1, 2, 3, 4)
+    val s2 = HashSetOf[int](3, 4, 5, 6)
+    val diff = s1.Diff(s2)
+    val t1 = Eq[int](t, diff.Size(), 2)
+    val t2 = IsTrue(t1, diff.Contains(1))
+    val t3 = IsTrue(t2, diff.Contains(2))
     return IsFalse(t3, diff.Contains(3))
 }
 
 func TestHashSetSymmetricDiff(t T) T {
-    var s1 = HashSetOf[int](1, 2, 3)
-    var s2 = HashSetOf[int](3, 4, 5)
-    var symDiff = s1.SymmetricDiff(s2)
-    var t1 = Eq[int](t, symDiff.Size(), 4)
-    var t2 = IsTrue(t1, symDiff.Contains(1))
-    var t3 = IsTrue(t2, symDiff.Contains(2))
-    var t4 = IsFalse(t3, symDiff.Contains(3))
-    var t5 = IsTrue(t4, symDiff.Contains(4))
+    val s1 = HashSetOf[int](1, 2, 3)
+    val s2 = HashSetOf[int](3, 4, 5)
+    val symDiff = s1.SymmetricDiff(s2)
+    val t1 = Eq[int](t, symDiff.Size(), 4)
+    val t2 = IsTrue(t1, symDiff.Contains(1))
+    val t3 = IsTrue(t2, symDiff.Contains(2))
+    val t4 = IsFalse(t3, symDiff.Contains(3))
+    val t5 = IsTrue(t4, symDiff.Contains(4))
     return IsTrue(t5, symDiff.Contains(5))
 }
 
 func TestHashSetSubsetOf(t T) T {
-    var s1 = HashSetOf[int](1, 2)
-    var s2 = HashSetOf[int](1, 2, 3, 4)
-    var s3 = HashSetOf[int](1, 5)
-    var t1 = IsTrue(t, s1.SubsetOf(s2))
+    val s1 = HashSetOf[int](1, 2)
+    val s2 = HashSetOf[int](1, 2, 3, 4)
+    val s3 = HashSetOf[int](1, 5)
+    val t1 = IsTrue(t, s1.SubsetOf(s2))
     return IsFalse(t1, s3.SubsetOf(s2))
 }
 
 func TestHashSetSupersetOf(t T) T {
-    var s1 = HashSetOf[int](1, 2, 3, 4)
-    var s2 = HashSetOf[int](1, 2)
+    val s1 = HashSetOf[int](1, 2, 3, 4)
+    val s2 = HashSetOf[int](1, 2)
     return IsTrue(t, s1.SupersetOf(s2))
 }
 
 func TestHashSetDisjoint(t T) T {
-    var s1 = HashSetOf[int](1, 2, 3)
-    var s2 = HashSetOf[int](4, 5, 6)
-    var s3 = HashSetOf[int](3, 4, 5)
-    var t1 = IsTrue(t, s1.Disjoint(s2))
+    val s1 = HashSetOf[int](1, 2, 3)
+    val s2 = HashSetOf[int](4, 5, 6)
+    val s3 = HashSetOf[int](3, 4, 5)
+    val t1 = IsTrue(t, s1.Disjoint(s2))
     return IsFalse(t1, s1.Disjoint(s3))
 }
 
 // === HashSet In-Place Operations Tests ===
 
 func TestHashSetUnionInPlace(t T) T {
-    var s1 = HashSetOf[int](1, 2, 3)
-    var s2 = HashSetOf[int](3, 4, 5)
+    val s1 = HashSetOf[int](1, 2, 3)
+    val s2 = HashSetOf[int](3, 4, 5)
     s1.UnionInPlace(s2)
-    var t1 = Eq[int](t, s1.Size(), 5)
+    val t1 = Eq[int](t, s1.Size(), 5)
     return IsTrue(t1, s1.Contains(4))
 }
 
 func TestHashSetIntersectInPlace(t T) T {
-    var s1 = HashSetOf[int](1, 2, 3, 4)
-    var s2 = HashSetOf[int](3, 4, 5, 6)
+    val s1 = HashSetOf[int](1, 2, 3, 4)
+    val s2 = HashSetOf[int](3, 4, 5, 6)
     s1.IntersectInPlace(s2)
-    var t1 = Eq[int](t, s1.Size(), 2)
-    var t2 = IsTrue(t1, s1.Contains(3))
+    val t1 = Eq[int](t, s1.Size(), 2)
+    val t2 = IsTrue(t1, s1.Contains(3))
     return IsFalse(t2, s1.Contains(1))
 }
 
 func TestHashSetDiffInPlace(t T) T {
-    var s1 = HashSetOf[int](1, 2, 3, 4)
-    var s2 = HashSetOf[int](3, 4, 5, 6)
+    val s1 = HashSetOf[int](1, 2, 3, 4)
+    val s2 = HashSetOf[int](3, 4, 5, 6)
     s1.DiffInPlace(s2)
-    var t1 = Eq[int](t, s1.Size(), 2)
-    var t2 = IsTrue(t1, s1.Contains(1))
+    val t1 = Eq[int](t, s1.Size(), 2)
+    val t2 = IsTrue(t1, s1.Contains(1))
     return IsFalse(t2, s1.Contains(3))
 }
 
@@ -182,34 +182,34 @@ func TestHashSetDiffInPlace(t T) T {
 func isHashSetEven(x int) bool = x % 2 == 0
 
 func TestHashSetFilter(t T) T {
-    var s = HashSetOf[int](1, 2, 3, 4, 5, 6)
-    var filtered = s.Filter(isHashSetEven)
-    var t1 = Eq[int](t, filtered.Size(), 3)
-    var t2 = IsTrue(t1, filtered.Contains(2))
-    var t3 = IsTrue(t2, filtered.Contains(4))
+    val s = HashSetOf[int](1, 2, 3, 4, 5, 6)
+    val filtered = s.Filter(isHashSetEven)
+    val t1 = Eq[int](t, filtered.Size(), 3)
+    val t2 = IsTrue(t1, filtered.Contains(2))
+    val t3 = IsTrue(t2, filtered.Contains(4))
     return IsFalse(t3, filtered.Contains(1))
 }
 
 func TestHashSetFilterNot(t T) T {
-    var s = HashSetOf[int](1, 2, 3, 4, 5, 6)
-    var filtered = s.FilterNot(isHashSetEven)
-    var t1 = Eq[int](t, filtered.Size(), 3)
-    var t2 = IsTrue(t1, filtered.Contains(1))
+    val s = HashSetOf[int](1, 2, 3, 4, 5, 6)
+    val filtered = s.FilterNot(isHashSetEven)
+    val t1 = Eq[int](t, filtered.Size(), 3)
+    val t2 = IsTrue(t1, filtered.Contains(1))
     return IsFalse(t2, filtered.Contains(2))
 }
 
 func TestHashSetPartition(t T) T {
-    var s = HashSetOf[int](1, 2, 3, 4, 5, 6)
-    var parts = s.Partition(isHashSetEven)
-    var t1 = Eq[int](t, parts.V1.Size(), 3)
+    val s = HashSetOf[int](1, 2, 3, 4, 5, 6)
+    val parts = s.Partition(isHashSetEven)
+    val t1 = Eq[int](t, parts.V1.Size(), 3)
     return Eq[int](t1, parts.V2.Size(), 3)
 }
 
 func hashSetAddFn(acc int, x int) int = acc + x
 
 func TestHashSetFoldLeft(t T) T {
-    var s = HashSetOf[int](1, 2, 3, 4)
-    var result = s.FoldLeft(0, hashSetAddFn)
+    val s = HashSetOf[int](1, 2, 3, 4)
+    val result = s.FoldLeft(0, hashSetAddFn)
     return Eq[int](t, result, 10)
 }
 
@@ -218,85 +218,85 @@ func TestHashSetFoldLeft(t T) T {
 func isHashSetGreaterThanTwo(x int) bool = x > 2
 
 func TestHashSetExists(t T) T {
-    var s = HashSetOf[int](1, 2, 3)
+    val s = HashSetOf[int](1, 2, 3)
     return IsTrue(t, s.Exists(isHashSetGreaterThanTwo))
 }
 
 func isHashSetGreaterThanTen(x int) bool = x > 10
 
 func TestHashSetExistsFalse(t T) T {
-    var s = HashSetOf[int](1, 2, 3)
+    val s = HashSetOf[int](1, 2, 3)
     return IsFalse(t, s.Exists(isHashSetGreaterThanTen))
 }
 
 func isHashSetPositive(x int) bool = x > 0
 
 func TestHashSetForAll(t T) T {
-    var s = HashSetOf[int](1, 2, 3)
+    val s = HashSetOf[int](1, 2, 3)
     return IsTrue(t, s.ForAll(isHashSetPositive))
 }
 
 func TestHashSetForAllFalse(t T) T {
-    var s = HashSetOf[int](-1, 0, 1)
+    val s = HashSetOf[int](-1, 0, 1)
     return IsFalse(t, s.ForAll(isHashSetPositive))
 }
 
 func TestHashSetFind(t T) T {
-    var s = HashSetOf[int](1, 2, 3, 4, 5)
-    var found = s.Find(isHashSetGreaterThanTwo)
+    val s = HashSetOf[int](1, 2, 3, 4, 5)
+    val found = s.Find(isHashSetGreaterThanTwo)
     return IsFalse(t, found.IsEmpty())
 }
 
 func TestHashSetCount(t T) T {
-    var s = HashSetOf[int](1, 2, 3, 4, 5)
-    var count = s.Count(isHashSetGreaterThanTwo)
+    val s = HashSetOf[int](1, 2, 3, 4, 5)
+    val count = s.Count(isHashSetGreaterThanTwo)
     return Eq[int](t, count, 3)
 }
 
 // === HashSet Element Access Tests ===
 
 func TestHashSetHead(t T) T {
-    var s = HashSetOf[int](1, 2, 3)
-    var head = s.Head()
+    val s = HashSetOf[int](1, 2, 3)
+    val head = s.Head()
     return IsTrue(t, s.Contains(head))
 }
 
 func TestHashSetHeadOption(t T) T {
-    var s = HashSetOf[int](1, 2, 3)
-    var opt = s.HeadOption()
+    val s = HashSetOf[int](1, 2, 3)
+    val opt = s.HeadOption()
     return IsFalse(t, opt.IsEmpty())
 }
 
 func TestHashSetHeadOptionEmpty(t T) T {
-    var s = EmptyHashSet[int]()
-    var opt = s.HeadOption()
+    val s = EmptyHashSet[int]()
+    val opt = s.HeadOption()
     return IsTrue(t, opt.IsEmpty())
 }
 
 // === HashSet Conversion Tests ===
 
 func TestHashSetToGoSlice(t T) T {
-    var s = HashSetOf[int](1, 2, 3)
-    var slice = s.ToGoSlice()
+    val s = HashSetOf[int](1, 2, 3)
+    val slice = s.ToGoSlice()
     return Eq[int](t, len(slice), 3)
 }
 
 func TestHashSetToArray(t T) T {
-    var s = HashSetOf[int](1, 2, 3)
-    var arr = s.ToArray()
+    val s = HashSetOf[int](1, 2, 3)
+    val arr = s.ToArray()
     return Eq[int](t, arr.Size(), 3)
 }
 
 func TestHashSetToList(t T) T {
-    var s = HashSetOf[int](1, 2, 3)
-    var list = s.ToList()
+    val s = HashSetOf[int](1, 2, 3)
+    val list = s.ToList()
     return Eq[int](t, list.Size(), 3)
 }
 
 func TestHashSetCollect(t T) T {
-    var s = HashSetOf(1, 2, 3, 4, 5)
+    val s = HashSetOf(1, 2, 3, 4, 5)
     // Collect even numbers doubled
-    var result = s.Collect((x int) => {
+    val result = s.Collect((x) => {
         if x % 2 == 0 {
             return Some(x * 2)
         }
@@ -307,40 +307,40 @@ func TestHashSetCollect(t T) T {
 }
 
 func TestHashSetClone(t T) T {
-    var s = HashSetOf[int](1, 2, 3)
-    var clone = s.Clone()
+    val s = HashSetOf[int](1, 2, 3)
+    val clone = s.Clone()
     clone.Add(4)
-    var t1 = Eq[int](t, s.Size(), 3)
+    val t1 = Eq[int](t, s.Size(), 3)
     return Eq[int](t1, clone.Size(), 4)
 }
 
 func TestHashSetString(t T) T {
-    var s = EmptyHashSet[int]()
+    val s = EmptyHashSet[int]()
     return Eq[string](t, s.String(), "HashSet()")
 }
 
 // === Large HashSet Tests ===
 
 func TestHashSetLarge(t T) T {
-    var s = EmptyHashSet[int]()
+    val s = EmptyHashSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var t1 = Eq[int](t, s.Size(), 10000)
-    var t2 = IsTrue(t1, s.Contains(0))
-    var t3 = IsTrue(t2, s.Contains(5000))
+    val t1 = Eq[int](t, s.Size(), 10000)
+    val t2 = IsTrue(t1, s.Contains(0))
+    val t3 = IsTrue(t2, s.Contains(5000))
     return IsTrue(t3, s.Contains(9999))
 }
 
 func TestHashSetLargeRemove(t T) T {
-    var s = EmptyHashSet[int]()
+    val s = EmptyHashSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
     for i := 0; i < 5000; i++ {
         s.Remove(i)
     }
-    var t1 = Eq[int](t, s.Size(), 5000)
-    var t2 = IsFalse(t1, s.Contains(0))
+    val t1 = Eq[int](t, s.Size(), 5000)
+    val t2 = IsFalse(t1, s.Contains(0))
     return IsTrue(t2, s.Contains(5000))
 }

--- a/collection_mutable/list.gala
+++ b/collection_mutable/list.gala
@@ -1,7 +1,6 @@
 package collection_mutable
 
 import (
-    "fmt"
     . "martianoff/gala/std"
     "martianoff/gala/go_interop"
 )
@@ -98,7 +97,7 @@ func (l *List[T]) nodeAt(index int) *listNode[T] {
 // Panics if index is out of bounds.
 func (l *List[T]) Get(index int) T {
     if (index < 0) || (index >= l.length) {
-        panic(fmt.Sprintf("List.Get: index %d out of bounds [0, %d)", index, l.length))
+        panic(f"List.Get: index $index out of bounds [0, ${l.length})")
     }
     var node = l.nodeAt(index)
     return node.value
@@ -152,7 +151,7 @@ func (l *List[T]) LastOption() Option[T] {
 // Panics if index is out of bounds.
 func (l *List[T]) Set(index int, value T) {
     if (index < 0) || (index >= l.length) {
-        panic(fmt.Sprintf("List.Set: index %d out of bounds [0, %d)", index, l.length))
+        panic(f"List.Set: index $index out of bounds [0, ${l.length})")
     }
     var node = l.nodeAt(index)
     node.value = value
@@ -213,7 +212,7 @@ func (l *List[T]) AppendFrom(other *List[T]) {
 // Panics if index is out of bounds (0 <= index <= length).
 func (l *List[T]) Insert(index int, value T) {
     if (index < 0) || (index > l.length) {
-        panic(fmt.Sprintf("List.Insert: index %d out of bounds [0, %d]", index, l.length))
+        panic(f"List.Insert: index $index out of bounds [0, ${l.length}]")
     }
     if index == 0 {
         l.Prepend(value)
@@ -235,7 +234,7 @@ func (l *List[T]) Insert(index int, value T) {
 // Panics if index is out of bounds.
 func (l *List[T]) RemoveAt(index int) T {
     if (index < 0) || (index >= l.length) {
-        panic(fmt.Sprintf("List.RemoveAt: index %d out of bounds [0, %d)", index, l.length))
+        panic(f"List.RemoveAt: index $index out of bounds [0, ${l.length})")
     }
     var node = l.nodeAt(index)
     var removed = node.value
@@ -769,7 +768,7 @@ func (l *List[T]) String() string {
         if !first {
             result = result + ", "
         }
-        result = result + fmt.Sprintf("%v", current.value)
+        result = result + s"${current.value}"
         current = current.next
         first = false
     }
@@ -788,7 +787,7 @@ func (l *List[T]) MkString(sep string) string {
         if !first {
             result = result + sep
         }
-        result = result + fmt.Sprintf("%v", current.value)
+        result = result + s"${current.value}"
         current = current.next
         first = false
     }

--- a/collection_mutable/list_test.gala
+++ b/collection_mutable/list_test.gala
@@ -10,149 +10,149 @@ import (
 // === List Creation Tests ===
 
 func TestEmptyList(t T) T {
-    var list = EmptyList[int]()
-    var t1 = IsTrue(t, list.IsEmpty())
+    val list = EmptyList[int]()
+    val t1 = IsTrue(t, list.IsEmpty())
     return Eq[int](t1, list.Length(), 0)
 }
 
 func TestListOf(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var t1 = IsFalse(t, list.IsEmpty())
+    val list = ListOf(1, 2, 3)
+    val t1 = IsFalse(t, list.IsEmpty())
     return Eq[int](t1, list.Length(), 3)
 }
 
 func TestListFromSlice(t T) T {
-    var slice = go_interop.SliceOf(10, 20, 30)
-    var list = ListFromSlice(slice)
-    var t1 = Eq[int](t, list.Length(), 3)
+    val slice = go_interop.SliceOf(10, 20, 30)
+    val list = ListFromSlice(slice)
+    val t1 = Eq[int](t, list.Length(), 3)
     return Eq[int](t1, list.Get(0), 10)
 }
 
 // === List Access Tests ===
 
 func TestListGet(t T) T {
-    var list = ListOf[int](10, 20, 30)
-    var t1 = Eq[int](t, list.Get(0), 10)
-    var t2 = Eq[int](t1, list.Get(1), 20)
+    val list = ListOf(10, 20, 30)
+    val t1 = Eq[int](t, list.Get(0), 10)
+    val t2 = Eq[int](t1, list.Get(1), 20)
     return Eq[int](t2, list.Get(2), 30)
 }
 
 func TestListHead(t T) T {
-    var list = ListOf[string]("first", "second", "third")
+    val list = ListOf("first", "second", "third")
     return Eq[string](t, list.Head(), "first")
 }
 
 func TestListLast(t T) T {
-    var list = ListOf[string]("first", "second", "third")
+    val list = ListOf("first", "second", "third")
     return Eq[string](t, list.Last(), "third")
 }
 
 func TestListHeadOption(t T) T {
-    var list = ListOf[int](42)
-    var opt = list.HeadOption()
-    var t1 = IsSome(t, opt)
+    val list = ListOf(42)
+    val opt = list.HeadOption()
+    val t1 = IsSome(t, opt)
     return Eq[int](t1, opt.Get(), 42)
 }
 
 func TestListHeadOptionEmpty(t T) T {
-    var list = EmptyList[int]()
-    var opt = list.HeadOption()
+    val list = EmptyList[int]()
+    val opt = list.HeadOption()
     return IsNone(t, opt)
 }
 
 func TestListLastOption(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var opt = list.LastOption()
-    var t1 = IsSome(t, opt)
+    val list = ListOf(1, 2, 3)
+    val opt = list.LastOption()
+    val t1 = IsSome(t, opt)
     return Eq[int](t1, opt.Get(), 3)
 }
 
 // === List Mutation Tests ===
 
 func TestListSet(t T) T {
-    var list = ListOf[int](1, 2, 3)
+    val list = ListOf(1, 2, 3)
     list.Set(1, 99)
     return Eq[int](t, list.Get(1), 99)
 }
 
 func TestListPrepend(t T) T {
-    var list = ListOf[int](2, 3)
+    val list = ListOf(2, 3)
     list.Prepend(1)
-    var t1 = Eq[int](t, list.Length(), 3)
+    val t1 = Eq[int](t, list.Length(), 3)
     return Eq[int](t1, list.Head(), 1)
 }
 
 func TestListAppend(t T) T {
-    var list = ListOf[int](1, 2)
+    val list = ListOf(1, 2)
     list.Append(3)
-    var t1 = Eq[int](t, list.Length(), 3)
+    val t1 = Eq[int](t, list.Length(), 3)
     return Eq[int](t1, list.Last(), 3)
 }
 
 func TestListInsert(t T) T {
-    var list = ListOf[int](1, 3)
+    val list = ListOf(1, 3)
     list.Insert(1, 2)
-    var t1 = Eq[int](t, list.Length(), 3)
-    var t2 = Eq[int](t1, list.Get(0), 1)
-    var t3 = Eq[int](t2, list.Get(1), 2)
+    val t1 = Eq[int](t, list.Length(), 3)
+    val t2 = Eq[int](t1, list.Get(0), 1)
+    val t3 = Eq[int](t2, list.Get(1), 2)
     return Eq[int](t3, list.Get(2), 3)
 }
 
 func TestListRemoveAt(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var removed = list.RemoveAt(1)
-    var t1 = Eq[int](t, removed, 2)
-    var t2 = Eq[int](t1, list.Length(), 2)
-    var t3 = Eq[int](t2, list.Get(0), 1)
+    val list = ListOf(1, 2, 3)
+    val removed = list.RemoveAt(1)
+    val t1 = Eq[int](t, removed, 2)
+    val t2 = Eq[int](t1, list.Length(), 2)
+    val t3 = Eq[int](t2, list.Get(0), 1)
     return Eq[int](t3, list.Get(1), 3)
 }
 
 func TestListRemoveFirst(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var removed = list.RemoveFirst()
-    var t1 = Eq[int](t, removed, 1)
-    var t2 = Eq[int](t1, list.Length(), 2)
+    val list = ListOf(1, 2, 3)
+    val removed = list.RemoveFirst()
+    val t1 = Eq[int](t, removed, 1)
+    val t2 = Eq[int](t1, list.Length(), 2)
     return Eq[int](t2, list.Head(), 2)
 }
 
 func TestListRemoveLast(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var removed = list.RemoveLast()
-    var t1 = Eq[int](t, removed, 3)
-    var t2 = Eq[int](t1, list.Length(), 2)
+    val list = ListOf(1, 2, 3)
+    val removed = list.RemoveLast()
+    val t1 = Eq[int](t, removed, 3)
+    val t2 = Eq[int](t1, list.Length(), 2)
     return Eq[int](t2, list.Last(), 2)
 }
 
 func TestListClear(t T) T {
-    var list = ListOf[int](1, 2, 3)
+    val list = ListOf(1, 2, 3)
     list.Clear()
     return IsTrue(t, list.IsEmpty())
 }
 
 func TestListReverse(t T) T {
-    var list = ListOf[int](1, 2, 3)
+    val list = ListOf(1, 2, 3)
     list.Reverse()
-    var t1 = Eq[int](t, list.Get(0), 3)
-    var t2 = Eq[int](t1, list.Get(1), 2)
+    val t1 = Eq[int](t, list.Get(0), 3)
+    val t2 = Eq[int](t1, list.Get(1), 2)
     return Eq[int](t2, list.Get(2), 1)
 }
 
 // === List Search Tests ===
 
 func TestListContains(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var t1 = IsTrue(t, list.Contains(2))
+    val list = ListOf(1, 2, 3)
+    val t1 = IsTrue(t, list.Contains(2))
     return IsFalse(t1, list.Contains(5))
 }
 
 func TestListIndexOf(t T) T {
-    var list = ListOf[string]("a", "b", "c")
-    var t1 = Eq[int](t, list.IndexOf("b"), 1)
+    val list = ListOf("a", "b", "c")
+    val t1 = Eq[int](t, list.IndexOf("b"), 1)
     return Eq[int](t1, list.IndexOf("z"), -1)
 }
 
 func TestListLastIndexOf(t T) T {
-    var list = ListOf[int](1, 2, 1, 3)
+    val list = ListOf(1, 2, 1, 3)
     return Eq[int](t, list.LastIndexOf(1), 2)
 }
 
@@ -161,28 +161,28 @@ func TestListLastIndexOf(t T) T {
 func doubleValueList(x int) int = x * 2
 
 func TestListMap(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var mapped = List_Map[int, int](list, doubleValueList)
-    var t1 = Eq[int](t, mapped.Get(0), 2)
-    var t2 = Eq[int](t1, mapped.Get(1), 4)
+    val list = ListOf(1, 2, 3)
+    val mapped = List_Map[int, int](list, doubleValueList)
+    val t1 = Eq[int](t, mapped.Get(0), 2)
+    val t2 = Eq[int](t1, mapped.Get(1), 4)
     return Eq[int](t2, mapped.Get(2), 6)
 }
 
 func isEvenList(x int) bool = x % 2 == 0
 
 func TestListFilter(t T) T {
-    var list = ListOf[int](1, 2, 3, 4, 5)
-    var filtered = list.Filter(isEvenList)
-    var t1 = Eq[int](t, filtered.Length(), 2)
-    var t2 = Eq[int](t1, filtered.Get(0), 2)
+    val list = ListOf(1, 2, 3, 4, 5)
+    val filtered = list.Filter(isEvenList)
+    val t1 = Eq[int](t, filtered.Length(), 2)
+    val t2 = Eq[int](t1, filtered.Get(0), 2)
     return Eq[int](t2, filtered.Get(1), 4)
 }
 
 func sumList(acc int, x int) int = acc + x
 
 func TestListFoldLeft(t T) T {
-    var list = ListOf[int](1, 2, 3, 4)
-    var result = List_FoldLeft[int](list, 0, sumList)
+    val list = ListOf(1, 2, 3, 4)
+    val result = List_FoldLeft[int](list, 0, sumList)
     return Eq[int](t, result, 10)
 }
 
@@ -194,8 +194,8 @@ func foldRightHelper(x int, acc string) string {
 }
 
 func TestListFoldRight(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var result = list.FoldRight[string]("", foldRightHelper)
+    val list = ListOf(1, 2, 3)
+    val result = list.FoldRight[string]("", foldRightHelper)
     return Eq[string](t, result, "1,2,3")
 }
 
@@ -204,176 +204,176 @@ func TestListFoldRight(t T) T {
 func isGreaterThanZeroList(x int) bool = x > 0
 
 func TestListExists(t T) T {
-    var list = ListOf[int](-1, 0, 1, 2)
+    val list = ListOf(-1, 0, 1, 2)
     return IsTrue(t, list.Exists(isGreaterThanZeroList))
 }
 
 func TestListForAll(t T) T {
-    var list1 = ListOf[int](1, 2, 3)
-    var list2 = ListOf[int](-1, 0, 1)
-    var t1 = IsTrue(t, list1.ForAll(isGreaterThanZeroList))
+    val list1 = ListOf(1, 2, 3)
+    val list2 = ListOf(-1, 0, 1)
+    val t1 = IsTrue(t, list1.ForAll(isGreaterThanZeroList))
     return IsFalse(t1, list2.ForAll(isGreaterThanZeroList))
 }
 
 func isGreaterThanTenList(x int) bool = x > 10
 
 func TestListFind(t T) T {
-    var list = ListOf[int](5, 15, 25)
-    var found = list.Find(isGreaterThanTenList)
-    var t1 = IsSome(t, found)
+    val list = ListOf(5, 15, 25)
+    val found = list.Find(isGreaterThanTenList)
+    val t1 = IsSome(t, found)
     return Eq[int](t1, found.Get(), 15)
 }
 
 func TestListFindLast(t T) T {
-    var list = ListOf[int](5, 15, 25)
-    var found = list.FindLast(isGreaterThanTenList)
-    var t1 = IsSome(t, found)
+    val list = ListOf(5, 15, 25)
+    val found = list.FindLast(isGreaterThanTenList)
+    val t1 = IsSome(t, found)
     return Eq[int](t1, found.Get(), 25)
 }
 
 func TestListCount(t T) T {
-    var list = ListOf[int](1, 2, 3, 4, 5)
-    var count = list.Count(isEvenList)
+    val list = ListOf(1, 2, 3, 4, 5)
+    val count = list.Count(isEvenList)
     return Eq[int](t, count, 2)
 }
 
 // === List Utility Tests ===
 
 func TestListTake(t T) T {
-    var list = ListOf[int](1, 2, 3, 4, 5)
-    var taken = list.Take(3)
-    var t1 = Eq[int](t, taken.Length(), 3)
+    val list = ListOf(1, 2, 3, 4, 5)
+    val taken = list.Take(3)
+    val t1 = Eq[int](t, taken.Length(), 3)
     return Eq[int](t1, taken.Last(), 3)
 }
 
 func TestListDrop(t T) T {
-    var list = ListOf[int](1, 2, 3, 4, 5)
-    var dropped = list.Drop(2)
-    var t1 = Eq[int](t, dropped.Length(), 3)
+    val list = ListOf(1, 2, 3, 4, 5)
+    val dropped = list.Drop(2)
+    val t1 = Eq[int](t, dropped.Length(), 3)
     return Eq[int](t1, dropped.Head(), 3)
 }
 
 func TestListSlice(t T) T {
-    var list = ListOf[int](1, 2, 3, 4, 5)
-    var sliced = list.Slice(1, 4)
-    var t1 = Eq[int](t, sliced.Length(), 3)
-    var t2 = Eq[int](t1, sliced.Head(), 2)
+    val list = ListOf(1, 2, 3, 4, 5)
+    val sliced = list.Slice(1, 4)
+    val t1 = Eq[int](t, sliced.Length(), 3)
+    val t2 = Eq[int](t1, sliced.Head(), 2)
     return Eq[int](t2, sliced.Last(), 4)
 }
 
 func TestListClone(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var clone = list.Clone()
+    val list = ListOf(1, 2, 3)
+    val clone = list.Clone()
     clone.Set(0, 99)
-    var t1 = Eq[int](t, list.Get(0), 1)
+    val t1 = Eq[int](t, list.Get(0), 1)
     return Eq[int](t1, clone.Get(0), 99)
 }
 
 func TestListDistinct(t T) T {
-    var list = ListOf[int](1, 2, 2, 3, 3, 3)
-    var distinct = list.Distinct()
+    val list = ListOf(1, 2, 2, 3, 3, 3)
+    val distinct = list.Distinct()
     return Eq[int](t, distinct.Length(), 3)
 }
 
 func TestListZip(t T) T {
-    var list1 = ListOf[int](1, 2, 3)
-    var list2 = ListOf[string]("a", "b", "c")
-    var zipped = list1.Zip[string](list2)
-    var t1 = Eq[int](t, zipped.Length(), 3)
-    var first = zipped.Get(0)
-    var t2 = Eq[int](t1, first.V1.Get(), 1)
+    val list1 = ListOf(1, 2, 3)
+    val list2 = ListOf("a", "b", "c")
+    val zipped = list1.Zip[string](list2)
+    val t1 = Eq[int](t, zipped.Length(), 3)
+    val first = zipped.Get(0)
+    val t2 = Eq[int](t1, first.V1.Get(), 1)
     return Eq[string](t2, first.V2.Get(), "a")
 }
 
 func TestListString(t T) T {
-    var list = ListOf[int](1, 2, 3)
+    val list = ListOf(1, 2, 3)
     return Eq[string](t, list.String(), "List(1, 2, 3)")
 }
 
 func TestEmptyListString(t T) T {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     return Eq[string](t, list.String(), "List()")
 }
 
 // === List Mutability Tests ===
 
 func TestListMutability(t T) T {
-    var list = ListOf[int](1, 2, 3)
+    val list = ListOf(1, 2, 3)
     list.Append(4)
     list.Set(0, 10)
-    var t1 = Eq[int](t, list.Length(), 4)
-    var t2 = Eq[int](t1, list.Get(0), 10)
+    val t1 = Eq[int](t, list.Length(), 4)
+    val t2 = Eq[int](t1, list.Get(0), 10)
     return Eq[int](t2, list.Get(3), 4)
 }
 
 func TestListMultipleMutations(t T) T {
-    var list = ListOf[int](1, 2, 3)
+    val list = ListOf(1, 2, 3)
     list.Append(4)
     list.Prepend(0)
     list.Set(2, 99)
     list.RemoveAt(3)
-    var t1 = Eq[int](t, list.Length(), 4)
-    var t2 = Eq[int](t1, list.Get(0), 0)
-    var t3 = Eq[int](t2, list.Get(2), 99)
+    val t1 = Eq[int](t, list.Length(), 4)
+    val t2 = Eq[int](t1, list.Get(0), 0)
+    val t3 = Eq[int](t2, list.Get(2), 99)
     return Eq[int](t3, list.Get(3), 4)
 }
 
 // === Large List Tests ===
 
 func TestListLargeAppend(t T) T {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var t1 = Eq[int](t, list.Length(), 10000)
-    var t2 = Eq[int](t1, list.Head(), 0)
+    val t1 = Eq[int](t, list.Length(), 10000)
+    val t2 = Eq[int](t1, list.Head(), 0)
     return Eq[int](t2, list.Last(), 9999)
 }
 
 func TestListLargePrepend(t T) T {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Prepend(i)
     }
-    var t1 = Eq[int](t, list.Length(), 10000)
-    var t2 = Eq[int](t1, list.Head(), 9999)
+    val t1 = Eq[int](t, list.Length(), 10000)
+    val t2 = Eq[int](t1, list.Head(), 9999)
     return Eq[int](t2, list.Last(), 0)
 }
 
 // === O(1) Head/Tail Tests ===
 
 func TestListO1Head(t T) T {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var h = list.Head()
+    val h = list.Head()
     return Eq[int](t, h, 0)
 }
 
 func TestListO1Last(t T) T {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var l = list.Last()
+    val l = list.Last()
     return Eq[int](t, l, 9999)
 }
 
 // === Conversion Tests ===
 
 func TestListToGoSlice(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var slice = list.ToGoSlice()
-    var t1 = Eq[int](t, len(slice), 3)
-    var t2 = Eq[int](t1, slice[0], 1)
+    val list = ListOf(1, 2, 3)
+    val slice = list.ToGoSlice()
+    val t1 = Eq[int](t, len(slice), 3)
+    val t2 = Eq[int](t1, slice[0], 1)
     return Eq[int](t2, slice[2], 3)
 }
 
 func TestListToArray(t T) T {
-    var list = ListOf[int](1, 2, 3)
-    var arr = list.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 3)
-    var t2 = Eq[int](t1, arr.Get(0), 1)
+    val list = ListOf(1, 2, 3)
+    val arr = list.ToArray()
+    val t1 = Eq[int](t, arr.Length(), 3)
+    val t2 = Eq[int](t1, arr.Get(0), 1)
     return Eq[int](t2, arr.Get(2), 3)
 }

--- a/collection_mutable/perf_test.gala
+++ b/collection_mutable/perf_test.gala
@@ -8,11 +8,11 @@ import (
 
 // Performance test utilities
 func measureNs(iterations int, f func()) int64 {
-    var start = time.Now()
+    val start = time.Now()
     for i := 0; i < iterations; i++ {
         f()
     }
-    var elapsed = time.Since(start)
+    val elapsed = time.Since(start)
     return elapsed.Nanoseconds() / int64(iterations)
 }
 
@@ -24,8 +24,8 @@ func printResult(name string, nsPerOp int64) {
 
 // Array creation benchmark - small
 func benchArrayCreation100() {
-    var ns = measureNs(10000, () => {
-        var arr = EmptyArray[int]()
+    val ns = measureNs(10000, () => {
+        val arr = EmptyArray[int]()
         for i := 0; i < 100; i++ {
             arr.Append(i)
         }
@@ -35,8 +35,8 @@ func benchArrayCreation100() {
 
 // Array creation benchmark - medium
 func benchArrayCreation10000() {
-    var ns = measureNs(1000, () => {
-        var arr = EmptyArray[int]()
+    val ns = measureNs(1000, () => {
+        val arr = EmptyArray[int]()
         for i := 0; i < 10000; i++ {
             arr.Append(i)
         }
@@ -46,8 +46,8 @@ func benchArrayCreation10000() {
 
 // Array creation benchmark - large
 func benchArrayCreation100000() {
-    var ns = measureNs(100, () => {
-        var arr = EmptyArray[int]()
+    val ns = measureNs(100, () => {
+        val arr = EmptyArray[int]()
         for i := 0; i < 100000; i++ {
             arr.Append(i)
         }
@@ -57,8 +57,8 @@ func benchArrayCreation100000() {
 
 // Array creation with capacity - medium
 func benchArrayCreationWithCapacity10000() {
-    var ns = measureNs(1000, () => {
-        var arr = ArrayWithCapacity[int](10000)
+    val ns = measureNs(1000, () => {
+        val arr = ArrayWithCapacity[int](10000)
         for i := 0; i < 10000; i++ {
             arr.Append(i)
         }
@@ -68,11 +68,11 @@ func benchArrayCreationWithCapacity10000() {
 
 // Array append benchmark
 func benchArrayAppend() {
-    var arr = ArrayWithCapacity[int](10001)
+    val arr = ArrayWithCapacity[int](10001)
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         arr.Append(999)
         arr.RemoveLast()
     })
@@ -81,11 +81,11 @@ func benchArrayAppend() {
 
 // Array prepend benchmark
 func benchArrayPrepend() {
-    var arr = ArrayWithCapacity[int](10001)
+    val arr = ArrayWithCapacity[int](10001)
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         arr.Prepend(999)
         arr.RemoveFirst()
     })
@@ -94,11 +94,11 @@ func benchArrayPrepend() {
 
 // Array head benchmark
 func benchArrayHead() {
-    var arr = EmptyArray[int]()
+    val arr = EmptyArray[int]()
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = arr.Head()
     })
     printResult("Array.Head (size=10000)", ns)
@@ -106,11 +106,11 @@ func benchArrayHead() {
 
 // Array get benchmark - beginning
 func benchArrayGetFirst() {
-    var arr = EmptyArray[int]()
+    val arr = EmptyArray[int]()
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = arr.Get(0)
     })
     printResult("Array.Get(0) (size=10000)", ns)
@@ -118,11 +118,11 @@ func benchArrayGetFirst() {
 
 // Array get benchmark - middle
 func benchArrayGetMiddle() {
-    var arr = EmptyArray[int]()
+    val arr = EmptyArray[int]()
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = arr.Get(5000)
     })
     printResult("Array.Get(5000) (size=10000)", ns)
@@ -130,11 +130,11 @@ func benchArrayGetMiddle() {
 
 // Array get benchmark - end
 func benchArrayGetLast() {
-    var arr = EmptyArray[int]()
+    val arr = EmptyArray[int]()
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = arr.Get(9999)
     })
     printResult("Array.Get(9999) (size=10000)", ns)
@@ -142,11 +142,11 @@ func benchArrayGetLast() {
 
 // Array set benchmark
 func benchArraySet() {
-    var arr = EmptyArray[int]()
+    val arr = EmptyArray[int]()
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         arr.Set(5000, 999)
     })
     printResult("Array.Set(5000) (size=10000)", ns)
@@ -154,35 +154,35 @@ func benchArraySet() {
 
 // Array filter benchmark
 func benchArrayFilter() {
-    var arr = EmptyArray[int]()
+    val arr = EmptyArray[int]()
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
-    var ns = measureNs(1000, () => {
-        var _ = arr.Filter((x int) => x % 2 == 0)
+    val ns = measureNs(1000, () => {
+        var _ = arr.Filter((x) => x % 2 == 0)
     })
     printResult("Array.Filter (size=10000)", ns)
 }
 
 // Array map benchmark
 func benchArrayMap() {
-    var arr = EmptyArray[int]()
+    val arr = EmptyArray[int]()
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
-    var ns = measureNs(1000, () => {
-        var _ = arr.Map((x int) => x * 2)
+    val ns = measureNs(1000, () => {
+        var _ = arr.Map((x) => x * 2)
     })
     printResult("Array.Map (size=10000)", ns)
 }
 
 // Array foldLeft benchmark
 func benchArrayFoldLeft() {
-    var arr = EmptyArray[int]()
+    val arr = EmptyArray[int]()
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
-    var ns = measureNs(10000, () => {
+    val ns = measureNs(10000, () => {
         var _ = Array_FoldLeft[int](arr, 0, (acc int, x int) => acc + x)
     })
     printResult("Array.FoldLeft (size=10000)", ns)
@@ -190,11 +190,11 @@ func benchArrayFoldLeft() {
 
 // Array clone benchmark
 func benchArrayClone() {
-    var arr = EmptyArray[int]()
+    val arr = EmptyArray[int]()
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = arr.Clone()
     })
     printResult("Array.Clone (size=10000)", ns)
@@ -202,11 +202,11 @@ func benchArrayClone() {
 
 // Array reverse in place benchmark
 func benchArrayReverse() {
-    var arr = EmptyArray[int]()
+    val arr = EmptyArray[int]()
     for i := 0; i < 10000; i++ {
         arr.Append(i)
     }
-    var ns = measureNs(10000, () => {
+    val ns = measureNs(10000, () => {
         arr.Reverse()
     })
     printResult("Array.Reverse (size=10000)", ns)
@@ -216,8 +216,8 @@ func benchArrayReverse() {
 
 // List creation benchmark - small
 func benchListCreation100() {
-    var ns = measureNs(10000, () => {
-        var list = EmptyList[int]()
+    val ns = measureNs(10000, () => {
+        val list = EmptyList[int]()
         for i := 0; i < 100; i++ {
             list.Append(i)
         }
@@ -227,8 +227,8 @@ func benchListCreation100() {
 
 // List creation benchmark - medium
 func benchListCreation10000() {
-    var ns = measureNs(1000, () => {
-        var list = EmptyList[int]()
+    val ns = measureNs(1000, () => {
+        val list = EmptyList[int]()
         for i := 0; i < 10000; i++ {
             list.Append(i)
         }
@@ -238,8 +238,8 @@ func benchListCreation10000() {
 
 // List creation benchmark - large
 func benchListCreation100000() {
-    var ns = measureNs(100, () => {
-        var list = EmptyList[int]()
+    val ns = measureNs(100, () => {
+        val list = EmptyList[int]()
         for i := 0; i < 100000; i++ {
             list.Append(i)
         }
@@ -249,11 +249,11 @@ func benchListCreation100000() {
 
 // List prepend benchmark (O(1))
 func benchListPrepend() {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         list.Prepend(999)
         list.RemoveFirst()
     })
@@ -262,11 +262,11 @@ func benchListPrepend() {
 
 // List append benchmark (O(1))
 func benchListAppend() {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         list.Append(999)
         list.RemoveLast()
     })
@@ -275,11 +275,11 @@ func benchListAppend() {
 
 // List head benchmark (O(1))
 func benchListHead() {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = list.Head()
     })
     printResult("List.Head (size=10000)", ns)
@@ -287,11 +287,11 @@ func benchListHead() {
 
 // List last benchmark (O(1))
 func benchListLast() {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = list.Last()
     })
     printResult("List.Last (size=10000)", ns)
@@ -299,11 +299,11 @@ func benchListLast() {
 
 // List get benchmark - beginning
 func benchListGetFirst() {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = list.Get(0)
     })
     printResult("List.Get(0) (size=10000)", ns)
@@ -311,11 +311,11 @@ func benchListGetFirst() {
 
 // List get benchmark - middle (bidirectional optimization)
 func benchListGetMiddle() {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = list.Get(5000)
     })
     printResult("List.Get(5000) (size=10000)", ns)
@@ -323,11 +323,11 @@ func benchListGetMiddle() {
 
 // List get benchmark - end (bidirectional optimization)
 func benchListGetLast() {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = list.Get(9999)
     })
     printResult("List.Get(9999) (size=10000)", ns)
@@ -335,35 +335,35 @@ func benchListGetLast() {
 
 // List filter benchmark
 func benchListFilter() {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var ns = measureNs(1000, () => {
-        var _ = list.Filter((x int) => x % 2 == 0)
+    val ns = measureNs(1000, () => {
+        var _ = list.Filter((x) => x % 2 == 0)
     })
     printResult("List.Filter (size=10000)", ns)
 }
 
 // List map benchmark
 func benchListMap() {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var ns = measureNs(1000, () => {
-        var _ = list.Map((x int) => x * 2)
+    val ns = measureNs(1000, () => {
+        var _ = list.Map((x) => x * 2)
     })
     printResult("List.Map (size=10000)", ns)
 }
 
 // List foldLeft benchmark
 func benchListFoldLeft() {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var ns = measureNs(10000, () => {
+    val ns = measureNs(10000, () => {
         var _ = List_FoldLeft[int](list, 0, (acc int, x int) => acc + x)
     })
     printResult("List.FoldLeft (size=10000)", ns)
@@ -371,11 +371,11 @@ func benchListFoldLeft() {
 
 // List reverse in place benchmark
 func benchListReverse() {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var ns = measureNs(10000, () => {
+    val ns = measureNs(10000, () => {
         list.Reverse()
     })
     printResult("List.Reverse (size=10000)", ns)
@@ -383,11 +383,11 @@ func benchListReverse() {
 
 // List removeFirst/removeLast benchmark
 func benchListRemoveFirst() {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         list.Prepend(0)
         list.RemoveFirst()
     })
@@ -395,11 +395,11 @@ func benchListRemoveFirst() {
 }
 
 func benchListRemoveLast() {
-    var list = EmptyList[int]()
+    val list = EmptyList[int]()
     for i := 0; i < 10000; i++ {
         list.Append(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         list.Append(0)
         list.RemoveLast()
     })
@@ -410,8 +410,8 @@ func benchListRemoveLast() {
 
 // HashSet creation benchmark - small
 func benchHashSetCreation100() {
-    var ns = measureNs(10000, () => {
-        var s = EmptyHashSet[int]()
+    val ns = measureNs(10000, () => {
+        val s = EmptyHashSet[int]()
         for i := 0; i < 100; i++ {
             s.Add(i)
         }
@@ -421,8 +421,8 @@ func benchHashSetCreation100() {
 
 // HashSet creation benchmark - medium
 func benchHashSetCreation10000() {
-    var ns = measureNs(1000, () => {
-        var s = EmptyHashSet[int]()
+    val ns = measureNs(1000, () => {
+        val s = EmptyHashSet[int]()
         for i := 0; i < 10000; i++ {
             s.Add(i)
         }
@@ -432,8 +432,8 @@ func benchHashSetCreation10000() {
 
 // HashSet creation benchmark - large
 func benchHashSetCreation100000() {
-    var ns = measureNs(100, () => {
-        var s = EmptyHashSet[int]()
+    val ns = measureNs(100, () => {
+        val s = EmptyHashSet[int]()
         for i := 0; i < 100000; i++ {
             s.Add(i)
         }
@@ -443,11 +443,11 @@ func benchHashSetCreation100000() {
 
 // HashSet add benchmark
 func benchHashSetAdd() {
-    var s = EmptyHashSet[int]()
+    val s = EmptyHashSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         s.Add(99999)
         s.Remove(99999)
     })
@@ -456,11 +456,11 @@ func benchHashSetAdd() {
 
 // HashSet contains benchmark - hit
 func benchHashSetContainsHit() {
-    var s = EmptyHashSet[int]()
+    val s = EmptyHashSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = s.Contains(5000)
     })
     printResult("HashSet.Contains hit (size=10000)", ns)
@@ -468,11 +468,11 @@ func benchHashSetContainsHit() {
 
 // HashSet contains benchmark - miss
 func benchHashSetContainsMiss() {
-    var s = EmptyHashSet[int]()
+    val s = EmptyHashSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = s.Contains(99999)
     })
     printResult("HashSet.Contains miss (size=10000)", ns)
@@ -480,11 +480,11 @@ func benchHashSetContainsMiss() {
 
 // HashSet remove benchmark
 func benchHashSetRemove() {
-    var s = EmptyHashSet[int]()
+    val s = EmptyHashSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         s.Add(99999)
         s.Remove(99999)
     })
@@ -493,25 +493,25 @@ func benchHashSetRemove() {
 
 // HashSet filter benchmark
 func benchHashSetFilter() {
-    var s = EmptyHashSet[int]()
+    val s = EmptyHashSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(1000, () => {
-        var _ = s.Filter((x int) => x % 2 == 0)
+    val ns = measureNs(1000, () => {
+        var _ = s.Filter((x) => x % 2 == 0)
     })
     printResult("HashSet.Filter (size=10000)", ns)
 }
 
 // HashSet union benchmark
 func benchHashSetUnion() {
-    var s1 = EmptyHashSet[int]()
-    var s2 = EmptyHashSet[int]()
+    val s1 = EmptyHashSet[int]()
+    val s2 = EmptyHashSet[int]()
     for i := 0; i < 5000; i++ {
         s1.Add(i)
         s2.Add(i + 2500)
     }
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var _ = s1.Union(s2)
     })
     printResult("HashSet.Union (size=5000+5000)", ns)
@@ -519,13 +519,13 @@ func benchHashSetUnion() {
 
 // HashSet intersect benchmark
 func benchHashSetIntersect() {
-    var s1 = EmptyHashSet[int]()
-    var s2 = EmptyHashSet[int]()
+    val s1 = EmptyHashSet[int]()
+    val s2 = EmptyHashSet[int]()
     for i := 0; i < 5000; i++ {
         s1.Add(i)
         s2.Add(i + 2500)
     }
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var _ = s1.Intersect(s2)
     })
     printResult("HashSet.Intersect (size=5000+5000)", ns)
@@ -533,11 +533,11 @@ func benchHashSetIntersect() {
 
 // HashSet clone benchmark
 func benchHashSetClone() {
-    var s = EmptyHashSet[int]()
+    val s = EmptyHashSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = s.Clone()
     })
     printResult("HashSet.Clone (size=10000)", ns)
@@ -547,8 +547,8 @@ func benchHashSetClone() {
 
 // TreeSet creation benchmark - small
 func benchTreeSetCreation100() {
-    var ns = measureNs(10000, () => {
-        var s = EmptyTreeSet[int]()
+    val ns = measureNs(10000, () => {
+        val s = EmptyTreeSet[int]()
         for i := 0; i < 100; i++ {
             s.Add(i)
         }
@@ -558,8 +558,8 @@ func benchTreeSetCreation100() {
 
 // TreeSet creation benchmark - medium
 func benchTreeSetCreation10000() {
-    var ns = measureNs(1000, () => {
-        var s = EmptyTreeSet[int]()
+    val ns = measureNs(1000, () => {
+        val s = EmptyTreeSet[int]()
         for i := 0; i < 10000; i++ {
             s.Add(i)
         }
@@ -569,8 +569,8 @@ func benchTreeSetCreation10000() {
 
 // TreeSet creation benchmark - large
 func benchTreeSetCreation100000() {
-    var ns = measureNs(100, () => {
-        var s = EmptyTreeSet[int]()
+    val ns = measureNs(100, () => {
+        val s = EmptyTreeSet[int]()
         for i := 0; i < 100000; i++ {
             s.Add(i)
         }
@@ -580,11 +580,11 @@ func benchTreeSetCreation100000() {
 
 // TreeSet add benchmark
 func benchTreeSetAdd() {
-    var s = EmptyTreeSet[int]()
+    val s = EmptyTreeSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         s.Add(99999)
         s.Remove(99999)
     })
@@ -593,11 +593,11 @@ func benchTreeSetAdd() {
 
 // TreeSet contains benchmark - hit
 func benchTreeSetContainsHit() {
-    var s = EmptyTreeSet[int]()
+    val s = EmptyTreeSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = s.Contains(5000)
     })
     printResult("TreeSet.Contains hit (size=10000)", ns)
@@ -605,11 +605,11 @@ func benchTreeSetContainsHit() {
 
 // TreeSet contains benchmark - miss
 func benchTreeSetContainsMiss() {
-    var s = EmptyTreeSet[int]()
+    val s = EmptyTreeSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = s.Contains(99999)
     })
     printResult("TreeSet.Contains miss (size=10000)", ns)
@@ -617,11 +617,11 @@ func benchTreeSetContainsMiss() {
 
 // TreeSet remove benchmark
 func benchTreeSetRemove() {
-    var s = EmptyTreeSet[int]()
+    val s = EmptyTreeSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         s.Add(99999)
         s.Remove(99999)
     })
@@ -630,11 +630,11 @@ func benchTreeSetRemove() {
 
 // TreeSet min benchmark
 func benchTreeSetMin() {
-    var s = EmptyTreeSet[int]()
+    val s = EmptyTreeSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = s.Min()
     })
     printResult("TreeSet.Min (size=10000)", ns)
@@ -642,11 +642,11 @@ func benchTreeSetMin() {
 
 // TreeSet max benchmark
 func benchTreeSetMax() {
-    var s = EmptyTreeSet[int]()
+    val s = EmptyTreeSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = s.Max()
     })
     printResult("TreeSet.Max (size=10000)", ns)
@@ -654,25 +654,25 @@ func benchTreeSetMax() {
 
 // TreeSet filter benchmark
 func benchTreeSetFilter() {
-    var s = EmptyTreeSet[int]()
+    val s = EmptyTreeSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(1000, () => {
-        var _ = s.Filter((x int) => x % 2 == 0)
+    val ns = measureNs(1000, () => {
+        var _ = s.Filter((x) => x % 2 == 0)
     })
     printResult("TreeSet.Filter (size=10000)", ns)
 }
 
 // TreeSet union benchmark
 func benchTreeSetUnion() {
-    var s1 = EmptyTreeSet[int]()
-    var s2 = EmptyTreeSet[int]()
+    val s1 = EmptyTreeSet[int]()
+    val s2 = EmptyTreeSet[int]()
     for i := 0; i < 5000; i++ {
         s1.Add(i)
         s2.Add(i + 2500)
     }
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var _ = s1.Union(s2)
     })
     printResult("TreeSet.Union (size=5000+5000)", ns)
@@ -680,13 +680,13 @@ func benchTreeSetUnion() {
 
 // TreeSet intersect benchmark
 func benchTreeSetIntersect() {
-    var s1 = EmptyTreeSet[int]()
-    var s2 = EmptyTreeSet[int]()
+    val s1 = EmptyTreeSet[int]()
+    val s2 = EmptyTreeSet[int]()
     for i := 0; i < 5000; i++ {
         s1.Add(i)
         s2.Add(i + 2500)
     }
-    var ns = measureNs(100, () => {
+    val ns = measureNs(100, () => {
         var _ = s1.Intersect(s2)
     })
     printResult("TreeSet.Intersect (size=5000+5000)", ns)
@@ -694,11 +694,11 @@ func benchTreeSetIntersect() {
 
 // TreeSet range benchmark
 func benchTreeSetRange() {
-    var s = EmptyTreeSet[int]()
+    val s = EmptyTreeSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = s.Range(2500, 7500)
     })
     printResult("TreeSet.Range (size=10000)", ns)
@@ -706,11 +706,11 @@ func benchTreeSetRange() {
 
 // TreeSet clone benchmark
 func benchTreeSetClone() {
-    var s = EmptyTreeSet[int]()
+    val s = EmptyTreeSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = s.Clone()
     })
     printResult("TreeSet.Clone (size=10000)", ns)
@@ -720,8 +720,8 @@ func benchTreeSetClone() {
 
 // HashMap creation benchmark - small
 func benchHashMapCreation100() {
-    var ns = measureNs(10000, () => {
-        var m = EmptyHashMap[int, int]()
+    val ns = measureNs(10000, () => {
+        val m = EmptyHashMap[int, int]()
         for i := 0; i < 100; i++ {
             m.Put(i, i)
         }
@@ -731,8 +731,8 @@ func benchHashMapCreation100() {
 
 // HashMap creation benchmark - medium
 func benchHashMapCreation10000() {
-    var ns = measureNs(1000, () => {
-        var m = EmptyHashMap[int, int]()
+    val ns = measureNs(1000, () => {
+        val m = EmptyHashMap[int, int]()
         for i := 0; i < 10000; i++ {
             m.Put(i, i)
         }
@@ -742,8 +742,8 @@ func benchHashMapCreation10000() {
 
 // HashMap creation benchmark - large
 func benchHashMapCreation100000() {
-    var ns = measureNs(100, () => {
-        var m = EmptyHashMap[int, int]()
+    val ns = measureNs(100, () => {
+        val m = EmptyHashMap[int, int]()
         for i := 0; i < 100000; i++ {
             m.Put(i, i)
         }
@@ -753,11 +753,11 @@ func benchHashMapCreation100000() {
 
 // HashMap put benchmark
 func benchHashMapPut() {
-    var m = EmptyHashMap[int, int]()
+    val m = EmptyHashMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         m.Put(99999, 99999)
         m.Remove(99999)
     })
@@ -766,11 +766,11 @@ func benchHashMapPut() {
 
 // HashMap get benchmark - hit
 func benchHashMapGetHit() {
-    var m = EmptyHashMap[int, int]()
+    val m = EmptyHashMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = m.Get(5000)
     })
     printResult("HashMap.Get hit (size=10000)", ns)
@@ -778,11 +778,11 @@ func benchHashMapGetHit() {
 
 // HashMap get benchmark - miss
 func benchHashMapGetMiss() {
-    var m = EmptyHashMap[int, int]()
+    val m = EmptyHashMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = m.Get(99999)
     })
     printResult("HashMap.Get miss (size=10000)", ns)
@@ -790,11 +790,11 @@ func benchHashMapGetMiss() {
 
 // HashMap contains benchmark - hit
 func benchHashMapContainsHit() {
-    var m = EmptyHashMap[int, int]()
+    val m = EmptyHashMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = m.Contains(5000)
     })
     printResult("HashMap.Contains hit (size=10000)", ns)
@@ -802,11 +802,11 @@ func benchHashMapContainsHit() {
 
 // HashMap contains benchmark - miss
 func benchHashMapContainsMiss() {
-    var m = EmptyHashMap[int, int]()
+    val m = EmptyHashMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = m.Contains(99999)
     })
     printResult("HashMap.Contains miss (size=10000)", ns)
@@ -814,11 +814,11 @@ func benchHashMapContainsMiss() {
 
 // HashMap remove benchmark
 func benchHashMapRemove() {
-    var m = EmptyHashMap[int, int]()
+    val m = EmptyHashMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         m.Put(99999, 99999)
         m.Remove(99999)
     })
@@ -827,35 +827,35 @@ func benchHashMapRemove() {
 
 // HashMap filter benchmark
 func benchHashMapFilter() {
-    var m = EmptyHashMap[int, int]()
+    val m = EmptyHashMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(1000, () => {
-        var _ = m.Filter((k int, v int) => v % 2 == 0)
+    val ns = measureNs(1000, () => {
+        var _ = m.Filter((k, v) => v % 2 == 0)
     })
     printResult("HashMap.Filter (size=10000)", ns)
 }
 
 // HashMap mapValues benchmark
 func benchHashMapMapValues() {
-    var m = EmptyHashMap[int, int]()
+    val m = EmptyHashMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(1000, () => {
-        var _ = m.MapValues[int]((v int) => v * 2)
+    val ns = measureNs(1000, () => {
+        var _ = m.MapValues[int]((v) => v * 2)
     })
     printResult("HashMap.MapValues (size=10000)", ns)
 }
 
 // HashMap clone benchmark
 func benchHashMapClone() {
-    var m = EmptyHashMap[int, int]()
+    val m = EmptyHashMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = m.Clone()
     })
     printResult("HashMap.Clone (size=10000)", ns)
@@ -863,14 +863,14 @@ func benchHashMapClone() {
 
 // HashMap string keys benchmark
 func benchHashMapStringKeys() {
-    var m = EmptyHashMap[string, int]()
+    val m = EmptyHashMap[string, int]()
     var keys []string
     for i := 0; i < 10000; i++ {
-        var key = "key" + string(rune(i%26+65)) + string(rune((i/26)%26+65))
+        val key = "key" + string(rune(i%26+65)) + string(rune((i/26)%26+65))
         keys = append(keys, key)
         m.Put(key, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.Get(keys[5000])
     })
     printResult("HashMap.Get string key (size=10000)", ns)
@@ -880,8 +880,8 @@ func benchHashMapStringKeys() {
 
 // TreeMap creation benchmark - small
 func benchTreeMapCreation100() {
-    var ns = measureNs(10000, () => {
-        var m = EmptyTreeMap[int, int]()
+    val ns = measureNs(10000, () => {
+        val m = EmptyTreeMap[int, int]()
         for i := 0; i < 100; i++ {
             m.Put(i, i)
         }
@@ -891,8 +891,8 @@ func benchTreeMapCreation100() {
 
 // TreeMap creation benchmark - medium
 func benchTreeMapCreation10000() {
-    var ns = measureNs(1000, () => {
-        var m = EmptyTreeMap[int, int]()
+    val ns = measureNs(1000, () => {
+        val m = EmptyTreeMap[int, int]()
         for i := 0; i < 10000; i++ {
             m.Put(i, i)
         }
@@ -902,8 +902,8 @@ func benchTreeMapCreation10000() {
 
 // TreeMap creation benchmark - large
 func benchTreeMapCreation100000() {
-    var ns = measureNs(100, () => {
-        var m = EmptyTreeMap[int, int]()
+    val ns = measureNs(100, () => {
+        val m = EmptyTreeMap[int, int]()
         for i := 0; i < 100000; i++ {
             m.Put(i, i)
         }
@@ -913,11 +913,11 @@ func benchTreeMapCreation100000() {
 
 // TreeMap put benchmark
 func benchTreeMapPut() {
-    var m = EmptyTreeMap[int, int]()
+    val m = EmptyTreeMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         m.Put(99999, 99999)
         m.Remove(99999)
     })
@@ -926,11 +926,11 @@ func benchTreeMapPut() {
 
 // TreeMap get benchmark - hit
 func benchTreeMapGetHit() {
-    var m = EmptyTreeMap[int, int]()
+    val m = EmptyTreeMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.Get(5000)
     })
     printResult("TreeMap.Get hit (size=10000)", ns)
@@ -938,11 +938,11 @@ func benchTreeMapGetHit() {
 
 // TreeMap get benchmark - miss
 func benchTreeMapGetMiss() {
-    var m = EmptyTreeMap[int, int]()
+    val m = EmptyTreeMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.Get(99999)
     })
     printResult("TreeMap.Get miss (size=10000)", ns)
@@ -950,11 +950,11 @@ func benchTreeMapGetMiss() {
 
 // TreeMap contains benchmark - hit
 func benchTreeMapContainsHit() {
-    var m = EmptyTreeMap[int, int]()
+    val m = EmptyTreeMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.Contains(5000)
     })
     printResult("TreeMap.Contains hit (size=10000)", ns)
@@ -962,11 +962,11 @@ func benchTreeMapContainsHit() {
 
 // TreeMap contains benchmark - miss
 func benchTreeMapContainsMiss() {
-    var m = EmptyTreeMap[int, int]()
+    val m = EmptyTreeMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = m.Contains(99999)
     })
     printResult("TreeMap.Contains miss (size=10000)", ns)
@@ -974,11 +974,11 @@ func benchTreeMapContainsMiss() {
 
 // TreeMap remove benchmark
 func benchTreeMapRemove() {
-    var m = EmptyTreeMap[int, int]()
+    val m = EmptyTreeMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         m.Put(99999, 99999)
         m.Remove(99999)
     })
@@ -987,11 +987,11 @@ func benchTreeMapRemove() {
 
 // TreeMap minKey benchmark
 func benchTreeMapMinKey() {
-    var m = EmptyTreeMap[int, int]()
+    val m = EmptyTreeMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = m.MinKey()
     })
     printResult("TreeMap.MinKey (size=10000)", ns)
@@ -999,11 +999,11 @@ func benchTreeMapMinKey() {
 
 // TreeMap maxKey benchmark
 func benchTreeMapMaxKey() {
-    var m = EmptyTreeMap[int, int]()
+    val m = EmptyTreeMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = m.MaxKey()
     })
     printResult("TreeMap.MaxKey (size=10000)", ns)
@@ -1011,11 +1011,11 @@ func benchTreeMapMaxKey() {
 
 // TreeMap range benchmark
 func benchTreeMapRange() {
-    var m = EmptyTreeMap[int, int]()
+    val m = EmptyTreeMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = m.Range(2500, 7500)
     })
     printResult("TreeMap.Range (size=10000)", ns)
@@ -1023,38 +1023,38 @@ func benchTreeMapRange() {
 
 // TreeMap filter benchmark
 func benchTreeMapFilter() {
-    var m = EmptyTreeMap[int, int]()
+    val m = EmptyTreeMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(1000, () => {
-        var _ = m.Filter((k int, v int) => v % 2 == 0)
+    val ns = measureNs(1000, () => {
+        var _ = m.Filter((k, v) => v % 2 == 0)
     })
     printResult("TreeMap.Filter (size=10000)", ns)
 }
 
 // TreeMap mapValues benchmark
 func benchTreeMapMapValues() {
-    var m = EmptyTreeMap[int, int]()
+    val m = EmptyTreeMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(1000, () => {
-        var _ = m.MapValues[int]((v int) => v * 2)
+    val ns = measureNs(1000, () => {
+        var _ = m.MapValues[int]((v) => v * 2)
     })
     printResult("TreeMap.MapValues (size=10000)", ns)
 }
 
 // TreeMap putFrom benchmark
 func benchTreeMapPutFrom() {
-    var m1 = EmptyTreeMap[int, int]()
-    var m2 = EmptyTreeMap[int, int]()
+    val m1 = EmptyTreeMap[int, int]()
+    val m2 = EmptyTreeMap[int, int]()
     for i := 0; i < 1000; i++ {
         m1.Put(i, i)
         m2.Put(i + 500, i + 500)
     }
-    var ns = measureNs(100, () => {
-        var clone = m1.Clone()
+    val ns = measureNs(100, () => {
+        val clone = m1.Clone()
         clone.PutFrom(m2)
     })
     printResult("TreeMap.PutFrom (2x1000)", ns)
@@ -1062,11 +1062,11 @@ func benchTreeMapPutFrom() {
 
 // TreeMap clone benchmark
 func benchTreeMapClone() {
-    var m = EmptyTreeMap[int, int]()
+    val m = EmptyTreeMap[int, int]()
     for i := 0; i < 10000; i++ {
         m.Put(i, i)
     }
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = m.Clone()
     })
     printResult("TreeMap.Clone (size=10000)", ns)

--- a/collection_mutable/treemap.gala
+++ b/collection_mutable/treemap.gala
@@ -263,11 +263,10 @@ func (m *TreeMap[K, V]) GetOrElse(key K, defaultValue V) V {
 
 // Apply returns the value for a key. Panics if key not found.
 func (m *TreeMap[K, V]) Apply(key K) V {
-    val opt = m.Get(key)
-    if opt.IsEmpty() {
-        panic(fmt.Sprintf("TreeMap: key not found: %v", key))
+    return m.Get(key) match {
+        case Some(v) => v
+        case None() => panic(s"TreeMap: key not found: $key")
     }
-    return opt.Get()
 }
 
 // === Mutating Operations ===
@@ -999,11 +998,9 @@ func (m *TreeMap[K, V]) PutFrom(other *TreeMap[K, V]) {
 // Merge merges another map, using a function for duplicate keys.
 func (m *TreeMap[K, V]) Merge(other *TreeMap[K, V], f func(V, V) V) {
     other.ForEachKV((k K, v V) => {
-        val existing = m.Get(k)
-        if existing.IsDefined() {
-            m.Put(k, f(existing.Get(), v))
-        } else {
-            m.Put(k, v)
+        m.Get(k) match {
+            case Some(e) => m.Put(k, f(e, v))
+            case None() => m.Put(k, v)
         }
     })
 }
@@ -1072,7 +1069,7 @@ func (m *TreeMap[K, V]) String() string {
         if !first {
             result = result + ", "
         }
-        result = result + fmt.Sprintf("%v -> %v", k, v)
+        result = result + s"$k -> $v"
         first = false
     })
     return result + ")"
@@ -1089,7 +1086,7 @@ func (m *TreeMap[K, V]) MkString(sep string) string {
         if !first {
             result = result + sep
         }
-        result = result + fmt.Sprintf("%v -> %v", k, v)
+        result = result + s"$k -> $v"
         first = false
     })
     return result

--- a/collection_mutable/treemap_test.gala
+++ b/collection_mutable/treemap_test.gala
@@ -10,8 +10,8 @@ import (
 
 func TestMutableTreeMapEmpty(t T) T {
     val m = EmptyTreeMap[string, int]()
-    var t1 = IsTrue(t, m.IsEmpty())
-    var t2 = IsFalse(t1, m.NonEmpty())
+    val t1 = IsTrue(t, m.IsEmpty())
+    val t2 = IsFalse(t1, m.NonEmpty())
     return Eq[int](t2, m.Size(), 0)
 }
 
@@ -28,21 +28,21 @@ func TestMutableTreeMapPutUpdate(t T) T {
     val isNew = m.Put("a", 1)
     val isUpdate = m.Put("a", 2)
 
-    var t1 = IsTrue(t, isNew)
-    var t2 = IsFalse(t1, isUpdate)
-    var t3 = Eq[int](t2, m.Size(), 1)
+    val t1 = IsTrue(t, isNew)
+    val t2 = IsFalse(t1, isUpdate)
+    val t3 = Eq[int](t2, m.Size(), 1)
     return Eq[int](t3, m.GetOrElse("a", 0), 2)
 }
 
 func TestMutableTreeMapOf(t T) T {
     val m = TreeMapOf[string, int](
-        Tuple[string, int](V1 = "a", V2 = 1),
-        Tuple[string, int](V1 = "b", V2 = 2),
-        Tuple[string, int](V1 = "c", V2 = 3)
+        ("a", 1),
+        ("b", 2),
+        ("c", 3)
     )
-    var t1 = Eq[int](t, m.Size(), 3)
-    var t2 = IsTrue(t1, m.Contains("a"))
-    var t3 = IsTrue(t2, m.Contains("b"))
+    val t1 = Eq[int](t, m.Size(), 3)
+    val t2 = IsTrue(t1, m.Contains("a"))
+    val t3 = IsTrue(t2, m.Contains("b"))
     return IsTrue(t3, m.Contains("c"))
 }
 
@@ -50,8 +50,8 @@ func TestMutableTreeMapContains(t T) T {
     val m = EmptyTreeMap[string, int]()
     m.Put("a", 1)
     m.Put("b", 2)
-    var t1 = IsTrue(t, m.Contains("a"))
-    var t2 = IsTrue(t1, m.Contains("b"))
+    val t1 = IsTrue(t, m.Contains("a"))
+    val t2 = IsTrue(t1, m.Contains("b"))
     return IsFalse(t2, m.Contains("c"))
 }
 
@@ -59,16 +59,16 @@ func TestMutableTreeMapGet(t T) T {
     val m = EmptyTreeMap[string, int]()
     m.Put("a", 1)
     m.Put("b", 2)
-    var t1 = IsSome(t, m.Get("a"))
-    var t2 = Eq[int](t1, m.Get("a").Get(), 1)
-    var t3 = Eq[int](t2, m.Get("b").Get(), 2)
+    val t1 = IsSome(t, m.Get("a"))
+    val t2 = Eq[int](t1, m.Get("a").Get(), 1)
+    val t3 = Eq[int](t2, m.Get("b").Get(), 2)
     return IsNone(t3, m.Get("c"))
 }
 
 func TestMutableTreeMapGetOrElse(t T) T {
     val m = EmptyTreeMap[string, int]()
     m.Put("a", 1)
-    var t1 = Eq[int](t, m.GetOrElse("a", 0), 1)
+    val t1 = Eq[int](t, m.GetOrElse("a", 0), 1)
     return Eq[int](t1, m.GetOrElse("b", 42), 42)
 }
 
@@ -79,10 +79,10 @@ func TestMutableTreeMapRemove(t T) T {
     m.Put("c", 3)
     val removed = m.Remove("b")
 
-    var t1 = IsTrue(t, removed)
-    var t2 = Eq[int](t1, m.Size(), 2)
-    var t3 = IsTrue(t2, m.Contains("a"))
-    var t4 = IsFalse(t3, m.Contains("b"))
+    val t1 = IsTrue(t, removed)
+    val t2 = Eq[int](t1, m.Size(), 2)
+    val t3 = IsTrue(t2, m.Contains("a"))
+    val t4 = IsFalse(t3, m.Contains("b"))
     return IsTrue(t4, m.Contains("c"))
 }
 
@@ -90,7 +90,7 @@ func TestMutableTreeMapRemoveNonExistent(t T) T {
     val m = EmptyTreeMap[string, int]()
     m.Put("a", 1)
     val removed = m.Remove("b")
-    var t1 = IsFalse(t, removed)
+    val t1 = IsFalse(t, removed)
     return Eq[int](t1, m.Size(), 1)
 }
 
@@ -109,11 +109,11 @@ func TestMutableTreeMapSortedOrder(t T) T {
         keys = append(keys, k)
     })
 
-    var t1 = Eq[int](t, len(keys), 5)
-    var t2 = Eq[int](t1, keys[0], 1)
-    var t3 = Eq[int](t2, keys[1], 2)
-    var t4 = Eq[int](t3, keys[2], 3)
-    var t5 = Eq[int](t4, keys[3], 4)
+    val t1 = Eq[int](t, len(keys), 5)
+    val t2 = Eq[int](t1, keys[0], 1)
+    val t3 = Eq[int](t2, keys[1], 2)
+    val t4 = Eq[int](t3, keys[2], 3)
+    val t5 = Eq[int](t4, keys[3], 4)
     return Eq[int](t5, keys[4], 5)
 }
 
@@ -141,7 +141,7 @@ func TestMutableTreeMapMinEntry(t T) T {
     m.Put(3, "c")
     m.Put(1, "a")
     val entry = m.MinEntry()
-    var t1 = Eq[int](t, entry.V1, 1)
+    val t1 = Eq[int](t, entry.V1, 1)
     return Eq[string](t1, entry.V2, "a")
 }
 
@@ -151,7 +151,7 @@ func TestMutableTreeMapMaxEntry(t T) T {
     m.Put(3, "c")
     m.Put(1, "a")
     val entry = m.MaxEntry()
-    var t1 = Eq[int](t, entry.V1, 5)
+    val t1 = Eq[int](t, entry.V1, 5)
     return Eq[string](t1, entry.V2, "e")
 }
 
@@ -163,9 +163,9 @@ func TestMutableTreeMapPutIfAbsent(t T) T {
     val added = m.PutIfAbsent("b", 2)
     val notAdded = m.PutIfAbsent("a", 99)
 
-    var t1 = IsTrue(t, added)
-    var t2 = IsFalse(t1, notAdded)
-    var t3 = Eq[int](t2, m.Size(), 2)
+    val t1 = IsTrue(t, added)
+    val t2 = IsFalse(t1, notAdded)
+    val t3 = Eq[int](t2, m.Size(), 2)
     // Original value should be preserved
     return Eq[int](t3, m.GetOrElse("a", 0), 1)
 }
@@ -174,11 +174,11 @@ func TestMutableTreeMapUpdate(t T) T {
     val m = EmptyTreeMap[string, int]()
     m.Put("a", 1)
     m.Put("b", 2)
-    val updated = m.Update("a", (v int) => v * 10)
-    val notUpdated = m.Update("c", (v int) => v * 10)
+    val updated = m.Update("a", (v) => v * 10)
+    val notUpdated = m.Update("c", (v) => v * 10)
 
-    var t1 = IsTrue(t, updated)
-    var t2 = IsFalse(t1, notUpdated)
+    val t1 = IsTrue(t, updated)
+    val t2 = IsFalse(t1, notUpdated)
     return Eq[int](t2, m.GetOrElse("a", 0), 10)
 }
 
@@ -189,9 +189,9 @@ func TestMutableTreeMapPopMinEntry(t T) T {
     m.Put(2, "b")
 
     val min = m.PopMinEntry()
-    var t1 = Eq[int](t, min.V1, 1)
-    var t2 = Eq[string](t1, min.V2, "a")
-    var t3 = Eq[int](t2, m.Size(), 2)
+    val t1 = Eq[int](t, min.V1, 1)
+    val t2 = Eq[string](t1, min.V2, "a")
+    val t3 = Eq[int](t2, m.Size(), 2)
     return IsFalse(t3, m.Contains(1))
 }
 
@@ -202,9 +202,9 @@ func TestMutableTreeMapPopMaxEntry(t T) T {
     m.Put(2, "b")
 
     val max = m.PopMaxEntry()
-    var t1 = Eq[int](t, max.V1, 3)
-    var t2 = Eq[string](t1, max.V2, "c")
-    var t3 = Eq[int](t2, m.Size(), 2)
+    val t1 = Eq[int](t, max.V1, 3)
+    val t2 = Eq[string](t1, max.V2, "c")
+    val t3 = Eq[int](t2, m.Size(), 2)
     return IsFalse(t3, m.Contains(3))
 }
 
@@ -214,7 +214,7 @@ func TestMutableTreeMapClear(t T) T {
     m.Put("b", 2)
     m.Put("c", 3)
     m.Clear()
-    var t1 = IsTrue(t, m.IsEmpty())
+    val t1 = IsTrue(t, m.IsEmpty())
     return Eq[int](t1, m.Size(), 0)
 }
 
@@ -224,10 +224,10 @@ func TestMutableTreeMapFilterInPlace(t T) T {
     m.Put("b", 2)
     m.Put("c", 3)
     m.Put("d", 4)
-    m.FilterInPlace((k string, v int) => v > 2)
+    m.FilterInPlace((k, v) => v > 2)
 
-    var t1 = Eq[int](t, m.Size(), 2)
-    var t2 = IsFalse(t1, m.Contains("a"))
+    val t1 = Eq[int](t, m.Size(), 2)
+    val t2 = IsFalse(t1, m.Contains("a"))
     return IsTrue(t2, m.Contains("c"))
 }
 
@@ -236,10 +236,10 @@ func TestMutableTreeMapUpdateAll(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     m.Put("c", 3)
-    m.UpdateAll((k string, v int) => v * 10)
+    m.UpdateAll((k, v) => v * 10)
 
-    var t1 = Eq[int](t, m.GetOrElse("a", 0), 10)
-    var t2 = Eq[int](t1, m.GetOrElse("b", 0), 20)
+    val t1 = Eq[int](t, m.GetOrElse("a", 0), 10)
+    val t2 = Eq[int](t1, m.GetOrElse("b", 0), 20)
     return Eq[int](t2, m.GetOrElse("c", 0), 30)
 }
 
@@ -252,7 +252,7 @@ func TestMutableTreeMapClone(t T) T {
     clone.Put("c", 3)
 
     // Original should not be affected
-    var t1 = Eq[int](t, m.Size(), 2)
+    val t1 = Eq[int](t, m.Size(), 2)
     return Eq[int](t1, clone.Size(), 3)
 }
 
@@ -265,10 +265,10 @@ func TestMutableTreeMapRange(t T) T {
     }
     val rangeMap = m.Range(3, 7)
 
-    var t1 = Eq[int](t, rangeMap.Size(), 5)
-    var t2 = IsTrue(t1, rangeMap.Contains(3))
-    var t3 = IsTrue(t2, rangeMap.Contains(7))
-    var t4 = IsFalse(t3, rangeMap.Contains(2))
+    val t1 = Eq[int](t, rangeMap.Size(), 5)
+    val t2 = IsTrue(t1, rangeMap.Contains(3))
+    val t3 = IsTrue(t2, rangeMap.Contains(7))
+    val t4 = IsFalse(t3, rangeMap.Contains(2))
     return IsFalse(t4, rangeMap.Contains(8))
 }
 
@@ -279,8 +279,8 @@ func TestMutableTreeMapRangeFrom(t T) T {
     }
     val rangeMap = m.RangeFrom(3)
 
-    var t1 = Eq[int](t, rangeMap.Size(), 3)
-    var t2 = IsTrue(t1, rangeMap.Contains(3))
+    val t1 = Eq[int](t, rangeMap.Size(), 3)
+    val t2 = IsTrue(t1, rangeMap.Contains(3))
     return IsFalse(t2, rangeMap.Contains(2))
 }
 
@@ -291,8 +291,8 @@ func TestMutableTreeMapRangeTo(t T) T {
     }
     val rangeMap = m.RangeTo(3)
 
-    var t1 = Eq[int](t, rangeMap.Size(), 3)
-    var t2 = IsTrue(t1, rangeMap.Contains(3))
+    val t1 = Eq[int](t, rangeMap.Size(), 3)
+    val t2 = IsTrue(t1, rangeMap.Contains(3))
     return IsFalse(t2, rangeMap.Contains(4))
 }
 
@@ -304,10 +304,10 @@ func TestMutableTreeMapFilter(t T) T {
     m.Put("b", 2)
     m.Put("c", 3)
     m.Put("d", 4)
-    val filtered = m.Filter((k string, v int) => v > 2)
+    val filtered = m.Filter((k, v) => v > 2)
 
-    var t1 = Eq[int](t, filtered.Size(), 2)
-    var t2 = IsFalse(t1, filtered.Contains("a"))
+    val t1 = Eq[int](t, filtered.Size(), 2)
+    val t2 = IsFalse(t1, filtered.Contains("a"))
     return IsTrue(t2, filtered.Contains("c"))
 }
 
@@ -316,10 +316,10 @@ func TestMutableTreeMapMapValues(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     m.Put("c", 3)
-    val doubled = m.MapValues[int]((v int) => v * 2)
+    val doubled = m.MapValues[int]((v) => v * 2)
 
-    var t1 = Eq[int](t, doubled.GetOrElse("a", 0), 2)
-    var t2 = Eq[int](t1, doubled.GetOrElse("b", 0), 4)
+    val t1 = Eq[int](t, doubled.GetOrElse("a", 0), 2)
+    val t2 = Eq[int](t1, doubled.GetOrElse("b", 0), 4)
     return Eq[int](t2, doubled.GetOrElse("c", 0), 6)
 }
 
@@ -329,11 +329,11 @@ func TestMutableTreeMapPartition(t T) T {
     m.Put("b", 2)
     m.Put("c", 3)
     m.Put("d", 4)
-    val result = m.Partition((k string, v int) => v % 2 == 0)
+    val result = m.Partition((k, v) => v % 2 == 0)
     val even = result.V1
     val odd = result.V2
 
-    var t1 = Eq[int](t, even.Size(), 2)
+    val t1 = Eq[int](t, even.Size(), 2)
     return Eq[int](t1, odd.Size(), 2)
 }
 
@@ -344,7 +344,7 @@ func TestMutableTreeMapFoldLeftKV(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     m.Put("c", 3)
-    val sum = m.FoldLeftKV[int](0, (acc int, k string, v int) => acc + v)
+    val sum = m.FoldLeftKV[int](0, (acc, k, v) => acc + v)
     return Eq[int](t, sum, 6)
 }
 
@@ -353,8 +353,8 @@ func TestMutableTreeMapExists(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     m.Put("c", 3)
-    var t1 = IsTrue(t, m.Exists((k string, v int) => v > 2))
-    return IsFalse(t1, m.Exists((k string, v int) => v > 10))
+    val t1 = IsTrue(t, m.Exists((k, v) => v > 2))
+    return IsFalse(t1, m.Exists((k, v) => v > 10))
 }
 
 func TestMutableTreeMapForAll(t T) T {
@@ -362,8 +362,8 @@ func TestMutableTreeMapForAll(t T) T {
     m.Put("a", 2)
     m.Put("b", 4)
     m.Put("c", 6)
-    var t1 = IsTrue(t, m.ForAll((k string, v int) => v % 2 == 0))
-    return IsFalse(t1, m.ForAll((k string, v int) => v < 5))
+    val t1 = IsTrue(t, m.ForAll((k, v) => v % 2 == 0))
+    return IsFalse(t1, m.ForAll((k, v) => v < 5))
 }
 
 func TestMutableTreeMapFind(t T) T {
@@ -371,8 +371,8 @@ func TestMutableTreeMapFind(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     m.Put("c", 3)
-    val found = m.Find((k string, v int) => v == 2)
-    var t1 = IsSome(t, found)
+    val found = m.Find((k, v) => v == 2)
+    val t1 = IsSome(t, found)
     return Eq[string](t1, found.Get().V1, "b")
 }
 
@@ -382,7 +382,7 @@ func TestMutableTreeMapCount(t T) T {
     m.Put("b", 2)
     m.Put("c", 3)
     m.Put("d", 4)
-    return Eq[int](t, m.Count((k string, v int) => v > 2), 2)
+    return Eq[int](t, m.Count((k, v) => v > 2), 2)
 }
 
 // === Merge Tests ===
@@ -396,8 +396,8 @@ func TestMutableTreeMapPutFrom(t T) T {
     m2.Put("d", 4)
     m1.PutFrom(m2)
 
-    var t1 = Eq[int](t, m1.Size(), 4)
-    var t2 = IsTrue(t1, m1.Contains("c"))
+    val t1 = Eq[int](t, m1.Size(), 4)
+    val t2 = IsTrue(t1, m1.Contains("c"))
     return IsTrue(t2, m1.Contains("d"))
 }
 
@@ -408,11 +408,11 @@ func TestMutableTreeMapMerge(t T) T {
     val m2 = EmptyTreeMap[string, int]()
     m2.Put("b", 3)
     m2.Put("c", 4)
-    m1.Merge(m2, (v1 int, v2 int) => v1 + v2)
+    m1.Merge(m2, (v1, v2) => v1 + v2)
 
-    var t1 = Eq[int](t, m1.Size(), 3)
-    var t2 = Eq[int](t1, m1.GetOrElse("a", 0), 1)
-    var t3 = Eq[int](t2, m1.GetOrElse("b", 0), 5)
+    val t1 = Eq[int](t, m1.Size(), 3)
+    val t2 = Eq[int](t1, m1.GetOrElse("a", 0), 1)
+    val t3 = Eq[int](t2, m1.GetOrElse("b", 0), 5)
     return Eq[int](t3, m1.GetOrElse("c", 0), 4)
 }
 
@@ -424,10 +424,10 @@ func TestMutableTreeMapToArray(t T) T {
     m.Put(1, "a")
     m.Put(2, "b")
     val arr = m.ToArray()
-    var t1 = Eq[int](t, arr.Size(), 3)
+    val t1 = Eq[int](t, arr.Size(), 3)
     // Verify via ToGoSlice to avoid Immutable wrapping issues
     val goSlice = arr.ToGoSlice()
-    var t2 = Eq[int](t1, goSlice[0].V1, 1)
+    val t2 = Eq[int](t1, goSlice[0].V1, 1)
     return Eq[int](t2, goSlice[2].V1, 3)
 }
 
@@ -436,7 +436,7 @@ func TestMutableTreeMapToGoMap(t T) T {
     m.Put("a", 1)
     m.Put("b", 2)
     val goMap = m.ToGoMap()
-    var t1 = Eq[int](t, len(goMap), 2)
+    val t1 = Eq[int](t, len(goMap), 2)
     return Eq[int](t1, goMap["a"], 1)
 }
 
@@ -446,8 +446,8 @@ func TestMutableTreeMapToHashMap(t T) T {
     m.Put("b", 2)
     m.Put("c", 3)
     val hm = m.ToHashMap()
-    var t1 = Eq[int](t, hm.Size(), 3)
-    var t2 = Eq[int](t1, hm.GetOrElse("a", 0), 1)
+    val t1 = Eq[int](t, hm.Size(), 3)
+    val t2 = Eq[int](t1, hm.GetOrElse("a", 0), 1)
     return Eq[int](t2, hm.GetOrElse("c", 0), 3)
 }
 
@@ -455,7 +455,7 @@ func TestMutableTreeMapToHashMap(t T) T {
 
 func TestMutableTreeMapString(t T) T {
     val empty = EmptyTreeMap[string, int]()
-    var t1 = Eq[string](t, empty.String(), "TreeMap()")
+    val t1 = Eq[string](t, empty.String(), "TreeMap()")
 
     val m = EmptyTreeMap[int, string]()
     m.Put(2, "b")
@@ -479,11 +479,11 @@ func TestMutableTreeMapLarge(t T) T {
     for i := 0; i < 1000; i++ {
         m.Put(i, i * 2)
     }
-    var t1 = Eq[int](t, m.Size(), 1000)
-    var t2 = Eq[int](t1, m.GetOrElse(0, -1), 0)
-    var t3 = Eq[int](t2, m.GetOrElse(500, -1), 1000)
-    var t4 = Eq[int](t3, m.GetOrElse(999, -1), 1998)
-    var t5 = Eq[int](t4, m.MinKey(), 0)
+    val t1 = Eq[int](t, m.Size(), 1000)
+    val t2 = Eq[int](t1, m.GetOrElse(0, -1), 0)
+    val t3 = Eq[int](t2, m.GetOrElse(500, -1), 1000)
+    val t4 = Eq[int](t3, m.GetOrElse(999, -1), 1998)
+    val t5 = Eq[int](t4, m.MinKey(), 0)
     return Eq[int](t5, m.MaxKey(), 999)
 }
 
@@ -495,9 +495,9 @@ func TestMutableTreeMapSorted(t T) T {
     m.Put(1, "a")
     m.Put(2, "b")
     val sorted = m.Sorted()
-    var t1 = Eq[int](t, sorted.Size(), 3)
+    val t1 = Eq[int](t, sorted.Size(), 3)
     val goSlice = sorted.ToGoSlice()
-    var t2 = Eq[int](t1, goSlice[0].V1, 1)
+    val t2 = Eq[int](t1, goSlice[0].V1, 1)
     return Eq[int](t2, goSlice[2].V1, 3)
 }
 
@@ -506,10 +506,10 @@ func TestMutableTreeMapSortWith(t T) T {
     m.Put("a", 3)
     m.Put("b", 1)
     m.Put("c", 2)
-    val sorted = m.SortWith((a Tuple[string, int], b Tuple[string, int]) => a.V2 < b.V2)
-    var t1 = Eq[int](t, sorted.Size(), 3)
+    val sorted = m.SortWith((a, b) => a.V2 < b.V2)
+    val t1 = Eq[int](t, sorted.Size(), 3)
     val goSlice = sorted.ToGoSlice()
-    var t2 = Eq[string](t1, goSlice[0].V1, "b")
+    val t2 = Eq[string](t1, goSlice[0].V1, "b")
     return Eq[string](t2, goSlice[2].V1, "a")
 }
 
@@ -518,10 +518,10 @@ func TestMutableTreeMapSortBy(t T) T {
     m.Put("a", 30)
     m.Put("b", 10)
     m.Put("c", 20)
-    val sorted = m.SortBy[int]((entry Tuple[string, int]) => entry.V2)
-    var t1 = Eq[int](t, sorted.Size(), 3)
+    val sorted = m.SortBy((entry) => entry.V2)
+    val t1 = Eq[int](t, sorted.Size(), 3)
     val goSlice = sorted.ToGoSlice()
-    var t2 = Eq[string](t1, goSlice[0].V1, "b")
+    val t2 = Eq[string](t1, goSlice[0].V1, "b")
     return Eq[string](t2, goSlice[2].V1, "a")
 }
 
@@ -533,7 +533,7 @@ func TestMutableTreeMapGetOrElseUpdate(t T) T {
     val existing = m.GetOrElseUpdate("a", () => 99)
     val computed = m.GetOrElseUpdate("b", () => 42)
 
-    var t1 = Eq[int](t, existing, 1)
-    var t2 = Eq[int](t1, computed, 42)
+    val t1 = Eq[int](t, existing, 1)
+    val t2 = Eq[int](t1, computed, 42)
     return Eq[int](t2, m.GetOrElse("b", 0), 42)
 }

--- a/collection_mutable/treeset.gala
+++ b/collection_mutable/treeset.gala
@@ -996,7 +996,7 @@ func (s *TreeSet[T]) String() string {
         if !first {
             result = result + ", "
         }
-        result = result + fmt.Sprintf("%v", elem)
+        result = result + s"$elem"
         first = false
     })
     return result + ")"
@@ -1013,7 +1013,7 @@ func (s *TreeSet[T]) MkString(sep string) string {
         if !first {
             result = result + sep
         }
-        result = result + fmt.Sprintf("%v", elem)
+        result = result + s"$elem"
         first = false
     })
     return result

--- a/collection_mutable/treeset_test.gala
+++ b/collection_mutable/treeset_test.gala
@@ -11,64 +11,64 @@ import (
 // === TreeSet Creation Tests ===
 
 func TestEmptyTreeSet(t T) T {
-    var s = EmptyTreeSet[int]()
-    var t1 = IsTrue(t, s.IsEmpty())
+    val s = EmptyTreeSet[int]()
+    val t1 = IsTrue(t, s.IsEmpty())
     return Eq[int](t1, s.Size(), 0)
 }
 
 func TestTreeSetOf(t T) T {
-    var s = TreeSetOf[int](3, 1, 2)
-    var t1 = IsFalse(t, s.IsEmpty())
+    val s = TreeSetOf[int](3, 1, 2)
+    val t1 = IsFalse(t, s.IsEmpty())
     return Eq[int](t1, s.Size(), 3)
 }
 
 func TestTreeSetOfDuplicates(t T) T {
-    var s = TreeSetOf[int](1, 2, 2, 3, 3, 3)
+    val s = TreeSetOf[int](1, 2, 2, 3, 3, 3)
     return Eq[int](t, s.Size(), 3)
 }
 
 func TestTreeSetFromSlice(t T) T {
-    var slice = go_interop.SliceOf(30, 10, 20)
-    var s = TreeSetFromSlice(slice)
-    var t1 = Eq[int](t, s.Size(), 3)
-    var t2 = IsTrue(t1, s.Contains(10))
-    var t3 = IsTrue(t2, s.Contains(20))
+    val slice = go_interop.SliceOf(30, 10, 20)
+    val s = TreeSetFromSlice(slice)
+    val t1 = Eq[int](t, s.Size(), 3)
+    val t2 = IsTrue(t1, s.Contains(10))
+    val t3 = IsTrue(t2, s.Contains(20))
     return IsTrue(t3, s.Contains(30))
 }
 
 // === TreeSet Basic Operations Tests ===
 
 func TestTreeSetAdd(t T) T {
-    var s = EmptyTreeSet[int]()
-    var added1 = s.Add(1)
-    var added2 = s.Add(2)
-    var added3 = s.Add(1) // Duplicate
-    var t1 = IsTrue(t, added1)
-    var t2 = IsTrue(t1, added2)
-    var t3 = IsFalse(t2, added3)
+    val s = EmptyTreeSet[int]()
+    val added1 = s.Add(1)
+    val added2 = s.Add(2)
+    val added3 = s.Add(1) // Duplicate
+    val t1 = IsTrue(t, added1)
+    val t2 = IsTrue(t1, added2)
+    val t3 = IsFalse(t2, added3)
     return Eq[int](t3, s.Size(), 2)
 }
 
 func TestTreeSetRemove(t T) T {
-    var s = TreeSetOf[int](1, 2, 3)
-    var removed1 = s.Remove(2)
-    var removed2 = s.Remove(5) // Not present
-    var t1 = IsTrue(t, removed1)
-    var t2 = IsFalse(t1, removed2)
-    var t3 = Eq[int](t2, s.Size(), 2)
+    val s = TreeSetOf[int](1, 2, 3)
+    val removed1 = s.Remove(2)
+    val removed2 = s.Remove(5) // Not present
+    val t1 = IsTrue(t, removed1)
+    val t2 = IsFalse(t1, removed2)
+    val t3 = Eq[int](t2, s.Size(), 2)
     return IsFalse(t3, s.Contains(2))
 }
 
 func TestTreeSetContains(t T) T {
-    var s = TreeSetOf[int](1, 2, 3)
-    var t1 = IsTrue(t, s.Contains(1))
-    var t2 = IsTrue(t1, s.Contains(2))
-    var t3 = IsTrue(t2, s.Contains(3))
+    val s = TreeSetOf[int](1, 2, 3)
+    val t1 = IsTrue(t, s.Contains(1))
+    val t2 = IsTrue(t1, s.Contains(2))
+    val t3 = IsTrue(t2, s.Contains(3))
     return IsFalse(t3, s.Contains(5))
 }
 
 func TestTreeSetClear(t T) T {
-    var s = TreeSetOf[int](1, 2, 3)
+    val s = TreeSetOf[int](1, 2, 3)
     s.Clear()
     return IsTrue(t, s.IsEmpty())
 }
@@ -76,193 +76,193 @@ func TestTreeSetClear(t T) T {
 // === TreeSet String Type Tests ===
 
 func TestTreeSetStrings(t T) T {
-    var s = TreeSetOf[string]("cherry", "apple", "banana")
-    var t1 = Eq[int](t, s.Size(), 3)
-    var t2 = IsTrue(t1, s.Contains("apple"))
-    var t3 = IsTrue(t2, s.Contains("banana"))
+    val s = TreeSetOf[string]("cherry", "apple", "banana")
+    val t1 = Eq[int](t, s.Size(), 3)
+    val t2 = IsTrue(t1, s.Contains("apple"))
+    val t3 = IsTrue(t2, s.Contains("banana"))
     return IsFalse(t3, s.Contains("orange"))
 }
 
 // === TreeSet Ordering Tests ===
 
 func TestTreeSetMin(t T) T {
-    var s = TreeSetOf[int](5, 3, 7, 1, 9)
+    val s = TreeSetOf[int](5, 3, 7, 1, 9)
     return Eq[int](t, s.Min(), 1)
 }
 
 func TestTreeSetMax(t T) T {
-    var s = TreeSetOf[int](5, 3, 7, 1, 9)
+    val s = TreeSetOf[int](5, 3, 7, 1, 9)
     return Eq[int](t, s.Max(), 9)
 }
 
 func TestTreeSetMinOption(t T) T {
-    var s = TreeSetOf[int](5, 3, 7)
-    var opt = s.MinOption()
-    var t1 = IsFalse(t, opt.IsEmpty())
+    val s = TreeSetOf[int](5, 3, 7)
+    val opt = s.MinOption()
+    val t1 = IsFalse(t, opt.IsEmpty())
     return Eq[int](t1, opt.Get(), 3)
 }
 
 func TestTreeSetMinOptionEmpty(t T) T {
-    var s = EmptyTreeSet[int]()
-    var opt = s.MinOption()
+    val s = EmptyTreeSet[int]()
+    val opt = s.MinOption()
     return IsTrue(t, opt.IsEmpty())
 }
 
 func TestTreeSetMaxOption(t T) T {
-    var s = TreeSetOf[int](5, 3, 7)
-    var opt = s.MaxOption()
-    var t1 = IsFalse(t, opt.IsEmpty())
+    val s = TreeSetOf[int](5, 3, 7)
+    val opt = s.MaxOption()
+    val t1 = IsFalse(t, opt.IsEmpty())
     return Eq[int](t1, opt.Get(), 7)
 }
 
 func TestTreeSetPopMin(t T) T {
-    var s = TreeSetOf[int](5, 3, 7, 1, 9)
-    var minVal = s.PopMin()
-    var t1 = Eq[int](t, minVal, 1)
-    var t2 = Eq[int](t1, s.Size(), 4)
+    val s = TreeSetOf[int](5, 3, 7, 1, 9)
+    val minVal = s.PopMin()
+    val t1 = Eq[int](t, minVal, 1)
+    val t2 = Eq[int](t1, s.Size(), 4)
     return IsFalse(t2, s.Contains(1))
 }
 
 func TestTreeSetPopMax(t T) T {
-    var s = TreeSetOf[int](5, 3, 7, 1, 9)
-    var maxVal = s.PopMax()
-    var t1 = Eq[int](t, maxVal, 9)
-    var t2 = Eq[int](t1, s.Size(), 4)
+    val s = TreeSetOf[int](5, 3, 7, 1, 9)
+    val maxVal = s.PopMax()
+    val t1 = Eq[int](t, maxVal, 9)
+    val t2 = Eq[int](t1, s.Size(), 4)
     return IsFalse(t2, s.Contains(9))
 }
 
 func TestTreeSetHead(t T) T {
-    var s = TreeSetOf[int](5, 3, 7)
+    val s = TreeSetOf[int](5, 3, 7)
     return Eq[int](t, s.Head(), 3)
 }
 
 func TestTreeSetLast(t T) T {
-    var s = TreeSetOf[int](5, 3, 7)
+    val s = TreeSetOf[int](5, 3, 7)
     return Eq[int](t, s.Last(), 7)
 }
 
 // === TreeSet Sorted Order Tests ===
 
 func TestTreeSetSortedOrder(t T) T {
-    var s = TreeSetOf[int](5, 3, 1, 4, 2)
-    var slice = s.ToGoSlice()
-    var t1 = Eq[int](t, slice[0], 1)
-    var t2 = Eq[int](t1, slice[1], 2)
-    var t3 = Eq[int](t2, slice[2], 3)
-    var t4 = Eq[int](t3, slice[3], 4)
+    val s = TreeSetOf[int](5, 3, 1, 4, 2)
+    val slice = s.ToGoSlice()
+    val t1 = Eq[int](t, slice[0], 1)
+    val t2 = Eq[int](t1, slice[1], 2)
+    val t3 = Eq[int](t2, slice[2], 3)
+    val t4 = Eq[int](t3, slice[3], 4)
     return Eq[int](t4, slice[4], 5)
 }
 
 func TestTreeSetStringSorted(t T) T {
-    var s = TreeSetOf[string]("cherry", "apple", "banana")
-    var slice = s.ToGoSlice()
-    var t1 = Eq[string](t, slice[0], "apple")
-    var t2 = Eq[string](t1, slice[1], "banana")
+    val s = TreeSetOf[string]("cherry", "apple", "banana")
+    val slice = s.ToGoSlice()
+    val t1 = Eq[string](t, slice[0], "apple")
+    val t2 = Eq[string](t1, slice[1], "banana")
     return Eq[string](t2, slice[2], "cherry")
 }
 
 // === TreeSet Set Operations Tests ===
 
 func TestTreeSetUnion(t T) T {
-    var s1 = TreeSetOf[int](1, 2, 3)
-    var s2 = TreeSetOf[int](3, 4, 5)
-    var union = s1.Union(s2)
-    var t1 = Eq[int](t, union.Size(), 5)
-    var t2 = IsTrue(t1, union.Contains(1))
-    var t3 = IsTrue(t2, union.Contains(3))
+    val s1 = TreeSetOf[int](1, 2, 3)
+    val s2 = TreeSetOf[int](3, 4, 5)
+    val union = s1.Union(s2)
+    val t1 = Eq[int](t, union.Size(), 5)
+    val t2 = IsTrue(t1, union.Contains(1))
+    val t3 = IsTrue(t2, union.Contains(3))
     return IsTrue(t3, union.Contains(5))
 }
 
 func TestTreeSetIntersect(t T) T {
-    var s1 = TreeSetOf[int](1, 2, 3, 4)
-    var s2 = TreeSetOf[int](3, 4, 5, 6)
-    var intersect = s1.Intersect(s2)
-    var t1 = Eq[int](t, intersect.Size(), 2)
-    var t2 = IsTrue(t1, intersect.Contains(3))
-    var t3 = IsTrue(t2, intersect.Contains(4))
-    var t4 = IsFalse(t3, intersect.Contains(1))
+    val s1 = TreeSetOf[int](1, 2, 3, 4)
+    val s2 = TreeSetOf[int](3, 4, 5, 6)
+    val intersect = s1.Intersect(s2)
+    val t1 = Eq[int](t, intersect.Size(), 2)
+    val t2 = IsTrue(t1, intersect.Contains(3))
+    val t3 = IsTrue(t2, intersect.Contains(4))
+    val t4 = IsFalse(t3, intersect.Contains(1))
     return IsFalse(t4, intersect.Contains(5))
 }
 
 func TestTreeSetDiff(t T) T {
-    var s1 = TreeSetOf[int](1, 2, 3, 4)
-    var s2 = TreeSetOf[int](3, 4, 5, 6)
-    var diff = s1.Diff(s2)
-    var t1 = Eq[int](t, diff.Size(), 2)
-    var t2 = IsTrue(t1, diff.Contains(1))
-    var t3 = IsTrue(t2, diff.Contains(2))
+    val s1 = TreeSetOf[int](1, 2, 3, 4)
+    val s2 = TreeSetOf[int](3, 4, 5, 6)
+    val diff = s1.Diff(s2)
+    val t1 = Eq[int](t, diff.Size(), 2)
+    val t2 = IsTrue(t1, diff.Contains(1))
+    val t3 = IsTrue(t2, diff.Contains(2))
     return IsFalse(t3, diff.Contains(3))
 }
 
 func TestTreeSetSubsetOf(t T) T {
-    var s1 = TreeSetOf[int](1, 2)
-    var s2 = TreeSetOf[int](1, 2, 3, 4)
-    var s3 = TreeSetOf[int](1, 5)
-    var t1 = IsTrue(t, s1.SubsetOf(s2))
+    val s1 = TreeSetOf[int](1, 2)
+    val s2 = TreeSetOf[int](1, 2, 3, 4)
+    val s3 = TreeSetOf[int](1, 5)
+    val t1 = IsTrue(t, s1.SubsetOf(s2))
     return IsFalse(t1, s3.SubsetOf(s2))
 }
 
 func TestTreeSetSupersetOf(t T) T {
-    var s1 = TreeSetOf[int](1, 2, 3, 4)
-    var s2 = TreeSetOf[int](1, 2)
+    val s1 = TreeSetOf[int](1, 2, 3, 4)
+    val s2 = TreeSetOf[int](1, 2)
     return IsTrue(t, s1.SupersetOf(s2))
 }
 
 // === TreeSet In-Place Operations Tests ===
 
 func TestTreeSetUnionInPlace(t T) T {
-    var s1 = TreeSetOf[int](1, 2, 3)
-    var s2 = TreeSetOf[int](3, 4, 5)
+    val s1 = TreeSetOf[int](1, 2, 3)
+    val s2 = TreeSetOf[int](3, 4, 5)
     s1.UnionInPlace(s2)
-    var t1 = Eq[int](t, s1.Size(), 5)
+    val t1 = Eq[int](t, s1.Size(), 5)
     return IsTrue(t1, s1.Contains(4))
 }
 
 func TestTreeSetIntersectInPlace(t T) T {
-    var s1 = TreeSetOf[int](1, 2, 3, 4)
-    var s2 = TreeSetOf[int](3, 4, 5, 6)
+    val s1 = TreeSetOf[int](1, 2, 3, 4)
+    val s2 = TreeSetOf[int](3, 4, 5, 6)
     s1.IntersectInPlace(s2)
-    var t1 = Eq[int](t, s1.Size(), 2)
-    var t2 = IsTrue(t1, s1.Contains(3))
+    val t1 = Eq[int](t, s1.Size(), 2)
+    val t2 = IsTrue(t1, s1.Contains(3))
     return IsFalse(t2, s1.Contains(1))
 }
 
 func TestTreeSetDiffInPlace(t T) T {
-    var s1 = TreeSetOf[int](1, 2, 3, 4)
-    var s2 = TreeSetOf[int](3, 4, 5, 6)
+    val s1 = TreeSetOf[int](1, 2, 3, 4)
+    val s2 = TreeSetOf[int](3, 4, 5, 6)
     s1.DiffInPlace(s2)
-    var t1 = Eq[int](t, s1.Size(), 2)
-    var t2 = IsTrue(t1, s1.Contains(1))
+    val t1 = Eq[int](t, s1.Size(), 2)
+    val t2 = IsTrue(t1, s1.Contains(1))
     return IsFalse(t2, s1.Contains(3))
 }
 
 // === TreeSet Range Operations Tests ===
 
 func TestTreeSetRange(t T) T {
-    var s = TreeSetOf[int](1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-    var ranged = s.Range(3, 7)
-    var t1 = Eq[int](t, ranged.Size(), 5)
-    var t2 = IsTrue(t1, ranged.Contains(3))
-    var t3 = IsTrue(t2, ranged.Contains(7))
-    var t4 = IsFalse(t3, ranged.Contains(2))
+    val s = TreeSetOf[int](1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    val ranged = s.Range(3, 7)
+    val t1 = Eq[int](t, ranged.Size(), 5)
+    val t2 = IsTrue(t1, ranged.Contains(3))
+    val t3 = IsTrue(t2, ranged.Contains(7))
+    val t4 = IsFalse(t3, ranged.Contains(2))
     return IsFalse(t4, ranged.Contains(8))
 }
 
 func TestTreeSetRangeFrom(t T) T {
-    var s = TreeSetOf[int](1, 2, 3, 4, 5)
-    var ranged = s.RangeFrom(3)
-    var t1 = Eq[int](t, ranged.Size(), 3)
-    var t2 = IsTrue(t1, ranged.Contains(3))
-    var t3 = IsTrue(t2, ranged.Contains(5))
+    val s = TreeSetOf[int](1, 2, 3, 4, 5)
+    val ranged = s.RangeFrom(3)
+    val t1 = Eq[int](t, ranged.Size(), 3)
+    val t2 = IsTrue(t1, ranged.Contains(3))
+    val t3 = IsTrue(t2, ranged.Contains(5))
     return IsFalse(t3, ranged.Contains(2))
 }
 
 func TestTreeSetRangeTo(t T) T {
-    var s = TreeSetOf[int](1, 2, 3, 4, 5)
-    var ranged = s.RangeTo(3)
-    var t1 = Eq[int](t, ranged.Size(), 3)
-    var t2 = IsTrue(t1, ranged.Contains(1))
-    var t3 = IsTrue(t2, ranged.Contains(3))
+    val s = TreeSetOf[int](1, 2, 3, 4, 5)
+    val ranged = s.RangeTo(3)
+    val t1 = Eq[int](t, ranged.Size(), 3)
+    val t2 = IsTrue(t1, ranged.Contains(1))
+    val t3 = IsTrue(t2, ranged.Contains(3))
     return IsFalse(t3, ranged.Contains(4))
 }
 
@@ -271,34 +271,34 @@ func TestTreeSetRangeTo(t T) T {
 func isTreeSetEven(x int) bool = x % 2 == 0
 
 func TestTreeSetFilter(t T) T {
-    var s = TreeSetOf[int](1, 2, 3, 4, 5, 6)
-    var filtered = s.Filter(isTreeSetEven)
-    var t1 = Eq[int](t, filtered.Size(), 3)
-    var t2 = IsTrue(t1, filtered.Contains(2))
-    var t3 = IsTrue(t2, filtered.Contains(4))
+    val s = TreeSetOf[int](1, 2, 3, 4, 5, 6)
+    val filtered = s.Filter(isTreeSetEven)
+    val t1 = Eq[int](t, filtered.Size(), 3)
+    val t2 = IsTrue(t1, filtered.Contains(2))
+    val t3 = IsTrue(t2, filtered.Contains(4))
     return IsFalse(t3, filtered.Contains(1))
 }
 
 func TestTreeSetFilterNot(t T) T {
-    var s = TreeSetOf[int](1, 2, 3, 4, 5, 6)
-    var filtered = s.FilterNot(isTreeSetEven)
-    var t1 = Eq[int](t, filtered.Size(), 3)
-    var t2 = IsTrue(t1, filtered.Contains(1))
+    val s = TreeSetOf[int](1, 2, 3, 4, 5, 6)
+    val filtered = s.FilterNot(isTreeSetEven)
+    val t1 = Eq[int](t, filtered.Size(), 3)
+    val t2 = IsTrue(t1, filtered.Contains(1))
     return IsFalse(t2, filtered.Contains(2))
 }
 
 func TestTreeSetPartition(t T) T {
-    var s = TreeSetOf[int](1, 2, 3, 4, 5, 6)
-    var parts = s.Partition(isTreeSetEven)
-    var t1 = Eq[int](t, parts.V1.Size(), 3)
+    val s = TreeSetOf[int](1, 2, 3, 4, 5, 6)
+    val parts = s.Partition(isTreeSetEven)
+    val t1 = Eq[int](t, parts.V1.Size(), 3)
     return Eq[int](t1, parts.V2.Size(), 3)
 }
 
 func treeSetAddFn(acc int, x int) int = acc + x
 
 func TestTreeSetFoldLeft(t T) T {
-    var s = TreeSetOf[int](1, 2, 3, 4)
-    var result = s.FoldLeft(0, treeSetAddFn)
+    val s = TreeSetOf[int](1, 2, 3, 4)
+    val result = s.FoldLeft(0, treeSetAddFn)
     return Eq[int](t, result, 10)
 }
 
@@ -307,70 +307,70 @@ func TestTreeSetFoldLeft(t T) T {
 func isTreeSetGreaterThanTwo(x int) bool = x > 2
 
 func TestTreeSetExists(t T) T {
-    var s = TreeSetOf[int](1, 2, 3)
+    val s = TreeSetOf[int](1, 2, 3)
     return IsTrue(t, s.Exists(isTreeSetGreaterThanTwo))
 }
 
 func isTreeSetGreaterThanTen(x int) bool = x > 10
 
 func TestTreeSetExistsFalse(t T) T {
-    var s = TreeSetOf[int](1, 2, 3)
+    val s = TreeSetOf[int](1, 2, 3)
     return IsFalse(t, s.Exists(isTreeSetGreaterThanTen))
 }
 
 func isTreeSetPositive(x int) bool = x > 0
 
 func TestTreeSetForAll(t T) T {
-    var s = TreeSetOf[int](1, 2, 3)
+    val s = TreeSetOf[int](1, 2, 3)
     return IsTrue(t, s.ForAll(isTreeSetPositive))
 }
 
 func TestTreeSetForAllFalse(t T) T {
-    var s = TreeSetOf[int](-1, 0, 1)
+    val s = TreeSetOf[int](-1, 0, 1)
     return IsFalse(t, s.ForAll(isTreeSetPositive))
 }
 
 func TestTreeSetFind(t T) T {
-    var s = TreeSetOf[int](1, 2, 3, 4, 5)
-    var found = s.Find(isTreeSetGreaterThanTwo)
-    var t1 = IsFalse(t, found.IsEmpty())
+    val s = TreeSetOf[int](1, 2, 3, 4, 5)
+    val found = s.Find(isTreeSetGreaterThanTwo)
+    val t1 = IsFalse(t, found.IsEmpty())
     return Eq[int](t1, found.Get(), 3) // First in sorted order > 2
 }
 
 func TestTreeSetCount(t T) T {
-    var s = TreeSetOf[int](1, 2, 3, 4, 5)
-    var count = s.Count(isTreeSetGreaterThanTwo)
+    val s = TreeSetOf[int](1, 2, 3, 4, 5)
+    val count = s.Count(isTreeSetGreaterThanTwo)
     return Eq[int](t, count, 3)
 }
 
 // === TreeSet Conversion Tests ===
 
 func TestTreeSetToGoSlice(t T) T {
-    var s = TreeSetOf[int](3, 1, 2)
-    var slice = s.ToGoSlice()
-    var t1 = Eq[int](t, len(slice), 3)
-    var t2 = Eq[int](t1, slice[0], 1) // Sorted
+    val s = TreeSetOf[int](3, 1, 2)
+    val slice = s.ToGoSlice()
+    val t1 = Eq[int](t, len(slice), 3)
+    val t2 = Eq[int](t1, slice[0], 1) // Sorted
     return Eq[int](t2, slice[2], 3)
 }
 
 func TestTreeSetToArray(t T) T {
-    var s = TreeSetOf[int](3, 1, 2)
-    var arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Size(), 3)
+    val s = TreeSetOf[int](3, 1, 2)
+    val arr = s.ToArray()
+    val t1 = Eq[int](t, arr.Size(), 3)
     return Eq[int](t1, arr.Get(0), 1) // Sorted
 }
 
 func TestTreeSetToList(t T) T {
-    var s = TreeSetOf[int](3, 1, 2)
-    var list = s.ToList()
-    var t1 = Eq[int](t, list.Size(), 3)
+    val s = TreeSetOf[int](3, 1, 2)
+    val list = s.ToList()
+    val t1 = Eq[int](t, list.Size(), 3)
     return Eq[int](t1, list.Head(), 1) // Sorted
 }
 
 func TestTreeSetCollect(t T) T {
-    var s = TreeSetOf(1, 2, 3, 4, 5)
+    val s = TreeSetOf(1, 2, 3, 4, 5)
     // Collect odd numbers as strings
-    var result = s.Collect((x int) => {
+    val result = s.Collect((x) => {
         if x % 2 == 1 {
             return Some(fmt.Sprintf("%d", x))
         }
@@ -381,65 +381,65 @@ func TestTreeSetCollect(t T) T {
 }
 
 func TestTreeSetToHashSet(t T) T {
-    var s = TreeSetOf[int](1, 2, 3)
-    var set = s.ToHashSet()
-    var t1 = Eq[int](t, set.Size(), 3)
+    val s = TreeSetOf[int](1, 2, 3)
+    val set = s.ToHashSet()
+    val t1 = Eq[int](t, set.Size(), 3)
     return IsTrue(t1, set.Contains(2))
 }
 
 func TestTreeSetClone(t T) T {
-    var s = TreeSetOf[int](1, 2, 3)
-    var clone = s.Clone()
+    val s = TreeSetOf[int](1, 2, 3)
+    val clone = s.Clone()
     clone.Add(4)
-    var t1 = Eq[int](t, s.Size(), 3)
+    val t1 = Eq[int](t, s.Size(), 3)
     return Eq[int](t1, clone.Size(), 4)
 }
 
 func TestTreeSetString(t T) T {
-    var s = EmptyTreeSet[int]()
+    val s = EmptyTreeSet[int]()
     return Eq[string](t, s.String(), "TreeSet()")
 }
 
 func TestTreeSetStringOutput(t T) T {
-    var s = TreeSetOf[int](3, 1, 2)
+    val s = TreeSetOf[int](3, 1, 2)
     return Eq[string](t, s.String(), "TreeSet(1, 2, 3)")
 }
 
 // === Large TreeSet Tests ===
 
 func TestTreeSetLarge(t T) T {
-    var s = EmptyTreeSet[int]()
+    val s = EmptyTreeSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
-    var t1 = Eq[int](t, s.Size(), 10000)
-    var t2 = IsTrue(t1, s.Contains(0))
-    var t3 = IsTrue(t2, s.Contains(5000))
-    var t4 = IsTrue(t3, s.Contains(9999))
-    var t5 = Eq[int](t4, s.Min(), 0)
+    val t1 = Eq[int](t, s.Size(), 10000)
+    val t2 = IsTrue(t1, s.Contains(0))
+    val t3 = IsTrue(t2, s.Contains(5000))
+    val t4 = IsTrue(t3, s.Contains(9999))
+    val t5 = Eq[int](t4, s.Min(), 0)
     return Eq[int](t5, s.Max(), 9999)
 }
 
 func TestTreeSetLargeRemove(t T) T {
-    var s = EmptyTreeSet[int]()
+    val s = EmptyTreeSet[int]()
     for i := 0; i < 10000; i++ {
         s.Add(i)
     }
     for i := 0; i < 5000; i++ {
         s.Remove(i)
     }
-    var t1 = Eq[int](t, s.Size(), 5000)
-    var t2 = IsFalse(t1, s.Contains(0))
-    var t3 = IsTrue(t2, s.Contains(5000))
+    val t1 = Eq[int](t, s.Size(), 5000)
+    val t2 = IsFalse(t1, s.Contains(0))
+    val t3 = IsTrue(t2, s.Contains(5000))
     return Eq[int](t3, s.Min(), 5000)
 }
 
 func TestTreeSetLargeReverse(t T) T {
-    var s = EmptyTreeSet[int]()
+    val s = EmptyTreeSet[int]()
     for i := 9999; i >= 0; i-- {
         s.Add(i)
     }
-    var t1 = Eq[int](t, s.Size(), 10000)
-    var t2 = Eq[int](t1, s.Min(), 0)
+    val t1 = Eq[int](t, s.Size(), 10000)
+    val t2 = Eq[int](t1, s.Min(), 0)
     return Eq[int](t2, s.Max(), 9999)
 }

--- a/concurrent/future.gala
+++ b/concurrent/future.gala
@@ -163,10 +163,7 @@ func (f Future[T]) Value() Option[Try[T]] {
     val c = f.state.complete
     val r = f.state.result
     f.state.mu.RUnlock()
-    if c {
-        return Some[Try[T]](r)
-    }
-    return None[Try[T]]()
+    return When(c, r)
 }
 
 // Await blocks until the Future is completed and returns the result.
@@ -186,7 +183,7 @@ func (f Future[T]) AwaitFor(timeout Duration) Option[Try[T]] {
         f.state.mu.RLock()
         val r = f.state.result
         f.state.mu.RUnlock()
-        return Some[Try[T]](r)
+        return Some(r)
     }
     return None[Try[T]]()
 }
@@ -239,8 +236,9 @@ func (f Future[T]) OnComplete(callback func(Try[T])) {
 // The callback is executed asynchronously.
 func (f Future[T]) OnSuccess(callback func(T)) {
     f.OnComplete((r Try[T]) => {
-        if r.IsSuccess() {
-            callback(r.Value)
+        r match {
+            case Success(v) => callback(v)
+            case Failure(_) => {}
         }
     })
 }
@@ -249,8 +247,9 @@ func (f Future[T]) OnSuccess(callback func(T)) {
 // The callback is executed asynchronously.
 func (f Future[T]) OnFailure(callback func(error)) {
     f.OnComplete((r Try[T]) => {
-        if r.IsFailure() {
-            callback(r.Err)
+        r match {
+            case Success(_) => {}
+            case Failure(e) => callback(e)
         }
     })
 }
@@ -272,12 +271,11 @@ func (f Future[T]) Map[U any](fn func(T) U) Future[U] {
 func (f Future[T]) FlatMap[U any](fn func(T) Future[U]) Future[U] {
     val p = NewPromiseWith[U](f.state.ec)
     f.OnComplete((r Try[T]) => {
-        if r.IsSuccess() {
-            fn(r.Value).OnComplete((innerResult Try[U]) => {
+        r match {
+            case Success(v) => fn(v).OnComplete((innerResult Try[U]) => {
                 p.Complete(innerResult)
             })
-        } else {
-            p.Failure(r.Err)
+            case Failure(e) => p.Failure(e)
         }
     })
     return p.Future()
@@ -313,10 +311,9 @@ func (f Future[T]) Recover(pf func(error) T) Future[T] {
 func (f Future[T]) RecoverWith(pf func(error) Future[T]) Future[T] {
     val p = NewPromiseWith[T](f.state.ec)
     f.OnComplete((r Try[T]) => {
-        if r.IsSuccess() {
-            p.Success(r.Value)
-        } else {
-            pf(r.Err).OnComplete((recovered Try[T]) => {
+        r match {
+            case Success(v) => p.Success(v)
+            case Failure(e) => pf(e).OnComplete((recovered Try[T]) => {
                 p.Complete(recovered)
             })
         }
@@ -329,10 +326,9 @@ func (f Future[T]) RecoverWith(pf func(error) Future[T]) Future[T] {
 func (f Future[T]) Transform[U any](s func(T) Try[U], fn func(error) Try[U]) Future[U] {
     val p = NewPromiseWith[U](f.state.ec)
     f.OnComplete((r Try[T]) => {
-        if r.IsSuccess() {
-            p.Complete(s(r.Value))
-        } else {
-            p.Complete(fn(r.Err))
+        r match {
+            case Success(v) => p.Complete(s(v))
+            case Failure(e) => p.Complete(fn(e))
         }
     })
     return p.Future()
@@ -343,12 +339,11 @@ func (f Future[T]) Transform[U any](s func(T) Try[U], fn func(error) Try[U]) Fut
 func (f Future[T]) TransformWith[U any](s func(T) Future[U], fn func(error) Future[U]) Future[U] {
     val p = NewPromiseWith[U](f.state.ec)
     f.OnComplete((r Try[T]) => {
-        if r.IsSuccess() {
-            s(r.Value).OnComplete((res Try[U]) => {
+        r match {
+            case Success(v) => s(v).OnComplete((res Try[U]) => {
                 p.Complete(res)
             })
-        } else {
-            fn(r.Err).OnComplete((res Try[U]) => {
+            case Failure(e) => fn(e).OnComplete((res Try[U]) => {
                 p.Complete(res)
             })
         }
@@ -424,20 +419,23 @@ func Sequence[T any](futures Array[Future[T]]) Future[Array[T]] {
             mu.Lock()
 
             if !failed {
-                if r.IsSuccess() {
-                    resultMap = resultMap.Put(idx, r.Value)
-                    remaining = remaining - 1
-                    if remaining == 0 {
-                        // Build the result array in order
-                        var result = EmptyArray[T]()
-                        for i := 0; i < size; i++ {
-                            result = result.Append(resultMap.GetOrElse(i, r.Value))
+                r match {
+                    case Success(v) => {
+                        resultMap = resultMap.Put(idx, v)
+                        remaining = remaining - 1
+                        if remaining == 0 {
+                            // Build the result array in order
+                            var result = EmptyArray[T]()
+                            for i := 0; i < size; i++ {
+                                result = result.Append(resultMap.GetOrElse(i, v))
+                            }
+                            p.Success(result)
                         }
-                        p.Success(result)
                     }
-                } else {
-                    failed = true
-                    p.Failure(r.Err)
+                    case Failure(e) => {
+                        failed = true
+                        p.Failure(e)
+                    }
                 }
             }
 
@@ -508,7 +506,7 @@ func (c Completed[T]) Unapply(f Future[T]) Option[Try[T]] {
     if f.state == nil {
         return None[Try[T]]()
     }
-    return Some[Try[T]](f.Await())
+    return Some(f.Await())
 }
 
 // Succeeded is an extractor for pattern matching on successful Futures.
@@ -527,11 +525,10 @@ func (s Succeeded[T]) Unapply(f Future[T]) Option[T] {
     if f.state == nil {
         return None[T]()
     }
-    val result = f.Await()
-    if result.IsSuccess() {
-        return Some[T](result.Value)
+    return f.Await() match {
+        case Success(v) => Some(v)
+        case Failure(_) => None[T]()
     }
-    return None[T]()
 }
 
 // Failed is an extractor for pattern matching on failed Futures.
@@ -550,11 +547,10 @@ func (fa Failed[T]) Unapply(f Future[T]) Option[error] {
     if f.state == nil {
         return None[error]()
     }
-    val result = f.Await()
-    if result.IsFailure() {
-        return Some[error](result.Err)
+    return f.Await() match {
+        case Success(_) => None[error]()
+        case Failure(e) => Some(e)
     }
-    return None[error]()
 }
 
 // === Sequence Pattern Matching Support ===
@@ -572,11 +568,10 @@ type AllSucceeded[T any] struct {}
 
 // Unapply sequences the Futures and extracts all values if all succeed.
 func (a AllSucceeded[T]) Unapply(futures Array[Future[T]]) Option[Array[T]] {
-    val result = Sequence[T](futures).Await()
-    if result.IsSuccess() {
-        return Some[Array[T]](result.Value)
+    return Sequence[T](futures).Await() match {
+        case Success(v) => Some(v)
+        case Failure(_) => None[Array[T]]()
     }
-    return None[Array[T]]()
 }
 
 // AnyFailed is an extractor for matching when any Future in a sequence fails.
@@ -592,9 +587,8 @@ type AnyFailed[T any] struct {}
 
 // Unapply returns the first error if any Future in the sequence fails.
 func (a AnyFailed[T]) Unapply(futures Array[Future[T]]) Option[error] {
-    val result = Sequence[T](futures).Await()
-    if result.IsFailure() {
-        return Some[error](result.Err)
+    return Sequence[T](futures).Await() match {
+        case Success(_) => None[error]()
+        case Failure(e) => Some(e)
     }
-    return None[error]()
 }

--- a/concurrent/future_test.gala
+++ b/concurrent/future_test.gala
@@ -9,138 +9,138 @@ import (
 )
 
 func TestFutureOf(t T) T {
-    val f = FutureOf[int](42)
+    val f = FutureOf(42)
     val result = f.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 42)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 42)
 }
 
 func TestFutureFailed(t T) T {
     val f = FutureFailed[int](FutureError(Message = "test error"))
     val result = f.Await()
-    var t1 = IsFailure(t, result)
-    return Eq[string](t1, result.Err.Error(), "test error")
+    val t1 = IsFailure(t, result)
+    return Eq(t1, result.Err.Error(), "test error")
 }
 
 func TestFutureApply(t T) T {
-    val f = FutureApply[int](() => 1 + 1)
+    val f = FutureApply(() => 1 + 1)
     val result = f.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 2)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 2)
 }
 
 func TestFutureMap(t T) T {
-    val f = FutureOf[int](10)
-    val mapped = f.Map[int]((x int) => x * 2)
+    val f = FutureOf(10)
+    val mapped = f.Map((x) => x * 2)
     val result = mapped.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 20)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 20)
 }
 
 func TestFutureMapFailure(t T) T {
     val f = FutureFailed[int](FutureError(Message = "error"))
-    val mapped = f.Map[int]((x int) => x * 2)
+    val mapped = f.Map((x) => x * 2)
     val result = mapped.Await()
     return IsFailure(t, result)
 }
 
 func TestFutureFlatMap(t T) T {
-    val f = FutureOf[int](5)
-    val chained = f.FlatMap[int]((x int) => FutureOf[int](x * 3))
+    val f = FutureOf(5)
+    val chained = f.FlatMap((x) => FutureOf(x * 3))
     val result = chained.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 15)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 15)
 }
 
 func TestFutureFlatMapChain(t T) T {
-    val f = FutureOf[int](2)
-        .FlatMap[int]((x int) => FutureOf[int](x + 3))
-        .FlatMap[int]((x int) => FutureOf[int](x * 2))
+    val f = FutureOf(2)
+        .FlatMap((x) => FutureOf(x + 3))
+        .FlatMap((x) => FutureOf(x * 2))
     val result = f.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 10)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 10)
 }
 
 func TestFutureFilter(t T) T {
-    val f = FutureOf[int](10)
-    val filtered = f.Filter((x int) => x > 5)
+    val f = FutureOf(10)
+    val filtered = f.Filter((x) => x > 5)
     val result = filtered.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 10)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 10)
 }
 
 func TestFutureFilterFails(t T) T {
-    val f = FutureOf[int](3)
-    val filtered = f.Filter((x int) => x > 5)
+    val f = FutureOf(3)
+    val filtered = f.Filter((x) => x > 5)
     val result = filtered.Await()
     return IsFailure(t, result)
 }
 
 func TestFutureRecover(t T) T {
     val f = FutureFailed[int](FutureError(Message = "error"))
-    val recovered = f.Recover((e error) => 100)
+    val recovered = f.Recover((e) => 100)
     val result = recovered.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 100)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 100)
 }
 
 func TestFutureRecoverWith(t T) T {
     val f = FutureFailed[int](FutureError(Message = "error"))
-    val recovered = f.RecoverWith((e error) => FutureOf[int](200))
+    val recovered = f.RecoverWith((e) => FutureOf(200))
     val result = recovered.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 200)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 200)
 }
 
 func TestFutureZip(t T) T {
-    val f1 = FutureOf[int](1)
-    val f2 = FutureOf[string]("hello")
-    val zipped = f1.Zip[string](f2)
+    val f1 = FutureOf(1)
+    val f2 = FutureOf("hello")
+    val zipped = f1.Zip(f2)
     val result = zipped.Await()
-    var t1 = IsSuccess(t, result)
+    val t1 = IsSuccess(t, result)
     val tuple = result.Get()
-    var t2 = Eq[int](t1, tuple.V1, 1)
-    return Eq[string](t2, tuple.V2, "hello")
+    val t2 = Eq(t1, tuple.V1, 1)
+    return Eq(t2, tuple.V2, "hello")
 }
 
 func TestFutureZipWith(t T) T {
-    val f1 = FutureOf[int](10)
-    val f2 = FutureOf[int](20)
-    val combined = f1.ZipWith[int, int](f2, (a int, b int) => a + b)
+    val f1 = FutureOf(10)
+    val f2 = FutureOf(20)
+    val combined = f1.ZipWith[int, int](f2, (a, b) => a + b)
     val result = combined.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 30)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 30)
 }
 
 func TestFutureFallback(t T) T {
     val f1 = FutureFailed[int](FutureError(Message = "first failed"))
-    val f2 = FutureOf[int](42)
+    val f2 = FutureOf(42)
     val result = f1.Fallback(f2).Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 42)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 42)
 }
 
 func TestSequence(t T) T {
     val futures = ArrayOf[Future[int]](
-        FutureOf[int](1),
-        FutureOf[int](2),
-        FutureOf[int](3)
+        FutureOf(1),
+        FutureOf(2),
+        FutureOf(3)
     )
     val sequenced = Sequence[int](futures)
     val result = sequenced.Await()
-    var t1 = IsSuccess(t, result)
+    val t1 = IsSuccess(t, result)
     val values = result.Get()
-    var t2 = Eq[int](t1, values.Size(), 3)
-    var t3 = Eq[int](t2, values.Get(0), 1)
-    var t4 = Eq[int](t3, values.Get(1), 2)
-    return Eq[int](t4, values.Get(2), 3)
+    val t2 = Eq(t1, values.Size(), 3)
+    val t3 = Eq(t2, values.Get(0), 1)
+    val t4 = Eq(t3, values.Get(1), 2)
+    return Eq(t4, values.Get(2), 3)
 }
 
 func TestSequenceWithFailure(t T) T {
     val futures = ArrayOf[Future[int]](
-        FutureOf[int](1),
+        FutureOf(1),
         FutureFailed[int](FutureError(Message = "error")),
-        FutureOf[int](3)
+        FutureOf(3)
     )
     val sequenced = Sequence[int](futures)
     val result = sequenced.Await()
@@ -148,38 +148,38 @@ func TestSequenceWithFailure(t T) T {
 }
 
 func TestTraverse(t T) T {
-    val items = ArrayOf[int](1, 2, 3)
-    val traversed = Traverse[int, int](items, (x int) => FutureOf[int](x * 2))
+    val items = ArrayOf(1, 2, 3)
+    val traversed = Traverse[int, int](items, (x) => FutureOf(x * 2))
     val result = traversed.Await()
-    var t1 = IsSuccess(t, result)
+    val t1 = IsSuccess(t, result)
     val values = result.Get()
-    var t2 = Eq[int](t1, values.Get(0), 2)
-    var t3 = Eq[int](t2, values.Get(1), 4)
-    return Eq[int](t3, values.Get(2), 6)
+    val t2 = Eq(t1, values.Get(0), 2)
+    val t3 = Eq(t2, values.Get(1), 4)
+    return Eq(t3, values.Get(2), 6)
 }
 
 func TestFold(t T) T {
     val futures = ArrayOf[Future[int]](
-        FutureOf[int](1),
-        FutureOf[int](2),
-        FutureOf[int](3)
+        FutureOf(1),
+        FutureOf(2),
+        FutureOf(3)
     )
-    val folded = Fold[int, int](futures, 0, (acc int, x int) => acc + x)
+    val folded = Fold[int, int](futures, 0, (acc, x) => acc + x)
     val result = folded.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 6)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 6)
 }
 
 func TestReduceLeft(t T) T {
     val futures = ArrayOf[Future[int]](
-        FutureOf[int](1),
-        FutureOf[int](2),
-        FutureOf[int](3)
+        FutureOf(1),
+        FutureOf(2),
+        FutureOf(3)
     )
-    val reduced = ReduceLeft[int](futures, (a int, b int) => a + b)
+    val reduced = ReduceLeft[int](futures, (a, b) => a + b)
     val result = reduced.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 6)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 6)
 }
 
 func TestPromiseSuccess(t T) T {
@@ -192,8 +192,8 @@ func TestPromiseSuccess(t T) T {
     })
 
     val result = f.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 42)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 42)
 }
 
 func TestPromiseFailure(t T) T {
@@ -206,45 +206,45 @@ func TestPromiseFailure(t T) T {
     })
 
     val result = f.Await()
-    var t1 = IsFailure(t, result)
-    return Eq[string](t1, result.Err.Error(), "async error")
+    val t1 = IsFailure(t, result)
+    return Eq(t1, result.Err.Error(), "async error")
 }
 
 func TestPromiseCompleteOnce(t T) T {
     val p = NewPromise[int]()
     val first = p.Success(1)
     val second = p.Success(2)
-    var t1 = IsTrue(t, first)
-    var t2 = IsFalse(t1, second)
-    return Eq[int](t2, p.Future().Await().Get(), 1)
+    val t1 = IsTrue(t, first)
+    val t2 = IsFalse(t1, second)
+    return Eq(t2, p.Future().Await().Get(), 1)
 }
 
 func TestAwaitFor(t T) T {
-    val f = FutureOf[int](42)
+    val f = FutureOf(42)
     val result = f.AwaitFor(Milliseconds(100))
-    var t1 = IsSome(t, result)
-    return Eq[int](t1, result.Get().Get(), 42)
+    val t1 = IsSome(t, result)
+    return Eq(t1, result.Get().Get(), 42)
 }
 
 func TestWithTimeoutDoesNotFire(t T) T {
-    val f = FutureOf[int](42)
+    val f = FutureOf(42)
     val result = f.WithTimeout(Seconds(5)).Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 42)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 42)
 }
 
 func TestWithTimeoutFires(t T) T {
     val p = NewPromise[int]()
     val result = p.Future().WithTimeout(Milliseconds(50)).Await()
-    var t1 = IsFailure(t, result)
+    val t1 = IsFailure(t, result)
     return Contains(t1, result.Err.Error(), "timed out")
 }
 
 func TestWithTimeoutPreservesOriginalFailure(t T) T {
     val f = FutureFailed[int](FutureError(Message = "original error"))
     val result = f.WithTimeout(Seconds(5)).Await()
-    var t1 = IsFailure(t, result)
-    return Eq[string](t1, result.Err.Error(), "original error")
+    val t1 = IsFailure(t, result)
+    return Eq(t1, result.Err.Error(), "original error")
 }
 
 func TestWithTimeoutSlowFutureBeats(t T) T {
@@ -254,43 +254,43 @@ func TestWithTimeoutSlowFutureBeats(t T) T {
         p.Success(7)
     })
     val result = p.Future().WithTimeout(Milliseconds(200)).Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 7)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 7)
 }
 
 func TestTransform(t T) T {
-    val f = FutureOf[int](5)
+    val f = FutureOf(5)
     val transformed = f.Transform[string](
-        (v int) => Success[string]("success"),
-        (e error) => Success[string]("recovered")
+        (v) => Success[string]("success"),
+        (e) => Success[string]("recovered")
     )
     val result = transformed.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[string](t1, result.Get(), "success")
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), "success")
 }
 
 func TestTransformFailure(t T) T {
     val f = FutureFailed[int](FutureError(Message = "err"))
     val transformed = f.Transform[string](
-        (v int) => Success[string]("success"),
-        (e error) => Success[string]("recovered")
+        (v) => Success[string]("success"),
+        (e) => Success[string]("recovered")
     )
     val result = transformed.Await()
-    var t1 = IsSuccess(t, result)
-    return Eq[string](t1, result.Get(), "recovered")
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), "recovered")
 }
 
 func TestGetOrElse(t T) T {
     val f = FutureFailed[int](FutureError(Message = "err"))
     val result = f.GetOrElse(99)
-    return Eq[int](t, result, 99)
+    return Eq(t, result, 99)
 }
 
 func TestToOption(t T) T {
-    val f1 = FutureOf[int](42)
+    val f1 = FutureOf(42)
     val opt1 = f1.ToOption()
-    var t1 = IsSome(t, opt1)
-    var t2 = Eq[int](t1, opt1.Get(), 42)
+    val t1 = IsSome(t, opt1)
+    val t2 = Eq(t1, opt1.Get(), 42)
 
     val f2 = FutureFailed[int](FutureError(Message = "err"))
     val opt2 = f2.ToOption()
@@ -298,10 +298,10 @@ func TestToOption(t T) T {
 }
 
 func TestToEither(t T) T {
-    val f1 = FutureOf[int](42)
+    val f1 = FutureOf(42)
     val either1 = f1.ToEither()
-    var t1 = IsTrue(t, either1.IsRight())
-    var t2 = Eq[int](t1, either1.GetRight(), 42)
+    val t1 = IsTrue(t, either1.IsRight())
+    val t2 = Eq(t1, either1.GetRight(), 42)
 
     val f2 = FutureFailed[int](FutureError(Message = "err"))
     val either2 = f2.ToEither()
@@ -310,16 +310,14 @@ func TestToEither(t T) T {
 
 func TestAndThen(t T) T {
     var sideEffect = 0
-    val f = FutureOf[int](10).AndThen((r Try[int]) => {
-        if r.IsSuccess() {
-            sideEffect = r.Get()
-        }
+    val f = FutureOf(10).AndThen((r) => {
+        r.ForEach((v) => { sideEffect = v })
     })
     val result = f.Await()
-    var t1 = IsSuccess(t, result)
-    var t2 = Eq[int](t1, result.Get(), 10)
+    val t1 = IsSuccess(t, result)
+    val t2 = Eq(t1, result.Get(), 10)
     Sleep(Milliseconds(10))
-    return Eq[int](t2, sideEffect, 10)
+    return Eq(t2, sideEffect, 10)
 }
 
 // === ExecutionContext Tests ===
@@ -329,8 +327,8 @@ func TestFutureApplyWithCustomEC(t T) T {
     val f = FutureApplyWith[int](() => 1 + 1, pool)
     val result = f.Await()
     pool.Shutdown()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 2)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 2)
 }
 
 func TestFutureOfWithCustomEC(t T) T {
@@ -338,8 +336,8 @@ func TestFutureOfWithCustomEC(t T) T {
     val f = FutureOfWith[int](42, pool)
     val result = f.Await()
     pool.Shutdown()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 42)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 42)
 }
 
 func TestFutureFailedWithCustomEC(t T) T {
@@ -357,40 +355,40 @@ func TestPromiseWithCustomEC(t T) T {
     p.Success(42)
     val result = f.Await()
     pool.Shutdown()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 42)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 42)
 }
 
 func TestECInheritanceThroughMap(t T) T {
     val pool = NewFixedPoolEC(2)
     val f = FutureOfWith[int](10, pool)
-    val mapped = f.Map[int]((x int) => x * 2)
+    val mapped = f.Map((x) => x * 2)
     val result = mapped.Await()
     pool.Shutdown()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 20)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 20)
 }
 
 func TestECInheritanceThroughFlatMap(t T) T {
     val pool = NewFixedPoolEC(2)
     val f = FutureOfWith[int](5, pool)
-    val chained = f.FlatMap[int]((x int) => FutureOf[int](x * 3))
+    val chained = f.FlatMap((x) => FutureOf(x * 3))
     val result = chained.Await()
     pool.Shutdown()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 15)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 15)
 }
 
 func TestECInheritanceChain(t T) T {
     val pool = NewFixedPoolEC(2)
     val f = FutureOfWith[int](2, pool)
-        .Map[int]((x int) => x + 3)
-        .Map[int]((x int) => x * 2)
-        .Filter((x int) => x > 5)
+        .Map((x) => x + 3)
+        .Map((x) => x * 2)
+        .Filter((x) => x > 5)
     val result = f.Await()
     pool.Shutdown()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 10)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 10)
 }
 
 func TestSingleThreadEC(t T) T {
@@ -403,46 +401,46 @@ func TestSingleThreadEC(t T) T {
     val r2 = f2.Await()
     ec.Shutdown()
 
-    var t1 = IsSuccess(t, r1)
-    var t2 = IsSuccess(t1, r2)
-    var t3 = Eq[int](t2, r1.Get(), 2)
-    return Eq[int](t3, r2.Get(), 4)
+    val t1 = IsSuccess(t, r1)
+    val t2 = IsSuccess(t1, r2)
+    val t3 = Eq(t2, r1.Get(), 2)
+    return Eq(t3, r2.Get(), 4)
 }
 
 func TestECInheritanceWithRecover(t T) T {
     val pool = NewFixedPoolEC(2)
     val f = FutureFailedWith[int](FutureError(Message = "error"), pool)
-    val recovered = f.Recover((e error) => 100)
+    val recovered = f.Recover((e) => 100)
     val result = recovered.Await()
     pool.Shutdown()
-    var t1 = IsSuccess(t, result)
-    return Eq[int](t1, result.Get(), 100)
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 100)
 }
 
 func TestECInheritanceWithTransform(t T) T {
     val pool = NewFixedPoolEC(2)
     val f = FutureOfWith[int](5, pool)
     val transformed = f.Transform[string](
-        (v int) => Success[string]("success"),
-        (e error) => Success[string]("recovered")
+        (v) => Success[string]("success"),
+        (e) => Success[string]("recovered")
     )
     val result = transformed.Await()
     pool.Shutdown()
-    var t1 = IsSuccess(t, result)
-    return Eq[string](t1, result.Get(), "success")
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), "success")
 }
 
 func TestECInheritanceWithZip(t T) T {
     val pool = NewFixedPoolEC(2)
     val f1 = FutureOfWith[int](1, pool)
-    val f2 = FutureOf[string]("hello")
-    val zipped = f1.Zip[string](f2)
+    val f2 = FutureOf("hello")
+    val zipped = f1.Zip(f2)
     val result = zipped.Await()
     pool.Shutdown()
-    var t1 = IsSuccess(t, result)
+    val t1 = IsSuccess(t, result)
     val tuple = result.Get()
-    var t2 = Eq[int](t1, tuple.V1, 1)
-    return Eq[string](t2, tuple.V2, "hello")
+    val t2 = Eq(t1, tuple.V1, 1)
+    return Eq(t2, tuple.V2, "hello")
 }
 
 func TestPoolShutdownGraceful(t T) T {
@@ -458,8 +456,8 @@ func TestPoolShutdownGraceful(t T) T {
 
     pool.Shutdown()
 
-    var t1 = IsSuccess(t, r1)
-    var t2 = Eq[int](t1, r1.Get(), 10)
-    var t3 = Eq[int](t2, r2.Get(), 20)
-    return Eq[int](t3, r3.Get(), 30)
+    val t1 = IsSuccess(t, r1)
+    val t2 = Eq(t1, r1.Get(), 10)
+    val t3 = Eq(t2, r2.Get(), 20)
+    return Eq(t3, r3.Get(), 30)
 }

--- a/concurrent/retry.gala
+++ b/concurrent/retry.gala
@@ -27,11 +27,11 @@ func Retry[T any](maxAttempts int, backoff func(int) Duration, action func(int) 
 
 // ConstantBackoff returns a backoff function that always waits the same duration.
 func ConstantBackoff(d Duration) func(int) Duration =
-    (_ int) => d
+    (_) => d
 
 // ExponentialBackoff returns a backoff function with exponential growth capped at max.
-func ExponentialBackoff(initial Duration, max Duration) func(int) Duration {
-    return (attempt int) => {
+func ExponentialBackoff(initial Duration, max Duration) func(int) Duration =
+    (attempt) => {
         var d = initial
         for i := 0; i < attempt; i++ {
             d = d.Multiply(2)
@@ -39,8 +39,7 @@ func ExponentialBackoff(initial Duration, max Duration) func(int) Duration {
         }
         return d
     }
-}
 
 // NoBackoff returns a backoff function with zero delay.
 func NoBackoff() func(int) Duration =
-    (_ int) => ZeroDuration()
+    (_) => ZeroDuration()

--- a/crypto/crypto.gala
+++ b/crypto/crypto.gala
@@ -31,27 +31,18 @@ func (d Digest) Bytes() Array[byte] = d.bytes
 func (d Digest) Size() int = d.bytes.Size()
 
 // Hex returns the lowercase hex encoding of the digest.
-func (d Digest) Hex() string {
-    var goBytes = d.bytes.ToGoSlice()
-    return hex.EncodeToString(goBytes)
-}
+func (d Digest) Hex() string = hex.EncodeToString(d.bytes.ToGoSlice())
 
 // Base64 returns the standard (padded) base64 encoding of the digest.
-func (d Digest) Base64() string {
-    var goBytes = d.bytes.ToGoSlice()
-    return base64.StdEncoding.EncodeToString(goBytes)
-}
+func (d Digest) Base64() string = base64.StdEncoding.EncodeToString(d.bytes.ToGoSlice())
 
 // String returns the hex encoding (same as Hex).
 func (d Digest) String() string = d.Hex()
 
 // Equal compares two digests in constant time. Different sizes compare
 // as not equal (subtle.ConstantTimeCompare returns 0 on length mismatch).
-func (d Digest) Equal(other Digest) bool {
-    var a = d.bytes.ToGoSlice()
-    var b = other.bytes.ToGoSlice()
-    return subtle.ConstantTimeCompare(a, b) == 1
-}
+func (d Digest) Equal(other Digest) bool =
+    subtle.ConstantTimeCompare(d.bytes.ToGoSlice(), other.bytes.ToGoSlice()) == 1
 
 // Hasher is a streaming hash. Holds a Go hash.Hash; mutable because the
 // underlying stdlib hashers are inherently stateful. Hasher is the only
@@ -64,8 +55,7 @@ type Hasher struct {
 // Update feeds more bytes into the running hash and returns the receiver
 // for chaining: h.Update(a).Update(b).Finish().
 func (h *Hasher) Update(data Array[byte]) *Hasher {
-    var goData = data.ToGoSlice()
-    var _, _ = h.h.Write(goData)
+    h.h.Write(data.ToGoSlice())
     return h
 }
 
@@ -89,11 +79,9 @@ func (s Sha256) Algorithm() string = "SHA-256"
 func (s Sha256) Size() int = 32
 
 func (s Sha256) Hash(data Array[byte]) Digest {
-    var goData = data.ToGoSlice()
-    var h = sha256.New()
-    var _, _ = h.Write(goData)
-    val sum = h.Sum(nil)
-    return Digest(bytes = ArrayFromSlice(sum))
+    val h = sha256.New()
+    h.Write(data.ToGoSlice())
+    return Digest(bytes = ArrayFromSlice(h.Sum(nil)))
 }
 
 func (s Sha256) NewHasher() *Hasher {
@@ -107,11 +95,9 @@ func (s Sha512) Algorithm() string = "SHA-512"
 func (s Sha512) Size() int = 64
 
 func (s Sha512) Hash(data Array[byte]) Digest {
-    var goData = data.ToGoSlice()
-    var h = sha512.New()
-    var _, _ = h.Write(goData)
-    val sum = h.Sum(nil)
-    return Digest(bytes = ArrayFromSlice(sum))
+    val h = sha512.New()
+    h.Write(data.ToGoSlice())
+    return Digest(bytes = ArrayFromSlice(h.Sum(nil)))
 }
 
 func (s Sha512) NewHasher() *Hasher {
@@ -126,11 +112,9 @@ func (s Sha1) Algorithm() string = "SHA-1"
 func (s Sha1) Size() int = 20
 
 func (s Sha1) Hash(data Array[byte]) Digest {
-    var goData = data.ToGoSlice()
-    var h = sha1.New()
-    var _, _ = h.Write(goData)
-    val sum = h.Sum(nil)
-    return Digest(bytes = ArrayFromSlice(sum))
+    val h = sha1.New()
+    h.Write(data.ToGoSlice())
+    return Digest(bytes = ArrayFromSlice(h.Sum(nil)))
 }
 
 func (s Sha1) NewHasher() *Hasher {
@@ -145,11 +129,9 @@ func (s Md5) Algorithm() string = "MD5"
 func (s Md5) Size() int = 16
 
 func (s Md5) Hash(data Array[byte]) Digest {
-    var goData = data.ToGoSlice()
-    var h = md5.New()
-    var _, _ = h.Write(goData)
-    val sum = h.Sum(nil)
-    return Digest(bytes = ArrayFromSlice(sum))
+    val h = md5.New()
+    h.Write(data.ToGoSlice())
+    return Digest(bytes = ArrayFromSlice(h.Sum(nil)))
 }
 
 func (s Md5) NewHasher() *Hasher {
@@ -170,17 +152,13 @@ func (h HmacSha256) Algorithm() string = "HMAC-SHA256"
 func (h HmacSha256) Size() int = 32
 
 func (h HmacSha256) Sum(data Array[byte]) Digest {
-    var goKey = h.Key.ToGoSlice()
-    var goData = data.ToGoSlice()
-    var mac = hmac.New(sha256.New, goKey)
-    var _, _ = mac.Write(goData)
-    val tag = mac.Sum(nil)
-    return Digest(bytes = ArrayFromSlice(tag))
+    val mac = hmac.New(sha256.New, h.Key.ToGoSlice())
+    mac.Write(data.ToGoSlice())
+    return Digest(bytes = ArrayFromSlice(mac.Sum(nil)))
 }
 
 func (h HmacSha256) NewHasher() *Hasher {
-    var goKey = h.Key.ToGoSlice()
-    return &Hasher(algorithm = "HMAC-SHA256", h = hmac.New(sha256.New, goKey))
+    return &Hasher(algorithm = "HMAC-SHA256", h = hmac.New(sha256.New, h.Key.ToGoSlice()))
 }
 
 // HmacSha512 is HMAC-SHA-512, 64-byte tag.
@@ -190,17 +168,13 @@ func (h HmacSha512) Algorithm() string = "HMAC-SHA512"
 func (h HmacSha512) Size() int = 64
 
 func (h HmacSha512) Sum(data Array[byte]) Digest {
-    var goKey = h.Key.ToGoSlice()
-    var goData = data.ToGoSlice()
-    var mac = hmac.New(sha512.New, goKey)
-    var _, _ = mac.Write(goData)
-    val tag = mac.Sum(nil)
-    return Digest(bytes = ArrayFromSlice(tag))
+    val mac = hmac.New(sha512.New, h.Key.ToGoSlice())
+    mac.Write(data.ToGoSlice())
+    return Digest(bytes = ArrayFromSlice(mac.Sum(nil)))
 }
 
 func (h HmacSha512) NewHasher() *Hasher {
-    var goKey = h.Key.ToGoSlice()
-    return &Hasher(algorithm = "HMAC-SHA512", h = hmac.New(sha512.New, goKey))
+    return &Hasher(algorithm = "HMAC-SHA512", h = hmac.New(sha512.New, h.Key.ToGoSlice()))
 }
 
 // HmacSha1 is HMAC-SHA-1, 20-byte tag. SHA-1 collision resistance is
@@ -211,17 +185,13 @@ func (h HmacSha1) Algorithm() string = "HMAC-SHA1"
 func (h HmacSha1) Size() int = 20
 
 func (h HmacSha1) Sum(data Array[byte]) Digest {
-    var goKey = h.Key.ToGoSlice()
-    var goData = data.ToGoSlice()
-    var mac = hmac.New(sha1.New, goKey)
-    var _, _ = mac.Write(goData)
-    val tag = mac.Sum(nil)
-    return Digest(bytes = ArrayFromSlice(tag))
+    val mac = hmac.New(sha1.New, h.Key.ToGoSlice())
+    mac.Write(data.ToGoSlice())
+    return Digest(bytes = ArrayFromSlice(mac.Sum(nil)))
 }
 
 func (h HmacSha1) NewHasher() *Hasher {
-    var goKey = h.Key.ToGoSlice()
-    return &Hasher(algorithm = "HMAC-SHA1", h = hmac.New(sha1.New, goKey))
+    return &Hasher(algorithm = "HMAC-SHA1", h = hmac.New(sha1.New, h.Key.ToGoSlice()))
 }
 
 // ---- random + constant-time helpers --------------------------------------
@@ -236,8 +206,8 @@ func RandomBytes(n int) Try[Array[byte]] {
     if n == 0 {
         return Success[Array[byte]](EmptyArray[byte]())
     }
-    var buf = ArrayFill[byte](n, byte(0)).ToGoSlice()
-    var _, err = rand.Read(buf)
+    val buf = ArrayFill[byte](n, byte(0)).ToGoSlice()
+    val _, err = rand.Read(buf)
     if err != nil {
         return Failure[Array[byte]](errors.New(s"crypto.RandomBytes: rand.Read failed: ${err.Error()}"))
     }
@@ -248,11 +218,8 @@ func RandomBytes(n int) Try[Array[byte]] {
 // a constant-time comparison. Different lengths return false (subtle
 // handles this). Generalizes Digest.Equal to arbitrary byte slices — useful
 // for comparing tokens, MACs, or any secret-bearing bytes.
-func ConstantTimeEqual(a Array[byte], b Array[byte]) bool {
-    var aGo = a.ToGoSlice()
-    var bGo = b.ToGoSlice()
-    return subtle.ConstantTimeCompare(aGo, bGo) == 1
-}
+func ConstantTimeEqual(a Array[byte], b Array[byte]) bool =
+    subtle.ConstantTimeCompare(a.ToGoSlice(), b.ToGoSlice()) == 1
 
 // ==========================================================================
 // Ed25519 — EdDSA digital signatures (RFC 8032).
@@ -274,7 +241,7 @@ struct Signature(bytes Array[byte])
 // GenerateEd25519KeyPair returns a fresh Ed25519 keypair drawn from
 // crypto/rand. Panics if the OS RNG fails — a broken RNG is unrecoverable.
 func GenerateEd25519KeyPair() Ed25519KeyPair {
-    var pub, priv, err = ed25519.GenerateKey(rand.Reader)
+    val pub, priv, err = ed25519.GenerateKey(rand.Reader)
     if err != nil {
         panic(s"crypto: ed25519.GenerateKey failed: ${err.Error()}")
     }
@@ -287,8 +254,7 @@ func GenerateEd25519KeyPair() Ed25519KeyPair {
 // Ed25519PrivateKeyFromSeed derives the 64-byte Ed25519 private key from a
 // 32-byte seed (the canonical RFC 8032 wire format for an Ed25519 secret).
 func Ed25519PrivateKeyFromSeed(seed Array[byte]) Ed25519PrivateKey {
-    var goSeed = seed.ToGoSlice()
-    val priv = ed25519.NewKeyFromSeed(goSeed)
+    val priv = ed25519.NewKeyFromSeed(seed.ToGoSlice())
     return Ed25519PrivateKey(bytes = ArrayFromSlice[byte](priv))
 }
 
@@ -307,26 +273,19 @@ func SignatureFromBytes(bytes Array[byte]) Signature =
 
 // Sign returns the Ed25519 signature of message under sk.
 func (sk Ed25519PrivateKey) Sign(message Array[byte]) Signature {
-    var goSk  = sk.bytes.ToGoSlice()
-    var goMsg = message.ToGoSlice()
-    val sig = ed25519.Sign(goSk, goMsg)
+    val sig = ed25519.Sign(sk.bytes.ToGoSlice(), message.ToGoSlice())
     return Signature(bytes = ArrayFromSlice[byte](sig))
 }
 
 // Verify reports whether sig is a valid Ed25519 signature on message under pk.
-func (pk Ed25519PublicKey) Verify(message Array[byte], sig Signature) bool {
-    var goPk  = pk.bytes.ToGoSlice()
-    var goMsg = message.ToGoSlice()
-    var goSig = sig.bytes.ToGoSlice()
-    return ed25519.Verify(goPk, goMsg, goSig)
-}
+func (pk Ed25519PublicKey) Verify(message Array[byte], sig Signature) bool =
+    ed25519.Verify(pk.bytes.ToGoSlice(), message.ToGoSlice(), sig.bytes.ToGoSlice())
 
 // PublicKey returns the Ed25519 public key embedded in sk. Go's
 // PrivateKey is laid out as seed||pub, so this is a slice — no curve
 // math needed.
 func (sk Ed25519PrivateKey) PublicKey() Ed25519PublicKey {
-    var goSk = sk.bytes.ToGoSlice()
-    val pub = go_interop.SliceDrop(goSk, 32)
+    val pub = go_interop.SliceDrop(sk.bytes.ToGoSlice(), 32)
     return Ed25519PublicKey(bytes = ArrayFromSlice[byte](pub))
 }
 
@@ -340,25 +299,16 @@ func (sk Ed25519PrivateKey) Bytes() Array[byte] = sk.bytes
 func (s Signature) Bytes() Array[byte] = s.bytes
 
 // Hex returns the lowercase hex encoding of the signature.
-func (s Signature) Hex() string {
-    var goBytes = s.bytes.ToGoSlice()
-    return hex.EncodeToString(goBytes)
-}
+func (s Signature) Hex() string = hex.EncodeToString(s.bytes.ToGoSlice())
 
 // Base64 returns the standard (padded) base64 encoding of the signature.
-func (s Signature) Base64() string {
-    var goBytes = s.bytes.ToGoSlice()
-    return base64.StdEncoding.EncodeToString(goBytes)
-}
+func (s Signature) Base64() string = base64.StdEncoding.EncodeToString(s.bytes.ToGoSlice())
 
 // Equal compares two signatures in constant time. Different sizes
 // compare as not equal (subtle.ConstantTimeCompare returns 0 on length
 // mismatch).
-func (s Signature) Equal(other Signature) bool {
-    var a = s.bytes.ToGoSlice()
-    var b = other.bytes.ToGoSlice()
-    return subtle.ConstantTimeCompare(a, b) == 1
-}
+func (s Signature) Equal(other Signature) bool =
+    subtle.ConstantTimeCompare(s.bytes.ToGoSlice(), other.bytes.ToGoSlice()) == 1
 
 // ==========================================================================
 // X25519 — Diffie-Hellman key agreement (RFC 7748).
@@ -377,7 +327,7 @@ struct X25519KeyPair(Public X25519PublicKey, Private X25519PrivateKey)
 // crypto/rand. Panics if the OS RNG fails — a broken RNG is unrecoverable.
 func GenerateX25519KeyPair() X25519KeyPair {
     val curve = ecdh.X25519()
-    var priv, err = curve.GenerateKey(rand.Reader)
+    val priv, err = curve.GenerateKey(rand.Reader)
     if err != nil {
         panic(s"crypto: ecdh.GenerateKey failed: ${err.Error()}")
     }
@@ -401,17 +351,15 @@ func X25519PublicKeyFromBytes(bytes Array[byte]) X25519PublicKey =
 // and returns an error in those cases — that error becomes Failure here.
 func (sk X25519PrivateKey) ECDH(peer X25519PublicKey) Try[Array[byte]] {
     val curve = ecdh.X25519()
-    var goSk = sk.bytes.ToGoSlice()
-    var privKey, perr = curve.NewPrivateKey(goSk)
+    val privKey, perr = curve.NewPrivateKey(sk.bytes.ToGoSlice())
     if perr != nil {
         return Failure[Array[byte]](perr)
     }
-    var goPk = peer.bytes.ToGoSlice()
-    var pubKey, kerr = curve.NewPublicKey(goPk)
+    val pubKey, kerr = curve.NewPublicKey(peer.bytes.ToGoSlice())
     if kerr != nil {
         return Failure[Array[byte]](kerr)
     }
-    var secret, eerr = privKey.ECDH(pubKey)
+    val secret, eerr = privKey.ECDH(pubKey)
     if eerr != nil {
         return Failure[Array[byte]](eerr)
     }
@@ -423,8 +371,7 @@ func (sk X25519PrivateKey) ECDH(peer X25519PublicKey) Try[Array[byte]] {
 // (corrupt or incorrectly constructed key), not a runtime condition.
 func (sk X25519PrivateKey) PublicKey() X25519PublicKey {
     val curve = ecdh.X25519()
-    var goSk = sk.bytes.ToGoSlice()
-    var privKey, err = curve.NewPrivateKey(goSk)
+    val privKey, err = curve.NewPrivateKey(sk.bytes.ToGoSlice())
     if err != nil {
         panic(s"crypto: invalid X25519 private key: ${err.Error()}")
     }
@@ -445,8 +392,8 @@ func (sk X25519PrivateKey) Bytes() Array[byte] = sk.bytes
 // RandomHex returns a hex-encoded string of n random bytes drawn from
 // crypto/rand (length 2n). Panics if the OS RNG fails.
 func RandomHex(n int) string {
-    var buf = go_interop.SliceWithSize[byte](n)
-    var _, err = rand.Read(buf)
+    val buf = go_interop.SliceWithSize[byte](n)
+    val _, err = rand.Read(buf)
     if err != nil {
         panic(s"crypto: rand.Read failed: ${err.Error()}")
     }
@@ -456,8 +403,8 @@ func RandomHex(n int) string {
 // RandomBase64URL returns base64.RawURLEncoding (URL-safe, no padding) of
 // n random bytes drawn from crypto/rand. Panics if the OS RNG fails.
 func RandomBase64URL(n int) string {
-    var buf = go_interop.SliceWithSize[byte](n)
-    var _, err = rand.Read(buf)
+    val buf = go_interop.SliceWithSize[byte](n)
+    val _, err = rand.Read(buf)
     if err != nil {
         panic(s"crypto: rand.Read failed: ${err.Error()}")
     }

--- a/crypto/crypto_test.gala
+++ b/crypto/crypto_test.gala
@@ -17,7 +17,7 @@ func bytesOf(s string) Array[byte] = ArrayFromSlice(ToBytes(s))
 // only used in tests with hard-coded vectors, so a malformed input is a
 // test bug.
 func hexBytes(s string) Array[byte] {
-    var decoded, err = hex.DecodeString(s)
+    val decoded, err = hex.DecodeString(s)
     if err != nil {
         panic(s"hexBytes: invalid hex: ${err.Error()}")
     }
@@ -32,7 +32,7 @@ func TestSha256KnownVectors(t T) T {
     return RunCases[HashCase, string](t,
         (sub T, c HashCase, _ string) => {
             val d = crypto.Sha256{}.Hash(bytesOf(c.Input))
-            return Eq[string](sub, d.Hex(), c.ExpectedHex)
+            return Eq(sub, d.Hex(), c.ExpectedHex)
         },
         Case[HashCase, string](
             Name = "empty",
@@ -58,37 +58,37 @@ func TestSha256KnownVectors(t T) T {
 func TestSha512KnownVectors(t T) T {
     val expected = "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
     val d = crypto.Sha512{}.Hash(bytesOf("abc"))
-    return Eq[string](t, d.Hex(), expected)
+    return Eq(t, d.Hex(), expected)
 }
 
 func TestSha1KnownVectors(t T) T {
     val d = crypto.Sha1{}.Hash(bytesOf("abc"))
-    return Eq[string](t, d.Hex(), "a9993e364706816aba3e25717850c26c9cd0d89d")
+    return Eq(t, d.Hex(), "a9993e364706816aba3e25717850c26c9cd0d89d")
 }
 
 func TestMd5KnownVectors(t T) T {
     val d = crypto.Md5{}.Hash(bytesOf("abc"))
-    return Eq[string](t, d.Hex(), "900150983cd24fb0d6963f7d28e17f72")
+    return Eq(t, d.Hex(), "900150983cd24fb0d6963f7d28e17f72")
 }
 
 // ---- algorithm metadata --------------------------------------------------
 
 func TestAlgorithmMetadata(t T) T {
-    var t1 = Eq[string](t, crypto.Sha256{}.Algorithm(), "SHA-256")
-    var t2 = Eq[int](t1, crypto.Sha256{}.Size(), 32)
-    var t3 = Eq[string](t2, crypto.Sha512{}.Algorithm(), "SHA-512")
-    var t4 = Eq[int](t3, crypto.Sha512{}.Size(), 64)
-    var t5 = Eq[string](t4, crypto.Sha1{}.Algorithm(), "SHA-1")
-    var t6 = Eq[int](t5, crypto.Sha1{}.Size(), 20)
-    var t7 = Eq[string](t6, crypto.Md5{}.Algorithm(), "MD5")
-    return Eq[int](t7, crypto.Md5{}.Size(), 16)
+    val t1 = Eq(t, crypto.Sha256{}.Algorithm(), "SHA-256")
+    val t2 = Eq(t1, crypto.Sha256{}.Size(), 32)
+    val t3 = Eq(t2, crypto.Sha512{}.Algorithm(), "SHA-512")
+    val t4 = Eq(t3, crypto.Sha512{}.Size(), 64)
+    val t5 = Eq(t4, crypto.Sha1{}.Algorithm(), "SHA-1")
+    val t6 = Eq(t5, crypto.Sha1{}.Size(), 20)
+    val t7 = Eq(t6, crypto.Md5{}.Algorithm(), "MD5")
+    return Eq(t7, crypto.Md5{}.Size(), 16)
 }
 
 // ---- digest size matches algorithm --------------------------------------
 
 func TestDigestSize(t T) T {
     val d = crypto.Sha256{}.Hash(bytesOf("hello"))
-    return Eq[int](t, d.Size(), 32)
+    return Eq(t, d.Size(), 32)
 }
 
 // ---- streaming matches one-shot -----------------------------------------
@@ -104,7 +104,7 @@ func TestStreamingMatchesOneShot(t T) T {
         Update(bytesOf("the lazy dog")).
         Finish()
 
-    var t1 = Eq[string](t, oneShot.Hex(), streamed.Hex())
+    val t1 = Eq(t, oneShot.Hex(), streamed.Hex())
     return IsTrue(t1, oneShot.Equal(streamed))
 }
 
@@ -115,30 +115,30 @@ func TestStreamingSha512(t T) T {
         Update(bytesOf("b")).
         Update(bytesOf("c")).
         Finish()
-    return Eq[string](t, oneShot.Hex(), streamed.Hex())
+    return Eq(t, oneShot.Hex(), streamed.Hex())
 }
 
 func TestHasherAlgorithm(t T) T {
     val h = crypto.Sha256{}.NewHasher()
-    return Eq[string](t, h.Algorithm(), "SHA-256")
+    return Eq(t, h.Algorithm(), "SHA-256")
 }
 
 // ---- encoding -----------------------------------------------------------
 
 func TestDigestHex(t T) T {
     val d = crypto.Sha256{}.Hash(bytesOf(""))
-    return Eq[string](t, d.Hex(), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    return Eq(t, d.Hex(), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
 }
 
 func TestDigestBase64(t T) T {
     // SHA-256("abc") base64-std = "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0="
     val d = crypto.Sha256{}.Hash(bytesOf("abc"))
-    return Eq[string](t, d.Base64(), "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=")
+    return Eq(t, d.Base64(), "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=")
 }
 
 func TestDigestStringEqualsHex(t T) T {
     val d = crypto.Sha256{}.Hash(bytesOf("abc"))
-    return Eq[string](t, d.String(), d.Hex())
+    return Eq(t, d.String(), d.Hex())
 }
 
 // ---- equality ------------------------------------------------------------
@@ -173,7 +173,7 @@ func TestHmacSha256Rfc4231Case1(t T) T {
     // RFC 4231 §4.2:
     //   b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7
     val mac = crypto.HmacSha256(rfc4231TestKey()).Sum(bytesOf("Hi There"))
-    return Eq[string](t, mac.Hex(),
+    return Eq(t, mac.Hex(),
         "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7")
 }
 
@@ -182,7 +182,7 @@ func TestHmacSha512Rfc4231Case1(t T) T {
     //   87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cde
     //   daa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854
     val mac = crypto.HmacSha512(rfc4231TestKey()).Sum(bytesOf("Hi There"))
-    return Eq[string](t, mac.Hex(),
+    return Eq(t, mac.Hex(),
         "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854")
 }
 
@@ -190,7 +190,7 @@ func TestHmacSha1Rfc2202Case1(t T) T {
     // RFC 2202 §3 test 1:
     //   b617318655057264e28bc0b6fb378c8ef146be00
     val mac = crypto.HmacSha1(rfc4231TestKey()).Sum(bytesOf("Hi There"))
-    return Eq[string](t, mac.Hex(),
+    return Eq(t, mac.Hex(),
         "b617318655057264e28bc0b6fb378c8ef146be00")
 }
 
@@ -207,7 +207,7 @@ func TestHmacStreamingMatchesOneShot(t T) T {
         Update(bytesOf("the lazy dog")).
         Finish()
 
-    var t1 = Eq[string](t, oneShot.Hex(), streamed.Hex())
+    val t1 = Eq(t, oneShot.Hex(), streamed.Hex())
     return IsTrue(t1, oneShot.Equal(streamed))
 }
 
@@ -215,17 +215,17 @@ func TestHmacStreamingMatchesOneShot(t T) T {
 
 func TestHmacAlgorithmMetadata(t T) T {
     val key = bytesOf("k")
-    var t1 = Eq[string](t, crypto.HmacSha256(key).Algorithm(), "HMAC-SHA256")
-    var t2 = Eq[int](t1, crypto.HmacSha256(key).Size(), 32)
-    var t3 = Eq[string](t2, crypto.HmacSha512(key).Algorithm(), "HMAC-SHA512")
-    var t4 = Eq[int](t3, crypto.HmacSha512(key).Size(), 64)
-    var t5 = Eq[string](t4, crypto.HmacSha1(key).Algorithm(), "HMAC-SHA1")
-    return Eq[int](t5, crypto.HmacSha1(key).Size(), 20)
+    val t1 = Eq(t, crypto.HmacSha256(key).Algorithm(), "HMAC-SHA256")
+    val t2 = Eq(t1, crypto.HmacSha256(key).Size(), 32)
+    val t3 = Eq(t2, crypto.HmacSha512(key).Algorithm(), "HMAC-SHA512")
+    val t4 = Eq(t3, crypto.HmacSha512(key).Size(), 64)
+    val t5 = Eq(t4, crypto.HmacSha1(key).Algorithm(), "HMAC-SHA1")
+    return Eq(t5, crypto.HmacSha1(key).Size(), 20)
 }
 
 func TestHmacHasherAlgorithm(t T) T {
     val h = crypto.HmacSha256(bytesOf("k")).NewHasher()
-    return Eq[string](t, h.Algorithm(), "HMAC-SHA256")
+    return Eq(t, h.Algorithm(), "HMAC-SHA256")
 }
 
 // ---- HMAC tag equality (constant-time) -----------------------------------
@@ -253,18 +253,18 @@ func TestHmacEqualDifferentData(t T) T {
 // ---- RandomBytes ---------------------------------------------------------
 
 func TestRandomBytesSize(t T) T {
-    var t1 = Eq[int](t, crypto.RandomBytes(32).Get().Size(), 32)
-    return Eq[int](t1, crypto.RandomBytes(0).Get().Size(), 0)
+    val t1 = Eq(t, crypto.RandomBytes(32).Get().Size(), 32)
+    return Eq(t1, crypto.RandomBytes(0).Get().Size(), 0)
 }
 
 func TestRandomBytesUnique(t T) T {
     val a = hex.EncodeToString(crypto.RandomBytes(32).Get().ToGoSlice())
     val b = hex.EncodeToString(crypto.RandomBytes(32).Get().ToGoSlice())
-    return NotEq[string](t, a, b)
+    return NotEq(t, a, b)
 }
 
 func TestRandomBytesNegative(t T) T {
-    return IsFailure[Array[byte]](t, crypto.RandomBytes(-1))
+    return IsFailure(t, crypto.RandomBytes(-1))
 }
 
 // ---- ConstantTimeEqual ---------------------------------------------------
@@ -298,10 +298,10 @@ func TestEd25519RFC8032Vector1(t T) T {
     val sk = crypto.Ed25519PrivateKeyFromSeed(seed)
     val pk = sk.PublicKey()
 
-    var t1 = Eq[string](t, hex.EncodeToString(pk.Bytes().ToGoSlice()), expectedPubHex)
+    val t1 = Eq(t, hex.EncodeToString(pk.Bytes().ToGoSlice()), expectedPubHex)
 
     val sig = sk.Sign(EmptyArray[byte]())
-    var t2 = Eq[string](t1, sig.Hex(), expectedSigHex)
+    val t2 = Eq(t1, sig.Hex(), expectedSigHex)
 
     return IsTrue(t2, pk.Verify(EmptyArray[byte](), sig))
 }
@@ -332,8 +332,8 @@ func TestEd25519VerifyTamperedSignature(t T) T {
     val msg = bytesOf("hello")
     val good = kp.Private.Sign(msg)
     // Flip the low bit of the first signature byte.
-    var raw = good.Bytes().ToGoSlice()
-    var copy = SliceCopy(raw)
+    val raw = good.Bytes().ToGoSlice()
+    val copy = SliceCopy(raw)
     copy[0] = copy[0] ^ 1
     val tampered = crypto.SignatureFromBytes(ArrayFromSlice[byte](copy))
     return IsFalse(t, kp.Public.Verify(msg, tampered))
@@ -345,23 +345,23 @@ func TestEd25519PublicKeyConsistency(t T) T {
     val derived = kp.Private.PublicKey()
     val a = kp.Public.Bytes().ToGoSlice()
     val b = derived.Bytes().ToGoSlice()
-    return Eq[string](t, hex.EncodeToString(a), hex.EncodeToString(b))
+    return Eq(t, hex.EncodeToString(a), hex.EncodeToString(b))
 }
 
 func TestEd25519SignatureSize(t T) T {
     val kp = crypto.GenerateEd25519KeyPair()
     val sig = kp.Private.Sign(bytesOf("hello"))
-    return Eq[int](t, sig.Bytes().Size(), 64)
+    return Eq(t, sig.Bytes().Size(), 64)
 }
 
 func TestEd25519PublicKeySize(t T) T {
     val kp = crypto.GenerateEd25519KeyPair()
-    return Eq[int](t, kp.Public.Bytes().Size(), 32)
+    return Eq(t, kp.Public.Bytes().Size(), 32)
 }
 
 func TestEd25519PrivateKeySize(t T) T {
     val kp = crypto.GenerateEd25519KeyPair()
-    return Eq[int](t, kp.Private.Bytes().Size(), 64)
+    return Eq(t, kp.Private.Bytes().Size(), 64)
 }
 
 func TestSignatureEqualSame(t T) T {
@@ -396,10 +396,10 @@ func TestX25519RFC7748Vector(t T) T {
     val aliceShared = alicePriv.ECDH(bobPub)
     val bobShared = bobPriv.ECDH(alicePub)
 
-    var t1 = IsSuccess[Array[byte]](t, aliceShared)
-    var t2 = IsSuccess[Array[byte]](t1, bobShared)
-    var t3 = Eq[string](t2, hex.EncodeToString(aliceShared.Get().ToGoSlice()), expectedHex)
-    return Eq[string](t3, hex.EncodeToString(bobShared.Get().ToGoSlice()), expectedHex)
+    val t1 = IsSuccess(t, aliceShared)
+    val t2 = IsSuccess(t1, bobShared)
+    val t3 = Eq(t2, hex.EncodeToString(aliceShared.Get().ToGoSlice()), expectedHex)
+    return Eq(t3, hex.EncodeToString(bobShared.Get().ToGoSlice()), expectedHex)
 }
 
 func TestX25519RoundTrip(t T) T {
@@ -409,9 +409,9 @@ func TestX25519RoundTrip(t T) T {
     val a = alice.Private.ECDH(bob.Public)
     val b = bob.Private.ECDH(alice.Public)
 
-    var t1 = IsSuccess[Array[byte]](t, a)
-    var t2 = IsSuccess[Array[byte]](t1, b)
-    return Eq[string](t2,
+    val t1 = IsSuccess(t, a)
+    val t2 = IsSuccess(t1, b)
+    return Eq(t2,
         hex.EncodeToString(a.Get().ToGoSlice()),
         hex.EncodeToString(b.Get().ToGoSlice()),
     )
@@ -420,7 +420,7 @@ func TestX25519RoundTrip(t T) T {
 func TestX25519PublicKeyConsistency(t T) T {
     val kp = crypto.GenerateX25519KeyPair()
     val derived = kp.Private.PublicKey()
-    return Eq[string](t,
+    return Eq(t,
         hex.EncodeToString(kp.Public.Bytes().ToGoSlice()),
         hex.EncodeToString(derived.Bytes().ToGoSlice()),
     )
@@ -428,18 +428,18 @@ func TestX25519PublicKeyConsistency(t T) T {
 
 func TestX25519PublicKeySize(t T) T {
     val kp = crypto.GenerateX25519KeyPair()
-    return Eq[int](t, kp.Public.Bytes().Size(), 32)
+    return Eq(t, kp.Public.Bytes().Size(), 32)
 }
 
 func TestX25519PrivateKeySize(t T) T {
     val kp = crypto.GenerateX25519KeyPair()
-    return Eq[int](t, kp.Private.Bytes().Size(), 32)
+    return Eq(t, kp.Private.Bytes().Size(), 32)
 }
 
 // ---- random helpers ------------------------------------------------------
 
 func TestRandomHexLength(t T) T {
-    return Eq[int](t, len(crypto.RandomHex(16)), 32)
+    return Eq(t, len(crypto.RandomHex(16)), 32)
 }
 
 func TestRandomHexDifferent(t T) T {
@@ -450,14 +450,14 @@ func TestRandomHexDifferent(t T) T {
 
 func TestRandomBase64URLLength(t T) T {
     // base64.RawURLEncoding.EncodedLen(32) == 43
-    return Eq[int](t, len(crypto.RandomBase64URL(32)), 43)
+    return Eq(t, len(crypto.RandomBase64URL(32)), 43)
 }
 
 func TestRandomBase64URLNoPadding(t T) T {
     val s = crypto.RandomBase64URL(32)
-    var decoded, err = base64.RawURLEncoding.DecodeString(s)
-    var t1 = IsNil(t, err)
-    return Eq[int](t1, len(decoded), 32)
+    val decoded, err = base64.RawURLEncoding.DecodeString(s)
+    val t1 = IsNil(t, err)
+    return Eq(t1, len(decoded), 32)
 }
 
 func TestRandomBase64URLDifferent(t T) T {

--- a/fs/dir_ops.gala
+++ b/fs/dir_ops.gala
@@ -25,10 +25,10 @@ struct WalkEntry(
 // Named CopyFile rather than Copy to avoid colliding with std.Copy,
 // the generic deep-copy helper exported as a prelude symbol.
 func CopyFile(src string, dst string, mode int) Try[bool] = Try[bool](() => {
-    var srcF, openErr = os.Open(src)
+    val srcF, openErr = os.Open(src)
     if openErr != nil { panic(openErr) }
     defer srcF.Close()
-    var dstF, createErr = os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(mode))
+    val dstF, createErr = os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(mode))
     if createErr != nil { panic(createErr) }
     defer dstF.Close()
     val _, copyErr = io.Copy(dstF, srcF)

--- a/fs/dir_ops_test.gala
+++ b/fs/dir_ops_test.gala
@@ -26,11 +26,11 @@ func TestCopyFile(t T) T {
     fs.WriteFileString(src, payload, 0o644)
 
     val r = fs.CopyFile(src, dst, 0o644)
-    var t1 = IsTrue(t, r.IsSuccess())
-    var t2 = IsTrue(t1, fs.Exists(dst))
+    val t1 = IsTrue(t, r.IsSuccess())
+    val t2 = IsTrue(t1, fs.Exists(dst))
     val read = fs.ReadFileString(dst)
-    var t3 = IsTrue(t2, read.IsSuccess())
-    return Eq[string](t3, read.Get(), payload)
+    val t3 = IsTrue(t2, read.IsSuccess())
+    return Eq(t3, read.Get(), payload)
 }
 
 func TestCopyMissingSource(t T) T {
@@ -52,11 +52,11 @@ func TestRename(t T) T {
     fs.WriteFileString(src, payload, 0o644)
 
     val r = fs.Rename(src, dst)
-    var t1 = IsTrue(t, r.IsSuccess())
-    var t2 = IsFalse(t1, fs.Exists(src))
-    var t3 = IsTrue(t2, fs.Exists(dst))
+    val t1 = IsTrue(t, r.IsSuccess())
+    val t2 = IsFalse(t1, fs.Exists(src))
+    val t3 = IsTrue(t2, fs.Exists(dst))
     val read = fs.ReadFileString(dst)
-    return Eq[string](t3, read.Get(), payload)
+    return Eq(t3, read.Get(), payload)
 }
 
 func TestWalk(t T) T {
@@ -70,13 +70,13 @@ func TestWalk(t T) T {
     fs.WriteFileString(filepath.Join(dir, "sub", "c.txt"), "333", 0o644)
 
     val r = fs.Walk(dir)
-    var t1 = IsTrue(t, r.IsSuccess())
+    val t1 = IsTrue(t, r.IsSuccess())
     val entries = r.Get()
     // root + a.txt + b.txt + sub + sub/c.txt = 5 entries
-    var t2 = Eq[int](t1, entries.Size(), 5)
+    val t2 = Eq(t1, entries.Size(), 5)
 
     // Assert every expected path is reachable; don't pin a specific order.
-    val expected = ArrayOf[string](
+    val expected = ArrayOf(
         dir,
         filepath.Join(dir, "a.txt"),
         filepath.Join(dir, "b.txt"),
@@ -106,8 +106,8 @@ func TestGlob(t T) T {
     fs.WriteFileString(filepath.Join(dir, "c.md"), "333", 0o644)
 
     val r = fs.Glob(filepath.Join(dir, "*.txt"))
-    var t1 = IsTrue(t, r.IsSuccess())
-    return Eq[int](t1, r.Get().Size(), 2)
+    val t1 = IsTrue(t, r.IsSuccess())
+    return Eq(t1, r.Get().Size(), 2)
 }
 
 func TestGlobNoMatches(t T) T {
@@ -115,8 +115,8 @@ func TestGlobNoMatches(t T) T {
     defer os.RemoveAll(dir)
 
     val r = fs.Glob(filepath.Join(dir, "*.nothing"))
-    var t1 = IsTrue(t, r.IsSuccess())
-    return Eq[int](t1, r.Get().Size(), 0)
+    val t1 = IsTrue(t, r.IsSuccess())
+    return Eq(t1, r.Get().Size(), 0)
 }
 
 func TestGlobMalformed(t T) T {

--- a/fs/fs.gala
+++ b/fs/fs.gala
@@ -79,10 +79,7 @@ func Stat(path string) Try[FileInfo] = Try[FileInfo](() => {
 // Returns false on any error (including NotExist, permission denied,
 // or transient IO failure). Callers who care about *why* something is
 // missing should use Stat directly.
-func Exists(path string) bool {
-    val _, err = os.Stat(path)
-    return err == nil
-}
+func Exists(path string) bool = Stat(path).IsSuccess()
 
 // MkdirAll creates `path` along with any necessary parents. It is a
 // no-op if the directory already exists. `mode` is the Unix permission

--- a/fs/fs_test.gala
+++ b/fs/fs_test.gala
@@ -24,11 +24,11 @@ func TestWriteAndReadFile(t T) T {
     val target = filepath.Join(dir, "hello.txt")
     val payload = "hello, world"
     val w = fs.WriteFileString(target, payload, 0o644)
-    var t1 = IsTrue(t, w.IsSuccess())
+    val t1 = IsTrue(t, w.IsSuccess())
 
     val r = fs.ReadFileString(target)
-    var t2 = IsTrue(t1, r.IsSuccess())
-    return Eq[string](t2, r.Get(), payload)
+    val t2 = IsTrue(t1, r.IsSuccess())
+    return Eq(t2, r.Get(), payload)
 }
 
 func TestReadFileBytesRoundTrip(t T) T {
@@ -36,13 +36,13 @@ func TestReadFileBytesRoundTrip(t T) T {
     defer os.RemoveAll(dir)
 
     val target = filepath.Join(dir, "bytes.bin")
-    val data = ArrayOf[byte](byte(1), byte(2), byte(3), byte(255))
+    val data = ArrayOf(byte(1), byte(2), byte(3), byte(255))
     val w = fs.WriteFile(target, data, 0o644)
-    var t1 = IsTrue(t, w.IsSuccess())
+    val t1 = IsTrue(t, w.IsSuccess())
 
     val r = fs.ReadFile(target)
-    var t2 = IsTrue(t1, r.IsSuccess())
-    return Eq[int](t2, r.Get().Size(), data.Size())
+    val t2 = IsTrue(t1, r.IsSuccess())
+    return Eq(t2, r.Get().Size(), data.Size())
 }
 
 func TestReadFileMissing(t T) T {
@@ -58,10 +58,10 @@ func TestStat(t T) T {
     fs.WriteFileString(target, "abcdef", 0o644)
 
     val info = fs.Stat(target)
-    var t1 = IsTrue(t, info.IsSuccess())
+    val t1 = IsTrue(t, info.IsSuccess())
     val fi = info.Get()
-    var t2 = Eq[string](t1, fi.Name, "info.txt")
-    var t3 = Eq[int64](t2, fi.Size, int64(6))
+    val t2 = Eq(t1, fi.Name, "info.txt")
+    val t3 = Eq(t2, fi.Size, int64(6))
     return IsFalse(t3, fi.IsDir)
 }
 
@@ -70,7 +70,7 @@ func TestStatDirectoryFlag(t T) T {
     defer os.RemoveAll(dir)
 
     val info = fs.Stat(dir)
-    var t1 = IsTrue(t, info.IsSuccess())
+    val t1 = IsTrue(t, info.IsSuccess())
     return IsTrue(t1, info.Get().IsDir)
 }
 
@@ -78,7 +78,7 @@ func TestExists(t T) T {
     val dir = scratchDir("fs_exists")
     defer os.RemoveAll(dir)
 
-    var t1 = IsTrue(t, fs.Exists(dir))
+    val t1 = IsTrue(t, fs.Exists(dir))
     return IsFalse(t1, fs.Exists(filepath.Join(dir, "nope")))
 }
 
@@ -88,13 +88,13 @@ func TestMkdirAll(t T) T {
 
     val nested = filepath.Join(dir, "a", "b", "c")
     val r = fs.MkdirAll(nested, 0o755)
-    var t1 = IsTrue(t, r.IsSuccess())
+    val t1 = IsTrue(t, r.IsSuccess())
     return IsTrue(t1, fs.Exists(nested))
 }
 
 func TestMkdirTemp(t T) T {
     val r = fs.MkdirTemp("", "fs_mkdirtemp_")
-    var t1 = IsTrue(t, r.IsSuccess())
+    val t1 = IsTrue(t, r.IsSuccess())
     val created = r.Get()
     val t2 = IsTrue(t1, fs.Exists(created))
     fs.RemoveAll(created)
@@ -107,9 +107,9 @@ func TestRemoveAll(t T) T {
     fs.MkdirAll(nested, 0o755)
     fs.WriteFileString(filepath.Join(nested, "f.txt"), "data", 0o644)
 
-    var t1 = IsTrue(t, fs.Exists(dir))
+    val t1 = IsTrue(t, fs.Exists(dir))
     val r = fs.RemoveAll(dir)
-    var t2 = IsTrue(t1, r.IsSuccess())
+    val t2 = IsTrue(t1, r.IsSuccess())
     return IsFalse(t2, fs.Exists(dir))
 }
 
@@ -129,7 +129,7 @@ func TestReadDir(t T) T {
     fs.MkdirAll(filepath.Join(dir, "sub"), 0o755)
 
     val r = fs.ReadDir(dir)
-    var t1 = IsTrue(t, r.IsSuccess())
+    val t1 = IsTrue(t, r.IsSuccess())
     val entries = r.Get()
-    return Eq[int](t1, entries.Size(), 3)
+    return Eq(t1, entries.Size(), 3)
 }

--- a/fs/streaming.gala
+++ b/fs/streaming.gala
@@ -34,10 +34,7 @@ func ReadLines(path string) Try[Array[string]] = Try[Array[string]](() => {
     val data, err = os.ReadFile(path)
     if err != nil { panic(err) }
     val parts = strings.Split(string(data), "\n")
-    var n = len(parts)
-    if n > 0 && parts[n-1] == "" {
-        n = n - 1
-    }
+    val n = if (len(parts) > 0 && parts[len(parts)-1] == "") len(parts) - 1 else len(parts)
     return ArrayFromSlice(SliceTake(parts, n))
 })
 

--- a/fs/streaming_test.gala
+++ b/fs/streaming_test.gala
@@ -22,17 +22,17 @@ func TestReadLinesRoundTrip(t T) T {
     defer os.RemoveAll(dir)
 
     val target = filepath.Join(dir, "lines.txt")
-    val lines = ArrayOf[string]("alpha", "beta", "gamma")
+    val lines = ArrayOf("alpha", "beta", "gamma")
     val w = fs.WriteLines(target, lines, 0o644)
-    var t1 = IsTrue(t, w.IsSuccess())
+    val t1 = IsTrue(t, w.IsSuccess())
 
     val r = fs.ReadLines(target)
-    var t2 = IsTrue(t1, r.IsSuccess())
+    val t2 = IsTrue(t1, r.IsSuccess())
     val read = r.Get()
-    var t3 = Eq[int](t2, read.Size(), 3)
-    var t4 = Eq[string](t3, read.Get(0), "alpha")
-    var t5 = Eq[string](t4, read.Get(1), "beta")
-    return Eq[string](t5, read.Get(2), "gamma")
+    val t3 = Eq(t2, read.Size(), 3)
+    val t4 = Eq(t3, read.Get(0), "alpha")
+    val t5 = Eq(t4, read.Get(1), "beta")
+    return Eq(t5, read.Get(2), "gamma")
 }
 
 func TestReadLinesEmptyFile(t T) T {
@@ -43,8 +43,8 @@ func TestReadLinesEmptyFile(t T) T {
     fs.WriteFileString(target, "", 0o644)
 
     val r = fs.ReadLines(target)
-    var t1 = IsTrue(t, r.IsSuccess())
-    return Eq[int](t1, r.Get().Size(), 0)
+    val t1 = IsTrue(t, r.IsSuccess())
+    return Eq(t1, r.Get().Size(), 0)
 }
 
 func TestReadLinesNoTrailingNewline(t T) T {
@@ -55,10 +55,10 @@ func TestReadLinesNoTrailingNewline(t T) T {
     fs.WriteFileString(target, "one\ntwo\nthree", 0o644)
 
     val r = fs.ReadLines(target)
-    var t1 = IsTrue(t, r.IsSuccess())
+    val t1 = IsTrue(t, r.IsSuccess())
     val read = r.Get()
-    var t2 = Eq[int](t1, read.Size(), 3)
-    return Eq[string](t2, read.Get(2), "three")
+    val t2 = Eq(t1, read.Size(), 3)
+    return Eq(t2, read.Get(2), "three")
 }
 
 func TestForEachLineVisitsAll(t T) T {
@@ -66,18 +66,18 @@ func TestForEachLineVisitsAll(t T) T {
     defer os.RemoveAll(dir)
 
     val target = filepath.Join(dir, "lines.txt")
-    fs.WriteLines(target, ArrayOf[string]("a", "b", "c"), 0o644)
+    fs.WriteLines(target, ArrayOf("a", "b", "c"), 0o644)
 
     var seen = EmptyArray[string]()
     val r = fs.ForEachLine(target, (line) => {
         seen = seen.Append(line)
         return true
     })
-    var t1 = IsTrue(t, r.IsSuccess())
-    var t2 = Eq[int](t1, seen.Size(), 3)
-    var t3 = Eq[string](t2, seen.Get(0), "a")
-    var t4 = Eq[string](t3, seen.Get(1), "b")
-    return Eq[string](t4, seen.Get(2), "c")
+    val t1 = IsTrue(t, r.IsSuccess())
+    val t2 = Eq(t1, seen.Size(), 3)
+    val t3 = Eq(t2, seen.Get(0), "a")
+    val t4 = Eq(t3, seen.Get(1), "b")
+    return Eq(t4, seen.Get(2), "c")
 }
 
 func TestForEachLineEarlyStop(t T) T {
@@ -85,16 +85,16 @@ func TestForEachLineEarlyStop(t T) T {
     defer os.RemoveAll(dir)
 
     val target = filepath.Join(dir, "lines.txt")
-    fs.WriteLines(target, ArrayOf[string]("a", "b", "c", "d"), 0o644)
+    fs.WriteLines(target, ArrayOf("a", "b", "c", "d"), 0o644)
 
     var seen = EmptyArray[string]()
     val r = fs.ForEachLine(target, (line) => {
         seen = seen.Append(line)
         return seen.Size() < 2
     })
-    var t1 = IsTrue(t, r.IsSuccess())
+    val t1 = IsTrue(t, r.IsSuccess())
     // Callback returned false on line 2, so iteration stopped there.
-    return Eq[int](t1, seen.Size(), 2)
+    return Eq(t1, seen.Size(), 2)
 }
 
 func TestForEachLineMissingFileFails(t T) T {
@@ -108,13 +108,13 @@ func TestAppendStringRoundTrip(t T) T {
 
     val target = filepath.Join(dir, "log.txt")
     val w1 = fs.AppendString(target, "a\n", 0o644)
-    var t1 = IsTrue(t, w1.IsSuccess())
+    val t1 = IsTrue(t, w1.IsSuccess())
     val w2 = fs.AppendString(target, "b\n", 0o644)
-    var t2 = IsTrue(t1, w2.IsSuccess())
+    val t2 = IsTrue(t1, w2.IsSuccess())
 
     val r = fs.ReadFileString(target)
-    var t3 = IsTrue(t2, r.IsSuccess())
-    return Eq[string](t3, r.Get(), "a\nb\n")
+    val t3 = IsTrue(t2, r.IsSuccess())
+    return Eq(t3, r.Get(), "a\nb\n")
 }
 
 func TestAppendStringCreatesFile(t T) T {
@@ -122,13 +122,13 @@ func TestAppendStringCreatesFile(t T) T {
     defer os.RemoveAll(dir)
 
     val target = filepath.Join(dir, "fresh.txt")
-    var t1 = IsFalse(t, fs.Exists(target))
+    val t1 = IsFalse(t, fs.Exists(target))
     val w = fs.AppendString(target, "hello", 0o644)
-    var t2 = IsTrue(t1, w.IsSuccess())
-    var t3 = IsTrue(t2, fs.Exists(target))
+    val t2 = IsTrue(t1, w.IsSuccess())
+    val t3 = IsTrue(t2, fs.Exists(target))
 
     val r = fs.ReadFileString(target)
-    return Eq[string](t3, r.Get(), "hello")
+    return Eq(t3, r.Get(), "hello")
 }
 
 func TestAppendBytesRoundTrip(t T) T {
@@ -136,14 +136,14 @@ func TestAppendBytesRoundTrip(t T) T {
     defer os.RemoveAll(dir)
 
     val target = filepath.Join(dir, "bytes.bin")
-    val payload1 = ArrayOf[byte](byte(1), byte(2))
-    val payload2 = ArrayOf[byte](byte(3), byte(4))
+    val payload1 = ArrayOf(byte(1), byte(2))
+    val payload2 = ArrayOf(byte(3), byte(4))
     val w1 = fs.Append(target, payload1, 0o644)
-    var t1 = IsTrue(t, w1.IsSuccess())
+    val t1 = IsTrue(t, w1.IsSuccess())
     val w2 = fs.Append(target, payload2, 0o644)
-    var t2 = IsTrue(t1, w2.IsSuccess())
+    val t2 = IsTrue(t1, w2.IsSuccess())
 
     val r = fs.ReadFile(target)
-    var t3 = IsTrue(t2, r.IsSuccess())
-    return Eq[int](t3, r.Get().Size(), 4)
+    val t3 = IsTrue(t2, r.IsSuccess())
+    return Eq(t3, r.Get().Size(), 4)
 }

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -736,11 +736,17 @@ func (t *galaASTTransformer) transformFunctionDeclaration(ctx *grammar.FunctionD
 		// expression is promoted to the implicit return below — signal that
 		// to transformBlock so a trailing bare `match` is NOT marked as
 		// statement-position (which would force the IIFE to void and break
-		// the implicit-return promotion).
-		if funcType.Results != nil && len(funcType.Results.List) > 0 {
-			t.blockLastStmtIsValue = true
-		}
+		// the implicit-return promotion). Set the flag explicitly for BOTH
+		// the value-returning and void cases and restore it afterward: a bare
+		// assignment that only set `true` would leak into the next top-level
+		// function, so a void function declared after a value-returning one
+		// would inherit `true` and a trailing bare `match` in its body would
+		// wrongly skip statement-position lowering (its arms then forced to
+		// unify to one type).
+		prevBlockLastStmtIsValue := t.blockLastStmtIsValue
+		t.blockLastStmtIsValue = funcType.Results != nil && len(funcType.Results.List) > 0
 		b, err := t.transformBlock(ctx.Block().(*grammar.BlockContext))
+		t.blockLastStmtIsValue = prevBlockLastStmtIsValue
 		if err != nil {
 			return nil, err
 		}

--- a/internal/transpiler/transformer/match_stmt_dispatch_test.go
+++ b/internal/transpiler/transformer/match_stmt_dispatch_test.go
@@ -59,6 +59,53 @@ func main() { dispatch(1) }`
 	assert.NotContains(t, out, "return bi()")
 }
 
+// TestStatementMatchAfterValueReturningMethod is a regression test for a
+// source-order state leak: a block-bodied, value-returning function/method
+// declared BEFORE a statement-position match left the transformer's
+// "block's last statement is the value" flag set to true, and the later
+// (void) method inherited it — so its trailing bare `match` was not recognized
+// as statement-position and its side-effect-dispatch arms were wrongly forced
+// to unify to one type. The function-declaration transform now restores the
+// flag after each body. The motivating real-world case was the JSON
+// pull-parser's Skip(), declared after the value-returning ReadBool().
+func TestStatementMatchAfterValueReturningMethod(t *testing.T) {
+	trans := newMatchDispatchTranspiler()
+
+	input := `package main
+
+type Dec struct {
+    var pos int
+}
+
+// value-returning, block body, declared BEFORE the statement-position match
+func (d *Dec) readBool() bool {
+    if d.pos > 0 {
+        return true
+    }
+    panic("eof")
+}
+
+func (d *Dec) readStr() string = "s"
+
+func (d *Dec) skip(c int) {
+    c match {
+        case 1 => { d.readStr() }
+        case 2 => { d.readBool() }
+        case _ => { d.pos = d.pos + 1 }
+    }
+}
+
+func main() {
+    val d = &Dec(pos = 1)
+    d.skip(2)
+}`
+
+	out, err := trans.Transpile(input, "stmt_match_order_test.gala")
+	require.NoError(t, err, "statement-position match must be recognized even when a value-returning method precedes it")
+	assert.NotContains(t, out, "return d.readStr()",
+		"discarded arm value must not be wrapped in return (void IIFE expected)")
+}
+
 // Note on scope: discard position is recognized for a match that is itself a
 // statement (the json pull-parser's flat `Skip()`/`writeEscapedJsonString`
 // dispatch). A *nested* match whose value flows up through an enclosing arm

--- a/io/io.gala
+++ b/io/io.gala
@@ -98,9 +98,9 @@ func ForEach[T any](io IO[T], f func(T)) IO[T] {
 func Effect(f func()) IO[bool] {
     return IO[bool](exec = () => {
         f()
-        return Success[bool](true)
+        return Success(true)
     })
 }
 
 // Unit creates an IO that succeeds with no meaningful value.
-func Unit() IO[bool] = Of[bool](true)
+func Unit() IO[bool] = Of(true)

--- a/io/io_test.gala
+++ b/io/io_test.gala
@@ -8,55 +8,55 @@ import (
 
 func TestOf(t T) T {
     val result = io.Of(42).Run()
-    return Eq[int](t, result.Get(), 42)
+    return Eq(t, result.Get(), 42)
 }
 
 func TestSuspend(t T) T {
     val result = io.Suspend(() => 21 * 2).Run()
-    return Eq[int](t, result.Get(), 42)
+    return Eq(t, result.Get(), 42)
 }
 
 func TestFail(t T) T {
     val result = io.Fail[int](errors.New("boom")).Run()
-    var t1 = IsTrue(t, result.IsFailure())
-    return Eq[string](t1, result.GetError().Error(), "boom")
+    val t1 = IsTrue(t, result.IsFailure())
+    return Eq(t1, result.GetError().Error(), "boom")
 }
 
 func TestMap(t T) T {
-    val result = io.Map[int, int](io.Of(10), (x int) => x * 5).Run()
-    return Eq[int](t, result.Get(), 50)
+    val result = io.Map[int, int](io.Of(10), (x) => x * 5).Run()
+    return Eq(t, result.Get(), 50)
 }
 
 func TestFlatMap(t T) T {
-    val result = io.FlatMap[int, int](io.Of(10), (x int) => io.Of(x + 32)).Run()
-    return Eq[int](t, result.Get(), 42)
+    val result = io.FlatMap[int, int](io.Of(10), (x) => io.Of(x + 32)).Run()
+    return Eq(t, result.Get(), 42)
 }
 
 func TestRecover(t T) T {
     val failing = io.Fail[int](errors.New("oops"))
     val recovered = io.Recover(failing, (err) => -1)
-    return Eq[int](t, recovered.Run().Get(), -1)
+    return Eq(t, recovered.Run().Get(), -1)
 }
 
 func TestRecoverWith(t T) T {
     val failing = io.Fail[int](errors.New("oops"))
     val recovered = io.RecoverWith(failing, (err) => io.Of(99))
-    return Eq[int](t, recovered.Run().Get(), 99)
+    return Eq(t, recovered.Run().Get(), 99)
 }
 
 func TestAndThen(t T) T {
     val first = io.Of(1)
     val second = io.Of(42)
     val result = io.AndThen[int, int](first, second).Run()
-    return Eq[int](t, result.Get(), 42)
+    return Eq(t, result.Get(), 42)
 }
 
 func TestEffect(t T) T {
     var counter = 0
     val eff = io.Effect(() => { counter = counter + 1 })
     val result = eff.Run()
-    var t1 = IsTrue(t, result.IsSuccess())
-    return Eq[int](t1, counter, 1)
+    val t1 = IsTrue(t, result.IsSuccess())
+    return Eq(t1, counter, 1)
 }
 
 func TestUnit(t T) T {
@@ -67,13 +67,13 @@ func TestUnit(t T) T {
 func TestForEach(t T) T {
     var seen = 0
     val result = io.ForEach(io.Of(42), (v) => { seen = v }).Run()
-    var t1 = IsTrue(t, result.IsSuccess())
-    return Eq[int](t1, seen, 42)
+    val t1 = IsTrue(t, result.IsSuccess())
+    return Eq(t1, seen, 42)
 }
 
 func TestFailurePropagation(t T) T {
     val failing = io.Fail[int](errors.New("initial"))
-    val chained = io.FlatMap[int, int](failing, (x int) => io.Of(x * 2))
+    val chained = io.FlatMap[int, int](failing, (x) => io.Of(x * 2))
     return IsTrue(t, chained.Run().IsFailure())
 }
 
@@ -88,10 +88,10 @@ func TestSuspendCatchesPanic(t T) T {
 
 func TestUnsafeRun(t T) T {
     val result = io.Of(42).UnsafeRun()
-    return Eq[int](t, result, 42)
+    return Eq(t, result, 42)
 }
 
 func TestFromTry(t T) T {
-    val result = io.FromTry(Success[int](42)).Run()
-    return Eq[int](t, result.Get(), 42)
+    val result = io.FromTry(Success(42)).Run()
+    return Eq(t, result.Get(), 42)
 }

--- a/json/codec.gala
+++ b/json/codec.gala
@@ -3,7 +3,6 @@ package json
 import (
     "bytes"
     "encoding/json"
-    "fmt"
     "strconv"
     "strings"
     . "martianoff/gala/std"
@@ -77,11 +76,7 @@ func (e *JsonEncoderImpl) WriteFloat64(v float64) {
 
 func (e *JsonEncoderImpl) WriteBool(v bool) {
     e.writeCommaIfNeeded()
-    if v {
-        e.buf.WriteString("true")
-    } else {
-        e.buf.WriteString("false")
-    }
+    e.buf.WriteString(if (v) "true" else "false")
     e.needsComma = true
 }
 
@@ -121,7 +116,7 @@ func (e *JsonEncoderImpl) writeEscapedJsonString(s string) {
         } else if c == '\t' {
             e.buf.WriteString("\\t")
         } else if c < 32 {
-            e.buf.WriteString(fmt.Sprintf("\\u%04x", c))
+            e.buf.WriteString(f"\\u${c}%04x")
         } else {
             e.buf.WriteByte(c)
         }
@@ -164,7 +159,7 @@ func (d *JsonDecoderImpl) StartObject() {
     d.consumeElemComma()
     d.skipWs()
     if d.pos >= len(d.data) || d.data[d.pos] != '{' {
-        panic(fmt.Sprintf("json at pos %d: expected '{'", d.pos))
+        panic(s"json at pos ${d.pos}: expected '{'")
     }
     d.pos = d.pos + 1
     d.stack = append(d.stack, 'o')
@@ -174,7 +169,7 @@ func (d *JsonDecoderImpl) StartObject() {
 func (d *JsonDecoderImpl) EndObject() {
     d.skipWs()
     if d.pos >= len(d.data) || d.data[d.pos] != '}' {
-        panic(fmt.Sprintf("json at pos %d: expected '}'", d.pos))
+        panic(s"json at pos ${d.pos}: expected '}'")
     }
     d.pos = d.pos + 1
     d.stack = TruncateBytes(d.stack, len(d.stack) - 1)
@@ -187,7 +182,7 @@ func (d *JsonDecoderImpl) StartArray() {
     d.consumeElemComma()
     d.skipWs()
     if d.pos >= len(d.data) || d.data[d.pos] != '[' {
-        panic(fmt.Sprintf("json at pos %d: expected '['", d.pos))
+        panic(s"json at pos ${d.pos}: expected '['")
     }
     d.pos = d.pos + 1
     d.stack = append(d.stack, 'a')
@@ -197,7 +192,7 @@ func (d *JsonDecoderImpl) StartArray() {
 func (d *JsonDecoderImpl) EndArray() {
     d.skipWs()
     if d.pos >= len(d.data) || d.data[d.pos] != ']' {
-        panic(fmt.Sprintf("json at pos %d: expected ']'", d.pos))
+        panic(s"json at pos ${d.pos}: expected ']'")
     }
     d.pos = d.pos + 1
     d.stack = TruncateBytes(d.stack, len(d.stack) - 1)
@@ -230,7 +225,7 @@ func (d *JsonDecoderImpl) ReadKey() string {
     val key = d.readJsonString()
     d.skipWs()
     if d.pos >= len(d.data) || d.data[d.pos] != ':' {
-        panic(fmt.Sprintf("json at pos %d: expected ':'", d.pos))
+        panic(s"json at pos ${d.pos}: expected ':'")
     }
     d.pos = d.pos + 1
     return key
@@ -248,7 +243,7 @@ func (d *JsonDecoderImpl) ReadInt() int {
     val s = d.readNumberStr()
     val v, err = strconv.Atoi(s)
     if err != nil {
-        panic(fmt.Sprintf("json at pos %d: invalid int %q", d.pos, s))
+        panic(f"json at pos ${d.pos}: invalid int ${s}%q")
     }
     return v
 }
@@ -259,7 +254,7 @@ func (d *JsonDecoderImpl) ReadInt64() int64 {
     val s = d.readNumberStr()
     val v, err = strconv.ParseInt(s, 10, 64)
     if err != nil {
-        panic(fmt.Sprintf("json at pos %d: invalid int64 %q", d.pos, s))
+        panic(f"json at pos ${d.pos}: invalid int64 ${s}%q")
     }
     return v
 }
@@ -270,7 +265,7 @@ func (d *JsonDecoderImpl) ReadFloat64() float64 {
     val s = d.readNumberStr()
     val v, err = strconv.ParseFloat(s, 64)
     if err != nil {
-        panic(fmt.Sprintf("json at pos %d: invalid float %q", d.pos, s))
+        panic(f"json at pos ${d.pos}: invalid float ${s}%q")
     }
     return v
 }
@@ -286,7 +281,7 @@ func (d *JsonDecoderImpl) ReadBool() bool {
         d.pos = d.pos + 5
         return false
     }
-    panic(fmt.Sprintf("json at pos %d: expected boolean", d.pos))
+    panic(s"json at pos ${d.pos}: expected boolean")
 }
 
 func (d *JsonDecoderImpl) ReadRune() rune {
@@ -310,7 +305,7 @@ func (d *JsonDecoderImpl) ReadNull() {
         d.pos = d.pos + 4
         return
     }
-    panic(fmt.Sprintf("json at pos %d: expected null", d.pos))
+    panic(s"json at pos ${d.pos}: expected null")
 }
 
 func (d *JsonDecoderImpl) Skip() {
@@ -318,27 +313,15 @@ func (d *JsonDecoderImpl) Skip() {
     d.skipWs()
     if d.pos >= len(d.data) { return }
     val c = d.data[d.pos]
-    if c == '"' {
-        d.readJsonString()
-        return
+    c match {
+        case '"' => { d.readJsonString() }
+        case '{' => { d.skipBetween('{', '}') }
+        case '[' => { d.skipBetween('[', ']') }
+        case 't' => { d.ReadBool() }
+        case 'f' => { d.ReadBool() }
+        case 'n' => { d.ReadNull() }
+        case _ => { d.readNumberStr() }
     }
-    if c == '{' {
-        d.skipBetween('{', '}')
-        return
-    }
-    if c == '[' {
-        d.skipBetween('[', ']')
-        return
-    }
-    if c == 't' || c == 'f' {
-        d.ReadBool()
-        return
-    }
-    if c == 'n' {
-        d.ReadNull()
-        return
-    }
-    d.readNumberStr()
 }
 
 // --- decoder internal helpers ---
@@ -370,7 +353,7 @@ func (d *JsonDecoderImpl) consumeElemComma() {
 func (d *JsonDecoderImpl) readJsonString() string {
     d.skipWs()
     if d.pos >= len(d.data) || d.data[d.pos] != '"' {
-        panic(fmt.Sprintf("json at pos %d: expected '\"'", d.pos))
+        panic(s"json at pos ${d.pos}: expected '\"'")
     }
     d.pos = d.pos + 1
 
@@ -388,25 +371,26 @@ func (d *JsonDecoderImpl) readJsonString() string {
             }
             val esc = d.data[d.pos]
             d.pos = d.pos + 1
-            if esc == '"' { sb.WriteByte('"') }
-            else if esc == '\\' { sb.WriteByte('\\') }
-            else if esc == '/' { sb.WriteByte('/') }
-            else if esc == 'n' { sb.WriteByte('\n') }
-            else if esc == 'r' { sb.WriteByte('\r') }
-            else if esc == 't' { sb.WriteByte('\t') }
-            else if esc == 'u' {
-                if d.pos + 4 > len(d.data) {
-                    panic("json: incomplete unicode escape")
+            esc match {
+                case '"' => { sb.WriteByte('"') }
+                case '\\' => { sb.WriteByte('\\') }
+                case '/' => { sb.WriteByte('/') }
+                case 'n' => { sb.WriteByte('\n') }
+                case 'r' => { sb.WriteByte('\r') }
+                case 't' => { sb.WriteByte('\t') }
+                case 'u' => {
+                    if d.pos + 4 > len(d.data) {
+                        panic("json: incomplete unicode escape")
+                    }
+                    val hexStr = BytesToString(d.data, d.pos, d.pos + 4)
+                    d.pos = d.pos + 4
+                    val cp, hexErr = strconv.ParseUint(hexStr, 16, 32)
+                    if hexErr != nil {
+                        panic("json: invalid unicode escape")
+                    }
+                    sb.WriteString(RuneToString(rune(cp)))
                 }
-                val hexStr = BytesToString(d.data, d.pos, d.pos + 4)
-                d.pos = d.pos + 4
-                val cp, hexErr = strconv.ParseUint(hexStr, 16, 32)
-                if hexErr != nil {
-                    panic("json: invalid unicode escape")
-                }
-                sb.WriteString(RuneToString(rune(cp)))
-            } else {
-                panic("json: invalid escape sequence")
+                case _ => { panic("json: invalid escape sequence") }
             }
         } else {
             sb.WriteByte(c)

--- a/json/helpers.gala
+++ b/json/helpers.gala
@@ -6,38 +6,29 @@ import (
 
 // KeyConfig holds field-level configuration for JSON serialization.
 type KeyConfig struct {
-    var NamingStrategy Naming
-    var Renames        HashMap[string, string]
-    var Omits          HashMap[string, bool]
-    var OmitEmpties    HashMap[string, bool]
+    NamingStrategy Naming
+    Renames        HashMap[string, string]
+    Omits          HashMap[string, bool]
+    OmitEmpties    HashMap[string, bool]
 }
 
-func NewKeyConfig() KeyConfig = KeyConfig{
-    NamingStrategy: AsIs(),
-    Renames:        EmptyHashMap[string, string](),
-    Omits:          EmptyHashMap[string, bool](),
-    OmitEmpties:    EmptyHashMap[string, bool](),
-}
+func NewKeyConfig() KeyConfig = KeyConfig(
+    NamingStrategy = AsIs(),
+    Renames = EmptyHashMap[string, string](),
+    Omits = EmptyHashMap[string, bool](),
+    OmitEmpties = EmptyHashMap[string, bool](),
+)
 
-func (c KeyConfig) WithNaming(n Naming) KeyConfig {
-    c.NamingStrategy = n
-    return c
-}
+func (c KeyConfig) WithNaming(n Naming) KeyConfig = c.Copy(NamingStrategy = n)
 
-func (c KeyConfig) WithRename(field string, key string) KeyConfig {
-    c.Renames = c.Renames.Put(field, key)
-    return c
-}
+func (c KeyConfig) WithRename(field string, key string) KeyConfig =
+    c.Copy(Renames = c.Renames.Put(field, key))
 
-func (c KeyConfig) WithOmit(field string) KeyConfig {
-    c.Omits = c.Omits.Put(field, true)
-    return c
-}
+func (c KeyConfig) WithOmit(field string) KeyConfig =
+    c.Copy(Omits = c.Omits.Put(field, true))
 
-func (c KeyConfig) WithOmitEmpty(field string) KeyConfig {
-    c.OmitEmpties = c.OmitEmpties.Put(field, true)
-    return c
-}
+func (c KeyConfig) WithOmitEmpty(field string) KeyConfig =
+    c.Copy(OmitEmpties = c.OmitEmpties.Put(field, true))
 
 // KeysConfig holds the computed key arrays for WriteTo/ReadFrom.
 type KeysConfig struct {
@@ -56,13 +47,13 @@ func BuildKeys(numFields int, fieldName func(int) string, naming Naming, config 
             keys = keys.Append("")
         } else {
             val renamed = config.Renames.Get(name)
-            val key = if (renamed.IsDefined()) renamed.Get() else ApplyNaming(name, naming)
+            val key = renamed.GetOrElse(ApplyNaming(name, naming))
             keys = keys.Append(key)
             reverseKeys = reverseKeys.Put(key, name)
         }
         i = i + 1
     }
-    return KeysConfig{Keys: keys, ReverseKeys: reverseKeys}
+    return KeysConfig(Keys = keys, ReverseKeys = reverseKeys)
 }
 
 // BuildKeysSimple computes keys with a naming strategy and no overrides.

--- a/json/json.gala
+++ b/json/json.gala
@@ -40,11 +40,11 @@ type Codec[T any] struct {}
 // when the user calls Codec[T](naming).
 func (c Codec[T]) Apply(meta StructMeta[T], naming Naming) JsonEncoder[T] {
     val config = NewKeyConfig().WithNaming(naming)
-    return JsonEncoder[T]{
-        Meta:   meta,
-        Config: config,
-        Keys:   BuildKeysSimple(meta.NumFields(), meta.FieldName, naming),
-    }
+    return JsonEncoder[T](
+        Meta = meta,
+        Config = config,
+        Keys = BuildKeysSimple(meta.NumFields(), meta.FieldName, naming),
+    )
 }
 
 // JsonEncoder[T] is a fully typed JSON codec instance.
@@ -73,11 +73,11 @@ func (c JsonEncoder[T]) OmitEmpty(field string) JsonEncoder[T] =
     rebuildEncoder[T](c.Meta, c.Config.WithOmitEmpty(field))
 
 func rebuildEncoder[T any](meta StructMeta[T], config KeyConfig) JsonEncoder[T] =
-    JsonEncoder[T]{
-        Meta:   meta,
-        Config: config,
-        Keys:   BuildKeys(meta.NumFields(), meta.FieldName, config.NamingStrategy, config),
-    }
+    JsonEncoder[T](
+        Meta = meta,
+        Config = config,
+        Keys = BuildKeys(meta.NumFields(), meta.FieldName, config.NamingStrategy, config),
+    )
 
 // nameFnFromKeys returns a function that maps a field index to its serialized
 // key.  An empty key signals an omitted field.
@@ -106,11 +106,8 @@ func (c JsonEncoder[T]) Encode(v T) Try[string] {
 }
 
 // EncodePretty serializes a value to a pretty-printed JSON string.
-func (c JsonEncoder[T]) EncodePretty(v T) Try[string] {
-    val result = c.Encode(v)
-    if result.IsFailure() { return result }
-    return PrettyIndent(result.Get(), "  ")
-}
+func (c JsonEncoder[T]) EncodePretty(v T) Try[string] =
+    c.Encode(v).FlatMap((s) => PrettyIndent(s, "  "))
 
 // Decode deserializes a JSON string into Try[T] (zero-reflection).
 // DecodeFields panics on malformed input; Try() catches the panic and
@@ -126,11 +123,7 @@ func (c JsonEncoder[T]) Decode(s string) Try[T] {
 
 // Unapply attempts to decode a JSON string using the codec's naming config.
 // Returns Option[T] for pattern matching support.
-func (c JsonEncoder[T]) Unapply(s string) Option[T] {
-    val decoded = c.Decode(s)
-    if decoded.IsFailure() { return None[T]() }
-    return Some[T](decoded.Get())
-}
+func (c JsonEncoder[T]) Unapply(s string) Option[T] = c.Decode(s).ToOption()
 
 // buildLookup turns the precomputed reverseKeys map (serialized key → GALA
 // field name) into the index-lookup function DecodeFields expects.
@@ -145,14 +138,6 @@ func buildLookup(
         nameToIdx = nameToIdx.Put(fieldName(i), i)
         i = i + 1
     }
-    return (key string) => {
-        val gName = reverseKeys.Get(key)
-        if gName.IsDefined() {
-            val idx = nameToIdx.Get(gName.Get())
-            if idx.IsDefined() {
-                return idx.Get()
-            }
-        }
-        return -1
-    }
+    return (key string) =>
+        reverseKeys.Get(key).FlatMap((gName) => nameToIdx.Get(gName)).GetOrElse(-1)
 }

--- a/lazy/lazy_test.gala
+++ b/lazy/lazy_test.gala
@@ -12,7 +12,7 @@ func TestNew(t T) T {
 
 func TestOf(t T) T {
     val l = Of[int](99)
-    var t1 = IsTrue(t, l.IsEvaluated())
+    val t1 = IsTrue(t, l.IsEvaluated())
     return Eq[int](t1, l.Get(), 99)
 }
 
@@ -24,29 +24,29 @@ func TestGetCaching(t T) T {
     })
     val first = l.Get()
     val second = l.Get()
-    var t1 = Eq[int](t, first, 10)
-    var t2 = Eq[int](t1, second, 10)
+    val t1 = Eq[int](t, first, 10)
+    val t2 = Eq[int](t1, second, 10)
     return Eq[int](t2, count, 1)
 }
 
 func TestIsEvaluated(t T) T {
     val l = New[int](() => 5)
-    var t1 = IsFalse(t, l.IsEvaluated())
+    val t1 = IsFalse(t, l.IsEvaluated())
     l.Get()
     return IsTrue(t1, l.IsEvaluated())
 }
 
 func TestMap(t T) T {
     val l = New[int](() => 10)
-    val mapped = l.Map[int]((x int) => x * 2)
-    var t1 = IsFalse(t, mapped.IsEvaluated())
-    var t2 = Eq[int](t1, mapped.Get(), 20)
+    val mapped = l.Map((x) => x * 2)
+    val t1 = IsFalse(t, mapped.IsEvaluated())
+    val t2 = Eq[int](t1, mapped.Get(), 20)
     return IsTrue(t2, mapped.IsEvaluated())
 }
 
 func TestFlatMap(t T) T {
     val l = New[int](() => 5)
-    val chained = l.FlatMap[int]((x int) => New[int](() => x + 3))
-    var t1 = IsFalse(t, chained.IsEvaluated())
+    val chained = l.FlatMap((x) => New[int](() => x + 3))
+    val t1 = IsFalse(t, chained.IsEvaluated())
     return Eq[int](t1, chained.Get(), 8)
 }

--- a/path/path_test.gala
+++ b/path/path_test.gala
@@ -14,65 +14,62 @@ func nativeJoin(parts ...string) string = path.Join(parts...)
 func TestJoin(t T) T {
     val joined = path.Join("a", "b", "c")
     val expected = nativeJoin("a", "b", "c")
-    return Eq[string](t, joined, expected)
+    return Eq(t, joined, expected)
 }
 
 func TestJoinIgnoresEmpty(t T) T {
     val joined = path.Join("a", "", "b")
     val expected = nativeJoin("a", "b")
-    return Eq[string](t, joined, expected)
+    return Eq(t, joined, expected)
 }
 
 func TestDir(t T) T {
     val full = path.Join("foo", "bar", "baz.txt")
     val expected = path.Join("foo", "bar")
-    return Eq[string](t, path.Dir(full), expected)
+    return Eq(t, path.Dir(full), expected)
 }
 
 func TestDirEmpty(t T) T {
-    return Eq[string](t, path.Dir(""), ".")
+    return Eq(t, path.Dir(""), ".")
 }
 
 func TestBase(t T) T {
     val full = path.Join("foo", "bar", "baz.txt")
-    return Eq[string](t, path.Base(full), "baz.txt")
+    return Eq(t, path.Base(full), "baz.txt")
 }
 
 func TestBaseEmpty(t T) T {
-    return Eq[string](t, path.Base(""), ".")
+    return Eq(t, path.Base(""), ".")
 }
 
 func TestExt(t T) T {
-    var t1 = Eq[string](t, path.Ext("file.gala"), ".gala")
-    var t2 = Eq[string](t1, path.Ext("file.tar.gz"), ".gz")
-    return Eq[string](t2, path.Ext("README"), "")
+    val t1 = Eq(t, path.Ext("file.gala"), ".gala")
+    val t2 = Eq(t1, path.Ext("file.tar.gz"), ".gz")
+    return Eq(t2, path.Ext("README"), "")
 }
 
 func TestIsAbs(t T) T {
     // Unix / Windows differ — pick a platform-native absolute and a
     // platform-native relative path and check both.
     if runtime.GOOS == "windows" {
-        var t1 = IsTrue(t, path.IsAbs("C:\\foo"))
+        val t1 = IsTrue(t, path.IsAbs("C:\\foo"))
         return IsFalse(t1, path.IsAbs("foo\\bar"))
     }
-    var t1 = IsTrue(t, path.IsAbs("/foo/bar"))
+    val t1 = IsTrue(t, path.IsAbs("/foo/bar"))
     return IsFalse(t1, path.IsAbs("foo/bar"))
 }
 
 func TestAbsResolvesRelative(t T) T {
     val result = path.Abs("foo")
-    var t1 = IsTrue(t, result.IsSuccess())
+    val t1 = IsTrue(t, result.IsSuccess())
     return IsTrue(t1, path.IsAbs(result.Get()))
 }
 
 func TestAbsAlreadyAbsolute(t T) T {
     // An already-absolute path stays absolute (and Clean-ed).
-    var input = "/already/abs"
-    if runtime.GOOS == "windows" {
-        input = "C:\\already\\abs"
-    }
+    val input = if (runtime.GOOS == "windows") "C:\\already\\abs" else "/already/abs"
     val result = path.Abs(input)
-    var t1 = IsTrue(t, result.IsSuccess())
+    val t1 = IsTrue(t, result.IsSuccess())
     return IsTrue(t1, path.IsAbs(result.Get()))
 }
 
@@ -80,18 +77,18 @@ func TestToSlash(t T) T {
     // ToSlash is identity on Unix; on Windows it replaces '\\' with '/'.
     val joined = path.Join("a", "b")
     val sl = path.ToSlash(joined)
-    return Eq[string](t, sl, "a/b")
+    return Eq(t, sl, "a/b")
 }
 
 func TestFromSlash(t T) T {
     // Round-trip: ToSlash(FromSlash(x)) == x for any forward-slash x.
     val original = "a/b/c"
     val native = path.FromSlash(original)
-    return Eq[string](t, path.ToSlash(native), original)
+    return Eq(t, path.ToSlash(native), original)
 }
 
 func TestClean(t T) T {
-    var t1 = Eq[string](t, path.Clean("a/./b"), nativeJoin("a", "b"))
-    var t2 = Eq[string](t1, path.Clean("a/b/.."), "a")
-    return Eq[string](t2, path.Clean(""), ".")
+    val t1 = Eq(t, path.Clean("a/./b"), nativeJoin("a", "b"))
+    val t2 = Eq(t1, path.Clean("a/b/.."), "a")
+    return Eq(t2, path.Clean(""), ".")
 }

--- a/regex/regex.gala
+++ b/regex/regex.gala
@@ -10,7 +10,7 @@ import (
 // Regex wraps a compiled regular expression with pattern matching support.
 type Regex struct {
     Pattern string
-    var Re  *regexp.Regexp
+    Re      *regexp.Regexp
 }
 
 // Compile compiles a regular expression pattern.
@@ -35,10 +35,7 @@ func (r Regex) Matches(s string) bool = r.Re.MatchString(s)
 // FindFirst returns the first match as Option[string].
 func (r Regex) FindFirst(s string) Option[string] {
     val result = r.Re.FindString(s)
-    if result == "" {
-        return None[string]()
-    }
-    return Some(result)
+    return When(result != "", result)
 }
 
 // FindAll returns all non-overlapping matches as an Array.
@@ -50,10 +47,7 @@ func (r Regex) FindAll(s string) Array[string] {
 // FindGroups returns the first match with capture groups as Option[Array[string]].
 func (r Regex) FindGroups(s string) Option[Array[string]] {
     val result = r.Re.FindStringSubmatch(s)
-    if result == nil {
-        return None[Array[string]]()
-    }
-    return Some[Array[string]](ArrayFromSlice(result))
+    return When(result != nil, ArrayFromSlice(result))
 }
 
 // ReplaceAll replaces all matches with the replacement string.
@@ -77,10 +71,7 @@ func (r Regex) Split(s string) Array[string] {
 //   }
 func (r Regex) Unapply(s string) Option[Array[string]] {
     val result = r.Re.FindStringSubmatch(s)
-    if result == nil {
-        return None[Array[string]]()
-    }
-    if len(result) < 2 {
+    if result == nil || len(result) < 2 {
         return None[Array[string]]()
     }
     return Some[Array[string]](ArrayFromSlice(go_interop.SliceFrom(result, 1)))

--- a/regex/regex_test.gala
+++ b/regex/regex_test.gala
@@ -7,14 +7,14 @@ import (
 
 func TestMatches(t T) T {
     val r = regex.MustCompile("\\d+")
-    var t1 = IsTrue(t, r.Matches("abc123"))
+    val t1 = IsTrue(t, r.Matches("abc123"))
     return IsFalse(t1, r.Matches("no digits"))
 }
 
 func TestFindFirst(t T) T {
     val r = regex.MustCompile("\\d+")
     val result = r.FindFirst("abc 123 def")
-    return Eq[string](t, result.Get(), "123")
+    return Eq(t, result.Get(), "123")
 }
 
 func TestFindFirstNoMatch(t T) T {
@@ -26,20 +26,20 @@ func TestFindFirstNoMatch(t T) T {
 func TestFindAll(t T) T {
     val r = regex.MustCompile("\\d+")
     val results = r.FindAll("a1 b22 c333")
-    var t1 = Eq[int](t, results.Size(), 3)
-    var t2 = Eq[string](t1, results.Get(0), "1")
-    var t3 = Eq[string](t2, results.Get(1), "22")
-    return Eq[string](t3, results.Get(2), "333")
+    val t1 = Eq(t, results.Size(), 3)
+    val t2 = Eq(t1, results.Get(0), "1")
+    val t3 = Eq(t2, results.Get(1), "22")
+    return Eq(t3, results.Get(2), "333")
 }
 
 func TestUnapplyMatch(t T) T {
     val dateRegex = regex.MustCompile("(\\d{4})-(\\d{2})-(\\d{2})")
     val groups = dateRegex.Unapply("2024-01-15")
-    var t1 = IsTrue(t, groups.IsDefined())
+    val t1 = IsTrue(t, groups.IsDefined())
     val g = groups.Get()
-    var t2 = Eq[string](t1, g.Get(0), "2024")
-    var t3 = Eq[string](t2, g.Get(1), "01")
-    return Eq[string](t3, g.Get(2), "15")
+    val t2 = Eq(t1, g.Get(0), "2024")
+    val t3 = Eq(t2, g.Get(1), "01")
+    return Eq(t3, g.Get(2), "15")
 }
 
 func TestUnapplyNoMatch(t T) T {
@@ -60,18 +60,18 @@ func TestCompileError(t T) T {
 
 func TestReplaceAll(t T) T {
     val r = regex.MustCompile("\\d+")
-    return Eq[string](t, r.ReplaceAll("a1b2c3", "X"), "aXbXcX")
+    return Eq(t, r.ReplaceAll("a1b2c3", "X"), "aXbXcX")
 }
 
 func TestSplit(t T) T {
     val r = regex.MustCompile("[,;\\s]+")
     val parts = r.Split("a, b; c d")
-    var t1 = Eq[int](t, parts.Size(), 4)
-    var t2 = Eq[string](t1, parts.Get(0), "a")
-    return Eq[string](t2, parts.Get(3), "d")
+    val t1 = Eq(t, parts.Size(), 4)
+    val t2 = Eq(t1, parts.Get(0), "a")
+    return Eq(t2, parts.Get(3), "d")
 }
 
 func TestString(t T) T {
     val r = regex.MustCompile("\\d+")
-    return Eq[string](t, r.String(), "Regex(\\d+)")
+    return Eq(t, r.String(), "Regex(\\d+)")
 }

--- a/std/option.gala
+++ b/std/option.gala
@@ -109,13 +109,7 @@ func (o Option[T]) Filter(p func(T) bool) Option[T] {
 }
 
 // When returns Some(value) if condition is true, None otherwise.
-func When[T any](condition bool, value T) Option[T] {
-    if condition { return Some(value) }
-    return None[T]()
-}
+func When[T any](condition bool, value T) Option[T] = if (condition) Some(value) else None[T]()
 
 // Unless returns Some(value) if condition is false, None otherwise.
-func Unless[T any](condition bool, value T) Option[T] {
-    if !condition { return Some(value) }
-    return None[T]()
-}
+func Unless[T any](condition bool, value T) Option[T] = if (!condition) Some(value) else None[T]()

--- a/std/ordered.gala
+++ b/std/ordered.gala
@@ -1,7 +1,5 @@
 package std
 
-import "fmt"
-
 // Ordered is an interface that types can implement to provide custom ordering.
 // Used by TreeSet and TreeMap for sorted collections.
 //
@@ -188,5 +186,5 @@ func compareValuesUint8s(a uint8, vb any) int {
 }
 
 func panicNotOrderable(v any) int {
-    panic(fmt.Sprintf("CompareValues: type %T does not support ordering", v))
+    panic(f"CompareValues: type $v%T does not support ordering")
 }

--- a/std/std_test.gala
+++ b/std/std_test.gala
@@ -7,28 +7,28 @@ import (
 // === Option Tests ===
 
 func TestSomeNotEmpty(t T) T {
-    var opt = std.Some[int](42)
+    val opt = std.Some(42)
     return IsSome(t, opt)
 }
 
 func TestNoneIsEmpty(t T) T {
-    var opt = std.None[int]()
+    val opt = std.None[int]()
     return IsNone(t, opt)
 }
 
 func TestSomeGet(t T) T {
-    var opt = std.Some[string]("hello")
-    return Eq[string](t, opt.Get(), "hello")
+    val opt = std.Some("hello")
+    return Eq(t, opt.Get(), "hello")
 }
 
 func TestSomeGetOrElse(t T) T {
-    var opt = std.Some[int](42)
-    return Eq[int](t, opt.GetOrElse(0), 42)
+    val opt = std.Some(42)
+    return Eq(t, opt.GetOrElse(0), 42)
 }
 
 func TestNoneGetOrElse(t T) T {
-    var opt = std.None[int]()
-    return Eq[int](t, opt.GetOrElse(99), 99)
+    val opt = std.None[int]()
+    return Eq(t, opt.GetOrElse(99), 99)
 }
 
 func mapIntToString(x int) string {
@@ -39,15 +39,15 @@ func mapIntToString(x int) string {
 }
 
 func TestSomeMap(t T) T {
-    var opt = std.Some[int](42)
-    var mapped = opt.Map[string](mapIntToString)
-    var t1 = IsSome(t, mapped)
-    return Eq[string](t1, mapped.Get(), "forty-two")
+    val opt = std.Some(42)
+    val mapped = opt.Map(mapIntToString)
+    val t1 = IsSome(t, mapped)
+    return Eq(t1, mapped.Get(), "forty-two")
 }
 
 func TestNoneMap(t T) T {
-    var opt = std.None[int]()
-    var mapped = opt.Map[string](mapIntToString)
+    val opt = std.None[int]()
+    val mapped = opt.Map(mapIntToString)
     return IsNone(t, mapped)
 }
 
@@ -56,40 +56,40 @@ func isPositive(x int) bool {
 }
 
 func TestSomeFilterPass(t T) T {
-    var opt = std.Some[int](42)
-    var filtered = opt.Filter(isPositive)
-    var t1 = IsSome(t, filtered)
-    return Eq[int](t1, filtered.Get(), 42)
+    val opt = std.Some(42)
+    val filtered = opt.Filter(isPositive)
+    val t1 = IsSome(t, filtered)
+    return Eq(t1, filtered.Get(), 42)
 }
 
 func TestSomeFilterFail(t T) T {
-    var opt = std.Some[int](-5)
-    var filtered = opt.Filter(isPositive)
+    val opt = std.Some(-5)
+    val filtered = opt.Filter(isPositive)
     return IsNone(t, filtered)
 }
 
 func TestNoneFilter(t T) T {
-    var opt = std.None[int]()
-    var filtered = opt.Filter(isPositive)
+    val opt = std.None[int]()
+    val filtered = opt.Filter(isPositive)
     return IsNone(t, filtered)
 }
 
 // === Either Tests ===
 
 func TestLeftGetLeft(t T) T {
-    var e = std.Left[string, int]("error")
-    return Eq[string](t, e.GetLeft(), "error")
+    val e = std.Left[string, int]("error")
+    return Eq(t, e.GetLeft(), "error")
 }
 
 func TestRightGetRight(t T) T {
-    var e = std.Right[string, int](42)
-    return Eq[int](t, e.GetRight(), 42)
+    val e = std.Right[string, int](42)
+    return Eq(t, e.GetRight(), 42)
 }
 
 func TestEitherSwap(t T) T {
-    var e = std.Left[string, int]("error")
-    var swapped = e.Swap()
-    return Eq[string](t, swapped.GetRight(), "error")
+    val e = std.Left[string, int]("error")
+    val swapped = e.Swap()
+    return Eq(t, swapped.GetRight(), "error")
 }
 
 func handleLeft(s string) int {
@@ -101,15 +101,15 @@ func handleRight(n int) int {
 }
 
 func TestLeftFold(t T) T {
-    var e = std.Left[string, int]("error")
-    var result = e.Fold[int](handleLeft, handleRight)
-    return Eq[int](t, result, -1)
+    val e = std.Left[string, int]("error")
+    val result = e.Fold(handleLeft, handleRight)
+    return Eq(t, result, -1)
 }
 
 func TestRightFold(t T) T {
-    var e = std.Right[string, int](21)
-    var result = e.Fold[int](handleLeft, handleRight)
-    return Eq[int](t, result, 42)
+    val e = std.Right[string, int](21)
+    val result = e.Fold(handleLeft, handleRight)
+    return Eq(t, result, 42)
 }
 
 func doubleInt(x int) int {
@@ -117,13 +117,13 @@ func doubleInt(x int) int {
 }
 
 func TestRightMap(t T) T {
-    var e = std.Right[string, int](21)
-    var mapped = e.Map[int](doubleInt)
-    return Eq[int](t, mapped.GetRight(), 42)
+    val e = std.Right[string, int](21)
+    val mapped = e.Map(doubleInt)
+    return Eq(t, mapped.GetRight(), 42)
 }
 
 func TestLeftMap(t T) T {
-    var e = std.Left[string, int]("error")
-    var mapped = e.Map[int](doubleInt)
-    return Eq[string](t, mapped.GetLeft(), "error")
+    val e = std.Left[string, int]("error")
+    val mapped = e.Map(doubleInt)
+    return Eq(t, mapped.GetLeft(), "error")
 }

--- a/std/try.gala
+++ b/std/try.gala
@@ -163,20 +163,16 @@ func (t Try[T]) ToEither() Either[error, T] {
 
 // FromOption creates a Try from an Option.
 // Returns Success if the Option is Some, Failure with NoSuchElementError if None.
-func FromOption[T any](o Option[T]) Try[T] {
-    if o.IsDefined() {
-        return Success[T](o.Get())
-    }
-    return Failure[T](NoSuchElementError(Message = "Option is None"))
+func FromOption[T any](o Option[T]) Try[T] = o match {
+    case Some(v) => Success[T](v)
+    case None() => Failure[T](NoSuchElementError(Message = "Option is None"))
 }
 
 // FromEitherError creates a Try from an Either[error, T].
 // Returns Success if Right, Failure if Left.
-func FromEitherError[T any](e Either[error, T]) Try[T] {
-    if e.IsRight() {
-        return Success[T](e.GetRight())
-    }
-    return Failure[T](e.GetLeft())
+func FromEitherError[T any](e Either[error, T]) Try[T] = e match {
+    case Right(v) => Success[T](v)
+    case Left(err) => Failure[T](err)
 }
 
 // TryApply executes f and catches any panic, converting it to a Failure.
@@ -201,6 +197,6 @@ func FromError(err error) Try[Void] {
     if err != nil {
         return Failure[Void](err)
     }
-    return Success[Void](Void{})
+    return Success[Void](Void())
 }
 

--- a/std/tuple.gala
+++ b/std/tuple.gala
@@ -1,7 +1,5 @@
 package std
 
-import "fmt"
-
 // Tuple represents a pair of values.
 type Tuple[A any, B any] struct {
     V1 A
@@ -9,7 +7,7 @@ type Tuple[A any, B any] struct {
 }
 
 func (t Tuple[A, B]) String() string =
-    fmt.Sprintf("(%v, %v)", t.V1, t.V2)
+    s"(${t.V1}, ${t.V2})"
 
 // Tuple3 represents a triple of values.
 type Tuple3[A any, B any, C any] struct {
@@ -19,7 +17,7 @@ type Tuple3[A any, B any, C any] struct {
 }
 
 func (t Tuple3[A, B, C]) String() string =
-    fmt.Sprintf("(%v, %v, %v)", t.V1, t.V2, t.V3)
+    s"(${t.V1}, ${t.V2}, ${t.V3})"
 
 // Tuple4 represents a quadruple of values.
 type Tuple4[A any, B any, C any, D any] struct {
@@ -30,7 +28,7 @@ type Tuple4[A any, B any, C any, D any] struct {
 }
 
 func (t Tuple4[A, B, C, D]) String() string =
-    fmt.Sprintf("(%v, %v, %v, %v)", t.V1, t.V2, t.V3, t.V4)
+    s"(${t.V1}, ${t.V2}, ${t.V3}, ${t.V4})"
 
 // Tuple5 represents a quintuple of values.
 type Tuple5[A any, B any, C any, D any, E any] struct {
@@ -42,7 +40,7 @@ type Tuple5[A any, B any, C any, D any, E any] struct {
 }
 
 func (t Tuple5[A, B, C, D, E]) String() string =
-    fmt.Sprintf("(%v, %v, %v, %v, %v)", t.V1, t.V2, t.V3, t.V4, t.V5)
+    s"(${t.V1}, ${t.V2}, ${t.V3}, ${t.V4}, ${t.V5})"
 
 // Tuple6 represents a sextuple of values.
 type Tuple6[A any, B any, C any, D any, E any, F any] struct {
@@ -55,7 +53,7 @@ type Tuple6[A any, B any, C any, D any, E any, F any] struct {
 }
 
 func (t Tuple6[A, B, C, D, E, F]) String() string =
-    fmt.Sprintf("(%v, %v, %v, %v, %v, %v)", t.V1, t.V2, t.V3, t.V4, t.V5, t.V6)
+    s"(${t.V1}, ${t.V2}, ${t.V3}, ${t.V4}, ${t.V5}, ${t.V6})"
 
 // Tuple7 represents a septuple of values.
 type Tuple7[A any, B any, C any, D any, E any, F any, G any] struct {
@@ -69,7 +67,7 @@ type Tuple7[A any, B any, C any, D any, E any, F any, G any] struct {
 }
 
 func (t Tuple7[A, B, C, D, E, F, G]) String() string =
-    fmt.Sprintf("(%v, %v, %v, %v, %v, %v, %v)", t.V1, t.V2, t.V3, t.V4, t.V5, t.V6, t.V7)
+    s"(${t.V1}, ${t.V2}, ${t.V3}, ${t.V4}, ${t.V5}, ${t.V6}, ${t.V7})"
 
 // Tuple8 represents an octuple of values.
 type Tuple8[A any, B any, C any, D any, E any, F any, G any, H any] struct {
@@ -84,7 +82,7 @@ type Tuple8[A any, B any, C any, D any, E any, F any, G any, H any] struct {
 }
 
 func (t Tuple8[A, B, C, D, E, F, G, H]) String() string =
-    fmt.Sprintf("(%v, %v, %v, %v, %v, %v, %v, %v)", t.V1, t.V2, t.V3, t.V4, t.V5, t.V6, t.V7, t.V8)
+    s"(${t.V1}, ${t.V2}, ${t.V3}, ${t.V4}, ${t.V5}, ${t.V6}, ${t.V7}, ${t.V8})"
 
 // Tuple9 represents a nonuple of values.
 type Tuple9[A any, B any, C any, D any, E any, F any, G any, H any, I any] struct {
@@ -100,7 +98,7 @@ type Tuple9[A any, B any, C any, D any, E any, F any, G any, H any, I any] struc
 }
 
 func (t Tuple9[A, B, C, D, E, F, G, H, I]) String() string =
-    fmt.Sprintf("(%v, %v, %v, %v, %v, %v, %v, %v, %v)", t.V1, t.V2, t.V3, t.V4, t.V5, t.V6, t.V7, t.V8, t.V9)
+    s"(${t.V1}, ${t.V2}, ${t.V3}, ${t.V4}, ${t.V5}, ${t.V6}, ${t.V7}, ${t.V8}, ${t.V9})"
 
 // Tuple10 represents a decuple of values.
 type Tuple10[A any, B any, C any, D any, E any, F any, G any, H any, I any, J any] struct {
@@ -117,4 +115,4 @@ type Tuple10[A any, B any, C any, D any, E any, F any, G any, H any, I any, J an
 }
 
 func (t Tuple10[A, B, C, D, E, F, G, H, I, J]) String() string =
-    fmt.Sprintf("(%v, %v, %v, %v, %v, %v, %v, %v, %v, %v)", t.V1, t.V2, t.V3, t.V4, t.V5, t.V6, t.V7, t.V8, t.V9, t.V10)
+    s"(${t.V1}, ${t.V2}, ${t.V3}, ${t.V4}, ${t.V5}, ${t.V6}, ${t.V7}, ${t.V8}, ${t.V9}, ${t.V10})"

--- a/stream/stream.gala
+++ b/stream/stream.gala
@@ -1,7 +1,6 @@
 package stream
 
 import (
-    "fmt"
     . "martianoff/gala/std"
     . "martianoff/gala/collection_immutable"
 )
@@ -34,10 +33,10 @@ func empty[T any]() Stream[T] {
 func cons[T any](head T, tail func() Stream[T]) Stream[T] {
     var nilTail *Stream[T] = nil
     return Stream[T](
-        headThunk = () => Some[T](head),
+        headThunk = () => Some(head),
         tailThunk = tail,
         evaluated = false,
-        cachedHead = Some[T](head),
+        cachedHead = Some(head),
         cachedTail = nilTail,
     )
 }
@@ -151,10 +150,10 @@ func Repeat[T any](elem T) Stream[T] = cons[T](elem, () => Repeat[T](elem))
 
 // Head returns the first element of the stream wrapped in Option.
 func (s Stream[T]) Head() Option[T] {
-    if s.cachedHead.IsDefined() {
-        return s.cachedHead
+    return s.cachedHead match {
+        case Some(h) => Some(h)
+        case None() => s.headThunk()
     }
-    return s.headThunk()
 }
 
 // HeadOrElse returns the first element or a default value.
@@ -179,20 +178,18 @@ func (s Stream[T]) NonEmpty() bool = s.Head().IsDefined()
 
 // Map transforms each element using a function (lazy).
 func (s Stream[T]) Map[U any](f func(T) U) Stream[U] {
-    val head = s.Head()
-    if head.IsDefined() {
-        return cons[U](f(head.Get()), () => s.Tail().Map[U](f))
+    return s.Head() match {
+        case Some(h) => cons[U](f(h), () => s.Tail().Map[U](f))
+        case None() => empty[U]()
     }
-    return empty[U]()
 }
 
 // FlatMap applies a function returning a stream to each element and flattens (lazy).
 func (s Stream[T]) FlatMap[U any](f func(T) Stream[U]) Stream[U] {
-    val head = s.Head()
-    if head.IsDefined() {
-        return f(head.Get()).Concat(Suspend[U](() => s.Tail().FlatMap[U](f)))
+    return s.Head() match {
+        case Some(h) => f(h).Concat(Suspend[U](() => s.Tail().FlatMap[U](f)))
+        case None() => empty[U]()
     }
-    return empty[U]()
 }
 
 // Suspend creates a stream that is entirely lazy - even existence of elements is deferred.
@@ -205,15 +202,10 @@ func Suspend[T any](thunk func() Stream[T]) Stream[T] {
 
 // Filter keeps only elements satisfying the predicate (lazy).
 func (s Stream[T]) Filter(p func(T) bool) Stream[T] {
-    val head = s.Head()
-    if head.IsDefined() {
-        val h = head.Get()
-        if p(h) {
-            return cons[T](h, () => s.Tail().Filter(p))
-        }
-        return s.Tail().Filter(p)
+    return s.Head() match {
+        case Some(h) => if (p(h)) cons[T](h, () => s.Tail().Filter(p)) else s.Tail().Filter(p)
+        case None() => empty[T]()
     }
-    return empty[T]()
 }
 
 // FilterNot keeps only elements not satisfying the predicate (lazy).
@@ -224,24 +216,18 @@ func (s Stream[T]) Take(n int) Stream[T] {
     if n <= 0 {
         return empty[T]()
     }
-    val head = s.Head()
-    if head.IsDefined() {
-        return cons[T](head.Get(), () => s.Tail().Take(n - 1))
+    return s.Head() match {
+        case Some(h) => cons[T](h, () => s.Tail().Take(n - 1))
+        case None() => empty[T]()
     }
-    return empty[T]()
 }
 
 // TakeWhile returns elements while predicate holds (lazy).
 func (s Stream[T]) TakeWhile(p func(T) bool) Stream[T] {
-    val head = s.Head()
-    if head.IsDefined() {
-        val h = head.Get()
-        if p(h) {
-            return cons[T](h, () => s.Tail().TakeWhile(p))
-        }
-        return empty[T]()
+    return s.Head() match {
+        case Some(h) => if (p(h)) cons[T](h, () => s.Tail().TakeWhile(p)) else empty[T]()
+        case None() => empty[T]()
     }
-    return empty[T]()
 }
 
 // Drop skips the first n elements (lazy).
@@ -249,53 +235,47 @@ func (s Stream[T]) Drop(n int) Stream[T] {
     if n <= 0 {
         return s
     }
-    val head = s.Head()
-    if head.IsDefined() {
-        return s.Tail().Drop(n - 1)
+    return s.Head() match {
+        case Some(_) => s.Tail().Drop(n - 1)
+        case None() => empty[T]()
     }
-    return empty[T]()
 }
 
 // DropWhile skips elements while predicate holds (lazy).
 func (s Stream[T]) DropWhile(p func(T) bool) Stream[T] {
-    val head = s.Head()
-    if head.IsDefined() {
-        if p(head.Get()) {
-            return s.Tail().DropWhile(p)
-        }
-        return s
+    return s.Head() match {
+        case Some(h) => if (p(h)) s.Tail().DropWhile(p) else s
+        case None() => empty[T]()
     }
-    return empty[T]()
 }
 
 // Zip combines two streams into a stream of tuples (lazy).
 func (s Stream[T]) Zip[U any](other Stream[U]) Stream[Tuple[T, U]] {
-    val h1 = s.Head()
-    val h2 = other.Head()
-    if h1.IsDefined() && h2.IsDefined() {
-        return cons[Tuple[T, U]]((h1.Get(), h2.Get()), () => s.Tail().Zip[U](other.Tail()))
+    return s.Head() match {
+        case Some(a) => other.Head() match {
+            case Some(b) => cons[Tuple[T, U]]((a, b), () => s.Tail().Zip[U](other.Tail()))
+            case None() => empty[Tuple[T, U]]()
+        }
+        case None() => empty[Tuple[T, U]]()
     }
-    return empty[Tuple[T, U]]()
 }
 
 // ZipWithIndex pairs each element with its index (lazy).
 func (s Stream[T]) ZipWithIndex() Stream[Tuple[T, int]] = zipWithIndexFrom[T](s, 0)
 
 func zipWithIndexFrom[T any](s Stream[T], idx int) Stream[Tuple[T, int]] {
-    val head = s.Head()
-    if head.IsDefined() {
-        return cons[Tuple[T, int]]((head.Get(), idx), () => zipWithIndexFrom[T](s.Tail(), idx + 1))
+    return s.Head() match {
+        case Some(h) => cons[Tuple[T, int]]((h, idx), () => zipWithIndexFrom[T](s.Tail(), idx + 1))
+        case None() => empty[Tuple[T, int]]()
     }
-    return empty[Tuple[T, int]]()
 }
 
 // Concat appends another stream (lazy).
 func (s Stream[T]) Concat(other Stream[T]) Stream[T] {
-    val head = s.Head()
-    if head.IsDefined() {
-        return cons[T](head.Get(), () => s.Tail().Concat(other))
+    return s.Head() match {
+        case Some(h) => cons[T](h, () => s.Tail().Concat(other))
+        case None() => other
     }
-    return other
 }
 
 // Append adds an element at the end (lazy, but must traverse to end).
@@ -306,32 +286,32 @@ func (s Stream[T]) Prepend(elem T) Stream[T] = cons[T](elem, () => s)
 
 // Intersperse inserts a separator between elements (lazy).
 func (s Stream[T]) Intersperse(sep T) Stream[T] {
-    val head = s.Head()
-    if head.IsDefined() {
-        val h = head.Get()
-        val tail = s.Tail()
-        if tail.IsEmpty() {
-            return cons[T](h, () => empty[T]())
+    return s.Head() match {
+        case Some(h) => {
+            val tail = s.Tail()
+            if tail.IsEmpty() {
+                return cons[T](h, () => empty[T]())
+            }
+            return cons[T](h, () => cons[T](sep, () => tail.Intersperse(sep)))
         }
-        return cons[T](h, () => cons[T](sep, () => tail.Intersperse(sep)))
+        case None() => empty[T]()
     }
-    return empty[T]()
 }
 
 // Distinct removes duplicates (lazy, uses O(n) memory for seen elements).
 func (s Stream[T]) Distinct() Stream[T] = distinctHelper[T](s, EmptyHashSet[any]())
 
 func distinctHelper[T any](s Stream[T], seen HashSet[any]) Stream[T] {
-    val head = s.Head()
-    if head.IsDefined() {
-        val h = head.Get()
-        val key any = h
-        if seen.Contains(key) {
-            return distinctHelper[T](s.Tail(), seen)
+    return s.Head() match {
+        case Some(h) => {
+            val key any = h
+            if seen.Contains(key) {
+                return distinctHelper[T](s.Tail(), seen)
+            }
+            return cons[T](h, () => distinctHelper[T](s.Tail(), seen.Add(key)))
         }
-        return cons[T](h, () => distinctHelper[T](s.Tail(), seen.Add(key)))
+        case None() => empty[T]()
     }
-    return empty[T]()
 }
 
 // ToArray forces evaluation and collects elements into an Array.
@@ -384,11 +364,10 @@ func (s Stream[T]) Fold[U any](zero U, f func(U, T) U) U {
 // Returns None for empty stream.
 // WARNING: Will not terminate for infinite streams!
 func (s Stream[T]) Reduce(f func(T, T) T) Option[T] {
-    val head = s.Head()
-    if head.IsDefined() {
-        return Some[T](s.Tail().Fold[T](head.Get(), f))
+    return s.Head() match {
+        case Some(h) => Some(s.Tail().Fold[T](h, f))
+        case None() => None[T]()
     }
-    return None[T]()
 }
 
 // Find returns the first element satisfying the predicate.
@@ -397,7 +376,7 @@ func (s Stream[T]) Find(p func(T) bool) Option[T] {
     for current.NonEmpty() {
         val h = current.Head().Get()
         if p(h) {
-            return Some[T](h)
+            return Some(h)
         }
         current = current.Tail()
     }
@@ -448,7 +427,7 @@ func (s Stream[T]) MkString(sep string) string {
         if !first {
             result = result + sep
         }
-        result = result + fmt.Sprintf("%v", current.Head().Get())
+        result = result + s"${current.Head().Get()}"
         first = false
         current = current.Tail()
     }
@@ -459,17 +438,8 @@ func (s Stream[T]) MkString(sep string) string {
 // Only shows first few elements to avoid infinite output.
 func (s Stream[T]) String() string {
     val preview = s.Take(10).ToArray()
-    var result = "Stream("
-    for i := 0; i < preview.Length(); i++ {
-        if i > 0 {
-            result = result + ", "
-        }
-        result = result + fmt.Sprintf("%v", preview.Get(i))
-    }
-    if s.Drop(10).NonEmpty() {
-        result = result + ", ..."
-    }
-    return result + ")"
+    val suffix = if (s.Drop(10).NonEmpty()) ", ..." else ""
+    return s"Stream(${preview.MkString(", ")}$suffix)"
 }
 
 // Get returns the element at index n.
@@ -485,15 +455,13 @@ func (s Stream[T]) Slice(start int, end int) Stream[T] = s.Drop(start).Take(end 
 
 // Collect applies a partial function and keeps defined results (lazy).
 func (s Stream[T]) Collect[U any](pf func(T) Option[U]) Stream[U] {
-    val head = s.Head()
-    if head.IsDefined() {
-        val result = pf(head.Get())
-        if result.IsDefined() {
-            return cons[U](result.Get(), () => s.Tail().Collect[U](pf))
+    return s.Head() match {
+        case Some(h) => pf(h) match {
+            case Some(v) => cons[U](v, () => s.Tail().Collect[U](pf))
+            case None() => s.Tail().Collect[U](pf)
         }
-        return s.Tail().Collect[U](pf)
+        case None() => empty[U]()
     }
-    return empty[U]()
 }
 
 // Scan produces a stream of cumulative results (lazy).
@@ -502,12 +470,13 @@ func (s Stream[T]) Scan[U any](zero U, f func(U, T) U) Stream[U] {
 }
 
 func scanHelper[T any, U any](s Stream[T], acc U, f func(U, T) U) Stream[U] {
-    val head = s.Head()
-    if head.IsDefined() {
-        val newAcc = f(acc, head.Get())
-        return cons[U](newAcc, () => scanHelper[T, U](s.Tail(), newAcc, f))
+    return s.Head() match {
+        case Some(h) => {
+            val newAcc = f(acc, h)
+            return cons[U](newAcc, () => scanHelper[T, U](s.Tail(), newAcc, f))
+        }
+        case None() => empty[U]()
     }
-    return empty[U]()
 }
 
 // SplitAt splits the stream at position n.
@@ -570,8 +539,8 @@ type StreamCons[T any] struct {}
 
 func (c StreamCons[T]) Unapply(s Stream[T]) Option[Tuple[T, Stream[T]]] {
     return s.Head() match {
-        case Some(h) => Some[Tuple[T, Stream[T]]]((h, s.Tail()))
-        case _ => None[Tuple[T, Stream[T]]]()
+        case Some(h) => Some((h, s.Tail()))
+        case None() => None[Tuple[T, Stream[T]]]()
     }
 }
 
@@ -579,8 +548,8 @@ func (c StreamCons[T]) Unapply(s Stream[T]) Option[Tuple[T, Stream[T]]] {
 type StreamNil[T any] struct {}
 
 func (n StreamNil[T]) Unapply(s Stream[T]) Option[bool] {
-    if s.IsEmpty() {
-        return Some[bool](true)
+    return s.Head() match {
+        case Some(_) => None[bool]()
+        case None() => Some(true)
     }
-    return None[bool]()
 }

--- a/stream/stream_test.gala
+++ b/stream/stream_test.gala
@@ -10,191 +10,191 @@ import (
 // Test empty stream
 func TestEmpty(t T) T {
     val s = Empty[int]()
-    var t1 = IsTrue(t, s.IsEmpty())
-    var t2 = IsFalse(t1, s.NonEmpty())
-    var t3 = Eq[int](t2, s.Count(), 0)
-    return Eq[Option[int]](t3, s.Head(), None[int]())
+    val t1 = IsTrue(t, s.IsEmpty())
+    val t2 = IsFalse(t1, s.NonEmpty())
+    val t3 = Eq(t2, s.Count(), 0)
+    return Eq(t3, s.Head(), None[int]())
 }
 
 // Test Of constructor
 func TestOf(t T) T {
     val s = Of(1, 2, 3)
-    var t1 = IsFalse(t, s.IsEmpty())
-    var t2 = Eq[int](t1, s.Head().GetOrElse(0), 1)
-    var t3 = Eq[int](t2, s.Tail().Head().GetOrElse(0), 2)
-    return Eq[int](t3, s.Tail().Tail().Head().GetOrElse(0), 3)
+    val t1 = IsFalse(t, s.IsEmpty())
+    val t2 = Eq(t1, s.Head().GetOrElse(0), 1)
+    val t3 = Eq(t2, s.Tail().Head().GetOrElse(0), 2)
+    return Eq(t3, s.Tail().Tail().Head().GetOrElse(0), 3)
 }
 
 // Test Cons constructor
 func TestCons(t T) T {
     val s = NewCons[int](1, () => NewCons[int](2, () => Empty[int]()))
-    var t1 = Eq[int](t, s.Head().GetOrElse(0), 1)
-    return Eq[int](t1, s.Tail().Head().GetOrElse(0), 2)
+    val t1 = Eq(t, s.Head().GetOrElse(0), 1)
+    return Eq(t1, s.Tail().Head().GetOrElse(0), 2)
 }
 
 // Test Range
 func TestRange(t T) T {
     val s = Range(1, 5)
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 4)
-    var t2 = Eq[int](t1, arr.Get(0), 1)
-    var t3 = Eq[int](t2, arr.Get(1), 2)
-    var t4 = Eq[int](t3, arr.Get(2), 3)
-    return Eq[int](t4, arr.Get(3), 4)
+    val t1 = Eq(t, arr.Length(), 4)
+    val t2 = Eq(t1, arr.Get(0), 1)
+    val t3 = Eq(t2, arr.Get(1), 2)
+    val t4 = Eq(t3, arr.Get(2), 3)
+    return Eq(t4, arr.Get(3), 4)
 }
 
 // Test RangeStep
 func TestRangeStep(t T) T {
     val s = RangeStep(0, 10, 2)
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 5)
-    var t2 = Eq[int](t1, arr.Get(0), 0)
-    var t3 = Eq[int](t2, arr.Get(1), 2)
-    var t4 = Eq[int](t3, arr.Get(2), 4)
-    return Eq[int](t4, arr.Get(4), 8)
+    val t1 = Eq(t, arr.Length(), 5)
+    val t2 = Eq(t1, arr.Get(0), 0)
+    val t3 = Eq(t2, arr.Get(1), 2)
+    val t4 = Eq(t3, arr.Get(2), 4)
+    return Eq(t4, arr.Get(4), 8)
 }
 
 // Test From (infinite stream)
 func TestFrom(t T) T {
     val s = From(10)
     val first5 = s.Take(5).ToArray()
-    var t1 = Eq[int](t, first5.Length(), 5)
-    var t2 = Eq[int](t1, first5.Get(0), 10)
-    var t3 = Eq[int](t2, first5.Get(1), 11)
-    return Eq[int](t3, first5.Get(4), 14)
+    val t1 = Eq(t, first5.Length(), 5)
+    val t2 = Eq(t1, first5.Get(0), 10)
+    val t3 = Eq(t2, first5.Get(1), 11)
+    return Eq(t3, first5.Get(4), 14)
 }
 
 // Test Repeat (infinite stream)
 func TestRepeat(t T) T {
     val s = Repeat("x")
     val first3 = s.Take(3).ToArray()
-    var t1 = Eq[int](t, first3.Length(), 3)
-    var t2 = Eq[string](t1, first3.Get(0), "x")
-    return Eq[string](t2, first3.Get(2), "x")
+    val t1 = Eq(t, first3.Length(), 3)
+    val t2 = Eq(t1, first3.Get(0), "x")
+    return Eq(t2, first3.Get(2), "x")
 }
 
 // Test Iterate
 func TestIterate(t T) T {
-    val powers = Iterate[int](1, (x int) => x * 2)
+    val powers = Iterate(1, (x) => x * 2)
     val first5 = powers.Take(5).ToArray()
-    var t1 = Eq[int](t, first5.Get(0), 1)
-    var t2 = Eq[int](t1, first5.Get(1), 2)
-    var t3 = Eq[int](t2, first5.Get(2), 4)
-    var t4 = Eq[int](t3, first5.Get(3), 8)
-    return Eq[int](t4, first5.Get(4), 16)
+    val t1 = Eq(t, first5.Get(0), 1)
+    val t2 = Eq(t1, first5.Get(1), 2)
+    val t3 = Eq(t2, first5.Get(2), 4)
+    val t4 = Eq(t3, first5.Get(3), 8)
+    return Eq(t4, first5.Get(4), 16)
 }
 
 // Test Map
 func TestMap(t T) T {
-    val s = Of(1, 2, 3).Map[int]((x int) => x * 2)
+    val s = Of(1, 2, 3).Map((x) => x * 2)
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Get(0), 2)
-    var t2 = Eq[int](t1, arr.Get(1), 4)
-    return Eq[int](t2, arr.Get(2), 6)
+    val t1 = Eq(t, arr.Get(0), 2)
+    val t2 = Eq(t1, arr.Get(1), 4)
+    return Eq(t2, arr.Get(2), 6)
 }
 
 // Test Filter
 func TestFilter(t T) T {
-    val s = Of(1, 2, 3, 4, 5).Filter((x int) => x % 2 == 0)
+    val s = Of(1, 2, 3, 4, 5).Filter((x) => x % 2 == 0)
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 2)
-    var t2 = Eq[int](t1, arr.Get(0), 2)
-    return Eq[int](t2, arr.Get(1), 4)
+    val t1 = Eq(t, arr.Length(), 2)
+    val t2 = Eq(t1, arr.Get(0), 2)
+    return Eq(t2, arr.Get(1), 4)
 }
 
 // Test Take
 func TestTake(t T) T {
     val s = Of(1, 2, 3, 4, 5).Take(3)
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 3)
-    var t2 = Eq[int](t1, arr.Get(0), 1)
-    return Eq[int](t2, arr.Get(2), 3)
+    val t1 = Eq(t, arr.Length(), 3)
+    val t2 = Eq(t1, arr.Get(0), 1)
+    return Eq(t2, arr.Get(2), 3)
 }
 
 // Test Drop
 func TestDrop(t T) T {
     val s = Of(1, 2, 3, 4, 5).Drop(2)
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 3)
-    var t2 = Eq[int](t1, arr.Get(0), 3)
-    return Eq[int](t2, arr.Get(2), 5)
+    val t1 = Eq(t, arr.Length(), 3)
+    val t2 = Eq(t1, arr.Get(0), 3)
+    return Eq(t2, arr.Get(2), 5)
 }
 
 // Test TakeWhile
 func TestTakeWhile(t T) T {
-    val s = Of(1, 2, 3, 4, 5).TakeWhile((x int) => x < 4)
+    val s = Of(1, 2, 3, 4, 5).TakeWhile((x) => x < 4)
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 3)
-    return Eq[int](t1, arr.Get(2), 3)
+    val t1 = Eq(t, arr.Length(), 3)
+    return Eq(t1, arr.Get(2), 3)
 }
 
 // Test DropWhile
 func TestDropWhile(t T) T {
-    val s = Of(1, 2, 3, 4, 5).DropWhile((x int) => x < 3)
+    val s = Of(1, 2, 3, 4, 5).DropWhile((x) => x < 3)
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 3)
-    return Eq[int](t1, arr.Get(0), 3)
+    val t1 = Eq(t, arr.Length(), 3)
+    return Eq(t1, arr.Get(0), 3)
 }
 
 // Test Zip - just verify basic operation
 func TestZip(t T) T {
     val s1 = Of(1, 2, 3)
     val s2 = Of("a", "b", "c")
-    val zipped = s1.Zip[string](s2).ToArray()
-    return Eq[int](t, zipped.Length(), 3)
+    val zipped = s1.Zip(s2).ToArray()
+    return Eq(t, zipped.Length(), 3)
 }
 
 // Test ZipWithIndex - just verify basic operation
 func TestZipWithIndex(t T) T {
     val arr = Of("a", "b", "c").ZipWithIndex().ToArray()
-    return Eq[int](t, arr.Length(), 3)
+    return Eq(t, arr.Length(), 3)
 }
 
 // Test Concat
 func TestConcat(t T) T {
     val s = Of(1, 2).Concat(Of(3, 4))
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 4)
-    var t2 = Eq[int](t1, arr.Get(0), 1)
-    return Eq[int](t2, arr.Get(3), 4)
+    val t1 = Eq(t, arr.Length(), 4)
+    val t2 = Eq(t1, arr.Get(0), 1)
+    return Eq(t2, arr.Get(3), 4)
 }
 
 // Test Fold
 func TestFold(t T) T {
-    val sum = Of(1, 2, 3, 4, 5).Fold[int](0, (acc int, x int) => acc + x)
-    return Eq[int](t, sum, 15)
+    val sum = Of(1, 2, 3, 4, 5).Fold(0, (acc, x) => acc + x)
+    return Eq(t, sum, 15)
 }
 
 // Test Reduce
 func TestReduce(t T) T {
-    val product = Of(1, 2, 3, 4).Reduce((a int, b int) => a * b)
-    return Eq[int](t, product.GetOrElse(0), 24)
+    val product = Of(1, 2, 3, 4).Reduce((a, b) => a * b)
+    return Eq(t, product.GetOrElse(0), 24)
 }
 
 // Test Find
 func TestFind(t T) T {
-    val found = Of(1, 2, 3, 4, 5).Find((x int) => x > 3)
-    var t1 = IsSome(t, found)
-    return Eq[int](t1, found.GetOrElse(0), 4)
+    val found = Of(1, 2, 3, 4, 5).Find((x) => x > 3)
+    val t1 = IsSome(t, found)
+    return Eq(t1, found.GetOrElse(0), 4)
 }
 
 // Test Exists
 func TestExists(t T) T {
-    var t1 = IsTrue(t, Of(1, 2, 3).Exists((x int) => x == 2))
-    return IsFalse(t1, Of(1, 2, 3).Exists((x int) => x == 5))
+    val t1 = IsTrue(t, Of(1, 2, 3).Exists((x) => x == 2))
+    return IsFalse(t1, Of(1, 2, 3).Exists((x) => x == 5))
 }
 
 // Test ForAll
 func TestForAll(t T) T {
-    var t1 = IsTrue(t, Of(2, 4, 6).ForAll((x int) => x % 2 == 0))
-    return IsFalse(t1, Of(2, 3, 6).ForAll((x int) => x % 2 == 0))
+    val t1 = IsTrue(t, Of(2, 4, 6).ForAll((x) => x % 2 == 0))
+    return IsFalse(t1, Of(2, 3, 6).ForAll((x) => x % 2 == 0))
 }
 
 // Test Get
 func TestGet(t T) T {
     val s = Of(10, 20, 30)
-    var t1 = Eq[int](t, s.Get(0).GetOrElse(0), 10)
-    var t2 = Eq[int](t1, s.Get(2).GetOrElse(0), 30)
+    val t1 = Eq(t, s.Get(0).GetOrElse(0), 10)
+    val t2 = Eq(t1, s.Get(2).GetOrElse(0), 30)
     return IsNone(t2, s.Get(5))
 }
 
@@ -202,82 +202,79 @@ func TestGet(t T) T {
 func TestSlice(t T) T {
     val s = Of(0, 1, 2, 3, 4, 5).Slice(1, 4)
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 3)
-    var t2 = Eq[int](t1, arr.Get(0), 1)
-    return Eq[int](t2, arr.Get(2), 3)
+    val t1 = Eq(t, arr.Length(), 3)
+    val t2 = Eq(t1, arr.Get(0), 1)
+    return Eq(t2, arr.Get(2), 3)
 }
 
 // Test Unfold (Fibonacci)
 func TestUnfold(t T) T {
     val fibs = Unfold[int, Tuple[int, int]](
-        Tuple[int, int](V1 = 0, V2 = 1),
-        (state Tuple[int, int]) => Some(Tuple[int, Tuple[int, int]](
-            V1 = state.V1,
-            V2 = Tuple[int, int](V1 = state.V2, V2 = state.V1 + state.V2),
-        )),
+        (0, 1),
+        (state) => Some((state.V1, (state.V2, state.V1 + state.V2))),
     )
     val first8 = fibs.Take(8).ToArray()
-    var t1 = Eq[int](t, first8.Get(0), 0)
-    var t2 = Eq[int](t1, first8.Get(1), 1)
-    var t3 = Eq[int](t2, first8.Get(2), 1)
-    var t4 = Eq[int](t3, first8.Get(3), 2)
-    var t5 = Eq[int](t4, first8.Get(4), 3)
-    var t6 = Eq[int](t5, first8.Get(5), 5)
-    var t7 = Eq[int](t6, first8.Get(6), 8)
-    return Eq[int](t7, first8.Get(7), 13)
+    val t1 = Eq(t, first8.Get(0), 0)
+    val t2 = Eq(t1, first8.Get(1), 1)
+    val t3 = Eq(t2, first8.Get(2), 1)
+    val t4 = Eq(t3, first8.Get(3), 2)
+    val t5 = Eq(t4, first8.Get(4), 3)
+    val t6 = Eq(t5, first8.Get(5), 5)
+    val t7 = Eq(t6, first8.Get(6), 8)
+    return Eq(t7, first8.Get(7), 13)
 }
 
 // Test Intersperse
 func TestIntersperse(t T) T {
     val s = Of(1, 2, 3).Intersperse(0)
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 5)
-    var t2 = Eq[int](t1, arr.Get(0), 1)
-    var t3 = Eq[int](t2, arr.Get(1), 0)
-    var t4 = Eq[int](t3, arr.Get(2), 2)
-    return Eq[int](t4, arr.Get(3), 0)
+    val t1 = Eq(t, arr.Length(), 5)
+    val t2 = Eq(t1, arr.Get(0), 1)
+    val t3 = Eq(t2, arr.Get(1), 0)
+    val t4 = Eq(t3, arr.Get(2), 2)
+    return Eq(t4, arr.Get(3), 0)
 }
 
 // Test Distinct
 func TestDistinct(t T) T {
     val s = Of(1, 2, 1, 3, 2, 4).Distinct()
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 4)
-    var t2 = Eq[int](t1, arr.Get(0), 1)
-    var t3 = Eq[int](t2, arr.Get(1), 2)
-    var t4 = Eq[int](t3, arr.Get(2), 3)
-    return Eq[int](t4, arr.Get(3), 4)
+    val t1 = Eq(t, arr.Length(), 4)
+    val t2 = Eq(t1, arr.Get(0), 1)
+    val t3 = Eq(t2, arr.Get(1), 2)
+    val t4 = Eq(t3, arr.Get(2), 3)
+    return Eq(t4, arr.Get(3), 4)
 }
 
 // Test Scan
 func TestScan(t T) T {
-    val s = Of(1, 2, 3).Scan[int](0, (acc int, x int) => acc + x)
+    val s = Of(1, 2, 3).Scan(0, (acc, x) => acc + x)
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 4)
-    var t2 = Eq[int](t1, arr.Get(0), 0)
-    var t3 = Eq[int](t2, arr.Get(1), 1)
-    var t4 = Eq[int](t3, arr.Get(2), 3)
-    return Eq[int](t4, arr.Get(3), 6)
+    val t1 = Eq(t, arr.Length(), 4)
+    val t2 = Eq(t1, arr.Get(0), 0)
+    val t3 = Eq(t2, arr.Get(1), 1)
+    val t4 = Eq(t3, arr.Get(2), 3)
+    return Eq(t4, arr.Get(3), 6)
 }
 
 // Test MkString
 func TestMkString(t T) T {
     val s = Of(1, 2, 3).MkString(", ")
-    return Eq[string](t, s, "1, 2, 3")
+    return Eq(t, s, "1, 2, 3")
 }
 
 // Test Contains
 func TestContains(t T) T {
     val s = Of(1, 2, 3)
-    var t1 = IsTrue(t, s.Contains(2))
+    val t1 = IsTrue(t, s.Contains(2))
     return IsFalse(t1, s.Contains(5))
 }
 
 // Test IndexOf
 func TestIndexOf(t T) T {
     val s = Of(10, 20, 30, 20)
-    var t1 = Eq[int](t, s.IndexOf(20), 1)
-    return Eq[int](t1, s.IndexOf(50), -1)
+    val t1 = Eq(t, s.IndexOf(20), 1)
+    return Eq(t1, s.IndexOf(50), -1)
 }
 
 // Test FromArray
@@ -285,9 +282,9 @@ func TestFromArray(t T) T {
     val arr = ArrayOf(1, 2, 3)
     val s = FromArray(arr)
     val result = s.ToArray()
-    var t1 = Eq[int](t, result.Length(), 3)
-    var t2 = Eq[int](t1, result.Get(0), 1)
-    return Eq[int](t2, result.Get(2), 3)
+    val t1 = Eq(t, result.Length(), 3)
+    val t2 = Eq(t1, result.Get(0), 1)
+    return Eq(t2, result.Get(2), 3)
 }
 
 // Test FromList
@@ -295,39 +292,37 @@ func TestFromList(t T) T {
     val list = ListOf(1, 2, 3)
     val s = FromList(list)
     val result = s.ToArray()
-    var t1 = Eq[int](t, result.Length(), 3)
-    var t2 = Eq[int](t1, result.Get(0), 1)
-    return Eq[int](t2, result.Get(2), 3)
+    val t1 = Eq(t, result.Length(), 3)
+    val t2 = Eq(t1, result.Get(0), 1)
+    return Eq(t2, result.Get(2), 3)
 }
 
 // Test laziness - Map should not be evaluated until forced
 func TestLazinessMap(t T) T {
     var evaluated = false
-    val s = Of(1, 2, 3).Map[int]((x int) => {
+    val s = Of(1, 2, 3).Map((x) => {
         evaluated = true
         return x * 2
     })
-    // s is created but not evaluated yet
-    // When we access head, only first element is evaluated
     val first = s.Head()
-    var t1 = IsTrue(t, evaluated)
-    return Eq[int](t1, first.GetOrElse(0), 2)
+    val t1 = IsTrue(t, evaluated)
+    return Eq(t1, first.GetOrElse(0), 2)
 }
 
 // Test laziness - infinite stream with Take should work
 func TestLazinessInfinite(t T) T {
     val naturals = From(1)
     val firstTen = naturals.Take(10).ToArray()
-    return Eq[int](t, firstTen.Length(), 10)
+    return Eq(t, firstTen.Length(), 10)
 }
 
 // Test Prepend
 func TestPrepend(t T) T {
     val s = Of(2, 3).Prepend(1)
     val arr = s.ToArray()
-    var t1 = Eq[int](t, arr.Length(), 3)
-    var t2 = Eq[int](t1, arr.Get(0), 1)
-    return Eq[int](t2, arr.Get(2), 3)
+    val t1 = Eq(t, arr.Length(), 3)
+    val t2 = Eq(t1, arr.Get(0), 1)
+    return Eq(t2, arr.Get(2), 3)
 }
 
 // Test pattern matching with StreamCons
@@ -337,7 +332,7 @@ func TestPatternMatchingCons(t T) T {
         case StreamCons(h, tail) => h + tail.Head().GetOrElse(0)
         case _ => 0
     }
-    return Eq[int](t, result, 3)
+    return Eq(t, result, 3)
 }
 
 // Test pattern matching with StreamNil
@@ -345,14 +340,10 @@ func TestPatternMatchingNil(t T) T {
     val s = Empty[int]()
     val result = s match {
         case StreamNil() => "empty"
-        case StreamCons(head, tail) => {
-            // Use both head and tail to avoid unused variable errors
-            var _ = head + tail.Count()
-            return "non-empty"
-        }
+        case StreamCons(_, _) => "non-empty"
         case _ => "unknown"
     }
-    return Eq[string](t, result, "empty")
+    return Eq(t, result, "empty")
 }
 
 // Test SplitAt
@@ -361,42 +352,40 @@ func TestSplitAt(t T) T {
     val parts = s.SplitAt(2)
     val first = parts.V1.ToArray()
     val second = parts.V2.ToArray()
-    var t1 = Eq[int](t, first.Length(), 2)
-    var t2 = Eq[int](t1, second.Length(), 3)
-    var t3 = Eq[int](t2, first.Get(1), 2)
-    return Eq[int](t3, second.Get(0), 3)
+    val t1 = Eq(t, first.Length(), 2)
+    val t2 = Eq(t1, second.Length(), 3)
+    val t3 = Eq(t2, first.Get(1), 2)
+    return Eq(t3, second.Get(0), 3)
 }
 
 // Test Span
 func TestSpan(t T) T {
     val s = Of(1, 2, 3, 4, 5)
-    val parts = s.Span((x int) => x < 3)
+    val parts = s.Span((x) => x < 3)
     val first = parts.V1.ToArray()
     val second = parts.V2.ToArray()
-    var t1 = Eq[int](t, first.Length(), 2)
-    return Eq[int](t1, second.Get(0), 3)
+    val t1 = Eq(t, first.Length(), 2)
+    return Eq(t1, second.Get(0), 3)
 }
 
 // Test Partition
 func TestPartition(t T) T {
     val s = Of(1, 2, 3, 4, 5)
-    val parts = s.Partition((x int) => x % 2 == 0)
+    val parts = s.Partition((x) => x % 2 == 0)
     val evens = parts.V1.ToArray()
     val odds = parts.V2.ToArray()
-    var t1 = Eq[int](t, evens.Length(), 2)
-    var t2 = Eq[int](t1, odds.Length(), 3)
-    var t3 = Eq[int](t2, evens.Get(0), 2)
-    return Eq[int](t3, odds.Get(0), 1)
+    val t1 = Eq(t, evens.Length(), 2)
+    val t2 = Eq(t1, odds.Length(), 3)
+    val t3 = Eq(t2, evens.Get(0), 2)
+    return Eq(t3, odds.Get(0), 1)
 }
 
 // Test complex composition
 func TestComplexComposition(t T) T {
-    // Sum of squares of even numbers from 1 to 10
     val result = From(1)
         .Take(10)
-        .Filter((x int) => x % 2 == 0)
-        .Map[int]((x int) => x * x)
-        .Fold[int](0, (acc int, x int) => acc + x)
-    // 2^2 + 4^2 + 6^2 + 8^2 + 10^2 = 4 + 16 + 36 + 64 + 100 = 220
-    return Eq[int](t, result, 220)
+        .Filter((x) => x % 2 == 0)
+        .Map((x) => x * x)
+        .Fold(0, (acc, x) => acc + x)
+    return Eq(t, result, 220)
 }

--- a/strings/perf_test.gala
+++ b/strings/perf_test.gala
@@ -1,9 +1,9 @@
 package main
 
 import (
-    "fmt"
     "unicode"
     "time"
+    . "martianoff/gala/std"
     . "martianoff/gala/strings"
 )
 
@@ -21,36 +21,36 @@ func countIfLetter(r rune) {
 
 // Performance test utilities
 func measureNs(iterations int, f func()) int64 {
-    var start = time.Now()
+    val start = time.Now()
     for i := 0; i < iterations; i++ {
         f()
     }
-    var elapsed = time.Since(start)
+    val elapsed = time.Since(start)
     return elapsed.Nanoseconds() / int64(iterations)
 }
 
 func printResult(name string, nsPerOp int64) {
-    fmt.Printf("%-55s %12d ns/op\n", name, nsPerOp)
+    Print(f"${name}%-55s ${nsPerOp}%12d ns/op\n")
 }
 
 // ============ TEST DATA ============
 
-var shortStr = S("Hello, World!")
-var mediumStr = S(Repeat("abcdefghij", 100))
-var longStr = S(Repeat("abcdefghij", 10000))
-var wordsStr = S("hello world foo bar baz qux quux corge grault garply")
+val shortStr = S("Hello, World!")
+val mediumStr = S(Repeat("abcdefghij", 100))
+val longStr = S(Repeat("abcdefghij", 10000))
+val wordsStr = S("hello world foo bar baz qux quux corge grault garply")
 
 // ============ CREATION ============
 
 func benchCreation() {
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = S(Repeat("abcdefghij", 100))
     })
     printResult("Str.S(1000)", ns)
 }
 
 func benchCreationLong() {
-    var ns = measureNs(1000, () => {
+    val ns = measureNs(1000, () => {
         var _ = S(Repeat("abcdefghij", 10000))
     })
     printResult("Str.S(100000)", ns)
@@ -59,7 +59,7 @@ func benchCreationLong() {
 // ============ LENGTH ============
 
 func benchLength() {
-    var ns = measureNs(10000000, () => {
+    val ns = measureNs(10000000, () => {
         var _ = mediumStr.Length()
     })
     printResult("Str.Length(1000)", ns)
@@ -68,14 +68,14 @@ func benchLength() {
 // ============ CASE TRANSFORMATIONS ============
 
 func benchToUpper() {
-    var ns = measureNs(10000, () => {
+    val ns = measureNs(10000, () => {
         var _ = mediumStr.ToUpper()
     })
     printResult("Str.ToUpper(1000)", ns)
 }
 
 func benchToLower() {
-    var ns = measureNs(10000, () => {
+    val ns = measureNs(10000, () => {
         var _ = mediumStr.ToLower()
     })
     printResult("Str.ToLower(1000)", ns)
@@ -84,8 +84,8 @@ func benchToLower() {
 // ============ TRIMMING ============
 
 func benchTrim() {
-    var padded = S("   " + Repeat("abcdefghij", 100) + "   ")
-    var ns = measureNs(100000, () => {
+    val padded = S("   " + Repeat("abcdefghij", 100) + "   ")
+    val ns = measureNs(100000, () => {
         var _ = padded.Trim()
     })
     printResult("Str.Trim(1000)", ns)
@@ -94,7 +94,7 @@ func benchTrim() {
 // ============ REPLACE ============
 
 func benchReplaceAll() {
-    var ns = measureNs(10000, () => {
+    val ns = measureNs(10000, () => {
         var _ = mediumStr.ReplaceAll("abc", "xyz")
     })
     printResult("Str.ReplaceAll(1000)", ns)
@@ -103,14 +103,14 @@ func benchReplaceAll() {
 // ============ CONTAINS / SEARCH ============
 
 func benchContains() {
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = mediumStr.Contains("fghij")
     })
     printResult("Str.Contains(1000)", ns)
 }
 
 func benchIndex() {
-    var ns = measureNs(1000000, () => {
+    val ns = measureNs(1000000, () => {
         var _ = mediumStr.IndexOf("fghij")
     })
     printResult("Str.IndexOf(1000)", ns)
@@ -119,15 +119,15 @@ func benchIndex() {
 // ============ SPLIT ============
 
 func benchSplit() {
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = wordsStr.Split(" ")
     })
     printResult("Str.Split(10 words)", ns)
 }
 
 func benchSplitLong() {
-    var longWords = S(Repeat("word ", 1000))
-    var ns = measureNs(1000, () => {
+    val longWords = S(Repeat("word ", 1000))
+    val ns = measureNs(1000, () => {
         var _ = longWords.Split(" ")
     })
     printResult("Str.Split(1000 words)", ns)
@@ -136,7 +136,7 @@ func benchSplitLong() {
 // ============ REVERSE ============
 
 func benchReverse() {
-    var ns = measureNs(10000, () => {
+    val ns = measureNs(10000, () => {
         var _ = mediumStr.Reverse()
     })
     printResult("Str.Reverse(1000)", ns)
@@ -145,21 +145,21 @@ func benchReverse() {
 // ============ FUNCTIONAL OPS ============
 
 func benchMap() {
-    var ns = measureNs(10000, () => {
+    val ns = measureNs(10000, () => {
         var _ = mediumStr.Map(toUpperRune)
     })
     printResult("Str.Map(1000)", ns)
 }
 
 func benchFilter() {
-    var ns = measureNs(10000, () => {
+    val ns = measureNs(10000, () => {
         var _ = mediumStr.Filter(isLetterRune)
     })
     printResult("Str.Filter(1000)", ns)
 }
 
 func benchForEachCount() {
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         globalCount = 0
         mediumStr.ForEach(countIfLetter)
         var _ = globalCount
@@ -170,8 +170,8 @@ func benchForEachCount() {
 // ============ COMPARISON ============
 
 func benchEquals() {
-    var other = S(Repeat("abcdefghij", 100))
-    var ns = measureNs(1000000, () => {
+    val other = S(Repeat("abcdefghij", 100))
+    val ns = measureNs(1000000, () => {
         var _ = mediumStr.Equals(other)
     })
     printResult("Str.Equals(1000)", ns)
@@ -180,9 +180,9 @@ func benchEquals() {
 // ============ CONCAT ============
 
 func benchConcat() {
-    var a = mediumStr.Take(500)
-    var b = mediumStr.Drop(500)
-    var ns = measureNs(100000, () => {
+    val a = mediumStr.Take(500)
+    val b = mediumStr.Drop(500)
+    val ns = measureNs(100000, () => {
         var _ = a.Concat(b)
     })
     printResult("Str.Concat(500+500)", ns)
@@ -191,8 +191,8 @@ func benchConcat() {
 // ============ PREDICATES ============
 
 func benchIsAlpha() {
-    var alpha = S(Repeat("abcdefghij", 100))
-    var ns = measureNs(10000, () => {
+    val alpha = S(Repeat("abcdefghij", 100))
+    val ns = measureNs(10000, () => {
         var _ = alpha.IsAlpha()
     })
     printResult("Str.IsAlpha(1000)", ns)
@@ -201,7 +201,7 @@ func benchIsAlpha() {
 // ============ SUBSTRING ============
 
 func benchSubstring() {
-    var ns = measureNs(100000, () => {
+    val ns = measureNs(100000, () => {
         var _ = mediumStr.Substring(100, 500)
     })
     printResult("Str.Substring(100,500)", ns)
@@ -210,8 +210,8 @@ func benchSubstring() {
 // ============ STRINGBUILDER ============
 
 func benchBuilderAppend100() {
-    var ns = measureNs(100000, () => {
-        var sb = NewStringBuilder()
+    val ns = measureNs(100000, () => {
+        val sb = NewStringBuilder()
         for i := 0; i < 100; i++ {
             sb.AppendString("hello")
         }
@@ -221,8 +221,8 @@ func benchBuilderAppend100() {
 }
 
 func benchBuilderAppend10000() {
-    var ns = measureNs(1000, () => {
-        var sb = NewStringBuilder()
+    val ns = measureNs(1000, () => {
+        val sb = NewStringBuilder()
         for i := 0; i < 10000; i++ {
             sb.AppendString("hello")
         }
@@ -232,8 +232,8 @@ func benchBuilderAppend10000() {
 }
 
 func benchBuilderAppendRune() {
-    var ns = measureNs(1000, () => {
-        var sb = NewStringBuilder()
+    val ns = measureNs(1000, () => {
+        val sb = NewStringBuilder()
         for i := 0; i < 10000; i++ {
             sb.AppendRune(rune(120))
         }
@@ -245,68 +245,68 @@ func benchBuilderAppendRune() {
 // ============ MAIN ============
 
 func main() {
-    fmt.Println("=== GALA Str Performance ===")
-    fmt.Println("")
+    Println("=== GALA Str Performance ===")
+    Println("")
 
-    fmt.Println("--- Creation / Conversion ---")
+    Println("--- Creation / Conversion ---")
     benchCreation()
     benchCreationLong()
-    fmt.Println("")
+    Println("")
 
-    fmt.Println("--- Length ---")
+    Println("--- Length ---")
     benchLength()
-    fmt.Println("")
+    Println("")
 
-    fmt.Println("--- Case Transformations ---")
+    Println("--- Case Transformations ---")
     benchToUpper()
     benchToLower()
-    fmt.Println("")
+    Println("")
 
-    fmt.Println("--- Trimming ---")
+    Println("--- Trimming ---")
     benchTrim()
-    fmt.Println("")
+    Println("")
 
-    fmt.Println("--- Replace ---")
+    Println("--- Replace ---")
     benchReplaceAll()
-    fmt.Println("")
+    Println("")
 
-    fmt.Println("--- Contains / Search ---")
+    Println("--- Contains / Search ---")
     benchContains()
     benchIndex()
-    fmt.Println("")
+    Println("")
 
-    fmt.Println("--- Split ---")
+    Println("--- Split ---")
     benchSplit()
     benchSplitLong()
-    fmt.Println("")
+    Println("")
 
-    fmt.Println("--- Reverse ---")
+    Println("--- Reverse ---")
     benchReverse()
-    fmt.Println("")
+    Println("")
 
-    fmt.Println("--- Functional Operations ---")
+    Println("--- Functional Operations ---")
     benchMap()
     benchFilter()
     benchForEachCount()
-    fmt.Println("")
+    Println("")
 
-    fmt.Println("--- Comparison ---")
+    Println("--- Comparison ---")
     benchEquals()
-    fmt.Println("")
+    Println("")
 
-    fmt.Println("--- Concat ---")
+    Println("--- Concat ---")
     benchConcat()
-    fmt.Println("")
+    Println("")
 
-    fmt.Println("--- Predicates ---")
+    Println("--- Predicates ---")
     benchIsAlpha()
-    fmt.Println("")
+    Println("")
 
-    fmt.Println("--- Substring ---")
+    Println("--- Substring ---")
     benchSubstring()
-    fmt.Println("")
+    Println("")
 
-    fmt.Println("--- StringBuilder ---")
+    Println("--- StringBuilder ---")
     benchBuilderAppend100()
     benchBuilderAppend10000()
     benchBuilderAppendRune()

--- a/strings/strings.gala
+++ b/strings/strings.gala
@@ -152,15 +152,6 @@ func stringToRunes(s string) Array[rune] {
 // runesToString converts an Array of runes to a string.
 func runesToString(runes Array[rune]) string = string(runes.ToGoSlice())
 
-// arrayFill creates an array of n copies of value.
-func arrayFill[T any](n int, value T) Array[T] {
-    var result = EmptyArray[T]()
-    for i := 0; i < n; i++ {
-        result = result.Append(value)
-    }
-    return result
-}
-
 // Length returns the number of runes. O(1).
 func (s Str) Length() int = s.runes.Get().Length()
 
@@ -288,7 +279,7 @@ func (s Str) PadLeft(length int, pad rune) Str {
         return s
     }
     val padCount = length - s.Length()
-    return strFromRunes(arrayFill(padCount, pad).AppendAll(s.runes.Get()))
+    return strFromRunes(ArrayFill(padCount, pad).AppendAll(s.runes.Get()))
 }
 
 // PadRight pads on the right.
@@ -297,7 +288,7 @@ func (s Str) PadRight(length int, pad rune) Str {
         return s
     }
     val padCount = length - s.Length()
-    return strFromRunes(s.runes.Get().AppendAll(arrayFill(padCount, pad)))
+    return strFromRunes(s.runes.Get().AppendAll(ArrayFill(padCount, pad)))
 }
 
 // Center pads on both sides.
@@ -308,7 +299,7 @@ func (s Str) Center(length int, pad rune) Str {
     val totalPad = length - s.Length()
     val leftPad = totalPad / 2
     val rightPad = totalPad - leftPad
-    return strFromRunes(arrayFill(leftPad, pad).AppendAll(s.runes.Get()).AppendAll(arrayFill(rightPad, pad)))
+    return strFromRunes(ArrayFill(leftPad, pad).AppendAll(s.runes.Get()).AppendAll(ArrayFill(rightPad, pad)))
 }
 
 // Capitalize capitalizes first character.
@@ -336,10 +327,8 @@ func (s Str) Uncapitalize() Str {
 func (s Str) TitleCase() Str = JoinStrs(s.Words().Map((w) => w.Capitalize()), " ")
 
 // Split splits the string by separator.
-func (s Str) Split(sep string) Array[Str] {
-    val parts = gostrings.Split(s.str, sep)
-    return ArrayTabulate(len(parts), (i int) => strFromString(parts[i]))
-}
+func (s Str) Split(sep string) Array[Str] =
+    ArrayFromSlice(gostrings.Split(s.str, sep)).Map(strFromString)
 
 // SplitAt splits at index.
 func (s Str) SplitAt(index int) Tuple[Str, Str] {
@@ -350,15 +339,12 @@ func (s Str) SplitAt(index int) Tuple[Str, Str] {
 // Lines splits into lines.
 func (s Str) Lines() Array[Str] {
     val normalized = gostrings.ReplaceAll(s.str, "\r\n", "\n")
-    val parts = gostrings.Split(normalized, "\n")
-    return ArrayTabulate(len(parts), (i int) => strFromString(parts[i]))
+    return ArrayFromSlice(gostrings.Split(normalized, "\n")).Map(strFromString)
 }
 
 // Words splits into words.
-func (s Str) Words() Array[Str] {
-    val parts = gostrings.Fields(s.str)
-    return ArrayTabulate(len(parts), (i int) => strFromString(parts[i]))
-}
+func (s Str) Words() Array[Str] =
+    ArrayFromSlice(gostrings.Fields(s.str)).Map(strFromString)
 
 // JoinStrs joins a sequence of Str values with a separator. The
 // `string`-shaped sibling lives under the bare name `Join`.
@@ -366,11 +352,7 @@ func JoinStrs(strs Array[Str], sep string) Str {
     if strs.IsEmpty() {
         return emptyStr()
     }
-    var goStrs []string
-    for i := 0; i < strs.Length(); i++ {
-        goStrs = append(goStrs, strs.Get(i).str)
-    }
-    return strFromString(gostrings.Join(goStrs, sep))
+    return strFromString(gostrings.Join(strs.Map((x) => x.str).ToGoSlice(), sep))
 }
 
 // Concat concatenates strings.
@@ -428,19 +410,13 @@ func (s Str) IsLower() bool {
 // IndexOf returns index of first occurrence of substring.
 func (s Str) IndexOf(substr string) Option[int] {
     val idx = gostrings.Index(s.str, substr)
-    if idx < 0 {
-        return None[int]()
-    }
-    return Some(byteIndexToRuneIndex(s.str, idx))
+    return When(idx >= 0, byteIndexToRuneIndex(s.str, idx))
 }
 
 // LastIndexOf returns index of last occurrence of substring.
 func (s Str) LastIndexOf(substr string) Option[int] {
     val idx = gostrings.LastIndex(s.str, substr)
-    if idx < 0 {
-        return None[int]()
-    }
-    return Some(byteIndexToRuneIndex(s.str, idx))
+    return When(idx >= 0, byteIndexToRuneIndex(s.str, idx))
 }
 
 // byteIndexToRuneIndex converts a byte index to a rune index.
@@ -459,12 +435,8 @@ func byteIndexToRuneIndex(str string, byteIdx int) int {
 
 // IndexOfChar returns index of rune.
 func (s Str) IndexOfChar(target rune) Option[int] {
-    for i := 0; i < s.runes.Get().Length(); i++ {
-        if s.runes.Get().Get(i) == target {
-            return Some(i)
-        }
-    }
-    return None[int]()
+    val idx = s.runes.Get().IndexOf(target)
+    return When(idx >= 0, idx)
 }
 
 // Map applies function to each character.
@@ -604,22 +576,11 @@ func (sb *StringBuilder) ToString() string {
 func (sb *StringBuilder) String() string = sb.ToString()
 
 // Length returns the total byte length of the built string.
-func (sb *StringBuilder) Length() int {
-    var total = 0
-    for i := 0; i < sb.parts.Length(); i++ {
-        total = total + len(sb.parts.Get(i))
-    }
-    return total
-}
+func (sb *StringBuilder) Length() int = sb.parts.FoldLeft(0, (acc, p) => acc + len(p))
 
 // RuneCount returns the total number of runes in the built string.
-func (sb *StringBuilder) RuneCount() int {
-    var total = 0
-    for i := 0; i < sb.parts.Length(); i++ {
-        total = total + utf8.RuneCountInString(sb.parts.Get(i))
-    }
-    return total
-}
+func (sb *StringBuilder) RuneCount() int =
+    sb.parts.FoldLeft(0, (acc, p) => acc + utf8.RuneCountInString(p))
 
 // IsEmpty returns true if the builder has no content.
 func (sb *StringBuilder) IsEmpty() bool = sb.parts.Length() == 0

--- a/strings/strings_test.gala
+++ b/strings/strings_test.gala
@@ -545,14 +545,14 @@ func TestStrConcat(t T) T {
 // Test Map
 func TestStrMap(t T) T {
     val str = s.S("abc")
-    val result = str.Map((r rune) => r + 1)
+    val result = str.Map((r) => r + 1)
     return Eq(t, result.ToString(), "bcd")
 }
 
 // Test Filter
 func TestStrFilter(t T) T {
     val str = s.S("hello world")
-    val result = str.Filter((r rune) => r != ' ')
+    val result = str.Filter((r) => r != ' ')
     return Eq(t, result.ToString(), "helloworld")
 }
 
@@ -565,17 +565,17 @@ func TestStrFold(t T) T {
 // Test Exists and ForAll
 func TestStrExistsForAll(t T) T {
     val str = s.S("hello")
-    val t1 = IsTrue(t, str.Exists((r rune) => r == 'l'))
-    val t2 = IsFalse(t1, str.Exists((r rune) => r == 'x'))
-    val t3 = IsTrue(t2, str.ForAll((r rune) => r >= 'a' && r <= 'z'))
-    return IsFalse(t3, str.ForAll((r rune) => r == 'h'))
+    val t1 = IsTrue(t, str.Exists((r) => r == 'l'))
+    val t2 = IsFalse(t1, str.Exists((r) => r == 'x'))
+    val t3 = IsTrue(t2, str.ForAll((r) => r >= 'a' && r <= 'z'))
+    return IsFalse(t3, str.ForAll((r) => r == 'h'))
 }
 
 // Test Find
 func TestStrFind(t T) T {
     val str = s.S("hello")
-    val t1 = Eq(t, str.Find((r rune) => r == 'l').GetOrElse('?'), 'l')
-    return IsNone(t1, str.Find((r rune) => r == 'x'))
+    val t1 = Eq(t, str.Find((r) => r == 'l').GetOrElse('?'), 'l')
+    return IsNone(t1, str.Find((r) => r == 'x'))
 }
 
 // Test ZipWithIndex

--- a/subprocess/subprocess.gala
+++ b/subprocess/subprocess.gala
@@ -70,15 +70,15 @@ func Spawn(opts SpawnOpts) Try[Process] {
     if eErr != nil { return Failure[Process](eErr) }
     val startErr = c.Start()
     if startErr != nil { return Failure[Process](startErr) }
-    return Success(Process(state = &processState{
-        cmd:        c,
-        stdin:      sin,
-        stdoutScan: newLineScanner(sout),
-        stderrScan: newLineScanner(serr),
-        stdinMu:    go_interop.NewMutex(),
-        waitOnce:   go_interop.NewOnce(),
-        waitDone:   go_interop.NewSignal(),
-    }))
+    return Success(Process(state = &processState(
+        cmd        = c,
+        stdin      = sin,
+        stdoutScan = newLineScanner(sout),
+        stderrScan = newLineScanner(serr),
+        stdinMu    = go_interop.NewMutex(),
+        waitOnce   = go_interop.NewOnce(),
+        waitDone   = go_interop.NewSignal(),
+    )))
 }
 
 // WriteLine writes s + "\n" to the child's stdin, flushing immediately.

--- a/test/assertions.gala
+++ b/test/assertions.gala
@@ -1,7 +1,6 @@
 package test
 
 import (
-    "fmt"
     "strings"
 )
 
@@ -12,7 +11,7 @@ import (
 // Eq asserts that actual equals expected.
 func Eq[V any](t T, actual V, expected V) T {
     if !std.Equal(actual, expected) {
-        return t.Error(fmt.Sprintf("expected %v, got %v", expected, actual))
+        return t.Error(s"expected ${expected}, got ${actual}")
     }
     return t
 }
@@ -20,7 +19,7 @@ func Eq[V any](t T, actual V, expected V) T {
 // NotEq asserts that actual does not equal expected.
 func NotEq[V any](t T, actual V, expected V) T {
     if std.Equal(actual, expected) {
-        return t.Error(fmt.Sprintf("expected value different from %v", expected))
+        return t.Error(s"expected value different from ${expected}")
     }
     return t
 }
@@ -28,7 +27,7 @@ func NotEq[V any](t T, actual V, expected V) T {
 // EqMsg asserts that actual equals expected with a custom message.
 func EqMsg[V any](t T, actual V, expected V, msg string) T {
     if !std.Equal(actual, expected) {
-        return t.Error(fmt.Sprintf("%s: expected %v, got %v", msg, expected, actual))
+        return t.Error(s"${msg}: expected ${expected}, got ${actual}")
     }
     return t
 }
@@ -36,7 +35,7 @@ func EqMsg[V any](t T, actual V, expected V, msg string) T {
 // IsNil asserts that the value is nil.
 func IsNil(t T, value any) T {
     if value != nil {
-        return t.Error(fmt.Sprintf("expected nil, got %v", value))
+        return t.Error(s"expected nil, got ${value}")
     }
     return t
 }
@@ -76,7 +75,7 @@ func IsFalse(t T, condition bool) T {
 // Greater asserts that a > b.
 func Greater[V any](t T, a V, b V) T {
     if std.CompareValues(a, b) <= 0 {
-        return t.Error(fmt.Sprintf("expected %v > %v", a, b))
+        return t.Error(s"expected ${a} > ${b}")
     }
     return t
 }
@@ -84,7 +83,7 @@ func Greater[V any](t T, a V, b V) T {
 // GreaterOrEq asserts that a >= b.
 func GreaterOrEq[V any](t T, a V, b V) T {
     if std.CompareValues(a, b) < 0 {
-        return t.Error(fmt.Sprintf("expected %v >= %v", a, b))
+        return t.Error(s"expected ${a} >= ${b}")
     }
     return t
 }
@@ -92,7 +91,7 @@ func GreaterOrEq[V any](t T, a V, b V) T {
 // Less asserts that a < b.
 func Less[V any](t T, a V, b V) T {
     if std.CompareValues(a, b) >= 0 {
-        return t.Error(fmt.Sprintf("expected %v < %v", a, b))
+        return t.Error(s"expected ${a} < ${b}")
     }
     return t
 }
@@ -100,7 +99,7 @@ func Less[V any](t T, a V, b V) T {
 // LessOrEq asserts that a <= b.
 func LessOrEq[V any](t T, a V, b V) T {
     if std.CompareValues(a, b) > 0 {
-        return t.Error(fmt.Sprintf("expected %v <= %v", a, b))
+        return t.Error(s"expected ${a} <= ${b}")
     }
     return t
 }
@@ -112,7 +111,7 @@ func LessOrEq[V any](t T, a V, b V) T {
 // Contains asserts that haystack contains needle.
 func Contains(t T, haystack string, needle string) T {
     if !strings.Contains(haystack, needle) {
-        return t.Error(fmt.Sprintf("expected %q to contain %q", haystack, needle))
+        return t.Error(f"expected $haystack%q to contain $needle%q")
     }
     return t
 }
@@ -120,7 +119,7 @@ func Contains(t T, haystack string, needle string) T {
 // NotContains asserts that haystack does not contain needle.
 func NotContains(t T, haystack string, needle string) T {
     if strings.Contains(haystack, needle) {
-        return t.Error(fmt.Sprintf("expected %q to not contain %q", haystack, needle))
+        return t.Error(f"expected $haystack%q to not contain $needle%q")
     }
     return t
 }
@@ -128,7 +127,7 @@ func NotContains(t T, haystack string, needle string) T {
 // HasPrefix asserts that s starts with prefix.
 func HasPrefix(t T, s string, prefix string) T {
     if !strings.HasPrefix(s, prefix) {
-        return t.Error(fmt.Sprintf("expected %q to have prefix %q", s, prefix))
+        return t.Error(f"expected $s%q to have prefix $prefix%q")
     }
     return t
 }
@@ -136,7 +135,7 @@ func HasPrefix(t T, s string, prefix string) T {
 // HasSuffix asserts that s ends with suffix.
 func HasSuffix(t T, s string, suffix string) T {
     if !strings.HasSuffix(s, suffix) {
-        return t.Error(fmt.Sprintf("expected %q to have suffix %q", s, suffix))
+        return t.Error(f"expected $s%q to have suffix $suffix%q")
     }
     return t
 }
@@ -156,7 +155,7 @@ func IsSome[V any](t T, opt Option[V]) T {
 // IsNone asserts that the Option is None (empty).
 func IsNone[V any](t T, opt Option[V]) T {
     if opt.IsDefined() {
-        return t.Error(fmt.Sprintf("expected None, got Some(%v)", opt.Get()))
+        return t.Error(s"expected None, got Some(${opt.Get()})")
     }
     return t
 }
@@ -168,7 +167,7 @@ func IsNone[V any](t T, opt Option[V]) T {
 // IsSuccess asserts that the Try is Success.
 func IsSuccess[V any](t T, tr Try[V]) T {
     if tr.IsFailure() {
-        return t.Error(fmt.Sprintf("expected Success, got Failure(%v)", tr.GetError()))
+        return t.Error(s"expected Success, got Failure(${tr.GetError()})")
     }
     return t
 }
@@ -176,7 +175,7 @@ func IsSuccess[V any](t T, tr Try[V]) T {
 // IsFailure asserts that the Try is Failure.
 func IsFailure[V any](t T, tr Try[V]) T {
     if tr.IsSuccess() {
-        return t.Error(fmt.Sprintf("expected Failure, got Success(%v)", tr.Get()))
+        return t.Error(s"expected Failure, got Success(${tr.Get()})")
     }
     return t
 }
@@ -204,7 +203,7 @@ func NotPanics(t T, f func()) T {
         return true
     })
     if result.IsFailure() {
-        return t.Error(fmt.Sprintf("expected no panic but got: %v", result.GetError()))
+        return t.Error(s"expected no panic but got: ${result.GetError()}")
     }
     return t
 }

--- a/test/bench.gala
+++ b/test/bench.gala
@@ -1,7 +1,6 @@
 package test
 
 import (
-    "fmt"
     "time"
 )
 
@@ -26,12 +25,12 @@ type BenchFunc struct {
 // Each benchmark is calibrated by doubling N until the elapsed time >= 1 second,
 // then the final measurement is reported in ns/op format.
 func RunBenchmarks(benchmarks ...BenchFunc) {
-    fmt.Println("=== STARTING BENCHMARKS ===")
+    Println("=== STARTING BENCHMARKS ===")
     for i := 0; i < len(benchmarks); i++ {
-        var bench = benchmarks[i]
+        val bench = benchmarks[i]
         runBenchmark(bench)
     }
-    fmt.Println("=== BENCHMARKS DONE ===")
+    Println("=== BENCHMARKS DONE ===")
 }
 
 func runBenchmark(bench BenchFunc) {
@@ -40,10 +39,10 @@ func runBenchmark(bench BenchFunc) {
 
     // Auto-calibrate: double N until elapsed >= 1s
     for {
-        var b = B(N = n, name = bench.Name)
-        var start = time.Now()
+        val b = B(N = n, name = bench.Name)
+        val start = time.Now()
         bench.Func(b)
-        var elapsed = time.Since(start)
+        val elapsed = time.Since(start)
         nsTotal = elapsed.Nanoseconds()
         if nsTotal >= 1000000000 {
             break
@@ -51,6 +50,6 @@ func runBenchmark(bench BenchFunc) {
         n = n * 2
     }
 
-    var nsPerOp = nsTotal / int64(n)
-    fmt.Printf("%-40s %10d %15d ns/op\n", bench.Name, n, nsPerOp)
+    val nsPerOp = nsTotal / int64(n)
+    Println(f"${bench.Name}%-40s ${n}%10d ${nsPerOp}%15d ns/op")
 }

--- a/test/framework.gala
+++ b/test/framework.gala
@@ -1,7 +1,6 @@
 package test
 
 import (
-    "fmt"
     "os"
     "time"
 )
@@ -10,8 +9,8 @@ import (
 // It tracks test state and provides assertion and logging methods.
 type T struct {
     name     string
-    var failed   bool
-    var skipped  bool
+    failed   bool
+    skipped  bool
 }
 
 // newT creates a new test context with the given name.
@@ -40,40 +39,40 @@ func (t T) Skip() T {
 
 // Log prints a message to the test output.
 func (t T) Log(msg string) {
-    fmt.Printf("    %s\n", msg)
+    Println(s"    ${msg}")
 }
 
 // Error logs an error message and marks the test as failed.
 func (t T) Error(msg string) T {
-    fmt.Printf("    ERROR: %s\n", msg)
+    Println(s"    ERROR: ${msg}")
     return T(name = t.name, failed = true, skipped = t.skipped)
 }
 
 // Fatal logs an error message, marks the test as failed, and stops execution.
 func (t T) Fatal(msg string) {
-    fmt.Printf("    FATAL: %s\n", msg)
-    panic(fmt.Sprintf("Test %s fatal error: %s", t.name, msg))
+    Println(s"    FATAL: ${msg}")
+    panic(s"Test ${t.name} fatal error: ${msg}")
 }
 
 // Run runs a subtest with the given name and function.
 // This enables table-driven testing patterns.
 // Panics in subtests are recovered and reported as failures.
 func (t T) Run(name string, f func(T) T) T {
-    var subT = newT(t.name + "/" + name)
-    fmt.Printf("=== RUN   %s\n", subT.name)
+    val subT = newT(t.name + "/" + name)
+    Println(s"=== RUN   ${subT.name}")
 
-    var start = time.Now()
-    var result = runTest(subT, f)
-    var elapsed = time.Since(start)
+    val start = time.Now()
+    val result = runTest(subT, f)
+    val elapsed = time.Since(start)
 
     if result.failed {
-        fmt.Printf("--- FAIL: %s (%.3fs)\n", subT.name, elapsed.Seconds())
+        Println(f"--- FAIL: ${subT.name} (${elapsed.Seconds()}%.3fs)")
         return T(name = t.name, failed = true, skipped = t.skipped)
     } else if result.skipped {
-        fmt.Printf("--- SKIP: %s (%.3fs)\n", subT.name, elapsed.Seconds())
+        Println(f"--- SKIP: ${subT.name} (${elapsed.Seconds()}%.3fs)")
         return t
     } else {
-        fmt.Printf("--- PASS: %s (%.3fs)\n", subT.name, elapsed.Seconds())
+        Println(f"--- PASS: ${subT.name} (${elapsed.Seconds()}%.3fs)")
         return t
     }
 }
@@ -82,10 +81,10 @@ func (t T) Run(name string, f func(T) T) T {
 // If the function panics, the panic is caught and reported as a test failure.
 func runTest(t T, f func(T) T) T {
     val result = Try[T](() => f(t))
-    if result.IsSuccess() {
-        return result.Get()
+    return result match {
+        case Success(v) => v
+        case Failure(e) => t.Error(s"PANIC: $e")
     }
-    return t.Error(fmt.Sprintf("PANIC: %v", result.GetError()))
 }
 
 // ============================================================================
@@ -100,20 +99,20 @@ type TestFunc struct {
 
 // Run executes the test function and returns the result.
 func (tf TestFunc) Run() T {
-    var t = newT(tf.Name)
-    fmt.Printf("=== RUN   %s\n", t.name)
+    val t = newT(tf.Name)
+    Println(s"=== RUN   ${t.name}")
 
-    var start = time.Now()
-    var result = runTest(t, tf.F)
-    var elapsed = time.Since(start)
+    val start = time.Now()
+    val result = runTest(t, tf.F)
+    val elapsed = time.Since(start)
 
     // Print result
     if result.failed {
-        fmt.Printf("--- FAIL: %s (%.3fs)\n", t.name, elapsed.Seconds())
+        Println(f"--- FAIL: ${t.name} (${elapsed.Seconds()}%.3fs)")
     } else if result.skipped {
-        fmt.Printf("--- SKIP: %s (%.3fs)\n", t.name, elapsed.Seconds())
+        Println(f"--- SKIP: ${t.name} (${elapsed.Seconds()}%.3fs)")
     } else {
-        fmt.Printf("--- PASS: %s (%.3fs)\n", t.name, elapsed.Seconds())
+        Println(f"--- PASS: ${t.name} (${elapsed.Seconds()}%.3fs)")
     }
     return result
 }
@@ -125,10 +124,10 @@ func RunTests(tests ...TestFunc) {
     var failed = 0
     var skipped = 0
 
-    fmt.Println("=== STARTING TESTS ===")
+    Println("=== STARTING TESTS ===")
     for i := 0; i < len(tests); i++ {
-        var test = tests[i]
-        var result = test.Run()
+        val test = tests[i]
+        val result = test.Run()
         if result.failed {
             failed++
         } else if result.skipped {
@@ -138,13 +137,13 @@ func RunTests(tests ...TestFunc) {
         }
     }
 
-    fmt.Println()
-    fmt.Println("=== RESULTS ===")
-    fmt.Printf("Passed: %d, Failed: %d, Skipped: %d\n", passed, failed, skipped)
+    Println()
+    Println("=== RESULTS ===")
+    Println(s"Passed: ${passed}, Failed: ${failed}, Skipped: ${skipped}")
 
     if failed > 0 {
-        fmt.Println("FAIL")
+        Println("FAIL")
         os.Exit(1)
     }
-    fmt.Println("PASS")
+    Println("PASS")
 }

--- a/test/framework_test.gala
+++ b/test/framework_test.gala
@@ -10,13 +10,13 @@ import (
 // ============================================================================
 
 func TestEq(t T) T {
-    var t1 = Eq(t, 1 + 1, 2)
-    var t2 = Eq(t1, "hello", "hello")
+    val t1 = Eq(t, 1 + 1, 2)
+    val t2 = Eq(t1, "hello", "hello")
     return Eq(t2, true, true)
 }
 
 func TestNotEq(t T) T {
-    var t1 = NotEq(t, 1, 2)
+    val t1 = NotEq(t, 1, 2)
     return NotEq(t1, "hello", "world")
 }
 
@@ -37,22 +37,22 @@ func TestIsFalse(t T) T = IsFalse(t, 1 + 1 == 3)
 // ============================================================================
 
 func TestGreater(t T) T {
-    var t1 = Greater(t, 10, 5)
+    val t1 = Greater(t, 10, 5)
     return Greater(t1, "b", "a")
 }
 
 func TestGreaterOrEq(t T) T {
-    var t1 = GreaterOrEq(t, 10, 5)
+    val t1 = GreaterOrEq(t, 10, 5)
     return GreaterOrEq(t1, 5, 5)
 }
 
 func TestLess(t T) T {
-    var t1 = Less(t, 5, 10)
+    val t1 = Less(t, 5, 10)
     return Less(t1, "a", "b")
 }
 
 func TestLessOrEq(t T) T {
-    var t1 = LessOrEq(t, 5, 10)
+    val t1 = LessOrEq(t, 5, 10)
     return LessOrEq(t1, 5, 5)
 }
 
@@ -106,7 +106,7 @@ func TestNotPanics(t T) T = NotPanics(t, doNothing)
 // which use the same Try-based mechanism. This test verifies that the framework's
 // panic recovery wraps errors correctly via the Panics assertion.
 func TestPanicRecovery(t T) T {
-    var t1 = Panics(t, doPanic)
+    val t1 = Panics(t, doPanic)
     return NotPanics(t1, doNothing)
 }
 
@@ -115,8 +115,8 @@ func TestPanicRecovery(t T) T {
 // ============================================================================
 
 func TestSubtests(t T) T {
-    var t1 = t.Run("first", (sub T) => Eq(sub, 1, 1))
-    return t1.Run("second", (sub T) => Eq(sub, 2, 2))
+    val t1 = t.Run("first", (sub) => Eq(sub, 1, 1))
+    return t1.Run("second", (sub) => Eq(sub, 2, 2))
 }
 
 // ============================================================================
@@ -125,7 +125,7 @@ func TestSubtests(t T) T {
 
 func TestRunCases(t T) T {
     return RunCases[int, int](t,
-        (sub T, input int, expected int) => Eq(sub, input * 2, expected),
+        (sub, input, expected) => Eq(sub, input * 2, expected),
         Case[int, int](Name = "zero", Input = 0, Expected = 0),
         Case[int, int](Name = "positive", Input = 5, Expected = 10),
         Case[int, int](Name = "negative", Input = -3, Expected = -6),
@@ -145,11 +145,11 @@ func TestSkip(t T) T {
 // ============================================================================
 
 func TestChainedAssertions(t T) T {
-    var t1 = Eq(t, 1, 1)
-    var t2 = IsTrue(t1, true)
-    var t3 = IsFalse(t2, false)
-    var t4 = Greater(t3, 10, 5)
-    var t5 = Contains(t4, "hello", "ell")
+    val t1 = Eq(t, 1, 1)
+    val t2 = IsTrue(t1, true)
+    val t3 = IsFalse(t2, false)
+    val t4 = Greater(t3, 10, 5)
+    val t5 = Contains(t4, "hello", "ell")
     return NotEq(t5, "a", "b")
 }
 

--- a/test/table.gala
+++ b/test/table.gala
@@ -6,9 +6,9 @@ package test
 
 // Case represents a single test case for table-driven tests.
 type Case[In any, Out any] struct {
-    var Name     string
-    var Input    In
-    var Expected Out
+    Name     string
+    Input    In
+    Expected Out
 }
 
 // RunCases runs a series of test cases as subtests.

--- a/time_utils/time_utils.gala
+++ b/time_utils/time_utils.gala
@@ -61,20 +61,12 @@ func (d Duration) Minus(other Duration) Duration = Duration(nanos = d.nanos - ot
 func (d Duration) Multiply(factor int64) Duration = Duration(nanos = d.nanos * factor)
 
 // Divide divides by a divisor.
-func (d Duration) Divide(divisor int64) Duration {
-    if divisor == 0 {
-        return d
-    }
-    return Duration(nanos = d.nanos / divisor)
-}
+func (d Duration) Divide(divisor int64) Duration =
+    if (divisor == 0) d else Duration(nanos = d.nanos / divisor)
 
 // Abs returns the absolute value.
-func (d Duration) Abs() Duration {
-    if d.nanos < 0 {
-        return Duration(nanos = -d.nanos)
-    }
-    return d
-}
+func (d Duration) Abs() Duration =
+    if (d.nanos < 0) Duration(nanos = -d.nanos) else d
 
 // Negate returns the negated duration.
 func (d Duration) Negate() Duration = Duration(nanos = -d.nanos)
@@ -154,13 +146,8 @@ func UnixEpoch() Instant = Instant(nanos = int64(0))
 
 // Parse parses a time string with the given layout.
 func Parse(layout string, value string) Option[Instant] {
-    var result time.Time
-    var err error
-    result, err = time.Parse(layout, value)
-    if err != nil {
-        return None[Instant]()
-    }
-    return Some(FromGoTime(result))
+    val result, err = time.Parse(layout, value)
+    return When(err == nil, FromGoTime(result))
 }
 
 // ParseISO parses an ISO 8601 time string.
@@ -208,20 +195,10 @@ func (i Instant) Compare(other Instant) int {
 }
 
 // Min returns the earlier of two instants.
-func (i Instant) Min(other Instant) Instant {
-    if i.nanos < other.nanos {
-        return i
-    }
-    return other
-}
+func (i Instant) Min(other Instant) Instant = if (i.nanos < other.nanos) i else other
 
 // Max returns the later of two instants.
-func (i Instant) Max(other Instant) Instant {
-    if i.nanos > other.nanos {
-        return i
-    }
-    return other
-}
+func (i Instant) Max(other Instant) Instant = if (i.nanos > other.nanos) i else other
 
 // Instant accessors
 
@@ -283,9 +260,7 @@ func (i Instant) YearDay() int = i.ToGoTime().YearDay()
 
 // InTimezone returns the Instant formatted in a specific timezone.
 func (i Instant) InTimezone(tz string) Option[time.Time] {
-    var loc *time.Location
-    var err error
-    loc, err = time.LoadLocation(tz)
+    val loc, err = time.LoadLocation(tz)
     if err != nil {
         return None[time.Time]()
     }

--- a/time_utils/time_utils_test.gala
+++ b/time_utils/time_utils_test.gala
@@ -9,37 +9,37 @@ import (
 
 func TestNanoseconds(t T) T {
     val d = Nanoseconds(1000)
-    return Eq[int64](t, d.ToNanos(), 1000)
+    return Eq(t, d.ToNanos(), 1000)
 }
 
 func TestMicroseconds(t T) T {
     val d = Microseconds(1000)
-    return Eq[int64](t, d.ToNanos(), 1000000)
+    return Eq(t, d.ToNanos(), 1000000)
 }
 
 func TestMilliseconds(t T) T {
     val d = Milliseconds(1000)
-    return Eq[int64](t, d.ToNanos(), 1000000000)
+    return Eq(t, d.ToNanos(), 1000000000)
 }
 
 func TestSeconds(t T) T {
     val d = Seconds(60)
-    return Eq[int64](t, d.ToNanos(), 60000000000)
+    return Eq(t, d.ToNanos(), 60000000000)
 }
 
 func TestMinutes(t T) T {
     val d = Minutes(2)
-    return Eq[int64](t, d.ToSeconds(), 120)
+    return Eq(t, d.ToSeconds(), 120)
 }
 
 func TestHours(t T) T {
     val d = Hours(2)
-    return Eq[int64](t, d.ToMinutes(), 120)
+    return Eq(t, d.ToMinutes(), 120)
 }
 
 func TestDays(t T) T {
     val d = Days(1)
-    return Eq[int64](t, d.ToHours(), 24)
+    return Eq(t, d.ToHours(), 24)
 }
 
 // Duration operations tests
@@ -48,50 +48,50 @@ func TestDurationPlus(t T) T {
     val d1 = Seconds(30)
     val d2 = Seconds(15)
     val result = d1.Plus(d2)
-    return Eq[int64](t, result.ToSeconds(), 45)
+    return Eq(t, result.ToSeconds(), 45)
 }
 
 func TestDurationMinus(t T) T {
     val d1 = Seconds(30)
     val d2 = Seconds(15)
     val result = d1.Minus(d2)
-    return Eq[int64](t, result.ToSeconds(), 15)
+    return Eq(t, result.ToSeconds(), 15)
 }
 
 func TestDurationMultiply(t T) T {
     val d = Seconds(10)
     val result = d.Multiply(3)
-    return Eq[int64](t, result.ToSeconds(), 30)
+    return Eq(t, result.ToSeconds(), 30)
 }
 
 func TestDurationDivide(t T) T {
     val d = Seconds(30)
     val result = d.Divide(3)
-    return Eq[int64](t, result.ToSeconds(), 10)
+    return Eq(t, result.ToSeconds(), 10)
 }
 
 func TestDurationDivideByZero(t T) T {
     val d = Seconds(30)
     val result = d.Divide(0)
-    return Eq[int64](t, result.ToSeconds(), 30)
+    return Eq(t, result.ToSeconds(), 30)
 }
 
 func TestDurationAbs(t T) T {
     val d = Seconds(-30)
     val result = d.Abs()
-    return Eq[int64](t, result.ToSeconds(), 30)
+    return Eq(t, result.ToSeconds(), 30)
 }
 
 func TestDurationAbsPositive(t T) T {
     val d = Seconds(30)
     val result = d.Abs()
-    return Eq[int64](t, result.ToSeconds(), 30)
+    return Eq(t, result.ToSeconds(), 30)
 }
 
 func TestDurationNegate(t T) T {
     val d = Seconds(30)
     val result = d.Negate()
-    return Eq[int64](t, result.ToSeconds(), -30)
+    return Eq(t, result.ToSeconds(), -30)
 }
 
 func TestDurationIsZero(t T) T {
@@ -113,9 +113,9 @@ func TestDurationCompare(t T) T {
     val d1 = Seconds(10)
     val d2 = Seconds(20)
     val d3 = Seconds(10)
-    val t1 =Eq[int](t, d1.Compare(d2), -1)
-    val t2 =Eq[int](t1, d2.Compare(d1), 1)
-    return Eq[int](t2, d1.Compare(d3), 0)
+    val t1 =Eq(t, d1.Compare(d2), -1)
+    val t2 =Eq(t1, d2.Compare(d1), 1)
+    return Eq(t2, d1.Compare(d3), 0)
 }
 
 func TestDurationEquals(t T) T {
@@ -130,55 +130,55 @@ func TestDurationEquals(t T) T {
 
 func TestDurationToMicros(t T) T {
     val d = Milliseconds(1)
-    return Eq[int64](t, d.ToMicros(), 1000)
+    return Eq(t, d.ToMicros(), 1000)
 }
 
 func TestDurationToMillis(t T) T {
     val d = Seconds(1)
-    return Eq[int64](t, d.ToMillis(), 1000)
+    return Eq(t, d.ToMillis(), 1000)
 }
 
 func TestDurationToMinutes(t T) T {
     val d = Hours(1)
-    return Eq[int64](t, d.ToMinutes(), 60)
+    return Eq(t, d.ToMinutes(), 60)
 }
 
 func TestDurationToHours(t T) T {
     val d = Days(1)
-    return Eq[int64](t, d.ToHours(), 24)
+    return Eq(t, d.ToHours(), 24)
 }
 
 func TestDurationToDays(t T) T {
     val d = Hours(48)
-    return Eq[int64](t, d.ToDays(), 2)
+    return Eq(t, d.ToDays(), 2)
 }
 
 func TestDurationString(t T) T {
     val d = Hours(1).Plus(Minutes(30)).Plus(Seconds(45))
     val s = d.String()
-    return Eq[string](t, s, "1h30m45s")
+    return Eq(t, s, "1h30m45s")
 }
 
 // Instant constructor tests
 
 func TestFromUnixSeconds(t T) T {
     val i = FromUnixSeconds(1000)
-    return Eq[int64](t, i.UnixSeconds(), 1000)
+    return Eq(t, i.UnixSeconds(), 1000)
 }
 
 func TestFromUnixMillis(t T) T {
     val i = FromUnixMillis(1000)
-    return Eq[int64](t, i.UnixMillis(), 1000)
+    return Eq(t, i.UnixMillis(), 1000)
 }
 
 func TestFromUnixNanos(t T) T {
     val i = FromUnixNanos(1000000000)
-    return Eq[int64](t, i.UnixSeconds(), 1)
+    return Eq(t, i.UnixSeconds(), 1)
 }
 
 func TestUnixEpoch(t T) T {
     val epoch = UnixEpoch()
-    return Eq[int64](t, epoch.UnixNanos(), 0)
+    return Eq(t, epoch.UnixNanos(), 0)
 }
 
 // Instant parsing tests
@@ -196,12 +196,12 @@ func TestParseISOInvalid(t T) T {
 func TestParseISOComponents(t T) T {
     val result = ParseISO("2024-06-15T10:30:45Z")
     val instant = result.Get()
-    val t1 =Eq[int](t, instant.Year(), 2024)
-    val t2 =Eq[int](t1, instant.Month(), 6)
-    val t3 =Eq[int](t2, instant.Day(), 15)
-    val t4 =Eq[int](t3, instant.Hour(), 10)
-    val t5 =Eq[int](t4, instant.Minute(), 30)
-    return Eq[int](t5, instant.Second(), 45)
+    val t1 =Eq(t, instant.Year(), 2024)
+    val t2 =Eq(t1, instant.Month(), 6)
+    val t3 =Eq(t2, instant.Day(), 15)
+    val t4 =Eq(t3, instant.Hour(), 10)
+    val t5 =Eq(t4, instant.Minute(), 30)
+    return Eq(t5, instant.Second(), 45)
 }
 
 // Instant operations tests
@@ -209,27 +209,27 @@ func TestParseISOComponents(t T) T {
 func TestInstantPlus(t T) T {
     val i = FromUnixSeconds(1000)
     val result = i.Plus(Seconds(500))
-    return Eq[int64](t, result.UnixSeconds(), 1500)
+    return Eq(t, result.UnixSeconds(), 1500)
 }
 
 func TestInstantMinus(t T) T {
     val i = FromUnixSeconds(1000)
     val result = i.Minus(Seconds(500))
-    return Eq[int64](t, result.UnixSeconds(), 500)
+    return Eq(t, result.UnixSeconds(), 500)
 }
 
 func TestInstantUntil(t T) T {
     val i1 = FromUnixSeconds(1000)
     val i2 = FromUnixSeconds(1500)
     val d = i1.Until(i2)
-    return Eq[int64](t, d.ToSeconds(), 500)
+    return Eq(t, d.ToSeconds(), 500)
 }
 
 func TestInstantSince(t T) T {
     val i1 = FromUnixSeconds(1500)
     val i2 = FromUnixSeconds(1000)
     val d = i1.Since(i2)
-    return Eq[int64](t, d.ToSeconds(), 500)
+    return Eq(t, d.ToSeconds(), 500)
 }
 
 func TestInstantIsBefore(t T) T {
@@ -258,21 +258,21 @@ func TestInstantCompare(t T) T {
     val i1 = FromUnixSeconds(1000)
     val i2 = FromUnixSeconds(2000)
     val i3 = FromUnixSeconds(1000)
-    val t1 =Eq[int](t, i1.Compare(i2), -1)
-    val t2 =Eq[int](t1, i2.Compare(i1), 1)
-    return Eq[int](t2, i1.Compare(i3), 0)
+    val t1 =Eq(t, i1.Compare(i2), -1)
+    val t2 =Eq(t1, i2.Compare(i1), 1)
+    return Eq(t2, i1.Compare(i3), 0)
 }
 
 func TestInstantMin(t T) T {
     val i1 = FromUnixSeconds(1000)
     val i2 = FromUnixSeconds(2000)
-    return Eq[int64](t, i1.Min(i2).UnixSeconds(), 1000)
+    return Eq(t, i1.Min(i2).UnixSeconds(), 1000)
 }
 
 func TestInstantMax(t T) T {
     val i1 = FromUnixSeconds(1000)
     val i2 = FromUnixSeconds(2000)
-    return Eq[int64](t, i1.Max(i2).UnixSeconds(), 2000)
+    return Eq(t, i1.Max(i2).UnixSeconds(), 2000)
 }
 
 // Between tests
@@ -281,61 +281,61 @@ func TestBetween(t T) T {
     val start = FromUnixSeconds(1000)
     val end = FromUnixSeconds(1500)
     val d = Between(start, end)
-    return Eq[int64](t, d.ToSeconds(), 500)
+    return Eq(t, d.ToSeconds(), 500)
 }
 
 // Formatting tests
 
 func TestFormatISO(t T) T {
     val i = ParseISO("2024-01-15T10:30:00Z").Get()
-    return Eq[string](t, i.FormatISO(), "2024-01-15T10:30:00Z")
+    return Eq(t, i.FormatISO(), "2024-01-15T10:30:00Z")
 }
 
 func TestString(t T) T {
     val i = ParseISO("2024-01-15T10:30:00Z").Get()
-    return Eq[string](t, i.String(), "2024-01-15T10:30:00Z")
+    return Eq(t, i.String(), "2024-01-15T10:30:00Z")
 }
 
 // Date component tests
 
 func TestYear(t T) T {
     val i = ParseISO("2024-06-15T10:30:00Z").Get()
-    return Eq[int](t, i.Year(), 2024)
+    return Eq(t, i.Year(), 2024)
 }
 
 func TestMonth(t T) T {
     val i = ParseISO("2024-06-15T10:30:00Z").Get()
-    return Eq[int](t, i.Month(), 6)
+    return Eq(t, i.Month(), 6)
 }
 
 func TestDay(t T) T {
     val i = ParseISO("2024-06-15T10:30:00Z").Get()
-    return Eq[int](t, i.Day(), 15)
+    return Eq(t, i.Day(), 15)
 }
 
 func TestHour(t T) T {
     val i = ParseISO("2024-06-15T10:30:00Z").Get()
-    return Eq[int](t, i.Hour(), 10)
+    return Eq(t, i.Hour(), 10)
 }
 
 func TestMinute(t T) T {
     val i = ParseISO("2024-06-15T10:30:00Z").Get()
-    return Eq[int](t, i.Minute(), 30)
+    return Eq(t, i.Minute(), 30)
 }
 
 func TestSecond(t T) T {
     val i = ParseISO("2024-06-15T10:30:45Z").Get()
-    return Eq[int](t, i.Second(), 45)
+    return Eq(t, i.Second(), 45)
 }
 
 func TestWeekday(t T) T {
     val i = ParseISO("2024-06-15T10:30:00Z").Get()
-    return Eq[int](t, i.Weekday(), 6)
+    return Eq(t, i.Weekday(), 6)
 }
 
 func TestYearDay(t T) T {
     val i = ParseISO("2024-01-15T10:30:00Z").Get()
-    return Eq[int](t, i.YearDay(), 15)
+    return Eq(t, i.YearDay(), 15)
 }
 
 // Truncation tests
@@ -343,28 +343,28 @@ func TestYearDay(t T) T {
 func TestTruncateToSecond(t T) T {
     val i = ParseRFC3339Nano("2024-06-15T10:30:45.123456789Z").Get()
     val truncated = i.TruncateToSecond()
-    return Eq[int](t, truncated.Nanosecond(), 0)
+    return Eq(t, truncated.Nanosecond(), 0)
 }
 
 func TestTruncateToMinute(t T) T {
     val i = ParseISO("2024-06-15T10:30:45Z").Get()
     val truncated = i.TruncateToMinute()
-    return Eq[int](t, truncated.Second(), 0)
+    return Eq(t, truncated.Second(), 0)
 }
 
 func TestTruncateToHour(t T) T {
     val i = ParseISO("2024-06-15T10:30:45Z").Get()
     val truncated = i.TruncateToHour()
-    val t1 =Eq[int](t, truncated.Minute(), 0)
-    return Eq[int](t1, truncated.Second(), 0)
+    val t1 =Eq(t, truncated.Minute(), 0)
+    return Eq(t1, truncated.Second(), 0)
 }
 
 func TestTruncateToDay(t T) T {
     val i = ParseISO("2024-06-15T10:30:45Z").Get()
     val truncated = i.TruncateToDay()
-    val t1 =Eq[int](t, truncated.Hour(), 0)
-    val t2 =Eq[int](t1, truncated.Minute(), 0)
-    return Eq[int](t2, truncated.Second(), 0)
+    val t1 =Eq(t, truncated.Hour(), 0)
+    val t2 =Eq(t1, truncated.Minute(), 0)
+    return Eq(t2, truncated.Second(), 0)
 }
 
 // Now() test - just verify it returns something reasonable
@@ -386,30 +386,30 @@ func TestAfter(t T) T {
 
 func TestInstantComponentsExtractor(t T) T {
     val i = ParseISO("2024-06-15T10:30:45Z").Get()
-    val extractor InstantComponents = InstantComponents{}
+    val extractor = InstantComponents()
     val components = extractor.Unapply(i).Get()
-    val t1 =Eq[int](t, components.V1, 2024)
-    val t2 =Eq[int](t1, components.V2, 6)
-    val t3 =Eq[int](t2, components.V3, 15)
-    val t4 =Eq[int](t3, components.V4, 10)
-    val t5 =Eq[int](t4, components.V5, 30)
-    return Eq[int](t5, components.V6, 45)
+    val t1 =Eq(t, components.V1, 2024)
+    val t2 =Eq(t1, components.V2, 6)
+    val t3 =Eq(t2, components.V3, 15)
+    val t4 =Eq(t3, components.V4, 10)
+    val t5 =Eq(t4, components.V5, 30)
+    return Eq(t5, components.V6, 45)
 }
 
 func TestDateOnlyExtractor(t T) T {
     val i = ParseISO("2024-06-15T10:30:45Z").Get()
-    val extractor DateOnly = DateOnly{}
+    val extractor = DateOnly()
     val date = extractor.Unapply(i).Get()
-    val t1 =Eq[int](t, date.V1, 2024)
-    val t2 =Eq[int](t1, date.V2, 6)
-    return Eq[int](t2, date.V3, 15)
+    val t1 =Eq(t, date.V1, 2024)
+    val t2 =Eq(t1, date.V2, 6)
+    return Eq(t2, date.V3, 15)
 }
 
 func TestTimeOnlyExtractor(t T) T {
     val i = ParseISO("2024-06-15T10:30:45Z").Get()
-    val extractor TimeOnly = TimeOnly{}
+    val extractor = TimeOnly()
     val tm = extractor.Unapply(i).Get()
-    val t1 =Eq[int](t, tm.V1, 10)
-    val t2 =Eq[int](t1, tm.V2, 30)
-    return Eq[int](t2, tm.V3, 45)
+    val t1 =Eq(t, tm.V1, 10)
+    val t2 =Eq(t1, tm.V2, 30)
+    return Eq(t2, tm.V3, 45)
 }

--- a/yaml/helpers.gala
+++ b/yaml/helpers.gala
@@ -7,38 +7,29 @@ import (
 // KeyConfig holds field-level configuration for YAML serialization.
 // Mirror of json.KeyConfig.
 type KeyConfig struct {
-    var NamingStrategy Naming
-    var Renames        HashMap[string, string]
-    var Omits          HashMap[string, bool]
-    var OmitEmpties    HashMap[string, bool]
+    NamingStrategy Naming
+    Renames        HashMap[string, string]
+    Omits          HashMap[string, bool]
+    OmitEmpties    HashMap[string, bool]
 }
 
-func NewKeyConfig() KeyConfig = KeyConfig{
-    NamingStrategy: AsIs(),
-    Renames:        EmptyHashMap[string, string](),
-    Omits:          EmptyHashMap[string, bool](),
-    OmitEmpties:    EmptyHashMap[string, bool](),
-}
+func NewKeyConfig() KeyConfig = KeyConfig(
+    NamingStrategy = AsIs(),
+    Renames = EmptyHashMap[string, string](),
+    Omits = EmptyHashMap[string, bool](),
+    OmitEmpties = EmptyHashMap[string, bool](),
+)
 
-func (c KeyConfig) WithNaming(n Naming) KeyConfig {
-    c.NamingStrategy = n
-    return c
-}
+func (c KeyConfig) WithNaming(n Naming) KeyConfig = c.Copy(NamingStrategy = n)
 
-func (c KeyConfig) WithRename(field string, key string) KeyConfig {
-    c.Renames = c.Renames.Put(field, key)
-    return c
-}
+func (c KeyConfig) WithRename(field string, key string) KeyConfig =
+    c.Copy(Renames = c.Renames.Put(field, key))
 
-func (c KeyConfig) WithOmit(field string) KeyConfig {
-    c.Omits = c.Omits.Put(field, true)
-    return c
-}
+func (c KeyConfig) WithOmit(field string) KeyConfig =
+    c.Copy(Omits = c.Omits.Put(field, true))
 
-func (c KeyConfig) WithOmitEmpty(field string) KeyConfig {
-    c.OmitEmpties = c.OmitEmpties.Put(field, true)
-    return c
-}
+func (c KeyConfig) WithOmitEmpty(field string) KeyConfig =
+    c.Copy(OmitEmpties = c.OmitEmpties.Put(field, true))
 
 // KeysConfig holds the computed key arrays for WriteTo/ReadFrom.
 type KeysConfig struct {
@@ -57,13 +48,13 @@ func BuildKeys(numFields int, fieldName func(int) string, naming Naming, config 
             keys = keys.Append("")
         } else {
             val renamed = config.Renames.Get(name)
-            val key = if (renamed.IsDefined()) renamed.Get() else ApplyNaming(name, naming)
+            val key = renamed.GetOrElse(ApplyNaming(name, naming))
             keys = keys.Append(key)
             reverseKeys = reverseKeys.Put(key, name)
         }
         i = i + 1
     }
-    return KeysConfig{Keys: keys, ReverseKeys: reverseKeys}
+    return KeysConfig(Keys = keys, ReverseKeys = reverseKeys)
 }
 
 // BuildKeysSimple computes keys with a naming strategy and no overrides.

--- a/yaml/yaml.gala
+++ b/yaml/yaml.gala
@@ -41,11 +41,11 @@ type Codec[T any] struct {}
 // when the user calls Codec[T](naming).
 func (c Codec[T]) Apply(meta StructMeta[T], naming Naming) YamlEncoder[T] {
     val config = NewKeyConfig().WithNaming(naming)
-    return YamlEncoder[T]{
-        Meta:   meta,
-        Config: config,
-        Keys:   BuildKeysSimple(meta.NumFields(), meta.FieldName, naming),
-    }
+    return YamlEncoder[T](
+        Meta = meta,
+        Config = config,
+        Keys = BuildKeysSimple(meta.NumFields(), meta.FieldName, naming),
+    )
 }
 
 // YamlEncoder[T] is a fully typed YAML codec instance.
@@ -74,11 +74,11 @@ func (c YamlEncoder[T]) OmitEmpty(field string) YamlEncoder[T] =
     rebuildEncoder[T](c.Meta, c.Config.WithOmitEmpty(field))
 
 func rebuildEncoder[T any](meta StructMeta[T], config KeyConfig) YamlEncoder[T] =
-    YamlEncoder[T]{
-        Meta:   meta,
-        Config: config,
-        Keys:   BuildKeys(meta.NumFields(), meta.FieldName, config.NamingStrategy, config),
-    }
+    YamlEncoder[T](
+        Meta = meta,
+        Config = config,
+        Keys = BuildKeys(meta.NumFields(), meta.FieldName, config.NamingStrategy, config),
+    )
 
 func nameFnFromKeys(keys Array[string]) func(int) string =
     (i int) => keys.GetOption(i).GetOrElse("")
@@ -116,11 +116,7 @@ func (c YamlEncoder[T]) Decode(s string) Try[T] {
 
 // Unapply attempts to decode a YAML string using the codec's naming config.
 // Returns Option[T] for pattern matching support.
-func (c YamlEncoder[T]) Unapply(s string) Option[T] {
-    val decoded = c.Decode(s)
-    if decoded.IsFailure() { return None[T]() }
-    return Some[T](decoded.Get())
-}
+func (c YamlEncoder[T]) Unapply(s string) Option[T] = c.Decode(s).ToOption()
 
 // buildLookup turns the precomputed reverseKeys map (serialized key → GALA
 // field name) into the index-lookup function DecodeFields expects.
@@ -135,14 +131,6 @@ func buildLookup(
         nameToIdx = nameToIdx.Put(fieldName(i), i)
         i = i + 1
     }
-    return (key string) => {
-        val gName = reverseKeys.Get(key)
-        if gName.IsDefined() {
-            val idx = nameToIdx.Get(gName.Get())
-            if idx.IsDefined() {
-                return idx.Get()
-            }
-        }
-        return -1
-    }
+    return (key string) =>
+        reverseKeys.Get(key).FlatMap((gName) => nameToIdx.Get(gName)).GetOrElse(-1)
 }


### PR DESCRIPTION
## Summary

Applies the idioms enforced by the `gala-lint` skill across the runtime library and test framework — **behavior-preserving** cleanups, verified by the full test suite (356 tests pass).

## ⚠️ Note: includes a dropped #385 commit
This branch carries **one transpiler commit** in addition to the cleanup: `fix(transpiler): restore block-last-stmt flag after each function body`. That fix was part of #385 but its **squash merge dropped it** (master has only #385's first two fixes). It's required here because the JSON decoder's `Skip` is converted to a statement-position `match`. Happy to split it into its own PR if preferred.

## What changed (cleanup commit)
- **`var` → `val`** for bindings never reassigned (pervasive in tests). Genuine loop counters, fold accumulators, and stream cursors stay `var`.
- **`fmt.Sprintf`/`Println`/`Printf` → interpolation** (`s"…"` / `f"…%verb"`) and `Println`; `import "fmt"` dropped where unused (kept for `fmt.Errorf` etc.).
- **if-else on `Option`/`Either`/`Try` → `match`** / `.GetOrElse` / `.ToOption` / combinator delegation.
- **Statement-position side-effect dispatch → `match`** (e.g. the JSON decoder's `Skip`).
- **Redundant generic type args / lambda param types dropped** where the value, declared type, or method signature pins them.
- **mutate-and-return builders → `.Copy(...)`**; Go colon-literals on GALA structs → named-arg construction.

## gala-lint refinement
Refines the `None[T]() → None()` rule to flag removal **only when the context pins a concrete type**. An abstract type parameter of an enclosing generic function/method still requires explicit `None[T]()` — bare `None()` there is rejected with `GALA-E0018`.

## Deliberately retained explicit forms
Block-bodied `Try[X](() => {…})`, `None[T]()` under an abstract `T`, `Left`/`Right`/multi-type-param generics, and empty collections.

## Scope
Runtime library + test framework only. The 378 `examples/` fixtures were left untouched.

`bazel build //...`, `bazel test //...` (356 tests), gazelle — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)