### PR TITLE
fix(transpiler): auto-unwrap Immutable fields in placeholder lambdas

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -209,6 +209,18 @@ gala_exec_test(
     deps = ["//collection_immutable"],
 )
 
+# Regression: placeholder-lambda `_.Field` must be equivalent to the explicit
+# lambda `(p) => p.Field`, including the Immutable field auto-unwrap. Prior to
+# the fix `_.Name` bound `_` to `any`, hiding the struct metadata from the
+# field-access transform, so it leaked Array[Immutable[string]] (printed as
+# {Alice}) instead of Array[string] (Alice).
+gala_exec_test(
+    name = "placeholder_field_unwrap",
+    src = "placeholder_field_unwrap.gala",
+    expected = "placeholder_field_unwrap.out",
+    deps = ["//collection_immutable"],
+)
+
 # Regression: empty collection literal as parameter default
 # (Array[T] = EmptyArray[T](), HashMap[K,V] = EmptyHashMap[K,V]()) must be
 # filled in at call sites that omit the defaulted arg. Prior to the fix the

--- a/examples/placeholder_field_unwrap.gala
+++ b/examples/placeholder_field_unwrap.gala
@@ -1,0 +1,25 @@
+package main
+
+import . "martianoff/gala/collection_immutable"
+
+// Shorthand struct: every field gets `val`/Immutable semantics, so field
+// access must auto-unwrap the Immutable[T] wrapper via .Get().
+struct Person(Name string, Age int)
+
+func main() {
+    val people = ArrayOf(Person(Name = "Alice", Age = 30), Person(Name = "Bob", Age = 25))
+
+    // Placeholder shorthand `_.Field` MUST behave exactly like the explicit
+    // lambda `(p) => p.Field`, including the Immutable auto-unwrap. Both must
+    // print unwrapped values (Alice, Bob), not wrapped ({Alice}, {Bob}).
+    val namesPlaceholder = people.Map(_.Name)
+    val namesExplicit = people.Map((p) => p.Name)
+    Println(namesPlaceholder.String())
+    Println(namesExplicit.String())
+
+    // Same for a non-string (int) field.
+    val agesPlaceholder = people.Map(_.Age)
+    val agesExplicit = people.Map((p) => p.Age)
+    Println(agesPlaceholder.String())
+    Println(agesExplicit.String())
+}

--- a/examples/placeholder_field_unwrap.out
+++ b/examples/placeholder_field_unwrap.out
@@ -1,0 +1,4 @@
+Array(Alice, Bob)
+Array(Alice, Bob)
+Array(30, 25)
+Array(30, 25)

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -1568,12 +1568,35 @@ func (t *galaASTTransformer) tryRewriteAsPlaceholderLambda(
 		}
 	}
 
-	// Install a fresh scope with `_` bound to `any` so the normal expression
-	// transformation can resolve the identifier without producing a
-	// scope-lookup error. The ident is renamed below after transformation.
+	// Install a fresh scope with `_` bound to the placeholder's parameter type
+	// so the normal expression transformation can resolve the identifier AND
+	// apply the same type-directed rewrites the explicit lambda path uses —
+	// most importantly the Immutable field auto-unwrap (`.Field` -> `.Field.Get()`).
+	// Binding `_` to `any` (as was done previously) hid the struct metadata
+	// from resolveFieldAccess, so `_.Field` diverged from `(p) => p.Field` by
+	// leaking an `Immutable[T]` instead of `T`.
+	//
+	// All placeholders share the single `_` scope var during transformation
+	// (they are renamed to distinct `__pN` params afterwards, positionally), so
+	// we can only supply one type here. When every placeholder maps to the same
+	// parameter type we use it; otherwise we fall back to `any` rather than risk
+	// mistyping a heterogeneous placeholder. The renamed params still carry
+	// their correct per-position types via paramTypes below.
+	scopeType := placeholderScopeType(paramTypes)
 	t.pushScope()
-	t.addVar("_", transpiler.BasicType{Name: "any"})
+	t.addVar("_", scopeType)
 	body, err := t.transformExpression(exprCtx)
