### PR TITLE
docs(website): showcase bind/also monadic binding

### DIFF
--- a/website/docs/language-reference.md
+++ b/website/docs/language-reference.md
@@ -392,7 +392,7 @@ func makePerson(name string, email string, age int) Validated[string, Person] {
     bind n = vName(name)
     also e = vEmail(email)
     also a = vAge(age)
-    Valid[string, Person](Person(n, e, a))
+    Valid(Person(n, e, a))
 }
 ```
 

--- a/website/docs/language-reference.md
+++ b/website/docs/language-reference.md
@@ -374,6 +374,30 @@ val res = arr match {
 }
 ```
 
+### Monadic Binding (`bind` / `also`)
+
+Inside a function whose result type is a monad `M`, `bind name = expr` unwraps `M` and binds the success value; the block lowers to a `FlatMap` chain, so every bound name stays in scope for later statements. `also` marks an *independent* clause: a `bind`+`also` group lowers through `Zip{N}` when the monad provides it — `Validated` (in the `validation` package) accumulates all errors, `Future` runs the clauses concurrently — and falls back to the sequential `FlatMap` chain for fail-fast monads (`Try`/`Option`/`Either`).
+
+```gala
+// bind: each value stays in scope; the first Failure short-circuits.
+func processOrder(id int) Try[Receipt] {
+    bind o = fetchOrder(id)
+    bind valid = validateOrder(o)
+    bind payment = chargePayment(valid)
+    Success(Receipt(o.Id, payment))
+}
+
+// also over Validated: report ALL invalid fields, not just the first.
+func makePerson(name string, email string, age int) Validated[string, Person] {
+    bind n = vName(name)
+    also e = vEmail(email)
+    also a = vAge(age)
+    Valid[string, Person](Person(n, e, a))
+}
+```
+
+Bound names are immutable `val`s. `bind`/`also` work over any user-defined monad that defines `FlatMap[U](f func(T) M[U]) M[U]`; a type without `FlatMap` is rejected with a clear compiler error. See [`bind` / `also` notation](https://github.com/martianoff/gala/blob/master/docs/BIND_NOTATION.MD) for the full specification and the user-monad extension guide.
+
 ### For Statement
 ```gala
 for i := 0; i < 10; i++ {

--- a/website/features/error-handling.md
+++ b/website/features/error-handling.md
@@ -391,19 +391,19 @@ The GALA version reads top-to-bottom. The happy path is the main path. Error han
 
 ## Monadic Binding: `bind` and `also`
 
-`Map`/`FlatMap` chains are great for a single linear pipeline — but the moment a later step needs a value from an **earlier** step, or you want to combine **independent** steps, they force awkward nesting. GALA's `bind`/`also` do-notation flattens both cases. Inside a function whose result is a monad, `bind name = expr` unwraps and names each step; the block lowers to the same `FlatMap` chain.
+`Map`/`FlatMap` chains are great for a single linear pipeline. `bind`/`also` do-notation earns its keep on two shapes they handle badly: reusing an earlier value several steps later (a **graph**), and combining **independent** steps — where `also` unlocks error *accumulation* and *concurrency* that a `FlatMap` chain cannot express at all. Inside a function whose result is a monad, `bind name = expr` unwraps and names each step; the block lowers to the same `FlatMap` chain.
 
 ### The "graph" case — reuse an earlier value later
 
-The final `Receipt` needs both the original order **and** the payment, so a `FlatMap` chain must nest (each value is trapped in a closure):
+The final `Receipt` needs both the original order **and** the payment, so a `FlatMap` chain must nest — each value is trapped in a closure, the accumulator type `[Receipt]` is repeated at every link, and the block ends in a pile of closing parens:
 
-**Before — nested `FlatMap`:**
+**Before — nested `FlatMap`** (`o` survives only via the deepening indentation):
 
 ```gala
 func processOrder(id int) Try[Receipt] =
-    fetchOrder(id).FlatMap((o) =>
-    validateOrder(o).FlatMap((valid) =>
-    chargePayment(valid).FlatMap((payment) =>
+    fetchOrder(id).FlatMap[Receipt]((o) =>
+    validateOrder(o).FlatMap[Receipt]((valid) =>
+    chargePayment(valid).FlatMap[Receipt]((payment) =>
     Success(Receipt(o.Id, payment)))))
 ```
 
@@ -429,11 +429,11 @@ func makePerson(name string, email string, age int) Validated[string, Person] {
     bind n = vName(name)
     also e = vEmail(email)
     also a = vAge(age)
-    Valid[string, Person](Person(n, e, a))
+    Valid(Person(n, e, a))
 }
 ```
 
-`makePerson("", "", -1).GetErrors().Size()` returns **3** — all three failures at once, not just the first. Swap the `also`s for `bind`s and you'd get `1`.
+`makePerson("", "", -1).GetErrors().Size()` returns **3** — all three failures at once, not just the first. A `FlatMap` chain cannot do this: it is fail-fast, so it stops at the first error. Swap the `also`s for `bind`s and you'd get `1`.
 
 ### Concurrency — run independent clauses in parallel
 

--- a/website/features/error-handling.md
+++ b/website/features/error-handling.md
@@ -389,6 +389,69 @@ The GALA version reads top-to-bottom. The happy path is the main path. Error han
 
 ---
 
+## Monadic Binding: `bind` and `also`
+
+`Map`/`FlatMap` chains are great for a single linear pipeline — but the moment a later step needs a value from an **earlier** step, or you want to combine **independent** steps, they force awkward nesting. GALA's `bind`/`also` do-notation flattens both cases. Inside a function whose result is a monad, `bind name = expr` unwraps and names each step; the block lowers to the same `FlatMap` chain.
+
+### The "graph" case — reuse an earlier value later
+
+The final `Receipt` needs both the original order **and** the payment, so a `FlatMap` chain must nest (each value is trapped in a closure):
+
+**Before — nested `FlatMap`:**
+
+```gala
+func processOrder(id int) Try[Receipt] =
+    fetchOrder(id).FlatMap((o) =>
+    validateOrder(o).FlatMap((valid) =>
+    chargePayment(valid).FlatMap((payment) =>
+    Success(Receipt(o.Id, payment)))))
+```
+
+**After — a flat `bind` block** (every value stays in scope, reads top-to-bottom):
+
+```gala
+func processOrder(id int) Try[Receipt] {
+    bind o = fetchOrder(id)
+    bind valid = validateOrder(o)
+    bind payment = chargePayment(valid)
+    Success(Receipt(o.Id, payment))   // `o` still in scope; first Failure short-circuits
+}
+```
+
+### Error accumulation — report ALL invalid fields
+
+`bind` is fail-fast: over `Try`/`Option`/`Either` the first failure wins. `also` marks **independent** clauses, and over `Validated` (in the `validation` package) it accumulates *every* error instead of stopping at the first:
+
+```gala
+import . "martianoff/gala/validation"
+
+func makePerson(name string, email string, age int) Validated[string, Person] {
+    bind n = vName(name)
+    also e = vEmail(email)
+    also a = vAge(age)
+    Valid[string, Person](Person(n, e, a))
+}
+```
+
+`makePerson("", "", -1).GetErrors().Size()` returns **3** — all three failures at once, not just the first. Swap the `also`s for `bind`s and you'd get `1`.
+
+### Concurrency — run independent clauses in parallel
+
+Over `Future`, an `also` group runs its clauses **concurrently** rather than threading each through the next:
+
+```gala
+func total() Future[int] {
+    bind a = compute(2)
+    also b = compute(3)   // independent — all three run at once
+    also c = compute(4)
+    Future[int](a + b + c)
+}
+```
+
+Bound names are immutable `val`s, and `bind`/`also` work over any user-defined monad that provides a `FlatMap` method. See the [language reference](/docs/language-reference/) for the full specification.
+
+---
+
 ## When Go's Error Handling Is Fine
 
 GALA's monadic types are not always the right tool. Honest trade-offs:


### PR DESCRIPTION
Adds `bind`/`also` to the Jekyll site, mirroring the in-repo docs (#403).

- **`website/features/error-handling.md`** — new "Monadic Binding" section with the compelling **before/after** examples: the nested `FlatMap` pyramid vs a flat `bind` block (graph case), `Validated` error accumulation (all 3 errors vs 1), and `Future` concurrency.
- **`website/docs/language-reference.md`** — a `bind`/`also` subsection under Control Flow.

Plain-markdown additions; Jekyll builds on Pages deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)