### PR TITLE
fix(release): bump version files to 0.61.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ module(
     # release-script tag and gala.mod so `bazel_dep(name = "gala",
     # version = X)` always matches the published binary the registry
     # serves for that version.
-    version = "0.60.0",
+    version = "0.61.0",
 )
 
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/gala.mod
+++ b/gala.mod
@@ -1,3 +1,3 @@
 module martianoff/gala
 
-gala 0.60.0
+gala 0.61.0


### PR DESCRIPTION
Mechanical release-prep bump of gala.mod and MODULE.bazel to 0.61.0. Tag follows.