### PR TITLE
fix(transpiler): type-assert `any` subject before struct destructuring in match

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1230,6 +1230,12 @@ gala_exec_test(
 )
 
 gala_exec_test(
+    name = "match_any_struct_pattern",
+    src = "match_any_struct_pattern.gala",
+    expected = "match_any_struct_pattern.out",
+)
+
+gala_exec_test(
     name = "match_literal_pattern",
     src = "match_literal_pattern.gala",
     expected = "match_literal_pattern.out",

--- a/examples/match_any_struct_pattern.gala
+++ b/examples/match_any_struct_pattern.gala
@@ -1,0 +1,22 @@
+package main
+
+// Verifies that a plain (non-sealed) struct destructuring pattern works when the
+// match subject is statically `any`. Mixing a type pattern (`case i: int`) with a
+// struct pattern forces the subject to stay `any`; the transpiler must insert a
+// type assertion (`v.(Person)`) before reading struct fields, otherwise the
+// generated Go fails with "type any has no field or method Name".
+struct Person(Name string, Age int)
+
+func describe(v any) string = v match {
+    case i: int                        => s"int: $i"
+    case Person(name, age) if age < 18 => s"$name is a minor"
+    case Person(name, _)               => s"$name is an adult"
+    case _                             => "unknown"
+}
+
+func main() {
+    Println(describe(Person("Bob", 15)))
+    Println(describe(Person("Alice", 30)))
+    Println(describe(42))
+    Println(describe("hello"))
+}

--- a/examples/match_any_struct_pattern.out
+++ b/examples/match_any_struct_pattern.out
@@ -1,0 +1,4 @@
+Bob is a minor
+Alice is an adult
+int: 42
+unknown

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -78,6 +78,7 @@ go_test(
         "import_test.go",
         "imports_test.go",
         "literals_test.go",
+        "match_any_struct_pattern_test.go",
         "match_arm_dispatch_matrix_test.go",
         "match_in_lambda_void_test.go",
         "match_literal_subpattern_test.go",

--- a/internal/transpiler/transformer/match_any_struct_pattern_test.go
+++ b/internal/transpiler/transformer/match_any_struct_pattern_test.go
@@ -1,0 +1,68 @@
+package transformer_test
+
+import (
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A plain-struct destructuring pattern over an `any`-typed subject must emit a
+// Go type assertion (`v.(Person)`) before reading fields; otherwise the
+// generated code fails to compile with "type any has no field or method Name".
+// Conversely, a concretely-typed subject must NOT be asserted — `p.(Person)` on
+// a non-interface value is itself a Go compile error.
+func TestMatchStructPatternAnySubjectAssertsType(t *testing.T) {
+	newTranspiler := func() *transpiler.GalaToGoTranspiler {
+		p := transpiler.NewAntlrGalaParser()
+		a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+		tr := transformer.NewGalaASTTransformer()
+		g := generator.NewGoCodeGenerator()
+		return transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+	}
+
+	t.Run("any subject inserts type assertion", func(t *testing.T) {
+		input := `package main
+
+struct Person(Name string, Age int)
+
+func describe(v any) string = v match {
+    case i: int            => s"int: $i"
+    case Person(name, age) => s"$name is $age"
+    case _                 => "unknown"
+}
+`
+		got, err := newTranspiler().Transpile(input, "")
+		require.NoError(t, err, "any-subject struct destructuring must transpile")
+		// The match subject is bound to `obj` in the generated closure; it must be
+		// type-asserted (`obj.(Person)`) before field access. Note the always-present
+		// Unapply method asserts `v.(Person)`, so we match on the `obj.` subject.
+		assert.Contains(t, got, "obj.(Person)", "must type-assert the any subject before field access")
+		// Fields must be read off the asserted value, never off the bare `any` subject.
+		assert.NotContains(t, got, "obj.Name", "must not read fields directly off the any subject")
+	})
+
+	t.Run("concrete subject does not assert", func(t *testing.T) {
+		input := `package main
+
+struct Person(Name string, Age int)
+
+func describe(p Person) string = p match {
+    case Person(name, age) => s"$name is $age"
+    case _                 => "unknown"
+}
+`
+		got, err := newTranspiler().Transpile(input, "")
+		require.NoError(t, err, "concrete-subject struct destructuring must transpile")
+		// A concretely-typed subject must read fields straight off `obj` with no
+		// assertion — `obj.(Person)` on a non-interface value is a Go compile error.
+		// (The Unapply method still asserts `v.(Person)`; that's why we check `obj.`.)
+		assert.NotContains(t, got, "obj.(Person)", "a concretely-typed subject must not be type-asserted (Go rejects asserting a non-interface)")
+		assert.Contains(t, got, "obj.Name.Get()", "a concretely-typed subject reads fields directly")
+	})
+}

--- a/internal/transpiler/transformer/patterns.go
+++ b/internal/transpiler/transformer/patterns.go
@@ -200,7 +200,7 @@ func (t *galaASTTransformer) transformConstructorCallPattern(rawName string, arg
 	// Use direct field access for known structs
 	resolvedStructName := t.resolveStructTypeName(rawName)
 	if fields, ok := t.structFields[resolvedStructName]; ok && len(fields) > 0 {
-		return t.generateDirectStructFieldMatch(objExpr, argList, fields, resolvedStructName)
+		return t.generateDirectStructFieldMatch(objExpr, argList, fields, resolvedStructName, matchedType)
 	}
 
 	// Check if rawName is a variable whose type has an Unapply method (instance extractor).
@@ -738,22 +738,42 @@ func (t *galaASTTransformer) generateDirectTupleStructMatch(objExpr ast.Expr, ar
 // For example, Person(name, age) matching against Person{Name: "Alice", Age: 25}
 // generates: name := obj.Name; age := obj.Age
 // The condition is always true since we're just extracting fields.
-func (t *galaASTTransformer) generateDirectStructFieldMatch(objExpr ast.Expr, argList *grammar.ArgumentListContext, fields []string, structName string) (ast.Expr, []ast.Stmt, error) {
-	if argList == nil {
-		return ast.NewIdent("true"), nil, nil
+func (t *galaASTTransformer) generateDirectStructFieldMatch(objExpr ast.Expr, argList *grammar.ArgumentListContext, fields []string, structName string, matchedType transpiler.Type) (ast.Expr, []ast.Stmt, error) {
+	var stmts []ast.Stmt
+	var conds []ast.Expr
+
+	// When the match subject is statically an interface (`any`) — e.g. a match
+	// that mixes a type pattern (`case i: int`) with a struct pattern, or a
+	// parameter declared `any` — the struct's fields are not directly reachable:
+	// Go requires a type assertion first. Insert `castVar, ok := obj.(Struct)`
+	// and gate the arm on `ok`; subsequent field access reads from castVar.
+	// (We assert ONLY for interface subjects: `p.(Struct)` on a concrete,
+	// non-interface value is itself a Go compile error, so a concretely-typed
+	// subject keeps reading fields straight off objExpr.)
+	baseExpr := objExpr
+	if matchedType != nil && matchedType.IsAny() {
+		castName := t.nextTempVar()
+		okName := t.nextTempVar()
+		stmts = append(stmts, &ast.AssignStmt{
+			Lhs: []ast.Expr{ast.NewIdent(castName), ast.NewIdent(okName)},
+			Tok: token.DEFINE,
+			Rhs: []ast.Expr{&ast.TypeAssertExpr{X: objExpr, Type: t.ident(structName)}},
+		})
+		conds = append(conds, ast.NewIdent(okName))
+		baseExpr = ast.NewIdent(castName)
 	}
 
-	args := argList.AllArgument()
+	var args []grammar.IArgumentContext
+	if argList != nil {
+		args = argList.AllArgument()
+	}
 	if len(args) == 0 {
-		return ast.NewIdent("true"), nil, nil
+		return combineStructMatchConds(conds, stmts)
 	}
 
 	if len(args) > len(fields) {
 		return nil, nil, galaerr.NewSemanticErrorAt(argList.GetStart().GetLine(), argList.GetStart().GetColumn(), fmt.Sprintf("struct '%s' has %d fields but pattern has %d arguments", structName, len(fields), len(args)))
 	}
-
-	var stmts []ast.Stmt
-	var conds []ast.Expr
 
 	// Get field types if available
 	fieldTypes := t.structFieldTypes[structName]
@@ -779,12 +799,13 @@ func (t *galaASTTransformer) generateDirectStructFieldMatch(objExpr ast.Expr, ar
 			}
 		}
 
-		// Generate direct field access: objExpr.FieldName.Get()
-		// Struct fields are stored as Immutable[T], so we need to call .Get()
+		// Generate direct field access: baseExpr.FieldName.Get()
+		// Struct fields are stored as Immutable[T], so we need to call .Get().
+		// baseExpr is the type-asserted castVar for `any` subjects, else objExpr.
 		elemExpr := &ast.CallExpr{
 			Fun: &ast.SelectorExpr{
 				X: &ast.SelectorExpr{
-					X:   objExpr,
+					X:   baseExpr,
 					Sel: ast.NewIdent(fieldName),
 				},
 				Sel: ast.NewIdent("Get"),
@@ -854,18 +875,19 @@ func (t *galaASTTransformer) generateDirectStructFieldMatch(objExpr ast.Expr, ar
 
 	t.needsStdImport = true
 
-	// Combine all conditions
+	return combineStructMatchConds(conds, stmts)
+}
+
+// combineStructMatchConds ANDs a struct pattern's accumulated conditions into a
+// single expression (or the literal `true` when there are none) and returns it
+// alongside the pattern's binding statements.
+func combineStructMatchConds(conds []ast.Expr, stmts []ast.Stmt) (ast.Expr, []ast.Stmt, error) {
 	if len(conds) == 0 {
 		return ast.NewIdent("true"), stmts, nil
 	}
-
 	finalCond := conds[0]
 	for i := 1; i < len(conds); i++ {
-		finalCond = &ast.BinaryExpr{
-			X:  finalCond,
-			Op: token.LAND,
-			Y:  conds[i],
-		}
+		finalCond = &ast.BinaryExpr{X: finalCond, Op: token.LAND, Y: conds[i]}
 	}
 	return finalCond, stmts, nil
 }

--- a/website/features/type-inference.md
+++ b/website/features/type-inference.md
@@ -82,6 +82,7 @@ val positive = opt.Filter((x) => x > 0)     // x inferred as int
 **Non-generic wrapper types** — Methods on concrete types that take function parameters:
 
 ```gala
+// S / Str come from martianoff/gala/strings
 val s = S("hello")
 val upper = s.Map((r) => r - 32)             // r inferred as rune
 val hasVowel = s.Exists((r) => r == 'a')     // r inferred as rune


### PR DESCRIPTION
## Summary
Follow-up to #409. Fixes the `any`-subject struct-destructuring transpiler bug found during the website-examples sweep.

A plain (non-sealed) struct destructuring pattern over a subject that is statically `any` — a match mixing a type pattern with a struct pattern, or a parameter declared `any` — generated direct field access on the interface value:

```go
name := obj.Name.Get()   // obj is `any`
```
which Go rejects: `type any has no field or method Name`.

## Fix
`generateDirectStructFieldMatch` now takes the matched type and, when the subject is an interface, emits a type assertion and gates the arm on it:
```go
if castVar, ok := obj.(Person); ok {
    name := castVar.Name.Get()
    ...
}
```
Concretely-typed subjects are unchanged — asserting a non-interface is itself a Go compile error. Condition-combining was factored into a small `combineStructMatchConds` helper.

## Tests / verification
- **Unit test** (`match_any_struct_pattern_test.go`): the `any` subject emits `obj.(Person)`; a concrete subject does **not** (distinguished from the always-generated `Unapply`'s `v.(Person)`).
- **Runnable example** (`examples/match_any_struct_pattern.gala`): mixed `case i: int` / `case Person(name, age)` match — passes `gala_exec_test` end-to-end.
- Full transformer suite + all `//examples/...` pass locally.
- This also unblocks the `pattern-matching.md` guard-clause example #409 had to leave as-is.

Also: a one-line clarifying comment in `type-inference.md` that `S`/`Str` come from the `strings` package (that snippet is a fragment that omitted its import).

## Not included (deferred)
- **Mutable `TreeMap` embed gap** — I confirmed the embed list omits `collection_mutable:treemap`, and adding it does make `treemap.gen.go` extract into the stdlib cache — but `gala build` still reports `undefined: TreeMapOf`, so the embed list is necessary-but-not-sufficient (a further analyzer/workspace wiring gap). Deferred to its own change rather than ship a half-fix.
- **`S`/`Str` "embedding gap"** from the #409 follow-up list was a **misdiagnosis**: the package is `strings` (not `string_utils`), it *is* embedded, and `S("hi")` builds fine with the import. Corrected here (doc comment only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)