### PR TITLE
fix(transpiler): reject cross-clause references within a bind/also group

### DIFF
--- a/internal/transpiler/transformer/bind.go
+++ b/internal/transpiler/transformer/bind.go
@@ -121,6 +121,76 @@ func collectBindGroup(stmts []grammar.IStatementContext) ([]bindEntry, []grammar
 	return group, stmts[i:]
 }
 
+// checkBindGroupIndependence rejects a clause that references a binding
+// introduced by a *sibling* clause of the same product group. A group is a
+// leading `bind` plus one or more `also` clauses; its clauses are evaluated
+// independently (concurrently for Future, error-accumulating for Validated), so
+// a sibling's bound value is genuinely not available. The clauses' RHS were
+// transformed before any group name was added to scope, so a same-group name
+// appearing in a clause can only be a forward reference — unless that name also
+// names a variable already in the enclosing scope (a legitimate outer binding
+// the sibling would merely shadow), which is left alone. Emitting a clear
+// diagnostic here replaces the raw Go "undefined: x" that the generated code
+// would otherwise produce far from the source.
+func (t *galaASTTransformer) checkBindGroupIndependence(group []bindEntry, prepped []preppedBind) error {
+	if len(group) < 2 {
+		return nil // a lone `bind` has no sibling to leak from.
+	}
+	for i := range group {
+		siblings := make(map[string]bool)
+		for j := range group {
+			if j == i {
+				continue
+			}
+			name := group[j].name
+			if name == "" || name == "_" || t.isNameInScope(name) {
+				continue
+			}
+			siblings[name] = true
+		}
+		if ref := firstReferencedName(prepped[i].recvExpr, siblings); ref != "" {
+			return t.semanticErrorAt(group[i].ctx,
+				"cannot reference `"+ref+"` here: clauses in a `bind`/`also` group are "+
+					"evaluated independently, so a binding from one clause is not in scope "+
+					"for its siblings. Move this clause to its own `bind` if it must see `"+ref+"`.")
+		}
+	}
+	return nil
+}
+
+// isNameInScope reports whether name resolves to a variable in the current
+// lexical scope chain. Group names are added to scope only after independence
+// checking, so during that check this distinguishes an outer binding from a
+// not-yet-bound same-group sibling.
+func (t *galaASTTransformer) isNameInScope(name string) bool {
+	for s := t.currentScope; s != nil; s = s.parent {
+		if _, ok := s.vals[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// firstReferencedName returns the first identifier in expr whose name is in
+// names, or "" if none.
+func firstReferencedName(expr ast.Expr, names map[string]bool) string {
+	if expr == nil || len(names) == 0 {
+		return ""
+	}
+	found := ""
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if found != "" {
+			return false
+		}
+		if id, ok := n.(*ast.Ident); ok && names[id.Name] {
+			found = id.Name
+			return false
+		}
+		return true
+	})
+	return found
+}
+
 // desugarBindChain lowers a run of statements beginning with a `bind` into a
 // FlatMap/Zip call expression of type resultType (the enclosing monad M[R]).
 func (t *galaASTTransformer) desugarBindChain(stmts []grammar.IStatementContext, resultType transpiler.Type) (ast.Expr, error) {
@@ -133,6 +203,10 @@ func (t *galaASTTransformer) desugarBindChain(stmts []grammar.IStatementContext,
 			return nil, err
 		}
 		prepped[i] = p
+	}
+
+	if err := t.checkBindGroupIndependence(group, prepped); err != nil {
+		return nil, err
 	}
 
 	// An `also` group whose monad provides a Zip combinator uses it (Future runs

--- a/internal/transpiler/transformer/bind_test.go
+++ b/internal/transpiler/transformer/bind_test.go
@@ -1,6 +1,7 @@
 package transformer_test
 
 import (
+	"strings"
 	"testing"
 
 	"martianoff/gala/internal/transpiler"
@@ -206,6 +207,47 @@ func run() Try[int] {
 	got, err := trans.Transpile(input, "")
 	assert.NoError(t, err)
 	assert.Contains(t, got, "FlatMap")
+}
+
+// A block may hold several product groups back-to-back. Each group lowers through
+// its own `Zip`, and consecutive groups compose via `FlatMap` (applicative within
+// a group, monadic across groups). Here two `also` groups each lower through the
+// monad's Zip2 and are threaded together, with every bound name in scope for the
+// trailing value.
+func TestBindMultipleZipGroupsCompose(t *testing.T) {
+	trans := newBindTranspiler()
+	input := `package main
+
+sealed type Box[T any] {
+    case Wrap(Value T)
+}
+
+func (b Box[T]) FlatMap[U any](f func(T) Box[U]) Box[U] = b match {
+    case Wrap(v) => f(v)
+}
+
+func (b Box[T]) Zip2[U any](o Box[U]) Box[Tuple[T, U]] = b match {
+    case Wrap(v) => o match {
+        case Wrap(w) => Wrap(Tuple(v, w))
+    }
+}
+
+func run() Box[int] {
+    bind a = Wrap(1)
+    also b = Wrap(2)
+    bind c = Wrap(3)
+    also d = Wrap(4)
+    Wrap(a + b + c + d)
+}
+`
+	got, err := trans.Transpile(input, "")
+	assert.NoError(t, err)
+	// Two distinct product groups, each lowered through its own Zip2 call
+	// (matching the instantiated call site, not the generic definition).
+	assert.Equal(t, 2, strings.Count(got, "Box_Zip2[int, int]("),
+		"each of the two `also` groups lowers through its own Zip2")
+	// All four bindings are in scope for the trailing value.
+	assert.Contains(t, got, "a.Get() + b.Get() + c.Get() + d.Get()")
 }
 
 // `bind` on a user-defined type that has other methods but no FlatMap is rejected

--- a/internal/transpiler/transformer/bind_test.go
+++ b/internal/transpiler/transformer/bind_test.go
@@ -169,6 +169,45 @@ func run() Try[int] {
 	assert.Contains(t, err.Error(), "also")
 }
 
+// A clause in an `also` product group may not reference a binding introduced by
+// a sibling clause of the same group: the clauses are evaluated independently
+// (a product/Zip), so the value is genuinely not available. This is reported
+// with a clear GALA diagnostic rather than the raw Go "undefined: a" that the
+// generated code would otherwise produce.
+func TestAlsoRejectsSiblingReference(t *testing.T) {
+	trans := newBindTranspiler()
+	input := `package main
+
+func run() Try[int] {
+    bind a = Success(1)
+    also b = Success(a)
+    Success(a + b)
+}
+`
+	_, err := trans.Transpile(input, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "independently")
+	assert.Contains(t, err.Error(), "`a`")
+}
+
+// The independence check must not flag a legitimate reference to a binding from
+// an EARLIER group (which is in scope): only same-group siblings are rejected.
+func TestBindAllowsCrossGroupReference(t *testing.T) {
+	trans := newBindTranspiler()
+	input := `package main
+
+func run() Try[int] {
+    bind a = Success(1)
+    also b = Success(2)
+    bind c = Success(a + b)
+    Success(a + b + c)
+}
+`
+	got, err := trans.Transpile(input, "")
+	assert.NoError(t, err)
+	assert.Contains(t, got, "FlatMap")
+}
+
 // `bind` on a user-defined type that has other methods but no FlatMap is rejected
 // with a clear "not a bindable monad" diagnostic — not a cryptic downstream Go
 // compile error.


### PR DESCRIPTION
## Problem

Clauses in an `also` **product group** (a leading `bind` plus one or more `also`) are evaluated **independently** — concurrently for `Future`, error-accumulating for `Validated`. So a binding introduced by one clause is genuinely not available to its siblings:

```gala
func makePerson(name string) Validated[string, Person] {
    bind n = vName(name)
    also e = vEmail(n)   // ← `n` is NOT available: the clauses run independently
    ...
}
```

Before this change that compiled to Go which failed with a raw `undefined: n` pointing at generated code, far from the source — violating the "clear compiler error" principle.

## Fix

Add an independence check in `desugarBindChain` that reports the reference with a clear GALA diagnostic:

> cannot reference `n` here: clauses in a `bind`/`also` group are evaluated independently, so a binding from one clause is not in scope for its siblings. Move this clause to its own `bind` if it must see `n`.

Precision:
- Fires only for **product groups** (size ≥ 2). A lone `bind` has no sibling.
- Flags only names a **sibling clause introduces**. A same-named binding already in the enclosing scope (which the sibling would merely shadow) is left alone, so a later `bind` legitimately reading an **earlier** group's binding keeps working — the clauses' RHS are transformed before any group name enters scope, so a same-group name can only be a forward reference unless it resolves to an outer binding.

## Tests

- `TestAlsoRejectsSiblingReference` — sibling reference → clear diagnostic (`independently`, names the binding).
- `TestBindAllowsCrossGroupReference` — a later `bind` reading an earlier group's binding still transpiles.
- All existing bind/also examples and unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)