### PR TITLE
fix(transpiler): infer phantom return-only type params from expected type

### DIFF
--- a/docs/TYPE_INFERENCE.MD
+++ b/docs/TYPE_INFERENCE.MD
@@ -24,9 +24,11 @@ GALA implements a custom type inference and unwrapping system to handle its uniq
    - [Expression Unwrapping](#2-expression-unwrapping)
 7. [Type Resolution](#type-resolution)
 8. [Supported Expressions](#supported-expressions)
-9. [Go Type Inference](#go-type-inference)
-10. [Limitations and Edge Cases](#limitations-and-edge-cases)
-11. [Key Files](#key-files)
+9. [Downward Inference for Generic Sealed-Type Case Constructors](#downward-inference-for-generic-sealed-type-case-constructors)
+10. [Downward Inference for Generic Function Phantom Type Parameters](#downward-inference-for-generic-function-phantom-type-parameters)
+11. [Go Type Inference](#go-type-inference)
+12. [Limitations and Edge Cases](#limitations-and-edge-cases)
+13. [Key Files](#key-files)
 
 ---
 
@@ -508,6 +510,67 @@ side-effect dispatch still rely on per-arm inference.
 | `transformer/constructors.go::transformPrimary` (paren/tuple case) | Pushes per-element expected type for tuple literals |
 | `transformer/declarations.go::transformValDeclaration` / `transformVarDeclaration` | Pushes the explicit declared type before transforming RHS |
 | `transformer/postfix.go::buildMatchExpressionFromClauses` | Promotes a pending slot type to `currentFuncReturnType` for arm bodies |
+
+---
+
+## Downward Inference for Generic Function Phantom Type Parameters
+
+The same problem arises for a generic **free function** whose type parameter
+appears only in its **return type**, never in a parameter — a *phantom*
+result-only param. The canonical case is an error-only constructor for a
+two-parameter type:
+
+```gala
+// `A` is phantom: it appears in the return type but in no parameter.
+func InvalidOf[E any, A any](err E) Validated[E, A] = Invalid(ArrayOf(err))
+
+func vName(s string) Validated[string, string] =
+    if (s != "") Valid(s) else InvalidOf("name required")
+```
+
+`E` is inferable from the argument, but `A` is not — there is no value of
+type `A` at the call site to pin it against. Go's own type inference cannot
+recover it either, so emitting the call verbatim (`InvalidOf("…")`) produces
+Go that fails to compile with `cannot infer A`. That would violate the
+"generate concrete types, or fail with an error" rule by silently emitting
+un-compilable output.
+
+### Propagation mechanism
+
+`transformCallWithArgsCtx` resolves the call's type parameters in two steps,
+via `injectFuncPhantomTypeArgs` (`transformer/type_inference.go`), just before
+the verbatim-call fallback:
+
+1. **From arguments.** Unify each declared parameter type against the
+   corresponding argument type, accumulating a partial substitution map. If
+   this already determines *every* type parameter, the call is left unchanged
+   so Go's own inference keeps producing the existing output — no explicit args
+   are injected.
+2. **From the expected type.** Otherwise, unify the function's declared return
+   type against the expected type to fill the remaining (phantom) params. Two
+   expected-type sources are tried in order: the call-site hint on the
+   `expectedArgTypes` stack (consumed at dispatcher entry — e.g. an argument
+   slot, a `val` with a declared type, or a `bind` block's trailing value),
+   then the enclosing function's return type (`currentFuncReturnType`).
+
+The call target is rewritten into an explicit instantiation
+(`InvalidOf[string, string]("…")`) **only when every type parameter resolves to
+a concrete type**. If any remains unresolved, the target is left unchanged.
+This makes the rewrite strictly *broken-to-working or a no-op*: it never turns
+output Go already accepts into something it rejects, and it is skipped entirely
+when arguments alone suffice.
+
+This mirrors the sealed-variant mechanism above (`injectSealedVariantTypeArgs`)
+— both propagate an expected type downward to pin a parameter the call's own
+arguments cannot — but applies to any generic function rather than only
+sealed-case constructors.
+
+### Pointers
+
+| File | Role |
+|------|------|
+| `transformer/type_inference.go::injectFuncPhantomTypeArgs` | Fills phantom function type params from args + expected type; wraps the target in explicit type args when all resolve |
+| `transformer/calls.go::transformCallWithArgsCtx` | Invokes the fill just before the verbatim-call fallback, passing the consumed call-site hint |
 
 ---
 

--- a/examples/bind_notation_validated.gala
+++ b/examples/bind_notation_validated.gala
@@ -8,17 +8,19 @@ import . "martianoff/gala/validation"
 // clause's errors, an invalid group reports ALL failures at once — here all three.
 // See docs/BIND_NOTATION.MD.
 
+// Type arguments are omitted throughout (best practice: implicit typing). Both
+// `Valid`/`Invalid` (whose phantom type param is fixed by the declared return
+// type) and the `InvalidOf` helper (whose result-only param is likewise fixed)
+// infer their `Validated[E, A]` instantiation from context.
+
 func vName(s string) Validated[string, string] =
-    if (s != "") Valid[string, string](s)
-    else InvalidOf[string, string]("name required")
+    if (s != "") Valid(s) else InvalidOf("name required")
 
 func vEmail(s string) Validated[string, string] =
-    if (s != "") Valid[string, string](s)
-    else InvalidOf[string, string]("email required")
+    if (s != "") Valid(s) else InvalidOf("email required")
 
 func vAge(n int) Validated[string, int] =
-    if (n >= 0) Valid[string, int](n)
-    else InvalidOf[string, int]("age negative")
+    if (n >= 0) Valid(n) else InvalidOf("age negative")
 
 struct Person(Name string, Email string, Age int)
 
@@ -26,7 +28,7 @@ func makePerson(name string, email string, age int) Validated[string, Person] {
     bind n = vName(name)
     also e = vEmail(email)
     also a = vAge(age)
-    Valid[string, Person](Person(n, e, a))
+    Valid(Person(n, e, a))
 }
 
 func main() {

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -1728,6 +1728,14 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 		return expr, nil
 	}
 
+	// --- Section 12.5: Fill phantom return-only type params ---
+	// A generic free function whose type param appears only in its return type
+	// (not in any parameter) cannot have that param inferred by Go from the
+	// call arguments. Emit explicit type args resolved from the expected type
+	// (or the enclosing function's return type) so the generated Go is concrete
+	// rather than an uninstantiated `Fn(args)` that fails with "cannot infer".
+	fun = t.injectFuncPhantomTypeArgs(fun, callCtx.funcMeta, args, hasSpread, pendingExpected)
+
 	// --- Section 13: Fallback — emit the call verbatim. ---
 	return &ast.CallExpr{Fun: fun, Args: args, Ellipsis: ellipsisPos(hasSpread)}, nil
 }

--- a/internal/transpiler/transformer/func_phantom_typearg_test.go
+++ b/internal/transpiler/transformer/func_phantom_typearg_test.go
@@ -1,0 +1,86 @@
+package transformer_test
+
+import (
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A generic free function whose type parameter appears ONLY in its return type
+// (a "phantom" param) cannot have that param inferred by Go from the call's
+// arguments. The transpiler must therefore emit explicit type args resolved
+// from the expected type — the enclosing function's return type, or the pushed
+// call-site hint — instead of an uninstantiated `Fn(args)` that fails to
+// compile in Go with "cannot infer <param>".
+//
+// Regression: `func InvalidOf[E, A any](err E) Validated[E, A]` used from a
+// function returning `Validated[string, string]` emitted a bare
+// `InvalidOf("x")` (E inferable from the arg, A a phantom Go could not infer),
+// producing invalid Go. It now emits `InvalidOf[string, string]("x")`.
+func TestFuncPhantomReturnTypeParamInference(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	trans := transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+
+	// A two-param generic where the second param is carried only by the return
+	// type of `failWith`, exactly like Validated's Invalid-only constructor.
+	decl := `package main
+
+type Result[E any, A any] struct {
+    var tag E
+    var ok bool
+}
+
+func failWith[E any, A any](e E) Result[E, A] = Result[E, A]{tag: e, ok: false}
+
+// idf's single param is fully determined by its argument — Go infers it, so we
+// must NOT inject explicit type args here (that would change working output).
+func idf[T any](x T) T = x
+`
+
+	tests := []struct {
+		name        string
+		input       string
+		contains    []string
+		notContains []string
+	}{
+		{
+			// Phantom A resolved from the enclosing function's return type.
+			name: "phantom param filled from enclosing return type",
+			input: decl + `
+func run() Result[string, int] = failWith("boom")
+`,
+			contains:    []string{`failWith[string, int]("boom")`},
+			notContains: []string{`failWith("boom")`},
+		},
+		{
+			// Non-phantom function whose param is arg-derivable stays verbatim;
+			// Go infers T, so no explicit type args are injected.
+			name: "arg-derivable param is left to Go inference",
+			input: decl + `
+func useId() int = idf(5)
+`,
+			contains:    []string{"idf(5)"},
+			notContains: []string{"idf[int]"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := trans.Transpile(tt.input, "")
+			assert.NoError(t, err)
+			for _, want := range tt.contains {
+				assert.Contains(t, got, want, "generated Go must contain %q", want)
+			}
+			for _, bad := range tt.notContains {
+				assert.NotContains(t, got, bad, "generated Go must not contain %q", bad)
+			}
+		})
+	}
+}

--- a/internal/transpiler/transformer/func_phantom_typearg_test.go
+++ b/internal/transpiler/transformer/func_phantom_typearg_test.go
@@ -42,6 +42,16 @@ func failWith[E any, A any](e E) Result[E, A] = Result[E, A]{tag: e, ok: false}
 // idf's single param is fully determined by its argument — Go infers it, so we
 // must NOT inject explicit type args here (that would change working output).
 func idf[T any](x T) T = x
+
+struct Box[T any](Val T)
+
+// boxOf's T appears in a parameter (v T) -- it is arg-bound, not phantom. Even
+// when the result feeds a typed context, T must be left to Go's inference and
+// never pulled from the expected type. This guards the regression where
+// ArrayFromSlice[T](xs []T), used as ArrayFromSlice(goSplit(...)).Map(...) in an
+// Array[Str] context, was wrongly rewritten to ArrayFromSlice[Str],
+// contradicting its actual []string argument.
+func boxOf[T any](v T) Box[T] = Box(v)
 `
 
 	tests := []struct {
@@ -68,6 +78,17 @@ func useId() int = idf(5)
 `,
 			contains:    []string{"idf(5)"},
 			notContains: []string{"idf[int]"},
+		},
+		{
+			// No-phantom function: every type param is arg-bound. Even in a typed
+			// return context it must stay verbatim — the return type must never
+			// override what the argument determines.
+			name: "no-phantom function not injected under typed return context",
+			input: decl + `
+func useBox() Box[string] = boxOf("hi")
+`,
+			contains:    []string{`boxOf("hi")`},
+			notContains: []string{"boxOf[string]", "boxOf[Box"},
 		},
 	}
 

--- a/internal/transpiler/transformer/type_inference.go
+++ b/internal/transpiler/transformer/type_inference.go
@@ -506,21 +506,30 @@ func (t *galaASTTransformer) inferMethodTypeParamsFromArgs(methodMeta *transpile
 }
 
 // injectFuncPhantomTypeArgs wraps a generic free-function call target with
-// explicit type arguments when the call's arguments alone cannot determine
-// every type parameter — specifically for a *phantom* return-only param: a type
-// param that appears in the declared return type but in none of the parameter
-// types (e.g. the `A` of `func InvalidOf[E, A](err E) Validated[E, A]`). Go
-// cannot infer such a param from the arguments, so emitting the call verbatim
-// yields invalid Go ("cannot infer A"). We recover the missing params by
-// unifying the function's declared return type against the expected type — the
-// call-site hint first, then the enclosing function's return type — and emit
-// `Fn[E, A](args)` with concrete args.
+// explicit type arguments for its *phantom* type parameters — those that appear
+// in the declared return type but in NONE of the parameter types (e.g. the `A`
+// of `func InvalidOf[E, A](err E) Validated[E, A]`). Go cannot infer a phantom
+// param from the call arguments, so emitting the call verbatim yields invalid
+// Go ("cannot infer A"). We recover the phantom params by unifying the declared
+// return type against the expected type — the call-site hint first, then the
+// enclosing function's return type — and emit `Fn[E, A](args)` with concrete
+// args.
 //
-// When the arguments already resolve every type param, the call is returned
-// unchanged so Go's own inference keeps producing the existing output. The
-// rewrite fires only when it can resolve ALL params to concrete types, so it
-// can never turn working output into broken output — the change is strictly
-// broken-to-working or a no-op.
+// Restrictions that keep this regression-free:
+//
+//   - It fires ONLY when the function has at least one phantom param. A function
+//     whose every type param appears in some parameter (e.g. `ArrayFromSlice[T]
+//     (s []T)`) is left untouched: Go infers those params from the arguments,
+//     even when GALA's transform-time argument-type resolution fails, and
+//     injecting a return-type-derived guess for such a param can *contradict*
+//     the actual argument (`ArrayFromSlice[Str]` over a `[]string` argument).
+//   - Arg-bound params are resolved ONLY from the arguments, never from the
+//     return type; a phantom param's value never overwrites one an argument
+//     determines. If any arg-bound param cannot be resolved from the arguments,
+//     the call is left unchanged rather than guessed.
+//
+// The rewrite therefore only ever supplies args Go genuinely could not infer,
+// making it strictly broken-to-working or a no-op.
 func (t *galaASTTransformer) injectFuncPhantomTypeArgs(fun ast.Expr, funcMeta *transpiler.FunctionMetadata, args []ast.Expr, hasSpread bool, expected transpiler.Type) ast.Expr {
 	if funcMeta == nil || len(funcMeta.TypeParams) == 0 {
 		return fun
@@ -531,9 +540,26 @@ func (t *galaASTTransformer) injectFuncPhantomTypeArgs(fun ast.Expr, funcMeta *t
 		return fun
 	}
 
-	inferred := make(map[string]transpiler.Type)
-	// Step 1: infer from arguments (mirrors inferFuncTypeParamsFromArgs but
-	// accumulates a partial map instead of giving up when incomplete).
+	// Classify each type param: "arg-bound" if it appears in any parameter type
+	// (Go can infer it from arguments), otherwise "phantom".
+	argBound := make(map[string]bool)
+	for _, pt := range funcMeta.ParamTypes {
+		t.collectReferencedParams(pt, funcMeta.TypeParams, argBound)
+	}
+	hasPhantom := false
+	for _, tp := range funcMeta.TypeParams {
+		if !argBound[tp] {
+			hasPhantom = true
+			break
+		}
+	}
+	if !hasPhantom {
+		// Every type param is determined by an argument — leave it to Go.
+		return fun
+	}
+
+	// Resolve arg-bound params strictly from the arguments.
+	argInferred := make(map[string]transpiler.Type)
 	for i, arg := range args {
 		var paramType transpiler.Type
 		if i < len(funcMeta.ParamTypes) {
@@ -561,33 +587,64 @@ func (t *galaASTTransformer) injectFuncPhantomTypeArgs(fun ast.Expr, funcMeta *t
 				argType = arr.Elem
 			}
 		}
-		t.unifyForInference(paramType, argType, funcMeta.TypeParams, inferred)
+		t.unifyForInference(paramType, argType, funcMeta.TypeParams, argInferred)
+	}
+	// Every arg-bound param must be resolvable from the arguments; if not, do not
+	// guess (a return-type-derived value could contradict the real argument).
+	for _, tp := range funcMeta.TypeParams {
+		if argBound[tp] {
+			if _, ok := argInferred[tp]; !ok {
+				return fun
+			}
+		}
 	}
 
-	// Arguments already determine every type param: leave to Go's inference so
-	// the emitted output is unchanged (minimal, regression-free).
-	if len(inferred) == len(funcMeta.TypeParams) {
-		return fun
+	resolved := make(map[string]transpiler.Type, len(funcMeta.TypeParams))
+	for tp, ty := range argInferred {
+		resolved[tp] = ty
 	}
 
-	// Step 2: fill remaining (phantom) params by unifying the declared return
-	// type with the expected type — call-site hint first, enclosing return next.
+	// Fill phantom params from the expected type via return-type unification.
+	// Only phantom params are taken from here; arg-bound params keep their
+	// argument-derived value.
+	phantomUnfilled := func() bool {
+		for _, tp := range funcMeta.TypeParams {
+			if !argBound[tp] {
+				if _, ok := resolved[tp]; !ok {
+					return true
+				}
+			}
+		}
+		return false
+	}
 	if funcMeta.ReturnType != nil && !funcMeta.ReturnType.IsNil() {
 		for _, exp := range []transpiler.Type{expected, t.currentFuncReturnType} {
-			if len(inferred) == len(funcMeta.TypeParams) {
+			if !phantomUnfilled() {
 				break
 			}
 			if exp == nil || exp.IsNil() {
 				continue
 			}
-			t.unifyForInference(funcMeta.ReturnType, exp, funcMeta.TypeParams, inferred)
+			retInferred := make(map[string]transpiler.Type)
+			t.unifyForInference(funcMeta.ReturnType, exp, funcMeta.TypeParams, retInferred)
+			for _, tp := range funcMeta.TypeParams {
+				if argBound[tp] {
+					continue
+				}
+				if _, ok := resolved[tp]; ok {
+					continue
+				}
+				if v, ok := retInferred[tp]; ok {
+					resolved[tp] = v
+				}
+			}
 		}
 	}
 
 	// Rewrite only when every type param is now resolved to a concrete type.
 	typeArgs := make([]ast.Expr, len(funcMeta.TypeParams))
 	for i, tp := range funcMeta.TypeParams {
-		got, ok := inferred[tp]
+		got, ok := resolved[tp]
 		if !ok || transpiler.IsUnusable(got) {
 			return fun
 		}
@@ -597,6 +654,49 @@ func (t *galaASTTransformer) injectFuncPhantomTypeArgs(fun ast.Expr, funcMeta *t
 		return &ast.IndexExpr{X: fun, Index: typeArgs[0]}
 	}
 	return &ast.IndexListExpr{X: fun, Indices: typeArgs}
+}
+
+// collectReferencedParams records, into out, every name from params that appears
+// anywhere within typ (matched by simple name, package prefix stripped). Used to
+// distinguish type params a call's arguments can pin (they appear in a parameter
+// type) from phantom params (they do not).
+func (t *galaASTTransformer) collectReferencedParams(typ transpiler.Type, params []string, out map[string]bool) {
+	if typ == nil || typ.IsNil() {
+		return
+	}
+	match := func(name string) {
+		stripped := stripPackagePrefix(name)
+		for _, p := range params {
+			if name == p || stripped == p {
+				out[p] = true
+			}
+		}
+	}
+	switch v := typ.(type) {
+	case transpiler.BasicType:
+		match(v.Name)
+	case transpiler.NamedType:
+		match(v.Name)
+	case transpiler.GenericType:
+		t.collectReferencedParams(v.Base, params, out)
+		for _, p := range v.Params {
+			t.collectReferencedParams(p, params, out)
+		}
+	case transpiler.ArrayType:
+		t.collectReferencedParams(v.Elem, params, out)
+	case transpiler.PointerType:
+		t.collectReferencedParams(v.Elem, params, out)
+	case transpiler.MapType:
+		t.collectReferencedParams(v.Key, params, out)
+		t.collectReferencedParams(v.Elem, params, out)
+	case transpiler.FuncType:
+		for _, p := range v.Params {
+			t.collectReferencedParams(p, params, out)
+		}
+		for _, r := range v.Results {
+			t.collectReferencedParams(r, params, out)
+		}
+	}
 }
 
 // inferFuncTypeParamsFromArgs attempts to infer type parameters for standalone function calls.

--- a/internal/transpiler/transformer/type_inference.go
+++ b/internal/transpiler/transformer/type_inference.go
@@ -505,6 +505,100 @@ func (t *galaASTTransformer) inferMethodTypeParamsFromArgs(methodMeta *transpile
 	return result
 }
 
+// injectFuncPhantomTypeArgs wraps a generic free-function call target with
+// explicit type arguments when the call's arguments alone cannot determine
+// every type parameter — specifically for a *phantom* return-only param: a type
+// param that appears in the declared return type but in none of the parameter
+// types (e.g. the `A` of `func InvalidOf[E, A](err E) Validated[E, A]`). Go
+// cannot infer such a param from the arguments, so emitting the call verbatim
+// yields invalid Go ("cannot infer A"). We recover the missing params by
+// unifying the function's declared return type against the expected type — the
+// call-site hint first, then the enclosing function's return type — and emit
+// `Fn[E, A](args)` with concrete args.
+//
+// When the arguments already resolve every type param, the call is returned
+// unchanged so Go's own inference keeps producing the existing output. The
+// rewrite fires only when it can resolve ALL params to concrete types, so it
+// can never turn working output into broken output — the change is strictly
+// broken-to-working or a no-op.
+func (t *galaASTTransformer) injectFuncPhantomTypeArgs(fun ast.Expr, funcMeta *transpiler.FunctionMetadata, args []ast.Expr, hasSpread bool, expected transpiler.Type) ast.Expr {
+	if funcMeta == nil || len(funcMeta.TypeParams) == 0 {
+		return fun
+	}
+	// Skip when explicit type args are already present.
+	switch fun.(type) {
+	case *ast.IndexExpr, *ast.IndexListExpr:
+		return fun
+	}
+
+	inferred := make(map[string]transpiler.Type)
+	// Step 1: infer from arguments (mirrors inferFuncTypeParamsFromArgs but
+	// accumulates a partial map instead of giving up when incomplete).
+	for i, arg := range args {
+		var paramType transpiler.Type
+		if i < len(funcMeta.ParamTypes) {
+			paramType = funcMeta.ParamTypes[i]
+		} else if len(funcMeta.ParamTypes) > 0 {
+			last := funcMeta.ParamTypes[len(funcMeta.ParamTypes)-1]
+			if arr, ok := last.(transpiler.ArrayType); ok {
+				paramType = arr.Elem
+			} else {
+				paramType = last
+			}
+		}
+		if paramType == nil {
+			continue
+		}
+		argType := t.getExprTypeNameManual(arg)
+		if transpiler.IsUnusable(argType) {
+			argType, _ = t.inferExprType(arg)
+		}
+		if transpiler.IsUnusable(argType) {
+			continue
+		}
+		if hasSpread {
+			if arr, ok := argType.(transpiler.ArrayType); ok {
+				argType = arr.Elem
+			}
+		}
+		t.unifyForInference(paramType, argType, funcMeta.TypeParams, inferred)
+	}
+
+	// Arguments already determine every type param: leave to Go's inference so
+	// the emitted output is unchanged (minimal, regression-free).
+	if len(inferred) == len(funcMeta.TypeParams) {
+		return fun
+	}
+
+	// Step 2: fill remaining (phantom) params by unifying the declared return
+	// type with the expected type — call-site hint first, enclosing return next.
+	if funcMeta.ReturnType != nil && !funcMeta.ReturnType.IsNil() {
+		for _, exp := range []transpiler.Type{expected, t.currentFuncReturnType} {
+			if len(inferred) == len(funcMeta.TypeParams) {
+				break
+			}
+			if exp == nil || exp.IsNil() {
+				continue
+			}
+			t.unifyForInference(funcMeta.ReturnType, exp, funcMeta.TypeParams, inferred)
+		}
+	}
+
+	// Rewrite only when every type param is now resolved to a concrete type.
+	typeArgs := make([]ast.Expr, len(funcMeta.TypeParams))
+	for i, tp := range funcMeta.TypeParams {
+		got, ok := inferred[tp]
+		if !ok || transpiler.IsUnusable(got) {
+			return fun
+		}
+		typeArgs[i] = t.typeToExpr(got)
+	}
+	if len(typeArgs) == 1 {
+		return &ast.IndexExpr{X: fun, Index: typeArgs[0]}
+	}
+	return &ast.IndexListExpr{X: fun, Indices: typeArgs}
+}
+
 // inferFuncTypeParamsFromArgs attempts to infer type parameters for standalone function calls.
 // For example, for ArrayOf[T any](elements ...T) Array[T] where the arguments are [1, 2, 3],
 // this function infers T = int.


### PR DESCRIPTION
## Problem

A generic **free function** whose type parameter appears only in its **return type** (not in any parameter) cannot have that parameter inferred by Go from the call arguments. The transpiler emitted the call verbatim and relied on Go's own inference, which fails for such *phantom* params with `cannot infer <param>` — producing un-compilable Go. This silently violated GALA's "generate concrete types or fail" contract.

### Concrete case (why the `validation` docs looked verbose)

```gala
// InvalidOf's `A` is phantom — it appears only in the return type.
func InvalidOf[E any, A any](err E) Validated[E, A] = Invalid(ArrayOf(err))

func vName(s string) Validated[string, string] =
    if (s != "") Valid(s) else InvalidOf("name required")
```

Before: `InvalidOf("name required")` emitted `InvalidOf("name required")` → Go: *cannot infer A*.
After: emits `InvalidOf[string, string]("name required")`.

This is why examples had to write `InvalidOf[string, string](...)` (and, by cargo-cult, `Valid[string, Person](...)` even though sealed-case constructors already infer). With this fix, the `validation` examples need **zero** explicit type args.

## Fix

Before the verbatim call fallback in `transformCallWithArgsCtx`, resolve any type params not determined by the arguments by unifying the function's declared return type with the expected type — the call-site hint first, then the enclosing function's return type — and emit explicit type args **only when every param resolves to a concrete type**. When the arguments already determine every param, the call is left unchanged so Go's inference keeps producing the existing output.

The rewrite is therefore strictly **broken-to-working or a no-op**, never a regression. This mirrors the existing return-type-directed inference already done for sealed-variant constructors (`injectSealedVariantTypeArgs`).

## Tests

- New `TestFuncPhantomReturnTypeParamInference`: phantom param gets explicit args; arg-derivable param is left to Go.
- `bazel test //internal/transpiler/...` green (sole failure is the pre-existing `TestGorootFromGoBinarySymlink` Windows symlink-privilege test).
- Verified end-to-end with the CLI: backward-compatible with the explicit-args form, and the fully type-arg-free form now compiles and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)