### PR TITLE
chore(release): bump version files to 0.60.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ module(
     # release-script tag and gala.mod so `bazel_dep(name = "gala",
     # version = X)` always matches the published binary the registry
     # serves for that version.
-    version = "0.56.1",
+    version = "0.60.0",
 )
 
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/gala.mod
+++ b/gala.mod
@@ -1,3 +1,3 @@
 module martianoff/gala
 
-gala 0.56.1
+gala 0.60.0


### PR DESCRIPTION
Bumps `gala.mod` and `MODULE.bazel` to **0.60.0** ahead of cutting the 0.60.0 release.

This release ships the breaking `concurrent` Future API redesign (#387): `FutureApply` → `Future[T](() => ...)`, `*With` variants folded into defaulted `ec` params, `Promise` as a value type, and `Try.Get` preserving error identity.

After merge: tag/release `0.60.0` (triggers the binary + IntelliJ plugin build) and add the `gala@0.60.0` entry to the rules-gala registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)