+	// Resolve the body's concrete result type while `_` is still bound in scope
+	// (before popScope and before the `_` -> `__pN` rename). This mirrors the
+	// explicit lambda path, which infers its return type from the body rather
+	// than from the expected callback result — the latter is frequently an
+	// unresolved `any` (e.g. `Array.Map`'s `func(T) U` where `U` is a free type
+	// param). Doing it here keeps `_.Name` producing a `string` result, exactly
+	// like `(p) => p.Name`, instead of a widened `any`.
+	var bodyResultType ast.Expr
+	if err == nil {
+		bodyResultType = t.getExprType(body)
+	}
 	t.popScope()
 	if err != nil {
 		return nil, false, err
@@ -1645,19 +1668,24 @@ func (t *galaASTTransformer) tryRewriteAsPlaceholderLambda(
 		})
 	}
 
-	// Build the result type from the expected FuncType if available.
-	// When no result type is declared, infer from the body expression.
+	// Build the result type. Prefer the concrete type inferred from the body —
+	// this matches the explicit lambda path and avoids widening a resolvable
+	// result (e.g. `string`) to the callback's unresolved `any`. Fall back to
+	// the expected FuncType's declared result only when the body type could not
+	// be resolved concretely.
 	var resultField *ast.FieldList
-	if len(ft.Results) > 0 && !ft.Results[0].IsNil() {
+	switch {
+	case !isAnyTypeExpr(bodyResultType):
+		resultField = &ast.FieldList{
+			List: []*ast.Field{{Type: bodyResultType}},
+		}
+	case len(ft.Results) > 0 && !ft.Results[0].IsNil():
 		resultField = &ast.FieldList{
 			List: []*ast.Field{{Type: t.typeToExpr(ft.Results[0])}},
 		}
-	} else {
-		bodyType := t.getExprType(body)
-		if bodyType != nil {
-			resultField = &ast.FieldList{
-				List: []*ast.Field{{Type: bodyType}},
-			}
+	case bodyResultType != nil:
+		resultField = &ast.FieldList{
+			List: []*ast.Field{{Type: bodyResultType}},
 		}
 	}
 
@@ -1671,6 +1699,50 @@ func (t *galaASTTransformer) tryRewriteAsPlaceholderLambda(
 		},
 	}
 	return funcLit, true, nil
+}
+
+// isAnyTypeExpr reports whether a Go type expression is the untyped `any`
+// placeholder that getExprType emits when it cannot resolve a concrete type.
+// Used to decide whether a placeholder-lambda's body yielded a usable result
+// type or whether we should fall back to the expected callback result type.
+func isAnyTypeExpr(e ast.Expr) bool {
+	if e == nil {
+		return true
+	}
+	if id, ok := e.(*ast.Ident); ok {
+		return id.Name == "any"
+	}
+	if _, ok := e.(*ast.InterfaceType); ok {
+		return true
+	}
+	return false
+}
+
+// placeholderScopeType picks the type to bind `_` to while a placeholder-lambda
+// body is transformed. All placeholders share one `_` scope var during
+// transformation, so a single type must serve every occurrence. When every
+// placeholder maps to the same (non-nil) parameter type we return it — this is
+// the common single-placeholder case (`_.Field`, `_.Method()`) and the
+// homogeneous multi-placeholder case (`_ + _`). Otherwise we return `any` so a
+// heterogeneous placeholder is never mistyped. Binding the concrete type is
+// what lets resolveFieldAccess apply the Immutable field auto-unwrap, keeping
+// `_.Field` identical to `(p) => p.Field`.
+func placeholderScopeType(paramTypes []transpiler.Type) transpiler.Type {
+	anyType := transpiler.BasicType{Name: "any"}
+	if len(paramTypes) == 0 {
+		return anyType
+	}
+	first := paramTypes[0]
+	if first == nil || first.IsNil() || first.IsAny() {
+		return anyType
+	}
+	firstName := first.String()
+	for _, pt := range paramTypes[1:] {
+		if pt == nil || pt.IsNil() || pt.String() != firstName {
+			return anyType
+		}
+	}
+	return first
 }
 
 // isGenericMethodName checks if a method is marked as generic for a given type name

