### PR TITLE
bind/also monadic binding — (3/N) sequential bind → FlatMap

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -103,6 +103,18 @@ gala_exec_test(
 )
 
 gala_exec_test(
+    name = "bind_notation",
+    src = "bind_notation.gala",
+    expected = "bind_notation.out",
+)
+
+gala_exec_test(
+    name = "bind_notation_user",
+    src = "bind_notation_user.gala",
+    expected = "bind_notation_user.out",
+)
+
+gala_exec_test(
     name = "bind_notation_desugared",
     src = "bind_notation_desugared.gala",
     expected = "bind_notation_desugared.out",

--- a/examples/bind_notation.gala
+++ b/examples/bind_notation.gala
@@ -1,0 +1,41 @@
+package main
+
+// Real `bind` monadic do-notation over std Try. This transpiles to the FlatMap
+// chain in bind_notation_desugared.gala (kept as a hand-written golden). See
+// docs/BIND_NOTATION.MD.
+//
+// `bind name = e` unwraps a Try, binds the success value, and short-circuits the
+// whole block on the first Failure. Every binding stays in scope — note `o` is
+// reused on the final line, the "graph" case a linear FlatMap/pipe cannot express.
+
+struct Order(Id int, Amount int)
+struct Receipt(OrderId int, Charged int)
+
+func fetchOrder(id int) Try[Order] =
+    if (id > 0) Success(Order(id, 100))
+    else Failure[Order](NoSuchElementError(Message = s"no order $id"))
+
+func validateOrder(o Order) Try[Order] =
+    if (o.Amount > 0) Success(o)
+    else Failure[Order](NoSuchElementError(Message = "invalid amount"))
+
+func chargePayment(o Order) Try[int] =
+    if (o.Amount <= 1000) Success(o.Amount)
+    else Failure[int](NoSuchElementError(Message = "amount too large"))
+
+func processOrder(id int) Try[Receipt] {
+    bind o = fetchOrder(id)
+    bind valid = validateOrder(o)
+    bind payment = chargePayment(valid)
+    Success(Receipt(o.Id, payment))
+}
+
+func describe(t Try[Receipt]) string = t match {
+    case Success(r) => s"ok: order=${r.OrderId} charged=${r.Charged}"
+    case Failure(e) => s"err: ${e.Error()}"
+}
+
+func main() {
+    Println(describe(processOrder(1)))   // happy path, all binds succeed
+    Println(describe(processOrder(0)))   // breaks at the first bind, short-circuits
+}

--- a/examples/bind_notation.out
+++ b/examples/bind_notation.out
@@ -1,0 +1,2 @@
+ok: order=1 charged=100
+err: no order 0

--- a/examples/bind_notation_user.gala
+++ b/examples/bind_notation_user.gala
@@ -1,0 +1,39 @@
+package main
+
+// Extensibility, proven with the real `bind` feature: `bind` works over a
+// user-defined monad exactly as over std. `Step` has no relationship to std and
+// provides only the minimal contract (a `FlatMap` method); `bind` desugars to
+// `Step_FlatMap` with no package qualifier and no transpiler special-casing.
+// See docs/BIND_NOTATION.MD section 7. Compare bind_notation_user_monad.gala,
+// the hand-written desugaring this transpiles to.
+
+sealed type Step[T any] {
+    case Go(Value T)
+    case Stop(Reason string)
+}
+
+// The only method `bind` requires: FlatMap. The short-circuit lives inside it.
+func (s Step[T]) FlatMap[U any](f func(T) Step[U]) Step[U] = s match {
+    case Go(v)   => f(v)
+    case Stop(r) => Stop[U](r)
+}
+
+func start(n int) Step[int] = if (n > 0) Go(n) else Stop[int](s"non-positive: $n")
+func twice(n int) Step[int] = if (n < 100) Go(n * 2) else Stop[int]("too big")
+
+func pipeline(n int) Step[int] {
+    bind a = start(n)
+    bind b = twice(a)
+    Go(a + b)              // `a` still in scope; a Stop anywhere short-circuits
+}
+
+func describe(s Step[int]) string = s match {
+    case Go(v)   => s"go: $v"
+    case Stop(r) => s"stop: $r"
+}
+
+func main() {
+    Println(describe(pipeline(5)))    // 5 -> 10 -> 5+10
+    Println(describe(pipeline(0)))    // short-circuits at start
+    Println(describe(pipeline(200)))  // short-circuits at twice
+}

--- a/examples/bind_notation_user.out
+++ b/examples/bind_notation_user.out
@@ -1,0 +1,3 @@
+go: 15
+stop: non-positive: 0
+stop: too big

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "transformer",
     srcs = [
+        "bind.go",
         "bridge.go",
         "call_context.go",
         "calls.go",
@@ -49,6 +50,7 @@ go_test(
         "assignment_test.go",
         "auto_method_override_test.go",
         "bare_funcref_test.go",
+        "bind_test.go",
         "chained_flatmap_test.go",
         "codec_boundary_test.go",
         "collect_partial_function_test.go",

--- a/internal/transpiler/transformer/bind.go
+++ b/internal/transpiler/transformer/bind.go
@@ -1,0 +1,220 @@
+package transformer
+
+import (
+	"go/ast"
+	"strings"
+
+	"martianoff/gala/internal/parser/grammar"
+	"martianoff/gala/internal/transpiler"
+)
+
+// bind.go implements the `bind` monadic do-notation.
+//
+// A block that contains `bind name = e` statements is lowered to a chain of
+// FlatMap calls, so that
+//
+//	bind o = fetchOrder(id)
+//	bind p = charge(o)
+//	Success(Receipt(o, p))
+//
+// becomes
+//
+//	M_FlatMap[R, A](fetchOrder(id), func(o A) M[R] {
+//	    return M_FlatMap[R, B](charge(o), func(p B) M[R] {
+//	        return Success(Receipt(o, p))
+//	    })
+//	})
+//
+// where M is the block's monad (Try/Option/Either/Future or any user type with a
+// FlatMap method) and M[R] is the enclosing function's return type. The lowering
+// is structural: no type is special-cased, so a user-defined monad works exactly
+// like std's. See docs/BIND_NOTATION.MD.
+
+// bindDeclFromStatement returns the BindDeclaration context if the statement is a
+// `bind name = expr`, else nil.
+func bindDeclFromStatement(stmtCtx grammar.IStatementContext) grammar.IBindDeclarationContext {
+	sc, ok := stmtCtx.(*grammar.StatementContext)
+	if !ok || sc == nil {
+		return nil
+	}
+	dc, ok := sc.Declaration().(*grammar.DeclarationContext)
+	if !ok || dc == nil {
+		return nil
+	}
+	if bd := dc.BindDeclaration(); bd != nil {
+		return bd
+	}
+	return nil
+}
+
+// alsoDeclFromStatement returns the AlsoDeclaration context if the statement is an
+// `also name = expr`, else nil.
+func alsoDeclFromStatement(stmtCtx grammar.IStatementContext) grammar.IAlsoDeclarationContext {
+	sc, ok := stmtCtx.(*grammar.StatementContext)
+	if !ok || sc == nil {
+		return nil
+	}
+	dc, ok := sc.Declaration().(*grammar.DeclarationContext)
+	if !ok || dc == nil {
+		return nil
+	}
+	if ad := dc.AlsoDeclaration(); ad != nil {
+		return ad
+	}
+	return nil
+}
+
+// trailingBindValueExpr extracts the value expression from a block's trailing
+// statement (e.g. `Success(...)`), or nil if the statement is not a bare
+// expression.
+func trailingBindValueExpr(stmtCtx grammar.IStatementContext) grammar.IExpressionContext {
+	sc, ok := stmtCtx.(*grammar.StatementContext)
+	if !ok || sc == nil {
+		return nil
+	}
+	dc, ok := sc.Declaration().(*grammar.DeclarationContext)
+	if !ok || dc == nil {
+		return nil
+	}
+	ss, ok := dc.SimpleStatement().(*grammar.SimpleStatementContext)
+	if !ok || ss == nil {
+		return nil
+	}
+	return ss.Expression()
+}
+
+// desugarBindChain lowers a run of statements beginning with a `bind` into a
+// FlatMap call expression of type resultType (the enclosing monad M[R]).
+func (t *galaASTTransformer) desugarBindChain(stmts []grammar.IStatementContext, resultType transpiler.Type) (ast.Expr, error) {
+	bindCtx := bindDeclFromStatement(stmts[0])
+	name := bindCtx.Identifier().GetText()
+
+	// Transform the bound expression e : M[A].
+	recvExpr, err := t.transformExpression(bindCtx.Expression())
+	if err != nil {
+		return nil, err
+	}
+	recvType, lookupBaseName := t.resolveReceiverTypeAndLookupKey(recvExpr)
+	// Normalize a current-package-qualified key (e.g. `main.Box`) to its bare
+	// form (`Box`) so metadata lookup and the emitted `Box_FlatMap` name match.
+	// std keys keep their `std.` prefix; imported packages keep theirs.
+	lookupBaseName = strings.TrimPrefix(lookupBaseName, t.packageName+".")
+
+	// Structural bindability check: M must expose a FlatMap method. No type is
+	// special-cased — std and user monads resolve through the same metadata.
+	typeMeta, _ := t.getTypeMetaResolved(lookupBaseName)
+	if typeMeta == nil || typeMeta.Methods["FlatMap"] == nil {
+		return nil, t.semanticErrorAt(bindCtx, "cannot `bind`: type "+recvType.String()+" has no FlatMap method (not a bindable monad)")
+	}
+
+	// The bound value's element type A. An explicit annotation on the bind wins.
+	elemType := t.monadElemType(recvType)
+	if bindCtx.Type_() != nil {
+		te, terr := t.transformType(bindCtx.Type_())
+		if terr != nil {
+			return nil, terr
+		}
+		elemType = t.astTypeToTranspilerType(te)
+	}
+
+	// Same-monad requirement for sequential bind: the bound expression's monad
+	// must match the block's monad. (Heterogeneous lift is a separate feature.)
+	// Compare normalized (local-package-stripped) base names on both sides.
+	resultBase := strings.TrimPrefix(resultType.BaseName(), t.packageName+".")
+	if !resultType.IsNil() && lookupBaseName != resultBase {
+		return nil, t.semanticErrorAt(bindCtx, "cannot `bind` a "+lookupBaseName+" inside a "+resultBase+" block (heterogeneous bind is not supported)")
+	}
+
+	// Register the bound name for the continuation. It is registered like a
+	// function parameter (raw, un-wrapped) rather than a `val` (Immutable-wrapped)
+	// because the value it names is the FlatMap callback's raw parameter, so reads
+	// must not emit `.Get()`.
+	t.addVar(name, elemType)
+	body, err := t.buildBindBody(stmts[1:], resultType)
+	if err != nil {
+		return nil, err
+	}
+
+	lambda := &ast.FuncLit{
+		Type: &ast.FuncType{
+			Params: &ast.FieldList{List: []*ast.Field{{
+				Names: []*ast.Ident{ast.NewIdent(name)},
+				Type:  t.typeToExpr(elemType),
+			}}},
+			Results: &ast.FieldList{List: []*ast.Field{{Type: t.typeToExpr(resultType)}}},
+		},
+		Body: body,
+	}
+
+	// Method-level type arg U = R (the result element). The receiver element T
+	// is appended by emitGenericMethodFreeFunc from recvType's own type args.
+	var methodTypeArgs []ast.Expr
+	if rElem := t.monadElemType(resultType); !rElem.IsNil() {
+		methodTypeArgs = []ast.Expr{t.typeToExpr(rElem)}
+	}
+
+	return t.emitGenericMethodFreeFunc("FlatMap", recvExpr, recvType, lookupBaseName, methodTypeArgs, nil, []ast.Expr{lambda}, false), nil
+}
+
+// buildBindBody builds the body block of a bind continuation lambda from the
+// statements following a `bind`. Regular statements are emitted as-is; a nested
+// `bind` recurses; the trailing statement becomes `return <value>`.
+func (t *galaASTTransformer) buildBindBody(stmts []grammar.IStatementContext, resultType transpiler.Type) (*ast.BlockStmt, error) {
+	body := &ast.BlockStmt{}
+	for i, s := range stmts {
+		if alsoDeclFromStatement(s) != nil {
+			return nil, t.semanticErrorAt(s.(*grammar.StatementContext), "`also` (applicative bind) is not yet implemented")
+		}
+		if bindDeclFromStatement(s) != nil {
+			expr, err := t.desugarBindChain(stmts[i:], resultType)
+			if err != nil {
+				return nil, err
+			}
+			body.List = append(body.List, &ast.ReturnStmt{Results: []ast.Expr{expr}})
+			return body, nil
+		}
+		if i == len(stmts)-1 {
+			expr, err := t.transformTrailingBindValue(s, resultType)
+			if err != nil {
+				return nil, err
+			}
+			body.List = append(body.List, &ast.ReturnStmt{Results: []ast.Expr{expr}})
+			return body, nil
+		}
+		stmt, err := t.transformStatement(s.(*grammar.StatementContext))
+		if err != nil {
+			return nil, err
+		}
+		body.List = append(body.List, stmt)
+	}
+	return body, nil
+}
+
+// transformTrailingBindValue transforms the block's trailing value expression
+// (the monad's result) with resultType pushed as the expected type so that
+// constructors like Success/Some infer their type argument.
+func (t *galaASTTransformer) transformTrailingBindValue(stmtCtx grammar.IStatementContext, resultType transpiler.Type) (ast.Expr, error) {
+	exprCtx := trailingBindValueExpr(stmtCtx)
+	if exprCtx == nil {
+		return nil, t.semanticErrorAt(stmtCtx.(*grammar.StatementContext), "a `bind` block must end with a value expression")
+	}
+	if !resultType.IsNil() {
+		release := t.expectedArgTypes.push(resultType)
+		defer release()
+	}
+	expr, err := t.transformExpression(exprCtx)
+	if err != nil {
+		return nil, err
+	}
+	return t.unwrapImmutable(expr), nil
+}
+
+// monadElemType returns the single element type of a monad type M[A], or NilType
+// if it has no type argument.
+func (t *galaASTTransformer) monadElemType(monadType transpiler.Type) transpiler.Type {
+	args := t.getReceiverTypeArgStrings(monadType)
+	if len(args) == 0 {
+		return transpiler.NilType{}
+	}
+	return transpiler.ParseType(args[0])
+}

--- a/internal/transpiler/transformer/bind_test.go
+++ b/internal/transpiler/transformer/bind_test.go
@@ -1,0 +1,103 @@
+package transformer_test
+
+import (
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newBindTranspiler() *transpiler.GalaToGoTranspiler {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	return transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+}
+
+// A `bind` block lowers to a nested FlatMap chain. Every bound name stays in
+// scope for later statements, and because each name is the raw FlatMap callback
+// parameter it must NOT be unwrapped with `.Get()`.
+func TestBindSequentialDesugarsToFlatMap(t *testing.T) {
+	trans := newBindTranspiler()
+	input := `package main
+
+func half(n int) Try[int] =
+    if (n % 2 == 0) Success(n / 2) else Failure[int](NoSuchElementError(Message = "odd"))
+
+func run(x int) Try[int] {
+    bind a = half(x)
+    bind b = half(a)
+    Success(a + b)
+}
+`
+	got, err := trans.Transpile(input, "")
+	assert.NoError(t, err)
+	// Outer FlatMap: result element int, source element int.
+	assert.Contains(t, got, "std.Try_FlatMap[int, int](half(x), func(a int) std.Try[int] {")
+	// Inner FlatMap over the second bind, `a` still in scope.
+	assert.Contains(t, got, "std.Try_FlatMap[int, int](half(a), func(b int) std.Try[int] {")
+	// Trailing value returned, using both bound names raw (no `.Get()`).
+	assert.Contains(t, got, "std.Success[int]{}.Apply(a + b)")
+	assert.NotContains(t, got, "a.Get()", "raw FlatMap callback params must not be unwrapped")
+}
+
+// The desugaring is structural: a user-defined monad with no relationship to std
+// works identically and is emitted as an unqualified `<Type>_FlatMap`.
+func TestBindWorksOverUserMonad(t *testing.T) {
+	trans := newBindTranspiler()
+	input := `package main
+
+sealed type Box[T any] {
+    case Wrap(Value T)
+}
+
+func (b Box[T]) FlatMap[U any](f func(T) Box[U]) Box[U] = b match {
+    case Wrap(v) => f(v)
+}
+
+func run() Box[int] {
+    bind a = Wrap(1)
+    bind c = Wrap(a + 1)
+    Wrap(a + c)
+}
+`
+	got, err := trans.Transpile(input, "")
+	assert.NoError(t, err)
+	assert.Contains(t, got, "Box_FlatMap[int, int]", "user monad lowers to its own <Type>_FlatMap")
+	assert.NotContains(t, got, "std.Box_FlatMap", "user monad must not be std-qualified")
+}
+
+// `bind` on a value whose type has no FlatMap method is rejected.
+func TestBindRejectsNonMonad(t *testing.T) {
+	trans := newBindTranspiler()
+	input := `package main
+
+func run() Try[int] {
+    bind a = 5
+    Success(a)
+}
+`
+	_, err := trans.Transpile(input, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "FlatMap")
+}
+
+// `also` with no preceding `bind` is rejected.
+func TestAlsoRequiresBind(t *testing.T) {
+	trans := newBindTranspiler()
+	input := `package main
+
+func run() Try[int] {
+    also a = Success(1)
+    Success(a)
+}
+`
+	_, err := trans.Transpile(input, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "also")
+}

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -575,6 +575,26 @@ func (t *galaASTTransformer) tryTransformGenericMethodAsFunction(
 		}
 	}
 
+	return true, t.emitGenericMethodFreeFunc(method, receiver, recvType, lookupBaseName, typeArgs, methodMeta, mArgs, hasSpread), nil
+}
+
+// emitGenericMethodFreeFunc builds the monomorphized free-function call that a
+// generic method lowers to: `pkg.TypeName_Method[typeArgs...](receiver, args...)`
+// (or unqualified `TypeName_Method[...]` for a non-std/current-package type).
+// It is the shared emission step used both by tryTransformGenericMethodAsFunction
+// (context-driven path) and by the `bind`/`also` desugaring, which synthesizes
+// the call directly. `explicitTypeArgs` are the method-level type args (e.g. U in
+// FlatMap[U]); the receiver's concrete type args (e.g. T of Try[T]) are appended.
+func (t *galaASTTransformer) emitGenericMethodFreeFunc(
+	method string,
+	receiver ast.Expr,
+	recvType transpiler.Type,
+	lookupBaseName string,
+	explicitTypeArgs []ast.Expr,
+	methodMeta *transpiler.MethodMetadata,
+	mArgs []ast.Expr,
+	hasSpread bool,
+) ast.Expr {
 	// Build the standalone function identifier: pkg.TypeName_Method or TypeName_Method.
 	var funExpr ast.Expr
 	if !recvType.IsNil() {
@@ -605,9 +625,9 @@ func (t *galaASTTransformer) tryTransformGenericMethodAsFunction(
 	// Decide whether to add type arguments:
 	// - If method has its own type params (e.g., Map[U]) and no explicit type args: let Go infer.
 	// - Otherwise: combine explicit type args with concrete receiver type args.
-	shouldAddTypeArgs := len(typeArgs) > 0 || (methodMeta == nil || len(methodMeta.TypeParams) == 0)
+	shouldAddTypeArgs := len(explicitTypeArgs) > 0 || (methodMeta == nil || len(methodMeta.TypeParams) == 0)
 	if shouldAddTypeArgs {
-		allTypeArgs := append(typeArgs, concreteRecvTypeArgs...)
+		allTypeArgs := append(explicitTypeArgs, concreteRecvTypeArgs...)
 		if len(allTypeArgs) == 1 {
 			funExpr = &ast.IndexExpr{X: funExpr, Index: allTypeArgs[0]}
 		} else if len(allTypeArgs) > 1 {
@@ -615,11 +635,11 @@ func (t *galaASTTransformer) tryTransformGenericMethodAsFunction(
 		}
 	}
 
-	return true, &ast.CallExpr{
+	return &ast.CallExpr{
 		Fun:      funExpr,
 		Args:     append([]ast.Expr{receiver}, mArgs...),
 		Ellipsis: ellipsisPos(hasSpread),
-	}, nil
+	}
 }
 
 // transformRegularMethodCall handles Section 4 of the call dispatcher: method

--- a/internal/transpiler/transformer/statements.go
+++ b/internal/transpiler/transformer/statements.go
@@ -297,6 +297,29 @@ func (t *galaASTTransformer) transformBlock(ctx *grammar.BlockContext) (*ast.Blo
 	allStmts := ctx.AllStatement()
 	lastIdx := len(allStmts) - 1
 	for i, stmtCtx := range allStmts {
+		// Monadic do-notation: a `bind` collapses itself and every following
+		// statement in the block into a FlatMap chain (see bind.go). Statements
+		// before the first `bind` are emitted normally by prior iterations. An
+		// `also` is only valid immediately following a `bind`/`also` (handled
+		// inside the chain), so one reached here has no preceding `bind`.
+		if alsoDeclFromStatement(stmtCtx) != nil {
+			return nil, t.semanticErrorAt(stmtCtx.(*grammar.StatementContext), "`also` must follow a `bind`")
+		}
+		if bindDeclFromStatement(stmtCtx) != nil {
+			if t.currentFuncReturnType == nil || t.currentFuncReturnType.IsNil() {
+				return nil, t.semanticErrorAt(stmtCtx.(*grammar.StatementContext), "`bind` requires the enclosing function to declare a monad return type")
+			}
+			expr, err := t.desugarBindChain(allStmts[i:], t.currentFuncReturnType)
+			if err != nil {
+				return nil, err
+			}
+			if lastStmtIsValue {
+				block.List = append(block.List, &ast.ReturnStmt{Results: []ast.Expr{expr}})
+			} else {
+				block.List = append(block.List, &ast.ExprStmt{X: expr})
+			}
+			return block, nil
+		}
 		// A bare `subject match { ... }` whose value is discarded by the
 		// surrounding ExprStmt must be lowered as a void IIFE; otherwise
 		// arms calling void Go functions (e.g. `d.Skip()`) get wrapped in


### PR DESCRIPTION
**PR 3 of the `bind`/`also` stack.** Stacked on #394.

Implements the **sequential** half of the notation: a `bind` block lowers to a nested `FlatMap` chain.

```gala
func processOrder(id int) Try[Receipt] {
    bind o = fetchOrder(id)
    bind valid = validateOrder(o)
    bind payment = chargePayment(valid)
    Success(Receipt(o.Id, payment))   // o still in scope
}
```
lowers to `std.Try_FlatMap[Receipt, Order](fetchOrder(id), func(o Order) std.Try[Receipt] { ... })` — verified identical to the hand-written golden in `bind_notation_desugared`.

### Highlights
- **`transformer/bind.go`** — the desugaring. Every bound name stays in scope for later statements (the "graph" case a linear FlatMap/pipe chain can't express); the first `Failure`/`None`/`Stop` short-circuits.
- **No std special-casing.** `FlatMap` is resolved structurally on the block's monad, so `Try`/`Option`/`Either` and any **user-defined** monad lower identically. `examples/bind_notation_user` binds a user `Box` monad and emits an unqualified `Box_FlatMap` — the extensibility contract, proven with the real feature.
- Bound names are registered like raw function params (not `Immutable`-wrapped `val`s), so reads aren't wrongly unwrapped with `.Get()`.
- **Diagnostics:** non-bindable receiver (no `FlatMap`), heterogeneous bind, `also` without a preceding `bind`, missing monad return type.
- **`calls.go`** — extracted `emitGenericMethodFreeFunc` so the desugaring and the existing generic-method path share one emission step (no divergence).

### Tests
- `transformer/bind_test.go`: golden output for std + user monad, plus the two error diagnostics.
- `examples/bind_notation`, `examples/bind_notation_user`: end-to-end `gala_exec_test`s.
- Full `bazel build //...` + `//internal/... //examples/...` pass (only the pre-existing `TestGorootFromGoBinarySymlink` Windows symlink test fails, unrelated).

### Not in this PR
`also` (applicative/independent bind) and its `Zip`/`Validated`/`Future` support — next stacked PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)