### PR TITLE
feat(concurrent): make Future(...) the async constructor; drop FutureApply

### DIFF
--- a/.claude/skills/gala-lint/SKILL.md
+++ b/.claude/skills/gala-lint/SKILL.md
@@ -226,7 +226,7 @@ for k, v := range config {
 
 | Issue | Pattern to Flag | Recommended Fix |
 |-------|-----------------|-----------------|
-| Channel for single async result | `ch := make(chan T, 1); go func() { ch <- f() }(); <-ch` | `FutureApply(() => f())` then `.Await()` or `.Map()` |
+| Channel for single async result | `ch := make(chan T, 1); go func() { ch <- f() }(); <-ch` | `Future[T](() => f())` then `.Await()` or `.Map()` |
 | Channel for timeout | `select { case r := <-ch: ... case <-time.After(d): ... }` | `future.WithTimeout(d)` or `FirstCompletedOf` |
 | Channel for fan-out | Spawning goroutines writing to shared channel | `Future.Sequence(futures)` or `Future.Traverse(items, f)` |
 | WaitGroup for completion | `sync.WaitGroup` + goroutines | `Future.Sequence(ArrayOf(futures...))` |

--- a/.github/workflows/perf-real-build.yml
+++ b/.github/workflows/perf-real-build.yml
@@ -42,7 +42,10 @@ jobs:
     # build failures will reveal real semantic drift.
     #
     env:
-      GALA_TUI_REF: main
+      # Temporarily pinned to the gala-tui migration branch for the
+      # Future(...) constructor change (gala-tui#18). Revert to `main`
+      # once that PR merges (after this change ships in a gala release).
+      GALA_TUI_REF: feat/future-name-constructor
       GALA_TEAM_REF: master
       WARM_BUDGET_SECONDS: "500"
       COLD_BUDGET_SECONDS: "600"

--- a/.github/workflows/perf-real-build.yml
+++ b/.github/workflows/perf-real-build.yml
@@ -42,11 +42,11 @@ jobs:
     # build failures will reveal real semantic drift.
     #
     env:
-      # Temporarily pinned to the gala-tui migration branch for the
-      # Future(...) constructor change (gala-tui#18). Revert to `main`
-      # once that PR merges (after this change ships in a gala release).
+      # Temporarily pinned to the migration branches for the Future(...)
+      # constructor change (gala-tui#18, gala-team#130). Revert both to
+      # main/master once those PRs merge (after this ships in a gala release).
       GALA_TUI_REF: feat/future-name-constructor
-      GALA_TEAM_REF: master
+      GALA_TEAM_REF: feat/future-name-constructor
       WARM_BUDGET_SECONDS: "500"
       COLD_BUDGET_SECONDS: "600"
 

--- a/concurrent/future.gala
+++ b/concurrent/future.gala
@@ -29,55 +29,66 @@ type FutureState[T any] struct {
 // To create completable futures, use Promise[T].
 //
 // Each Future has an associated ExecutionContext that determines where callbacks
-// and derived futures execute. By default, futures use GlobalEC(). Use the
-// *With variants (FutureApplyWith, FutureOfWith, etc.) to specify a custom EC.
-type Future[T any] struct {
-    var state *FutureState[T]
+// and derived futures execute. By default, futures use GlobalEC(). To run on a
+// custom ExecutionContext, use FutureOn; FutureOf, FutureFailed, and NewPromise
+// accept an optional ec argument that defaults to GlobalEC().
+//
+// Future is modeled as a single-case sealed type so that the type name itself
+// is the asynchronous constructor:
+//
+//   val f = Future[int](() => expensiveComputation())
+//
+// runs the body on GlobalEC(); a panic in the body becomes a Failure. The
+// internal state is built through the private `fut` case constructor.
+sealed type Future[T any] {
+    case fut(state *FutureState[T])
 }
 
 // Promise is a writable, single-assignment container that completes a Future.
 // A Promise can be completed exactly once, either with a success value or a failure.
-type Promise[T any] struct {
-    var future Future[T]
-}
+//
+// Like Future, Promise is a value type (handle pattern): it wraps a Future whose
+// shared state lives behind a pointer, so it can be passed by value.
+struct Promise[T any](future Future[T])
 
-// NewPromise creates a new Promise and its associated Future using GlobalEC().
-func NewPromise[T any]() *Promise[T] {
-    return NewPromiseWith[T](go_interop.GlobalEC())
-}
-
-// NewPromiseWith creates a new Promise and its associated Future with a custom ExecutionContext.
-func NewPromiseWith[T any](ec go_interop.ExecutionContext) *Promise[T] {
-    val f = Future[T](
+// NewPromise creates a new Promise and its associated Future. The Future runs on
+// the given ExecutionContext; a nil ec (the default) means GlobalEC().
+//
+// The default is a bare nil rather than GlobalEC() so the injected default at
+// each call site carries no package qualifier — callers need not import the
+// ExecutionContext's defining package.
+func NewPromise[T any](ec go_interop.ExecutionContext = nil) Promise[T] {
+    val resolvedEc = if (ec == nil) go_interop.GlobalEC() else ec
+    val f = fut[T](
         state = &FutureState[T](
             done = go_interop.NewSignal(),
             once = go_interop.NewOnce(),
             mu = go_interop.NewRWMutex(),
             complete = false,
-            ec = ec
+            ec = resolvedEc
         )
     )
-    return &Promise[T](future = f)
+    return Promise[T](future = f)
 }
 
 // Future returns the Future associated with this Promise.
-func (p *Promise[T]) Future() Future[T] = p.future
+func (p Promise[T]) Future() Future[T] = p.future
 
 // Success completes the Promise with a successful value.
 // Returns true if the Promise was completed, false if already completed.
-func (p *Promise[T]) Success(value T) bool {
+func (p Promise[T]) Success(value T) bool {
     return p.Complete(Success[T](value))
 }
 
 // Failure completes the Promise with an error.
 // Returns true if the Promise was completed, false if already completed.
-func (p *Promise[T]) Failure(err error) bool {
+func (p Promise[T]) Failure(err error) bool {
     return p.Complete(Failure[T](err))
 }
 
 // Complete completes the Promise with a Try result.
 // Returns true if the Promise was completed, false if already completed.
-func (p *Promise[T]) Complete(result Try[T]) bool {
+func (p Promise[T]) Complete(result Try[T]) bool {
     return p.future.state.once.Do(() => {
         p.future.state.mu.Lock()
         p.future.state.result = result
@@ -88,55 +99,56 @@ func (p *Promise[T]) Complete(result Try[T]) bool {
 }
 
 // IsCompleted returns true if the Promise has been completed.
-func (p *Promise[T]) IsCompleted() bool {
+func (p Promise[T]) IsCompleted() bool {
     p.future.state.mu.RLock()
     val c = p.future.state.complete
     p.future.state.mu.RUnlock()
     return c
 }
 
-// FutureOf creates an already successfully completed Future with the given value using GlobalEC().
-func FutureOf[T any](value T) Future[T] {
-    return FutureOfWith[T](value, go_interop.GlobalEC())
-}
-
-// FutureOfWith creates an already successfully completed Future with a custom ExecutionContext.
-func FutureOfWith[T any](value T, ec go_interop.ExecutionContext) Future[T] {
-    val p = NewPromiseWith[T](ec)
+// FutureOf creates an already successfully completed Future with the given value.
+// It runs on the given ExecutionContext; a nil ec (the default) means GlobalEC().
+func FutureOf[T any](value T, ec go_interop.ExecutionContext = nil) Future[T] {
+    val p = NewPromise[T](ec)
     p.Success(value)
     return p.Future()
 }
 
-// FutureFailed creates an already failed Future with the given error using GlobalEC().
-func FutureFailed[T any](err error) Future[T] {
-    return FutureFailedWith[T](err, go_interop.GlobalEC())
-}
-
-// FutureFailedWith creates an already failed Future with a custom ExecutionContext.
-func FutureFailedWith[T any](err error, ec go_interop.ExecutionContext) Future[T] {
-    val p = NewPromiseWith[T](ec)
+// FutureFailed creates an already failed Future with the given error.
+// It runs on the given ExecutionContext; a nil ec (the default) means GlobalEC().
+func FutureFailed[T any](err error, ec go_interop.ExecutionContext = nil) Future[T] {
+    val p = NewPromise[T](ec)
     p.Failure(err)
     return p.Future()
 }
 
-// FutureApply creates a Future that will execute the given function asynchronously using GlobalEC().
-// If the function panics, the Future will be completed with a Failure.
-func FutureApply[T any](f func() T) Future[T] {
-    return FutureApplyWith[T](f, go_interop.GlobalEC())
-}
-
-// FutureApplyWith creates a Future that will execute the given function asynchronously
-// using the specified ExecutionContext. If the function panics, the Future will be
-// completed with a Failure.
-func FutureApplyWith[T any](f func() T, ec go_interop.ExecutionContext) Future[T] {
-    val p = NewPromiseWith[T](ec)
-    val onSuccess = () => { p.Success(f()) }
+// runAsync executes body on the given ExecutionContext, completing the returned
+// Future with the result. A panic in body becomes a Failure with the panic's
+// error (Try.Get panics with the original error, so a Try-returning body that
+// fails via .Get() preserves its error identity).
+func runAsync[T any](body func() T, ec go_interop.ExecutionContext) Future[T] {
+    val p = NewPromise[T](ec)
+    val onSuccess = () => { p.Success(body()) }
     val onPanic = (r any) => {
         p.Failure(go_interop.PanicToError(r))
     }
     ec.ExecuteWithRecover(onSuccess, onPanic)
     return p.Future()
 }
+
+// Apply runs body asynchronously on GlobalEC() and is the companion constructor
+// for the Future type, so a Future is created by calling the type itself:
+//
+//   val f = Future[int](() => expensiveComputation())
+//
+// The receiver is an unused dispatch placeholder. If body panics, the Future is
+// completed with a Failure.
+func (f Future[T]) Apply(body func() T) Future[T] = runAsync[T](body, go_interop.GlobalEC())
+
+// FutureOn runs body asynchronously on the given ExecutionContext. Use it when a
+// root computation needs a specific ExecutionContext; derived futures inherit it.
+// If body panics, the Future is completed with a Failure.
+func FutureOn[T any](body func() T, ec go_interop.ExecutionContext) Future[T] = runAsync[T](body, ec)
 
 // FutureError is a custom error type for Future-related errors.
 struct FutureError(Message string)
@@ -196,7 +208,7 @@ func (f Future[T]) AwaitFor(timeout Duration) Option[Try[T]] {
 // run in the background after a timeout fires. Make async work cancellable
 // (e.g., honor context.Context) if that matters.
 func (f Future[T]) WithTimeout(timeout Duration) Future[T] {
-    val p = NewPromiseWith[T](f.state.ec)
+    val p = NewPromise[T](f.state.ec)
     f.OnComplete((r Try[T]) => {
         p.Complete(r)
     })
@@ -258,7 +270,7 @@ func (f Future[T]) OnFailure(callback func(error)) {
 // If this Future fails, the resulting Future will also fail with the same error.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) Map[U any](fn func(T) U) Future[U] {
-    val p = NewPromiseWith[U](f.state.ec)
+    val p = NewPromise[U](f.state.ec)
     f.OnComplete((r Try[T]) => {
         p.Complete(r.Map[U](fn))
     })
@@ -269,7 +281,7 @@ func (f Future[T]) Map[U any](fn func(T) U) Future[U] {
 // that returns another Future. This allows chaining asynchronous operations.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) FlatMap[U any](fn func(T) Future[U]) Future[U] {
-    val p = NewPromiseWith[U](f.state.ec)
+    val p = NewPromise[U](f.state.ec)
     f.OnComplete((r Try[T]) => {
         r match {
             case Success(v) => fn(v).OnComplete((innerResult Try[U]) => {
@@ -286,7 +298,7 @@ func (f Future[T]) FlatMap[U any](fn func(T) Future[U]) Future[U] {
 // NoSuchElementError.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) Filter(predicate func(T) bool) Future[T] {
-    val p = NewPromiseWith[T](f.state.ec)
+    val p = NewPromise[T](f.state.ec)
     f.OnComplete((r Try[T]) => {
         p.Complete(r.Filter(predicate))
     })
@@ -298,7 +310,7 @@ func (f Future[T]) Filter(predicate func(T) bool) Future[T] {
 // to produce a successful value.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) Recover(pf func(error) T) Future[T] {
-    val p = NewPromiseWith[T](f.state.ec)
+    val p = NewPromise[T](f.state.ec)
     f.OnComplete((r Try[T]) => {
         p.Complete(r.Recover(pf))
     })
@@ -309,7 +321,7 @@ func (f Future[T]) Recover(pf func(error) T) Future[T] {
 // that returns another Future.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) RecoverWith(pf func(error) Future[T]) Future[T] {
-    val p = NewPromiseWith[T](f.state.ec)
+    val p = NewPromise[T](f.state.ec)
     f.OnComplete((r Try[T]) => {
         r match {
             case Success(v) => p.Success(v)
@@ -324,7 +336,7 @@ func (f Future[T]) RecoverWith(pf func(error) Future[T]) Future[T] {
 // Transform applies success or failure function based on the result.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) Transform[U any](s func(T) Try[U], fn func(error) Try[U]) Future[U] {
-    val p = NewPromiseWith[U](f.state.ec)
+    val p = NewPromise[U](f.state.ec)
     f.OnComplete((r Try[T]) => {
         r match {
             case Success(v) => p.Complete(s(v))
@@ -337,7 +349,7 @@ func (f Future[T]) Transform[U any](s func(T) Try[U], fn func(error) Try[U]) Fut
 // TransformWith applies success or failure function that returns a Future.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) TransformWith[U any](s func(T) Future[U], fn func(error) Future[U]) Future[U] {
-    val p = NewPromiseWith[U](f.state.ec)
+    val p = NewPromise[U](f.state.ec)
     f.OnComplete((r Try[T]) => {
         r match {
             case Success(v) => s(v).OnComplete((res Try[U]) => {
@@ -377,7 +389,7 @@ func (f Future[T]) Fallback(that Future[T]) Future[T] {
 // with the same result after the callback executes.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) AndThen(callback func(Try[T])) Future[T] {
-    val p = NewPromiseWith[T](f.state.ec)
+    val p = NewPromise[T](f.state.ec)
     f.OnComplete((r Try[T]) => {
         callback(r)
         p.Complete(r)

--- a/concurrent/future_test.gala
+++ b/concurrent/future_test.gala
@@ -22,8 +22,8 @@ func TestFutureFailed(t T) T {
     return Eq(t1, result.Err.Error(), "test error")
 }
 
-func TestFutureApply(t T) T {
-    val f = FutureApply(() => 1 + 1)
+func TestFutureConstructor(t T) T {
+    val f = Future[int](() => 1 + 1)
     val result = f.Await()
     val t1 = IsSuccess(t, result)
     return Eq(t1, result.Get(), 2)
@@ -322,27 +322,27 @@ func TestAndThen(t T) T {
 
 // === ExecutionContext Tests ===
 
-func TestFutureApplyWithCustomEC(t T) T {
+func TestFutureOnCustomEC(t T) T {
     val pool = NewFixedPoolEC(2)
-    val f = FutureApplyWith[int](() => 1 + 1, pool)
+    val f = FutureOn[int](() => 1 + 1, pool)
     val result = f.Await()
     pool.Shutdown()
     val t1 = IsSuccess(t, result)
     return Eq(t1, result.Get(), 2)
 }
 
-func TestFutureOfWithCustomEC(t T) T {
+func TestFutureOfCustomEC(t T) T {
     val pool = NewFixedPoolEC(2)
-    val f = FutureOfWith[int](42, pool)
+    val f = FutureOf[int](42, pool)
     val result = f.Await()
     pool.Shutdown()
     val t1 = IsSuccess(t, result)
     return Eq(t1, result.Get(), 42)
 }
 
-func TestFutureFailedWithCustomEC(t T) T {
+func TestFutureFailedCustomEC(t T) T {
     val pool = NewFixedPoolEC(2)
-    val f = FutureFailedWith[int](FutureError(Message = "test error"), pool)
+    val f = FutureFailed[int](FutureError(Message = "test error"), pool)
     val result = f.Await()
     pool.Shutdown()
     return IsFailure(t, result)
@@ -350,7 +350,7 @@ func TestFutureFailedWithCustomEC(t T) T {
 
 func TestPromiseWithCustomEC(t T) T {
     val pool = NewFixedPoolEC(2)
-    val p = NewPromiseWith[int](pool)
+    val p = NewPromise[int](pool)
     val f = p.Future()
     p.Success(42)
     val result = f.Await()
@@ -361,7 +361,7 @@ func TestPromiseWithCustomEC(t T) T {
 
 func TestECInheritanceThroughMap(t T) T {
     val pool = NewFixedPoolEC(2)
-    val f = FutureOfWith[int](10, pool)
+    val f = FutureOf[int](10, pool)
     val mapped = f.Map((x) => x * 2)
     val result = mapped.Await()
     pool.Shutdown()
@@ -371,7 +371,7 @@ func TestECInheritanceThroughMap(t T) T {
 
 func TestECInheritanceThroughFlatMap(t T) T {
     val pool = NewFixedPoolEC(2)
-    val f = FutureOfWith[int](5, pool)
+    val f = FutureOf[int](5, pool)
     val chained = f.FlatMap((x) => FutureOf(x * 3))
     val result = chained.Await()
     pool.Shutdown()
@@ -381,7 +381,7 @@ func TestECInheritanceThroughFlatMap(t T) T {
 
 func TestECInheritanceChain(t T) T {
     val pool = NewFixedPoolEC(2)
-    val f = FutureOfWith[int](2, pool)
+    val f = FutureOf[int](2, pool)
         .Map((x) => x + 3)
         .Map((x) => x * 2)
         .Filter((x) => x > 5)
@@ -394,8 +394,8 @@ func TestECInheritanceChain(t T) T {
 func TestSingleThreadEC(t T) T {
     val ec = NewSingleThreadEC()
 
-    val f1 = FutureApplyWith[int](() => 1 + 1, ec)
-    val f2 = FutureApplyWith[int](() => 2 + 2, ec)
+    val f1 = FutureOn[int](() => 1 + 1, ec)
+    val f2 = FutureOn[int](() => 2 + 2, ec)
 
     val r1 = f1.Await()
     val r2 = f2.Await()
@@ -409,7 +409,7 @@ func TestSingleThreadEC(t T) T {
 
 func TestECInheritanceWithRecover(t T) T {
     val pool = NewFixedPoolEC(2)
-    val f = FutureFailedWith[int](FutureError(Message = "error"), pool)
+    val f = FutureFailed[int](FutureError(Message = "error"), pool)
     val recovered = f.Recover((e) => 100)
     val result = recovered.Await()
     pool.Shutdown()
@@ -419,7 +419,7 @@ func TestECInheritanceWithRecover(t T) T {
 
 func TestECInheritanceWithTransform(t T) T {
     val pool = NewFixedPoolEC(2)
-    val f = FutureOfWith[int](5, pool)
+    val f = FutureOf[int](5, pool)
     val transformed = f.Transform[string](
         (v) => Success[string]("success"),
         (e) => Success[string]("recovered")
@@ -432,7 +432,7 @@ func TestECInheritanceWithTransform(t T) T {
 
 func TestECInheritanceWithZip(t T) T {
     val pool = NewFixedPoolEC(2)
-    val f1 = FutureOfWith[int](1, pool)
+    val f1 = FutureOf[int](1, pool)
     val f2 = FutureOf("hello")
     val zipped = f1.Zip(f2)
     val result = zipped.Await()
@@ -446,9 +446,9 @@ func TestECInheritanceWithZip(t T) T {
 func TestPoolShutdownGraceful(t T) T {
     val pool = NewFixedPoolEC(4)
 
-    val f1 = FutureApplyWith[int](() => 10 * 1, pool)
-    val f2 = FutureApplyWith[int](() => 10 * 2, pool)
-    val f3 = FutureApplyWith[int](() => 10 * 3, pool)
+    val f1 = FutureOn[int](() => 10 * 1, pool)
+    val f2 = FutureOn[int](() => 10 * 2, pool)
+    val f3 = FutureOn[int](() => 10 * 3, pool)
 
     val r1 = f1.Await()
     val r2 = f2.Await()

--- a/docs/CONCURRENT.MD
+++ b/docs/CONCURRENT.MD
@@ -26,7 +26,7 @@ val immediate = FutureOf[int](42)
 val failed = FutureFailed[int](SomeError("oops"))
 
 // Runs asynchronously
-val async = FutureApply[int](() => expensiveComputation())
+val async = Future[int](() => expensiveComputation())
 ```
 
 ### Blocking Operations
@@ -67,7 +67,7 @@ Two complementary primitives:
 - `WithTimeout(duration) Future[T]` — monadic; the returned Future fails with `TimeoutError` if the original doesn't complete in time, otherwise mirrors its result.
 
 ```gala
-val slow = FutureApply[int](() => { Sleep(Seconds(2)); 42 })
+val slow = Future[int](() => { Sleep(Seconds(2)); 42 })
 
 // Monadic: stays a Future, composes with Map/Recover/etc.
 val bounded = slow.WithTimeout(Milliseconds(500))
@@ -171,11 +171,11 @@ Each Future has an associated `ExecutionContext` that determines where callbacks
 
 ```gala
 // Default: uses GlobalEC (UnboundedExecutionContext)
-val f1 = FutureApply[int](() => compute())
+val f1 = Future[int](() => compute())
 
 // With custom ExecutionContext
 val pool = NewFixedPoolEC(4)  // Worker pool with 4 goroutines
-val f2 = FutureApplyWith[int](() => compute(), pool)
+val f2 = FutureOn[int](() => compute(), pool)
 
 // Derived futures inherit EC from parent
 val f3 = f2.Map((n) => s"$n")                             // uses pool
@@ -212,12 +212,16 @@ pool.Shutdown()
 
 ### Constructor Variants with Custom EC
 
-| Default | With EC |
-|---------|---------|
-| `FutureApply[T](f)` | `FutureApplyWith[T](f, ec)` |
-| `FutureOf[T](v)` | `FutureOfWith[T](v, ec)` |
-| `FutureFailed[T](e)` | `FutureFailedWith[T](e, ec)` |
-| `NewPromise[T]()` | `NewPromiseWith[T](ec)` |
+The async constructor `Future[T](() => body)` always runs on `GlobalEC()`; use
+`FutureOn` for a custom EC. The eager constructors and `NewPromise` take an
+optional trailing `ec` argument (default `GlobalEC()`).
+
+| Default EC (GlobalEC) | Custom EC |
+|-----------------------|-----------|
+| `Future[T](() => f)` | `FutureOn[T](() => f, ec)` |
+| `FutureOf[T](v)` | `FutureOf[T](v, ec)` |
+| `FutureFailed[T](e)` | `FutureFailed[T](e, ec)` |
+| `NewPromise[T]()` | `NewPromise[T](ec)` |
 
 ---
 

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -1500,26 +1500,28 @@ tuple wrapping. Access tuple fields via `.V1`, `.V2`, etc. Supported patterns:
 
 `Future[T]` represents an asynchronous computation that will eventually produce a value of type T or fail with an error. It provides a functional approach to concurrent programming, similar to Scala's Future monad.
 
-**Pointer type:** All Future factory functions return `*Future[T]` (a pointer), not `Future[T]`. This is because `Future` contains mutable shared state (mutex, channel, completion flag) that must be shared by reference — copying a Future would break its synchronization. Use `*Future[T]` in explicit type annotations (function signatures, struct fields):
+**Value type (handle pattern):** `Future[T]` is a value type — pass it by value, never as `*Future[T]`. Although a Future holds mutable shared state (mutex, signal, completion flag), that state lives behind a pointer wrapped inside the Future, so copying a Future copies the handle and preserves its identity and synchronization. Use `Future[T]` in explicit type annotations (function signatures, struct fields):
 
 ```gala
-// Function returning a Future — use *Future[T]
-func fetchUser(id int) *Future[User] = FutureApply[User](() => loadFromDB(id))
+// Function returning a Future — use Future[T]
+func fetchUser(id int) Future[User] = Future[User](() => loadFromDB(id))
 
-// Struct with a Future field — use *Future[T]
+// Struct with a Future field — use Future[T]
 type AsyncResult struct {
-    future *Future[string]
+    future Future[string]
 }
 ```
 
-With `val` and type inference, the pointer type is inferred automatically:
+The async constructor is the type name itself: `Future[T](() => body)` runs body
+asynchronously on `GlobalEC()`. With `val` and type inference, the type is
+inferred automatically:
 
 ```gala
 import . "martianoff/gala/concurrent"
 
-// Create Futures — type is inferred as *Future[T]
+// Create Futures — type is inferred as Future[T]
 val immediate = FutureOf[int](42)                    // Already completed with value
-val async = FutureApply[int](() => expensiveComputation())  // Runs asynchronously
+val async = Future[int](() => expensiveComputation())  // Runs asynchronously
 
 // Blocking operations
 val result = async.Await()           // Returns Try[int]

--- a/examples/doc_verify/concurrent_md.gala
+++ b/examples/doc_verify/concurrent_md.gala
@@ -16,6 +16,12 @@ func testCreatingFutures() {
     Println(s"Failed isCompleted=${failed.IsCompleted()}")
 }
 
+// Async constructor — the type name itself runs body asynchronously on GlobalEC().
+func testAsyncConstructor() {
+    val f = Future[int](() => 21 * 2)
+    Println(s"Async=${f.Get()}")
+}
+
 // Blocking Operations (line 32-36)
 func testBlockingOps() {
     val f = FutureOf[int](100)
@@ -86,6 +92,7 @@ func testPromise() {
 
 func main() {
     testCreatingFutures()
+    testAsyncConstructor()
     testBlockingOps()
     testMonadicOps()
     testErrorRecovery()

--- a/examples/doc_verify/concurrent_md.out
+++ b/examples/doc_verify/concurrent_md.out
@@ -1,5 +1,6 @@
 Immediate value=42
 Failed isCompleted=true
+Async=42
 Await=Success(100)
 Get=100
 GetOrElse=100

--- a/examples/either_match_in_lambda.gala
+++ b/examples/either_match_in_lambda.gala
@@ -13,8 +13,8 @@ func main() {
     }
     fmt.Println(r1)
 
-    // Either match inside FutureApply lambda (BUG-WP-1)
-    val future = FutureApply[string](() => {
+    // Either match inside Future(...) lambda (BUG-WP-1)
+    val future = Future[string](() => {
         val result Either[string, string] = Right[string, string]("ok")
         return result match {
             case Right(output) => output

--- a/examples/execution_context.gala
+++ b/examples/execution_context.gala
@@ -13,19 +13,19 @@ func main() {
 
     // Example 1: Default EC (uses GlobalEC, which is UnboundedExecutionContext)
     fmt.Println("\n--- Default ExecutionContext ---")
-    val f1 = FutureApply[int](() => 42)
+    val f1 = Future[int](() => 42)
     fmt.Println("Default EC result:", f1.Await().Get())
 
     // Example 2: Custom FixedPoolExecutionContext
     fmt.Println("\n--- FixedPool ExecutionContext ---")
     val pool = NewFixedPoolEC(4)
 
-    val f2 = FutureApplyWith[int](() => 50 * 2, pool)
+    val f2 = FutureOn[int](() => 50 * 2, pool)
     fmt.Println("Pool EC result:", f2.Await().Get())
 
     // Example 3: EC inheritance through Map/FlatMap chain
     fmt.Println("\n--- EC Inheritance Through Chain ---")
-    val f3 = FutureOfWith[int](10, pool)
+    val f3 = FutureOf[int](10, pool)
         .Map[int]((x int) => x * 2)
         .Map[int]((x int) => x + 5)
         .Filter((x int) => x > 10)
@@ -34,11 +34,11 @@ func main() {
     // Example 4: Multiple concurrent computations on pool
     fmt.Println("\n--- Concurrent Computations on Pool ---")
     val futures = ArrayOf[Future[int]](
-        FutureApplyWith[int](() => 0 * 0, pool),
-        FutureApplyWith[int](() => 1 * 1, pool),
-        FutureApplyWith[int](() => 2 * 2, pool),
-        FutureApplyWith[int](() => 3 * 3, pool),
-        FutureApplyWith[int](() => 4 * 4, pool)
+        FutureOn[int](() => 0 * 0, pool),
+        FutureOn[int](() => 1 * 1, pool),
+        FutureOn[int](() => 2 * 2, pool),
+        FutureOn[int](() => 3 * 3, pool),
+        FutureOn[int](() => 4 * 4, pool)
     )
     val results = Sequence[int](futures).Await().Get()
     fmt.Println("Concurrent results count:", results.Size())
@@ -48,22 +48,22 @@ func main() {
     val singleEC = NewSingleThreadEC()
 
     val seqFutures = ArrayOf[Future[int]](
-        FutureApplyWith[int](() => 0, singleEC),
-        FutureApplyWith[int](() => 1, singleEC),
-        FutureApplyWith[int](() => 2, singleEC)
+        FutureOn[int](() => 0, singleEC),
+        FutureOn[int](() => 1, singleEC),
+        FutureOn[int](() => 2, singleEC)
     )
     val order = Sequence[int](seqFutures).Await().Get()
     fmt.Println("Sequential order:", order.ToGoSlice())
 
     // Example 6: Error handling with custom EC
     fmt.Println("\n--- Error Handling with Custom EC ---")
-    val f4 = FutureFailedWith[int](FutureError(Message = "computation error"), pool)
+    val f4 = FutureFailed[int](FutureError(Message = "computation error"), pool)
     val recovered = f4.Recover((e error) => -1)
     fmt.Println("Recovered result:", recovered.Await().Get())
 
     // Example 7: Promise with custom EC
     fmt.Println("\n--- Promise with Custom EC ---")
-    val promise = NewPromiseWith[string](pool)
+    val promise = NewPromise[string](pool)
     val future = promise.Future()
 
     // Complete promise asynchronously

--- a/examples/extractor_type_inference.gala
+++ b/examples/extractor_type_inference.gala
@@ -64,7 +64,7 @@ func main() {
     }
     fmt.Println(msg4)
 
-    // Test 5: Future with inferred type parameter - T inferred from f2's type *Future[int]
+    // Test 5: Future with inferred type parameter - T inferred from f2's type Future[int]
     val f2 = FutureOf[int](200)
     val msg5 = f2 match {
         case Succeeded(v) => fmt.Sprintf("Inferred Succeeded: %d", v)

--- a/examples/future_get_type_chain.gala
+++ b/examples/future_get_type_chain.gala
@@ -8,7 +8,7 @@ import . "martianoff/gala/collection_immutable"
 // type namespace (Array_FoldLeft, not Future_FoldLeft).
 // This tests that Future[Array[int]].Get() resolves to Array[int].
 func main() {
-    val f = FutureApply[Array[int]](() => ArrayOf(1, 2, 3, 4, 5))
+    val f = Future[Array[int]](() => ArrayOf(1, 2, 3, 4, 5))
     val result = f.Get()
     val sum = result.FoldLeft[int](0, (acc int, v int) => acc + v)
     fmt.Println(sum)

--- a/examples/future_pattern_match.gala
+++ b/examples/future_pattern_match.gala
@@ -72,9 +72,9 @@ func main() {
     fmt.Println(classify(smallValueFuture))
 
     // Pattern matching on async computation results
-    fmt.Println("\n=== Pattern Matching on FutureApply ===")
+    fmt.Println("\n=== Pattern Matching on Future(...) ===")
 
-    val computeFuture = FutureApply[int](() => 21 * 2)
+    val computeFuture = Future[int](() => 21 * 2)
 
     val computeResult = computeFuture match {
         case Succeeded[int](v) => fmt.Sprintf("Computation result: %d", v)

--- a/examples/future_pattern_match.out
+++ b/examples/future_pattern_match.out
@@ -10,7 +10,7 @@ Completed with failure: something went wrong
 Large value: 100
 Small value: 5
 
-=== Pattern Matching on FutureApply ===
+=== Pattern Matching on Future(...) ===
 Computation result: 42
 
 === Pattern Matching on Sequence of Futures ===

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -93,6 +93,7 @@ go_test(
         "pointer_receiver_test.go",
         "qualified_namedarg_shadow_test.go",
         "recursive_immutable_test.go",
+        "sealed_apply_dispatch_test.go",
         "sealed_call_arg_widen_test.go",
         "sealed_equal_synth_test.go",
         "sealed_string_func_field_test.go",

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -874,10 +874,22 @@ func (t *galaASTTransformer) tryTransformCompanionApplyOrStructCtor(
 	// Update typeName to resolved name for subsequent lookups.
 	typeName = resolvedTypeMeta
 
+	methodMeta, hasApply := typeMeta.Methods["Apply"]
+
 	// Positional struct construction has priority over Apply: when arg count
 	// equals field count, emit a struct literal directly.
+	//
+	// Exception: a sealed type's parent layout is synthetic (merged variant
+	// fields plus a `_variant` discriminator) and is never a valid positional
+	// construction target — callers construct sealed values through case
+	// constructors or the companion Apply. Without this guard, calling a sealed
+	// type that has an Apply method with an arg count that happens to equal the
+	// synthetic field count (e.g. `Future[T](() => x, ec)` where the parent has
+	// `state` + `_variant`) silently miscompiles into a wrong struct literal
+	// instead of dispatching to Apply.
 	resolvedTypeName := t.resolveStructTypeName(typeName)
-	if fields, structOk := t.structFields[resolvedTypeName]; structOk && len(args) > 0 && len(args) == len(fields) {
+	sealedWithApply := typeMeta.IsSealed && hasApply
+	if fields, structOk := t.structFields[resolvedTypeName]; structOk && len(args) > 0 && len(args) == len(fields) && !sealedWithApply {
 		// Infer type args from positional arg types when the call site omitted
 		// them. Without this, a generic struct like `Tuple(a, b)` emits
 		// `Tuple{V1: a, V2: b}` — Go rejects the bare generic type.
@@ -885,7 +897,6 @@ func (t *galaASTTransformer) tryTransformCompanionApplyOrStructCtor(
 		return true, t.buildStructLiteral(typedFun, resolvedTypeName, fields, args, false), nil
 	}
 
-	methodMeta, hasApply := typeMeta.Methods["Apply"]
 	if !hasApply {
 		// No Apply method. Still emit a struct literal if this is a known
 		// struct layout — callers may supply a subset of fields.

--- a/internal/transpiler/transformer/sealed_apply_dispatch_test.go
+++ b/internal/transpiler/transformer/sealed_apply_dispatch_test.go
@@ -1,0 +1,58 @@
+package transformer_test
+
+import (
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A sealed type's parent layout is synthetic (merged variant fields plus the
+// `_variant` discriminator). A call on the type name with an arg count that
+// happens to equal that synthetic field count must still dispatch to the
+// companion Apply method, never miscompile into a positional struct literal.
+func TestSealedTypeCompanionApplyDispatch(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	// `Box` is sealed with a single case carrying one field, so the synthetic
+	// parent struct has two fields: `value` + `_variant`. A two-argument call
+	// `Box[int](() => 7, "tag")` has arg count 2 == field count 2, which used to
+	// collide with positional struct construction.
+	input := `package main
+
+import . "martianoff/gala/std"
+
+sealed type Box[T any] {
+    case box(value T)
+}
+
+func (b Box[T]) Apply(body func() T, tag string) Box[T] = box(value = body())
+func (b Box[T]) Value() T = b.value
+
+func main() {
+    val b = Box[int](() => 7, "tag")
+    Println(b.Value())
+}`
+
+	out, err := trans.Transpile(input, "")
+	require.NoError(t, err)
+
+	idx := strings.Index(out, "func main()")
+	require.GreaterOrEqual(t, idx, 0)
+	mainBody := out[idx:]
+
+	// Must dispatch to Apply with both arguments preserved.
+	assert.Contains(t, mainBody, "Box[int]{}.Apply(", "two-arg call should dispatch to companion Apply")
+	assert.Contains(t, mainBody, `"tag"`, "the second argument must be preserved")
+	// Must NOT misroute the body thunk into the `value` field via a struct literal.
+	assert.NotContains(t, mainBody, "Box[int]{value:", "must not emit a positional struct literal")
+}

--- a/std/try.gala
+++ b/std/try.gala
@@ -24,9 +24,12 @@ func (t Try[T]) IsFailure() bool = t.isFailure()
 func (t Try[T]) Apply(f func() T) Try[T] = tryRecover[T](f)
 
 // Get returns the value if this is a Success, otherwise panics.
+// On Failure it panics with the original error value (not a string), so a
+// surrounding recover (e.g. a Future's panic capture) can recover the typed
+// error unchanged rather than a wrapped message.
 func (t Try[T]) Get() T {
     if t.isFailure() {
-        panic("Try.Get on Failure: " + t.Err.Error())
+        panic(t.Err)
     }
     return t.Value
 }

--- a/website/docs/language-reference.md
+++ b/website/docs/language-reference.md
@@ -443,7 +443,7 @@ val msg = result match {
 ```gala
 import . "martianoff/gala/concurrent"
 
-val async = FutureApply[int](() => expensiveComputation())
+val async = Future[int](() => expensiveComputation())
 val result = async.Await()           // Returns Try[int]
 val doubled = async.Map((v) => v * 2)
 ```

--- a/website/features/concurrency.md
+++ b/website/features/concurrency.md
@@ -17,8 +17,8 @@ Every Future runs on an `ExecutionContext` that controls goroutine scheduling. T
 ```gala
 import . "martianoff/gala/concurrent"
 
-val f1 = FutureApply[int](() => expensiveComputation())
-val f2 = FutureApply[string](() => fetchName())
+val f1 = Future[int](() => expensiveComputation())
+val f2 = Future[string](() => fetchName())
 
 val combined = f1.Zip(f2)
     .Map((pair) => s"Result: ${pair.V1} from ${pair.V2}")
@@ -36,7 +36,7 @@ Println(combined.Get())
 import . "martianoff/gala/concurrent"
 
 // Run a computation asynchronously in a goroutine
-val async = FutureApply[int](() => expensiveComputation())
+val async = Future[int](() => expensiveComputation())
 
 // Already completed with a known value
 val immediate = FutureOf[int](42)
@@ -54,13 +54,13 @@ val failed = FutureFailed[int](SomeError("oops"))
 `Map` transforms a successful result. `FlatMap` chains a function that returns another Future. Both propagate errors automatically:
 
 ```gala
-val userId = FutureApply[int](() => lookupUserId("alice"))
+val userId = Future[int](() => lookupUserId("alice"))
 
 // Map: transform the result
 val greeting = userId.Map((id) => s"User #$id")
 
 // FlatMap: chain another async operation
-val profile = userId.FlatMap((id) => FutureApply[string](() => fetchProfile(id)))
+val profile = userId.FlatMap((id) => Future[string](() => fetchProfile(id)))
 ```
 
 If the original Future fails, Map and FlatMap short-circuit — the error propagates through the chain without executing the transform function.
@@ -72,8 +72,8 @@ If the original Future fails, Map and FlatMap short-circuit — the error propag
 `Zip` runs two Futures concurrently and combines their results into a Tuple when both complete:
 
 ```gala
-val f1 = FutureApply[int](() => fetchCount())
-val f2 = FutureApply[string](() => fetchLabel())
+val f1 = Future[int](() => fetchCount())
+val f2 = Future[string](() => fetchLabel())
 
 val combined = f1.Zip(f2)  // Future[Tuple[int, string]]
 val pair = combined.Get()
@@ -93,13 +93,13 @@ val total = f1.ZipWith(f2, (count, label) => s"$label = $count")
 `Recover` provides a fallback value when a Future fails. `RecoverWith` provides a fallback Future:
 
 ```gala
-val risky = FutureApply[int](() => riskyOperation())
+val risky = Future[int](() => riskyOperation())
 
 // Recover with a default value
 val safe = risky.Recover((e) => 0)
 
 // Recover with another Future
-val retried = risky.RecoverWith((e) => FutureApply[int](() => fallbackOperation()))
+val retried = risky.RecoverWith((e) => Future[int](() => fallbackOperation()))
 
 // Fallback: use another Future if this one fails
 val withFallback = risky.Fallback(FutureOf[int](0))
@@ -112,7 +112,7 @@ val withFallback = risky.Fallback(FutureOf[int](0))
 Block the current goroutine until a Future completes:
 
 ```gala
-val f = FutureApply[int](() => compute())
+val f = Future[int](() => compute())
 
 // Block indefinitely, get Try[T]
 val result = f.Await()           // Try[int]
@@ -131,7 +131,7 @@ val safe = f.GetOrElse(0)       // int — returns 0 on failure
 Register callbacks that fire when a Future completes, without blocking:
 
 ```gala
-val f = FutureApply[int](() => compute())
+val f = Future[int](() => compute())
 
 f.OnSuccess((v) => Println(s"Got: $v"))
 f.OnFailure((e) => Println(s"Error: $e"))
@@ -219,7 +219,7 @@ import . "martianoff/gala/concurrent"
 val pool = NewFixedPoolEC(4)
 
 // Run futures on the pool
-val f1 = FutureApplyWith[int](() => compute(), pool)
+val f1 = FutureOn[int](() => compute(), pool)
 
 // Derived futures inherit the parent's EC
 val f2 = f1.Map((n) => s"$n")          // also runs on pool
@@ -280,9 +280,9 @@ import . "martianoff/gala/concurrent"
 
 func main() {
     // Launch three independent async operations
-    val userF    = FutureApply[string](() => fetchUser())
-    val ordersF  = FutureApply[int](() => fetchOrderCount())
-    val balanceF = FutureApply[float64](() => fetchBalance())
+    val userF    = Future[string](() => fetchUser())
+    val ordersF  = Future[int](() => fetchOrderCount())
+    val balanceF = Future[float64](() => fetchBalance())
 
     // Combine user and orders in parallel
     val summary = userF.ZipWith(ordersF, (user, orders) =>


### PR DESCRIPTION
## Summary

Redesigns the `concurrent` Future/Promise API so the **type name itself** is the async constructor, replacing the awkwardly-named `FutureApply`.

```gala
val f = Future[int](() => expensiveComputation())   // was FutureApply[int](...)
```

### API changes (breaking)

| Before | After |
|---|---|
| `FutureApply[T](f)` | `Future[T](() => f)` |
| `FutureApplyWith[T](f, ec)` | `FutureOn[T](() => f, ec)` |
| `FutureOfWith[T](v, ec)` | `FutureOf[T](v, ec)` |
| `FutureFailedWith[T](e, ec)` | `FutureFailed[T](e, ec)` |
| `NewPromiseWith[T](ec)` | `NewPromise[T](ec)` |

Eight names collapse to four. `Future` is now a **single-case sealed type** whose companion `Apply` runs the body on `GlobalEC()` (same mechanism as `Try[int](() => ...)`); `Promise` is now a **value type**, consistent with Future's handle pattern. The `*With` variants fold into an optional trailing `ec` argument.

### No `AsyncTry` — fixed at the source instead

A Try-returning async constructor seemed necessary only because `Try.Get` panicked with a *string*, destroying error identity across the async boundary. Fixed `std/try.gala` to `panic(t.Err)` (the original error value), so `Future[T](() => myTry.Get())` preserves the typed error through panic-capture and no second constructor is needed.

### Transpiler fix (CLAUDE.md rule 6)

A call on a sealed type that has a companion `Apply` method silently miscompiled into a wrong positional struct literal when the argument count happened to equal the synthetic parent field count (`field` + `_variant`). Now sealed-type companion `Apply` always wins. Adds `sealed_apply_dispatch_test.go` as a repro.

### Docs

Corrected stale `docs/GALA.MD` prose claiming Future returns `*Future[T]` (a pointer) — Future is a value type (handle pattern). Updated `CONCURRENT.MD`, website concurrency/language-reference pages, the gala-lint skill table, and the `concurrent_md` doc-verify example (now covers the async constructor).

## Test plan

- `bazel build //...` ✅
- `bazel test //...` ✅ **356/356**
- `examples/{execution_context,future_pattern_match,doc_verify/concurrent_md}` recompile and match their `.out` files
- New `sealed_apply_dispatch_test.go` covers the transpiler dispatch fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)