--- a/internal/transpiler/transformer/placeholder_field_immutable_test.go
+++ b/internal/transpiler/transformer/placeholder_field_immutable_test.go
@@ -1,0 +1,184 @@
+package transformer_test
+
+import (
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPlaceholderFieldImmutableUnwrap verifies that the placeholder-lambda
+// shorthand `_.Field` behaves exactly like the explicit lambda
+// `(p) => p.Field`. For a shorthand struct, every field has `val`/Immutable
+// semantics, so field access must auto-unwrap via `.Get()`. The placeholder
+// path previously bound `_` to `any`, which prevented the field-access
+// transform from finding the struct metadata and emitting the unwrap.
+func TestPlaceholderFieldImmutableUnwrap(t *testing.T) {
+	newTranspiler := func() *transpiler.GalaToGoTranspiler {
+		p := transpiler.NewAntlrGalaParser()
+		a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+		tr := transformer.NewGalaASTTransformer()
+		g := generator.NewGoCodeGenerator()
+		return transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+	}
+
+	const explicitSrc = `package main
+
+import . "martianoff/gala/collection_immutable"
+
+struct Person(Name string, Age int)
+
+func main() {
+    val people = ArrayOf(Person(Name = "Alice", Age = 30), Person(Name = "Bob", Age = 25))
+    val names = people.Map((p) => p.Name)
+    Println(names)
+}`
+
+	const placeholderSrc = `package main
+
+import . "martianoff/gala/collection_immutable"
+
+struct Person(Name string, Age int)
+
+func main() {
+    val people = ArrayOf(Person(Name = "Alice", Age = 30), Person(Name = "Bob", Age = 25))
+    val names = people.Map(_.Name)
+    Println(names)
+}`
+
+	explicit, err := newTranspiler().Transpile(explicitSrc, "")
+	require.NoError(t, err)
+	placeholder, err := newTranspiler().Transpile(placeholderSrc, "")
+	require.NoError(t, err)
+
+	// The explicit form must unwrap the Immutable field via .Get().
+	assert.Contains(t, explicit, ".Name.Get()",
+		"explicit lambda should unwrap the Immutable field")
+
+	// The placeholder form must do the SAME unwrap — this is the bug.
+	assert.Contains(t, placeholder, ".Name.Get()",
+		"placeholder lambda must unwrap the Immutable field just like the explicit form")
+
+	// Both should produce identical Map lambda bodies (modulo the param name).
+	explicitBody := normalizeParamName(extractMapLambda(explicit))
+	placeholderBody := normalizeParamName(extractMapLambda(placeholder))
+	assert.Equal(t, explicitBody, placeholderBody,
+		"placeholder and explicit Map lambdas must be equivalent")
+}
+
+// extractMapLambda returns the substring of the generated Go containing the
+// Map callback FuncLit, for a body comparison. The generated code lowers
+// `xs.Map(f)` to `Array_Map(xs.Get(), f)`, so we key off the emitted `func(`
+// literal that follows the Array_Map call.
+func extractMapLambda(src string) string {
+	call := strings.Index(src, "Array_Map(")
+	if call < 0 {
+		return ""
+	}
+	fn := strings.Index(src[call:], "func(")
+	if fn < 0 {
+		return ""
+	}
+	rest := src[call+fn:]
+	// Cut at the end of the lambda body (the closing `}` of the FuncLit).
+	if end := strings.Index(rest, "}"); end >= 0 {
+		return rest[:end+1]
+	}
+	return rest
+}
+
+// normalizeParamName rewrites the placeholder param `__p0` and an explicit
+// param `p` to a common token so the two lambda bodies can be compared.
+func normalizeParamName(s string) string {
+	s = strings.ReplaceAll(s, "__p0", "PARAM")
+	s = strings.ReplaceAll(s, "func(p ", "func(PARAM ")
+	s = strings.ReplaceAll(s, "p.Name", "PARAM.Name")
+	return s
+}
+
+// TestPlaceholderEquivalentToExplicitLambda checks that `_`-shorthand lambdas
+// produce lambda bodies equivalent to their explicit `(p) => ...` counterparts
+// across a range of forms: Immutable field access, non-field expressions,
+// nested/parenthesized placeholders, method calls, and multiple placeholders.
+func TestPlaceholderEquivalentToExplicitLambda(t *testing.T) {
+	newTranspiler := func() *transpiler.GalaToGoTranspiler {
+		p := transpiler.NewAntlrGalaParser()
+		a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+		tr := transformer.NewGalaASTTransformer()
+		g := generator.NewGoCodeGenerator()
+		return transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+	}
+
+	// prelude declares a struct with an Immutable field plus a method.
+	const prelude = `package main
+
+import . "martianoff/gala/collection_immutable"
+
+struct Person(Name string, Age int)
+
+func (p Person) Label() string = p.Name
+
+func main() {
+    val people = ArrayOf(Person(Name = "Alice", Age = 30), Person(Name = "Bob", Age = 25))
+`
+
+	// Each case: a single Map (or Reduce) call, once with `_` and once explicit.
+	tests := []struct {
+		name        string
+		placeholder string
+		explicit    string
+	}{
+		{
+			name:        "immutable field access",
+			placeholder: `    Println(people.Map(_.Name))`,
+			explicit:    `    Println(people.Map((p) => p.Name))`,
+		},
+		{
+			name:        "immutable int field access",
+			placeholder: `    Println(people.Map(_.Age))`,
+			explicit:    `    Println(people.Map((p) => p.Age))`,
+		},
+		{
+			name:        "method call via placeholder",
+			placeholder: `    Println(people.Map(_.Label()))`,
+			explicit:    `    Println(people.Map((p) => p.Label()))`,
+		},
+		{
+			name:        "nested parenthesized field",
+			placeholder: `    Println(people.Map((_.Age) + 1))`,
+			explicit:    `    Println(people.Map((p) => (p.Age) + 1))`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			phSrc := prelude + tt.placeholder + "\n}"
+			exSrc := prelude + tt.explicit + "\n}"
+
+			ph, err := newTranspiler().Transpile(phSrc, "")
+			require.NoError(t, err, "placeholder form should transpile")
+			ex, err := newTranspiler().Transpile(exSrc, "")
+			require.NoError(t, err, "explicit form should transpile")
+
+			assert.Equal(t,
+				normalizeLambda(extractMapLambda(ex)),
+				normalizeLambda(extractMapLambda(ph)),
+				"placeholder lambda must match explicit lambda\nexplicit:\n%s\nplaceholder:\n%s", ex, ph)
+		})
+	}
+}
+
+// normalizeLambda collapses the placeholder param name `__p0` and the explicit
+// param name `p` to a common token so the two rendered lambdas can be compared
+// structurally.
+func normalizeLambda(s string) string {
+	s = strings.ReplaceAll(s, "__p0", "PARAM")
+	s = strings.ReplaceAll(s, "func(p ", "func(PARAM ")
+	s = strings.ReplaceAll(s, "p.", "PARAM.")
+	return s
+}


