### PR TITLE
ci(perf-real-build): unpin canary refs back to main/master

### DIFF
--- a/.github/workflows/perf-real-build.yml
+++ b/.github/workflows/perf-real-build.yml
@@ -42,11 +42,8 @@ jobs:
     # build failures will reveal real semantic drift.
     #
     env:
-      # Temporarily pinned to the migration branches for the Future(...)
-      # constructor change (gala-tui#18, gala-team#130). Revert both to
-      # main/master once those PRs merge (after this ships in a gala release).
-      GALA_TUI_REF: feat/future-name-constructor
-      GALA_TEAM_REF: feat/future-name-constructor
+      GALA_TUI_REF: main
+      GALA_TEAM_REF: master
       WARM_BUDGET_SECONDS: "500"
       COLD_BUDGET_SECONDS: "600"
 


### PR DESCRIPTION
gala-tui#18 and gala-team#130 are merged; their default branches carry the Future(...) migration. Reverts the temporary canary ref pins added during the breaking-change rollout.