### PR TITLE
ci(pages): only deploy on website changes; cancel superseded deploys

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -2,9 +2,17 @@
 name: Deploy Jekyll with GitHub Pages dependencies preinstalled
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes targeting the default branch, but only when the published
+  # site actually changes. The Jekyll source is ./website, so commits that touch
+  # only code/docs (the vast majority) must NOT trigger a redeploy — doing so
+  # piled up concurrent Pages deployments on clustered merges, and the GitHub
+  # Pages backend fails the superseded ones with "Deployment failed, try again
+  # later." (`docs/` is repo documentation, not part of the published site.)
   push:
     branches: ["master"]
+    paths:
+      - "website/**"
+      - ".github/workflows/jekyll-gh-pages.yml"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -15,11 +23,13 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Allow only one concurrent deployment. When two website changes land close
+# together, cancel the older in-progress deploy so only the newest publishes —
+# for a static docs site the superseded version is never wanted, and letting
+# both run is exactly what triggers the Pages "try again later" failure.
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # Build job


### PR DESCRIPTION
## Why the website deploy kept failing

The **build** job always succeeded — only the **deploy** step failed, fast (~5s → `Deployment failed, try again later`). That's the GitHub Pages backend rejecting a *superseded* deployment, and it correlated exactly with **clustered pushes to master**:

- The workflow triggered on **every** push to master.
- Most commits (transpiler, tests, `docs/`) never change the published site (Jekyll source is `./website`), yet each still kicked off a redeploy.
- When a stack of PRs merged within minutes, those redundant deploys piled up on the single `pages` environment and the backend failed the superseded ones.

Every recent failure (the #405 and #406 merges, the earlier #393/#394/#395 stack) was a rapid, **non-`website/`** merge. Spaced-out commits deployed fine.

## Fix

- **`paths` filter** — deploy only when `website/**` or the workflow file changes. Code/doc-only merges no longer trigger a deploy at all (they never changed the site).
- **`cancel-in-progress: true`** — if two website changes *do* land close together, cancel the older in-flight deploy so only the newest publishes. For a static docs site the superseded build is never wanted, and running both is precisely what provokes the failure.

`workflow_dispatch` still allows a manual redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)