### PR DESCRIPTION
## Summary

Fixes a real bug where the placeholder-lambda shorthand `_.Field` diverged from the explicit `(p) => p.Field` for `val`/`Immutable` struct fields.

```gala
struct Person(Name string, Age int)
people.Map(_.Name)        // BUG: Array[Immutable[string]]  → renders {Alice}
people.Map((p) => p.Name) // correct: Array[string]         → Alice
```

## Root cause

In `tryRewriteAsPlaceholderLambda` (`internal/transpiler/transformer/lambdas.go`), `_` was bound to `any`. Field access unwrapping (`resolveFieldAccess` in `postfix.go`) only inserts the `Immutable` `.Get()` when it can see the base's concrete struct type — with `_` typed `any`, the struct metadata was invisible, so the placeholder path emitted a bare `__p0.Name` selector while the explicit path (with `p` typed `Person`) emitted `p.Name.Get()`. A second divergence: the result type fell back to the callback's unresolved `any` instead of the body's inferred type.

## Fix (confined to `lambdas.go`)

1. Bind `_` to the placeholder's concrete parameter type (new `placeholderScopeType`), routing the body through the same `resolveFieldAccess` unwrap the explicit path uses.
2. Infer the lambda result type from the transformed body, preferring it over the callback's `any`.

Before: `func(__p0 Person) any { return __p0.Name }`
After:  `func(__p0 Person) string { return __p0.Name.Get() }` — byte-identical to `(p) => p.Name`.

## Tests / example

- `placeholder_field_immutable_test.go` — asserts `.Name.Get()` + full equivalence to the explicit lambda; table-driven over Immutable string field, int field, method call `_.Label()`, nested `(_.Age)+1`. Confirmed FAILING before the fix.
- `examples/placeholder_field_unwrap.gala` (+`.out`) wired into `examples/BUILD.bazel`.

## Verification
- `bazel build //...` clean; `bazel test //...` 357 pass / 1 fail = only the known Windows symlink-privilege `TestGorootFromGoBinarySymlink`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)