### PR TITLE
docs(examples): verify all EXAMPLES.MD, reject grouped params, fix stdlib embed

### DIFF
--- a/docs/EXAMPLES.MD
+++ b/docs/EXAMPLES.MD
@@ -10,7 +10,7 @@ The following example demonstrates many of GALA's features, including structs, i
 package main
 
 
-struct Point(X, Y int)
+struct Point(X int, Y int)
 
 func moveX(p Point, delta int) Point = p.Copy(X = p.X + delta)
 
@@ -93,7 +93,7 @@ package main
 func main() {
     val x = Some(10)
     val y = x.Map((v) => v * 2)         // parameter type inferred as int
-    val z = None().GetOrElse(42)
+    val z = None[int]().GetOrElse(42)
 
     val res = y match {
         case Some(v) => v
@@ -102,6 +102,78 @@ func main() {
     
     Println(res, z)
 }
+```
+
+## Sealed Types (Algebraic Data Types)
+
+A `sealed type` defines a closed set of variants (an ADT). Because the compiler
+knows every case, a `match` over a sealed type is checked for exhaustiveness — no
+`case _` default is needed once all variants are covered. Variants may carry
+fields or be empty.
+
+```gala
+package main
+
+import . "martianoff/gala/collection_immutable"
+
+sealed type Shape {
+    case Circle(Radius float64)
+    case Rectangle(Width float64, Height float64)
+    case Point()
+}
+
+// Exhaustive match — every variant is covered, so no default case is required.
+func area(s Shape) float64 = s match {
+    case Circle(r)       => 3.14159 * r * r
+    case Rectangle(w, h) => w * h
+    case Point()         => 0.0
+}
+
+func main() {
+    val shapes = ArrayOf[Shape](Circle(2.0), Rectangle(3.0, 4.0), Point())
+    shapes.ForEach((s) => Println(s, "=> area", area(s)))
+}
+```
+
+Output:
+```
+Circle(2) => area 12.56636
+Rectangle(3, 4) => area 12
+Point() => area 0
+```
+
+## Either Monad
+
+`Either[L, R]` holds one of two values — conventionally `Left` for failure and
+`Right` for success. Monadic operations (`Map`, `FlatMap`) act on the `Right`
+side and pass `Left` through untouched.
+
+```gala
+package main
+
+func parseEven(n int) Either[string, int] =
+    if (n % 2 == 0) Right[string, int](n) else Left[string, int](s"$n is odd")
+
+func main() {
+    val a = parseEven(10)
+    val b = parseEven(7)
+
+    // Map transforms the Right side; a Left passes through unchanged.
+    val doubled = a.Map((v) => v * 2)
+    Println(doubled)   // Right(20)
+
+    val r = b match {
+        case Right(v) => s"got $v"
+        case Left(e)  => s"error: $e"
+    }
+    Println(r)         // error: 7 is odd
+}
+```
+
+Output:
+```
+Right(20)
+error: 7 is odd
 ```
 
 ## Generic Methods Example
@@ -126,17 +198,18 @@ func main() {
 ```gala
 package main
 
+import . "martianoff/gala/collection_immutable"
 
 struct Person(Name string, Age int)
 
 func main() {
-    val people = SliceOf(
+    val people = ArrayOf(
         Person("Alice", 25),
         Person("Bob", 15),
         Person("Charlie", 70),
     )
 
-    for _, p := range people {
+    people.ForEach((p) => {
         val status = p match {
             case Person(name, age) if age < 18 => name + " is a minor"
             case Person(name, age) if age > 65 => name + " is a senior"
@@ -144,7 +217,7 @@ func main() {
             case _                             => "Unknown"
         }
         Println(status)
-    }
+    })
 }
 ```
 
@@ -281,8 +354,8 @@ struct Circle(radius float64)
 func (c Circle) Area() float64 = 3.14159 * c.radius * c.radius
 
 func main() {
-    val r = Rect(10, 5)
-    val c = Circle(10)
+    val r = Rect(10.0, 5.0)
+    val c = Circle(10.0)
     
     val s1 Shaper = r
     val s2 Shaper = c
@@ -371,11 +444,116 @@ func main() {
 Boolean pattern matching is exhaustive when both `true` and `false` cases are covered:
 
 ```gala
-val desc = flag match {
-    case true  => "enabled"
-    case false => "disabled"
-    // No case _ needed — true/false is exhaustive
+package main
+
+func main() {
+    val flag = true
+    val desc = flag match {
+        case true  => "enabled"
+        case false => "disabled"
+        // No case _ needed — true/false is exhaustive
+    }
+    Println(desc)
 }
+```
+
+## For Loops
+
+GALA supports Go-style `for` in its familiar forms: a three-clause counting loop
+and a condition-only (while-style) loop. `break` and `continue` work as usual.
+For iterating collections, prefer the functional methods (`ForEach`, `Map`, …)
+shown elsewhere on this page.
+
+```gala
+package main
+
+func main() {
+    // Three-clause counting loop
+    for i := 0; i < 3; i++ {
+        Println(s"i = $i")
+    }
+
+    // Condition-only (while-style) loop
+    var n = 3
+    for n > 0 {
+        Println(s"countdown $n")
+        n = n - 1
+    }
+}
+```
+
+Output:
+```
+i = 0
+i = 1
+i = 2
+countdown 3
+countdown 2
+countdown 1
+```
+
+## String Interpolation
+
+GALA has two interpolated string forms. `s"..."` inserts values with `$var` or
+`${expr}`; `f"..."` adds explicit printf-style format specs. Neither needs an
+`fmt` import.
+
+```gala
+package main
+
+func main() {
+    val name = "Alice"
+    val age = 30
+    val pi = 3.14159
+
+    // s-string: value interpolation with $var and ${expr}
+    Println(s"$name is $age years old")
+    Println(s"Next year: ${age + 1}")
+    Println(s"Price: $$99")          // literal dollar sign
+
+    // f-string: explicit printf-style format specs
+    Println(f"Padded: $age%05d")
+    Println(f"Fixed point: $pi%.2f")
+}
+```
+
+Output:
+```
+Alice is 30 years old
+Next year: 31
+Price: $99
+Padded: 00030
+Fixed point: 3.14
+```
+
+## Variadic Functions and the Spread Operator
+
+A trailing `...T` parameter accepts any number of arguments. At a call site, an
+existing collection can be spread into such a parameter with the postfix `...`
+operator.
+
+```gala
+package main
+
+import . "martianoff/gala/collection_immutable"
+
+func sum(nums ...int) int = ArrayOf(nums...).FoldLeft(0, (acc, n) => acc + n)
+
+func main() {
+    Println(sum(1, 2, 3))              // 6
+    Println(sum())                     // 0
+
+    // Spread a collection into the variadic parameter.
+    val more = ArrayOf(4, 5, 6)
+    Println(sum(more.ToGoSlice()...))  // 15
+}
+```
+
+Output:
+```
+6
+0
+15
 ```
 
 ## Void Closures and Lambda Parameter Inference
@@ -383,26 +561,37 @@ val desc = flag match {
 Functions can accept void closures (no return value), and lambda parameter types can be inferred from context. Prefer omitting parameter types in lambdas — the compiler infers them from the method signature:
 
 ```gala
-val opt = Some(42)
+package main
 
-// ForEach takes func(T) — void, no return needed
-opt.ForEach((x) => {
-    Println(x)
-})
+import (
+    . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/strings"
+)
 
-// Parameter type inferred from Option[int].Filter's signature
-val positive = opt.Filter((x) => x > 0)
+func main() {
+    val opt = Some(42)
 
-// Method type param and lambda param both inferred
-val doubled = opt.Map((x) => x * 2)
+    // ForEach takes func(T) — void, no return needed
+    opt.ForEach((x) => {
+        Println(x)
+    })
 
-// FoldLeft accumulator type inferred from zero value
-val list = ArrayOf(1, 2, 3)
-val sum = list.FoldLeft(0, (acc, x) => acc + x)
+    // Parameter type inferred from Option[int].Filter's signature
+    val positive = opt.Filter((x) => x > 0)
 
-// Non-generic wrapper methods also infer lambda param types
-val s = S("hello")
-val hasVowel = s.Exists((r) => r == 'a' || r == 'e' || r == 'i' || r == 'o' || r == 'u')
+    // Method type param and lambda param both inferred
+    val doubled = opt.Map((x) => x * 2)
+
+    // FoldLeft accumulator type inferred from zero value
+    val list = ArrayOf(1, 2, 3)
+    val sum = list.FoldLeft(0, (acc, x) => acc + x)
+
+    // Non-generic wrapper methods also infer lambda param types
+    val s = S("hello")
+    val hasVowel = s.Exists((r) => r == 'a' || r == 'e' || r == 'i' || r == 'o' || r == 'u')
+
+    Println(positive, doubled, sum, hasVowel)
+}
 ```
 
 ## Collect - Filter and Transform in One Pass
@@ -459,8 +648,9 @@ func main() {
     // Function reference (preferred for zero-arg functions)
     val dir = Try(os.TempDir)
 
-    // Lambda form (use when args needed)
-    val result = Try(os.MkdirAll("/tmp/test", 0755))
+    // Lambda form (use when args needed) — a bare Try(...) statement discards
+    // the result; bind it to a val only when you go on to use it.
+    Try(os.MkdirAll("/tmp/test", 0755))
 
     dir.OnSuccess((d) => Println(s"Temp dir: $d"))
 }
@@ -506,6 +696,42 @@ Output:
 An argument that is already a function value is passed through untouched (never
 double-wrapped), and multi-argument function parameters still require an explicit
 lambda.
+
+## Future - Asynchronous Computations
+
+`Future[T]` runs a computation asynchronously. Thanks to by-name arguments,
+`Future(expr)` schedules `expr` on a background executor. Results compose with
+`Map`/`FlatMap` without blocking; `Get()` blocks until the value is available.
+`Succeeded`/`Failed` are extractor patterns, so a `case _` default is required.
+
+```gala
+package main
+
+import . "martianoff/gala/concurrent"
+
+func main() {
+    // Future(expr) runs the body asynchronously.
+    val f = Future(21 * 2)
+
+    // Transform the eventual result without blocking.
+    val g = f.Map((x) => x + 1)
+
+    Println(g.Get())   // 43 — Get() blocks for the result
+
+    val result = g match {
+        case Succeeded(v) => s"ok: $v"
+        case Failed(e)    => s"err: ${e.Error()}"
+        case _            => "pending"
+    }
+    Println(result)    // ok: 43
+}
+```
+
+Output:
+```
+43
+ok: 43
+```
 
 ## Try with Go Multi-Return Functions
 
@@ -566,6 +792,40 @@ func main() {
     val empty = EmptyArray[int]()
     Println(empty.MkString(", "))    // ""
 }
+```
+
+## HashMap - Immutable Key/Value Maps
+
+`HashMap[K, V]` is an immutable map: `Put`/`Remove` return a new map rather than
+mutating in place. Lookups return an `Option`, and the usual functional
+operations (`MapValues`, `Filter`, `FoldLeftKV`, …) are available.
+
+```gala
+package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    val scores = HashMapOf(("Alice", 85), ("Bob", 92))
+    val updated = scores.Put("Carol", 78)   // returns a new map
+
+    Println(updated.GetOrElse("Bob", 0))     // 92
+    Println(updated.Get("Dave"))             // None() — lookups return Option
+
+    // Transform every value; the key set is unchanged.
+    val grades = updated.MapValues((v) => v match {
+        case n if n >= 90 => "A"
+        case _            => "B"
+    })
+    Println(grades.GetOrElse("Bob", "?"))    // A
+}
+```
+
+Output:
+```
+92
+None()
+A
 ```
 
 ## Sorted API - Sorting Collections

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -142,6 +142,11 @@ func add(a int, b int) int {
 }
 ```
 
+> **Note:** Every parameter states its own type. GALA does not support Go-style
+> grouped parameters (`func add(a, b int)`); write `func add(a int, b int)`
+> instead. The same applies to struct-shorthand fields. A grouped declaration
+> is rejected with [GALA-E0034](errors/GALA-E0034.md).
+
 ### Expression Functions
 For simple functions, you can use the `=` syntax.
 

--- a/docs/errors/GALA-E0034.md
+++ b/docs/errors/GALA-E0034.md
@@ -1,0 +1,42 @@
+# GALA-E0034 — Untyped function/struct parameter
+
+**When it fires.** A function parameter, method parameter, or struct-shorthand
+field is written without a type. Unlike lambda parameters (see
+[GALA-E0033](GALA-E0033.md)), these declaration sites have no surrounding
+context to infer a type from, so every parameter and field must state its own
+type.
+
+The usual trigger is Go-style *grouped* parameter syntax, where several names
+share a single trailing type:
+
+```gala
+func add(a, b int) int = a + b       // ← GALA-E0034: `a` has no declared type
+
+struct Point(X, Y int)               // ← GALA-E0034: `X` has no declared type
+```
+
+GALA parses `(a, b int)` as a typeless `a` followed by a typed `b int`; it does
+**not** propagate the trailing type back over the earlier names. Grouped
+parameters are therefore not a supported feature.
+
+**Error output.**
+
+```
+[SemanticError GALA-E0034] file.gala:3:9 parameter "a" has no declared type (hint: type every parameter individually (e.g. `a int`); GALA does not support Go-style grouped parameters like `(a, b int)`)
+```
+
+**Fix.** Give every parameter and field its own type:
+
+```gala
+func add(a int, b int) int = a + b
+
+struct Point(X int, Y int)
+```
+
+**Rationale.** Emitting `any` for the untyped parameter would violate GALA's
+concrete-types invariant and only surface later as a confusing Go build failure
+(`mismatched types any and int`). Rejecting it at the declaration site names the
+exact parameter and points at the fix. GALA deliberately keeps one type per
+parameter rather than adopting Go's grouped-parameter shorthand, so the rule is
+uniform across function signatures, method signatures, and struct-shorthand
+fields.

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -40,6 +40,7 @@ Each code has a dedicated documentation page in this directory explaining:
 | `GALA-E0023` | Undefined variable | [GALA-E0023.md](GALA-E0023.md) |
 | `GALA-E0024` | Internal inference failure | [GALA-E0024.md](GALA-E0024.md) |
 | `GALA-E0033` | Untyped lambda parameter | [GALA-E0033.md](GALA-E0033.md) |
+| `GALA-E0034` | Untyped function/struct parameter | [GALA-E0034.md](GALA-E0034.md) |
 
 ## Adding a new code
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1266,7 +1266,8 @@ gala_exec_test(
     expected = "doc_verify/examples_md.out",
     deps = [
         "//collection_immutable",
-        "//go_interop",
+        "//concurrent",
+        "//strings",
     ],
 )
 

--- a/examples/doc_verify/examples_md.gala
+++ b/examples/doc_verify/examples_md.gala
@@ -1,10 +1,15 @@
 package main
 
-import . "martianoff/gala/collection_immutable"
-import . "martianoff/gala/go_interop"
-import "os"
+import (
+    . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/concurrent"
+    . "martianoff/gala/strings"
+    "os"
+)
 
-// Test examples from EXAMPLES.MD
+// Verifies the runnable examples in docs/EXAMPLES.MD. Each function mirrors one
+// documented section; main() runs them in document order. Kept in sync with the
+// markdown so the examples stay executable.
 
 // Complete Example
 struct Point(X int, Y int)
@@ -14,28 +19,75 @@ func moveX(p Point, delta int) Point = p.Copy(X = p.X + delta)
 func testCompleteExample() {
     val p1 = Point(10, 20)
     val p2 = moveX(p1, 5)
-
     val msg = if (p2.X > 10) "moved" else "static"
     Println(msg, p2)
 }
 
-// Option Monad Example
+// Named Arguments
+func describe(name string, age int, role string) string = s"$name ($role, age $age)"
+
+func testNamedArguments() {
+    Println(describe("Alice", 30, "engineer"))
+    Println(describe(role = "designer", name = "Bob", age = 25))
+}
+
+// Default Parameter Values
+func greet(name string, greeting string = "Hello", punctuation string = "!") string =
+    s"$greeting, $name$punctuation"
+
+func testDefaultParams() {
+    Println(greet("World"))
+    Println(greet("World", "Hi"))
+    Println(greet("World", punctuation = "?"))
+}
+
+// Option Monad
 func testOptionMonad() {
     val x = Some(10)
     val y = x.Map((v) => v * 2)
     val z = None[int]().GetOrElse(42)
-
     val res = y match {
         case Some(v) => v
         case _       => 0
     }
-
     Println(res, z)
 }
 
-// Generic Methods Example
-type Box[T any] struct { Value T }
+// Sealed Types (ADT)
+sealed type Shape {
+    case Circle(Radius float64)
+    case Rectangle(Width float64, Height float64)
+    case Point2()
+}
 
+func area(s Shape) float64 = s match {
+    case Circle(r)       => 3.14159 * r * r
+    case Rectangle(w, h) => w * h
+    case Point2()        => 0.0
+}
+
+func testSealedTypes() {
+    val shapes = ArrayOf[Shape](Circle(2.0), Rectangle(3.0, 4.0), Point2())
+    shapes.ForEach((s) => Println(s, "=> area", area(s)))
+}
+
+// Either Monad
+func parseEven(n int) Either[string, int] =
+    if (n % 2 == 0) Right[string, int](n) else Left[string, int](s"$n is odd")
+
+func testEither() {
+    val a = parseEven(10)
+    val b = parseEven(7)
+    Println(a.Map((v) => v * 2))
+    val r = b match {
+        case Right(v) => s"got $v"
+        case Left(e)  => s"error: $e"
+    }
+    Println(r)
+}
+
+// Generic Methods
+type Box[T any] struct { Value T }
 func (b Box[T]) Transform[U any](f func(T) U) Box[U] = Box[U](Value = f(b.Value))
 
 func testGenericMethods() {
@@ -44,17 +96,16 @@ func testGenericMethods() {
     Println(s.Value)
 }
 
-// Pattern Matching with Filters Example
+// Pattern Matching with Filters (Guards)
 struct Person(Name string, Age int)
 
 func testPatternFilters() {
-    val people = SliceOf(
+    val people = ArrayOf(
         Person("Alice", 25),
         Person("Bob", 15),
         Person("Charlie", 70),
     )
-
-    for _, p := range people {
+    people.ForEach((p) => {
         val status = p match {
             case Person(name, age) if age < 18 => name + " is a minor"
             case Person(name, age) if age > 65 => name + " is a senior"
@@ -62,170 +113,208 @@ func testPatternFilters() {
             case _                             => "Unknown"
         }
         Println(status)
-    }
+    })
 }
 
-// Custom Extractor Example
+// Pattern Matching with Extractors
 type Even struct {}
 func (e Even) Unapply(i int) Option[int] = if (i % 2 == 0) Some(i) else None[int]()
 
-func testCustomExtractor() {
+func testExtractors() {
     val number = 42
-
     val description = number match {
         case Even(n) => s"$n is an even number"
         case _       => s"$number is odd"
     }
-
     Println(description)
-
-    // Nested patterns
-    val opt = Some(10)
-    opt match {
-        case Some(Even(n)) => Println("Found some even number", n)
-        case Some(n)       => Println("Found some odd number", n)
-        case None()        => Println("Nothing found")
-        case _             => Println("Other")
-    }
 }
 
-// Type-Based Pattern Matching Example
+// Type-Based Pattern Matching
 func testTypeMatch() {
     val x any = "hello"
-
     val res = x match {
         case s: string => s"string: $s"
         case i: int    => s"int: $i"
         case _         => "unknown"
     }
-
     Println(res)
 }
 
-// Interface Example
+// Interface
 type Shaper interface {
     Area() float64
 }
-
 struct Rect(width float64, height float64)
 func (r Rect) Area() float64 = r.width * r.height
-
-struct Circle(radius float64)
-func (c Circle) Area() float64 = 3.14159 * c.radius * c.radius
+struct Circ(radius float64)
+func (c Circ) Area() float64 = 3.14159 * c.radius * c.radius
 
 func testInterface() {
-    val r = Rect(10.0, 5.0)
-    val c = Circle(10.0)
-
-    val s1 Shaper = r
-    val s2 Shaper = c
-
+    val s1 Shaper = Rect(10.0, 5.0)
+    val s2 Shaper = Circ(10.0)
     Println("Area 1:", s1.Area())
     Println("Area 2:", s2.Area())
 }
 
-// Apply Method Example
+// Apply Method
 type Adder struct { Delta int }
 func (a Adder) Apply(x int) int = x + a.Delta
-
 type Multiply struct {}
 func (m Multiply) Apply(x int, y int) int = x * y
 
-func testApplyMethod() {
+func testApply() {
     val add5 = Adder(Delta = 5)
-    val res1 = add5(10)
-
-    val res2 = Multiply(3, 4)
-
-    Println(res1, res2)
+    Println(add5(10), Multiply(3, 4))
 }
 
-// Type Aliases Example
-type MyString string
+// For Loops
+func testForLoops() {
+    for i := 0; i < 3; i++ {
+        Println(s"i = $i")
+    }
+    var n = 3
+    for n > 0 {
+        Println(s"countdown $n")
+        n = n - 1
+    }
+}
 
+// String Interpolation
+func testStringInterpolation() {
+    val name = "Alice"
+    val age = 30
+    val pi = 3.14159
+    Println(s"$name is $age years old")
+    Println(s"Next year: ${age + 1}")
+    Println(s"Price: $$99")
+    Println(f"Padded: $age%05d")
+    Println(f"Fixed point: $pi%.2f")
+}
+
+// Variadic + Spread
+func sum(nums ...int) int = ArrayOf(nums...).FoldLeft(0, (acc, n) => acc + n)
+
+func testVariadicSpread() {
+    Println(sum(1, 2, 3))
+    Println(sum())
+    val more = ArrayOf(4, 5, 6)
+    Println(sum(more.ToGoSlice()...))
+}
+
+// Void Closures / Lambda Inference
+func testVoidClosures() {
+    val opt = Some(42)
+    opt.ForEach((x) => {
+        Println(x)
+    })
+    val positive = opt.Filter((x) => x > 0)
+    val doubled = opt.Map((x) => x * 2)
+    val list = ArrayOf(1, 2, 3)
+    val total = list.FoldLeft(0, (acc, x) => acc + x)
+    val str = S("hello")
+    val hasVowel = str.Exists((r) => r == 'a' || r == 'e' || r == 'i' || r == 'o' || r == 'u')
+    Println(positive, doubled, total, hasVowel)
+}
+
+// Collect
+func testCollect() {
+    val nums = ArrayOf(1, 2, 3, 4, 5, 6)
+    Println(nums.Collect({ case n if n % 2 == 0 => n * 2 }))
+    val options = ArrayOf(Some(1), None[int](), Some(2), None[int](), Some(3))
+    Println(options.Collect({ case Some(v) => v * 10 }))
+}
+
+// Option.OrElse
+func testOrElse() {
+    val primary = None[string]()
+    val fallback = Some("default")
+    Println(primary.OrElse(fallback).Get())
+    Println(Some("actual").OrElse(fallback).Get())
+}
+
+// Try with Function References
+func testTryFuncRef() {
+    val dir = Try(os.TempDir)
+    dir.OnSuccess((d) => Println(s"Temp dir ok: ${d != ""}"))
+}
+
+// Future
+func testFuture() {
+    val f = Future(21 * 2)
+    val g = f.Map((x) => x + 1)
+    Println(g.Get())
+    val result = g match {
+        case Succeeded(v) => s"ok: $v"
+        case Failed(e)    => s"err: ${e.Error()}"
+        case _            => "pending"
+    }
+    Println(result)
+}
+
+// MkString
+func testMkString() {
+    val nums = ArrayOf(1, 2, 3, 4, 5)
+    Println(nums.MkString(", "))
+    val words = ListOf("hello", "world")
+    Println(words.MkString(" "))
+    Println(EmptyArray[int]().MkString(", "))
+}
+
+// HashMap
+func testHashMap() {
+    val scores = HashMapOf(("Alice", 85), ("Bob", 92))
+    val updated = scores.Put("Carol", 78)
+    Println(updated.GetOrElse("Bob", 0))
+    Println(updated.Get("Dave"))
+    val grades = updated.MapValues((v) => v match {
+        case n if n >= 90 => "A"
+        case _            => "B"
+    })
+    Println(grades.GetOrElse("Bob", "?"))
+}
+
+// Sorted
+func testSorted() {
+    val arr = ArrayOf(3, 1, 4, 1, 5, 9)
+    Println(arr.Sorted())
+    Println(arr.SortWith((a, b) => a > b))
+    Println(ArrayOf(1, 9, 3, 7, 5).SortBy((x) => x))
+    Println(ListOf("banana", "apple", "cherry").Sorted())
+    Println(TreeSetOf(30, 10, 20).Sorted())
+    Println(HashSetOf(5, 3, 1).Sorted())
+    Println(EmptyArray[int]().Sorted())
+}
+
+// Type Aliases
+type MyString string
 func testTypeAlias() {
     val s MyString = "hello"
     Println(s)
 }
 
-// Option.OrElse Example
-func testOrElse() {
-    val primary = None[string]()
-    val fallback = Some("default")
-
-    val result = primary.OrElse(fallback)
-    Println(result.Get())
-
-    val present = Some("actual")
-    val result2 = present.OrElse(fallback)
-    Println(result2.Get())
-}
-
-// Try with Function References Example
-func testTryFuncRef() {
-    val dir = Try(os.TempDir)
-    dir.OnSuccess((d) => Println(s"Temp dir success: ${d != ""}"))
-}
-
-// Collect Example
-func testCollect() {
-    val nums = ArrayOf(1, 2, 3, 4, 5, 6)
-
-    val evenDoubled = nums.Collect({ case n if n % 2 == 0 => n * 2 })
-    Println(evenDoubled)
-
-    val options = ArrayOf(Some(1), None[int](), Some(2), None[int](), Some(3))
-    val values = options.Collect({ case Some(v) => v * 10 })
-    Println(values)
-}
-
-// MkString Example
-func testMkString() {
-    val nums = ArrayOf(1, 2, 3, 4, 5)
-    Println(nums.MkString(", "))
-    Println(nums.MkString(" | "))
-
-    val words = ListOf("hello", "world")
-    Println(words.MkString(" "))
-
-    val empty = EmptyArray[int]()
-    Println(empty.MkString(", "))
-}
-
-// Sorted API Example
-func testSorted() {
-    val arr = ArrayOf(3, 1, 4, 1, 5, 9)
-    Println(arr.Sorted())
-    Println(arr.SortWith((a, b) => a > b))
-
-    val arr2 = ArrayOf(1, 9, 3, 7, 5)
-    Println(arr2.SortBy((x) => x))
-
-    val list = ListOf("banana", "apple", "cherry")
-    Println(list.Sorted())
-
-    val tree = TreeSetOf(30, 10, 20)
-    Println(tree.Sorted())
-
-    val set = HashSetOf(5, 3, 1)
-    Println(set.Sorted())
-
-    Println(EmptyArray[int]().Sorted())
-}
-
 func main() {
     testCompleteExample()
+    testNamedArguments()
+    testDefaultParams()
     testOptionMonad()
+    testSealedTypes()
+    testEither()
     testGenericMethods()
     testPatternFilters()
-    testCustomExtractor()
+    testExtractors()
     testTypeMatch()
     testInterface()
-    testApplyMethod()
-    testTypeAlias()
+    testApply()
+    testForLoops()
+    testStringInterpolation()
+    testVariadicSpread()
+    testVoidClosures()
+    testCollect()
     testOrElse()
     testTryFuncRef()
-    testCollect()
+    testFuture()
     testMkString()
+    testHashMap()
     testSorted()
+    testTypeAlias()
 }

--- a/examples/doc_verify/examples_md.out
+++ b/examples/doc_verify/examples_md.out
@@ -1,25 +1,53 @@
 moved {{15} {20}}
+Alice (engineer, age 30)
+Bob (designer, age 25)
+Hello, World!
+Hi, World!
+Hello, World?
 20 42
+Circle(2) => area 12.56636
+Rectangle(3, 4) => area 12
+Point2() => area 0
+Right(20)
+error: 7 is odd
 Value is 10
 Alice is an adult
 Bob is a minor
 Charlie is a senior
 42 is an even number
-Found some even number 10
 string: hello
 Area 1: 50
 Area 2: 314.159
 15 12
-hello
-default
-actual
-Temp dir success: true
+i = 0
+i = 1
+i = 2
+countdown 3
+countdown 2
+countdown 1
+Alice is 30 years old
+Next year: 31
+Price: $99
+Padded: 00030
+Fixed point: 3.14
+6
+0
+15
+42
+Some(42) Some(84) 6 true
 Array(4, 8, 12)
 Array(10, 20, 30)
+default
+actual
+Temp dir ok: true
+43
+ok: 43
 1, 2, 3, 4, 5
-1 | 2 | 3 | 4 | 5
 hello world
 
+92
+None()
+A
 Array(1, 1, 3, 4, 5, 9)
 Array(9, 5, 4, 3, 1, 1)
 Array(1, 3, 5, 7, 9)
@@ -27,3 +55,4 @@ List(apple, banana, cherry)
 Array(10, 20, 30)
 Array(1, 3, 5)
 Array()
+hello

--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -257,6 +257,16 @@ const (
 	// (`(x int) => ...`) or place the lambda in a typed context that supplies
 	// the parameter types.
 	CodeUntypedLambdaParam ErrorCode = "GALA-E0033"
+
+	// E0034: a function/method parameter or struct-shorthand field has no type
+	// annotation. Unlike lambda parameters, these declaration sites have no
+	// surrounding context to infer from, so every parameter/field must state its
+	// own type. This most often surfaces from Go-style grouped syntax such as
+	// `func add(a, b int)` or `struct Point(X, Y int)`, which GALA does not
+	// support — each parameter or field must be typed individually
+	// (`func add(a int, b int)`, `struct Point(X int, Y int)`). Emitting `any`
+	// for the untyped parameter would violate the concrete-types invariant.
+	CodeUntypedParam ErrorCode = "GALA-E0034"
 )
 
 // MultiError collects multiple GALA errors.

--- a/internal/stdlib/BUILD.bazel
+++ b/internal/stdlib/BUILD.bazel
@@ -60,11 +60,15 @@ genrule(
         "//collection_immutable:list_go",
         "//collection_immutable:hashmap_go",
         "//collection_immutable:hashset_go",
+        "//collection_immutable:treeset_go",
+        "//collection_immutable:treemap_go",
         # collection_immutable package - GALA source
         "//collection_immutable:array.gala",
         "//collection_immutable:list.gala",
         "//collection_immutable:hashmap.gala",
         "//collection_immutable:hashset.gala",
+        "//collection_immutable:treeset.gala",
+        "//collection_immutable:treemap.gala",
         # collection_mutable package - transpiled Go
         "//collection_mutable:array_go",
         "//collection_mutable:list_go",

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -945,7 +945,7 @@ func (t *galaASTTransformer) transformStructShorthandDeclaration(ctx *grammar.St
 			// For shorthand structs, we want the fields in the struct to be std.Immutable if isVal
 			// but transformParameter handles function parameters.
 			// We'll transform it as a parameter first, then adjust for the struct field.
-			field, err := t.transformParameter(param)
+			field, err := t.transformParameter(param, true)
 			if err != nil {
 				return nil, err
 			}
@@ -1310,7 +1310,13 @@ func (t *galaASTTransformer) transformImportDeclaration(ctx *grammar.ImportDecla
 	}, nil
 }
 
-func (t *galaASTTransformer) transformParameter(ctx *grammar.ParameterContext) (*ast.Field, error) {
+// transformParameter lowers a single parameter node to a Go field. When
+// requireType is true (function/method signatures and struct-shorthand fields)
+// a missing type annotation is a hard error (GALA-E0034): those sites have no
+// context to infer from and Go-style grouped syntax like `(a, b int)` is not
+// supported. When false (lambda parameters) a provisional `any` is returned so
+// the lambda lowering can thread an expected type or reject it with E0033.
+func (t *galaASTTransformer) transformParameter(ctx *grammar.ParameterContext, requireType bool) (*ast.Field, error) {
 	name := ctx.Identifier().GetText()
 	field := &ast.Field{
 		Names: []*ast.Ident{ast.NewIdent(name)},
@@ -1357,17 +1363,24 @@ func (t *galaASTTransformer) transformParameter(ctx *grammar.ParameterContext) (
 		} else {
 			field.Type = typ
 		}
+	} else if requireType {
+		// Function/method signatures and struct-shorthand fields have no context
+		// to infer a parameter type from. A missing type here comes from Go-style
+		// grouped syntax like `func add(a, b int)` or `struct Point(X, Y int)`,
+		// which GALA does not support. Reject it with a clear error rather than
+		// silently emitting `any` (which violates the concrete-types invariant and
+		// only surfaces later as a confusing Go build failure).
+		return nil, galaerr.NewCodedSemanticError(
+			galaerr.CodeUntypedParam,
+			ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+			fmt.Sprintf("parameter %q has no declared type", name),
+			fmt.Sprintf("type every parameter individually (e.g. `%s int`); GALA does not support Go-style grouped parameters like `(a, b int)`", name),
+		)
 	} else {
-		// Provisional `any` when no type is specified. For lambda parameters this
-		// is a placeholder that transformLambdaWithExpectedType either overrides
-		// with the threaded expected type or rejects with GALA-E0033 when no type
-		// can be inferred — so untyped lambda params never reach generated Go as
-		// `any`. The fallback survives here only for non-lambda callers (function
-		// and method signatures, struct-shorthand fields), where the grammar
-		// requires an explicit type, making this an unreachable safety net rather
-		// than a sanctioned `any`. A warning is still emitted so any such site is
-		// surfaced under GALA_WARN_TYPES.
-		t.warnInference("parameter %q has no declared type; defaulted to `any`", name)
+		// Provisional `any` for lambda parameters only: transformLambdaWithExpectedType
+		// either overrides this with the threaded expected type or rejects it with
+		// GALA-E0033 when no type can be inferred, so untyped lambda params never
+		// reach generated Go as `any`.
 		if isVariadic {
 			field.Type = &ast.Ellipsis{Elt: ast.NewIdent("any")}
 		} else {
@@ -1425,7 +1438,7 @@ func (t *galaASTTransformer) transformSignature(ctx *grammar.SignatureContext, t
 	fieldList := &ast.FieldList{}
 	if paramsCtx.ParameterList() != nil {
 		for _, pCtx := range paramsCtx.ParameterList().(*grammar.ParameterListContext).AllParameter() {
-			field, err := t.transformParameter(pCtx.(*grammar.ParameterContext))
+			field, err := t.transformParameter(pCtx.(*grammar.ParameterContext), true)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/transpiler/transformer/error_codes_test.go
+++ b/internal/transpiler/transformer/error_codes_test.go
@@ -375,6 +375,37 @@ func main() {
 			expectCode:     galaerr.CodeUntypedLambdaParam,
 			expectContains: `lambda parameter "x" has no type`,
 		},
+		{
+			// Go-style grouped function parameters `(a, b int)` parse as a
+			// typeless `a` followed by a typed `b int`. GALA has no group-type
+			// propagation, so the typeless `a` must be rejected rather than
+			// silently emitted as `any`.
+			name: "GALA-E0034 grouped function parameter",
+			input: `package main
+
+func add(a, b int) int = a + b
+
+func main() {
+    Println(add(3, 4))
+}`,
+			expectCode:     galaerr.CodeUntypedParam,
+			expectContains: `parameter "a" has no declared type`,
+		},
+		{
+			// The same grouped-shorthand shape in a struct declaration
+			// (`struct Point(X, Y int)`) must likewise be rejected.
+			name: "GALA-E0034 grouped struct-shorthand field",
+			input: `package main
+
+struct Point(X, Y int)
+
+func main() {
+    val p = Point(3, 4)
+    Println(p.X + p.Y)
+}`,
+			expectCode:     galaerr.CodeUntypedParam,
+			expectContains: `parameter "X" has no declared type`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -71,7 +71,7 @@ func (t *galaASTTransformer) transformLambdaWithExpectedType(ctx *grammar.Lambda
 		}
 		for i, pCtx := range allParams {
 			paramCtx := pCtx.(*grammar.ParameterContext)
-			field, err := t.transformParameter(paramCtx)
+			field, err := t.transformParameter(paramCtx, false)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary

Verified **every** code example in `docs/EXAMPLES.MD` by running each block through a `gala` CLI built from this branch. Because the CLI uses the *embedded* stdlib (while the bazel `examples/` tests read repo source directly), this surfaced real breakage the existing tests were masking. Root causes fixed, examples corrected, and coverage expanded to the major language features that were missing.

## Transpiler / stdlib fixes
- **Embedded stdlib gap (shipped-CLI bug):** the `//internal/stdlib` embed genrule listed `collection_immutable`'s array/list/hashmap/hashset but omitted **treeset/treemap** — so the real CLI failed with `undefined: TreeSetOf` on the Sorted example even though bazel tests passed. Added the four missing targets.
- **Grouped parameters silently typed as `any` (transpiler bug):** `func add(a, b int)` and `struct Point(X, Y int)` parsed but typed the leading names as `any`, violating the concrete-types invariant. Now rejected with a new hard error **`GALA-E0034`** and a clear hint. Lambda parameter inference is unaffected. Adds regression tests (`error_codes_test.go`) and a `docs/errors/GALA-E0034.md` page.

## Doc corrections (all examples now compile & run)
- Complete Example: grouped `Point` fields → explicit `X int, Y int`
- Option Monad: `None()` → `None[int]()`
- Pattern guards: `SliceOf`+`for range` (missing import) → idiomatic `ArrayOf`+`ForEach`
- Interface: int literals → `float64` literals
- Try func-ref: dropped unused `val`, use a bare `Try(...)` statement
- Two illustrative fragments promoted to complete, runnable programs

## Coverage added
Sealed Types (ADTs) · Either · For loops · String interpolation (`s""`/`f""`) · Variadic + spread · Future/async · HashMap — each with verified output.

## Regression guard
Rewrote `examples/doc_verify/examples_md.gala` into a comprehensive golden test over all sections; regenerated `.out`; updated deps.

## Testing
- `bazel build //...` ✅
- `bazel test //...` → 356/357 pass; the lone failure is the pre-existing Windows symlink-privilege test (`TestGorootFromGoBinarySymlink`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)