### PR TITLE
docs: fix three doc-vs-implementation drifts (sealed discriminators, Stream≠Seq, make)

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -2583,7 +2583,6 @@ Since GALA transpiles to Go, Go's built-in functions are available. The followin
 | `new(T)` | Allocate zeroed value, return pointer | `new(int)` |
 | `append(s, v...)` | Append to slice | `append(items, 4)` |
 | `delete(m, k)` | Delete map entry | `delete(myMap, "key")` |
-| `close(ch)` | Close a channel | `close(done)` |
 | `panic(v)` | Trigger a panic | `panic("error")` |
 | `recover()` | Recover from panic (in defer) | `recover()` |
 

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -531,7 +531,7 @@ Type aliases transpile to Go type aliases (`type X = Y`), so methods defined on 
 
 ### Sealed Types (Algebraic Data Types)
 
-Sealed types define algebraic data types (ADTs) concisely. The transpiler auto-generates the parent struct, companion objects, `Apply`/`Unapply` methods, `IsXxx()` discriminators, `Copy`, and `Equal`.
+Sealed types define algebraic data types (ADTs) concisely. The transpiler auto-generates the parent struct, companion objects, `Apply`/`Unapply` methods, `Copy`, and `Equal`. To test which variant a value is, `match` on it — that is the idiomatic (and exhaustive) approach.
 
 #### Basic Sealed Type
 ```gala
@@ -570,7 +570,6 @@ This generates:
 - Empty companion structs `Circle{}`, `Rectangle{}`, `Point{}`
 - `Apply` methods on each companion for construction
 - `Unapply` methods for pattern matching
-- `IsCircle()`, `IsRectangle()`, `IsPoint()` methods on `Shape`
 - `Copy()` and `Equal(other Shape) bool` on `Shape` — the same auto-synthesis as for ordinary structs (see [§4 Automatic Copy and Equal Methods](#automatic-copy-and-equal-methods)). `Equal` first compares the `_variant` tag, then dispatches field-wise via `std.Equal`, so `a.Equal(b)` is the canonical way to test sealed values for structural equality. The Go `==` operator also works on sealed values when every variant field is a Go-comparable type.
 
 #### Construction and Pattern Matching
@@ -578,11 +577,7 @@ This generates:
 val c = Circle(3.14)
 val r = Rectangle(10.0, 20.0)
 
-// IsXxx() checks
-fmt.Println(c.IsCircle())     // true
-fmt.Println(c.IsRectangle())  // false
-
-// Pattern matching
+// Pattern matching — the idiomatic way to test/branch on a variant
 val desc = c match {
     case Circle(radius) => fmt.Sprintf("radius=%.2f", radius)
     case Rectangle(w, h) => fmt.Sprintf("%fx%f", w, h)
@@ -2274,11 +2269,6 @@ val m2 = m1.Put("apple", 1).Put("banana", 2).Put("cherry", 3)
 // Using factory with tuple syntax
 val m3 = HashMapOf[string, int](("a", 1), ("b", 2))
 
-// From Go map
-var goMap = make(map[string]int)
-goMap["x"] = 100
-val m4 = HashMapFromGoMap[string, int](goMap)
-
 // Getting values
 val opt = m2.Get("apple")           // Option[int]
 val value = m2.GetOrElse("apple", 0) // int
@@ -2590,7 +2580,6 @@ Since GALA transpiles to Go, Go's built-in functions are available. The followin
 |----------|-------------|---------|
 | `len(x)` | Length of string, slice, array, or map | `len("hello")` → `5` |
 | `cap(x)` | Capacity of slice | `cap(mySlice)` |
-| `make(T, ...)` | Create slice, map, or channel | `make(map[string]int)` |
 | `new(T)` | Allocate zeroed value, return pointer | `new(int)` |
 | `append(s, v...)` | Append to slice | `append(items, 4)` |
 | `delete(m, k)` | Delete map entry | `delete(myMap, "key")` |

--- a/website/docs/streams.md
+++ b/website/docs/streams.md
@@ -383,51 +383,15 @@ val result = myStream match {
 }
 ```
 
-### Sequence Pattern Matching
+### Head/tail pattern matching
 
-Stream implements the `Seq[T]` interface, enabling sequence pattern matching syntax:
+A `Stream` is a lazy, possibly-infinite source — not a finite `Seq` — so array-style
+sequence/rest patterns (`case Stream(a, b, rest...)`) do **not** apply to it. Match a
+stream by its head and (lazy) tail with the `StreamCons` / `StreamNil` extractors shown
+above; these decompose a stream without forcing evaluation of the remaining elements.
 
-```gala
-val s = Of(1, 2, 3, 4, 5)
-
-val result = s match {
-    // Match first two elements, rest goes into 'tail'
-    case Stream(first, second, tail...) => {
-        Println(s"First: $first, Second: $second, Rest size: ${tail.Size()}")
-        return first + second
-    }
-    // Match single element
-    case Stream(only) => only
-    // Match empty stream
-    case Stream() => 0
-    case _ => -1
-}
-// Result: first=1, second=2, tail.Size()=3, returns 3
-```
-
-**Seq Interface Methods:**
-
-| Method | Description |
-|--------|-------------|
-| `Size()` | Number of elements (terminal operation) |
-| `Get(n)` | Element at index n, panics if out of bounds |
-| `GetOption(n)` | Element at index n as Option |
-| `SeqDrop(n)` | Drop first n elements (for rest pattern) |
-
-**WARNING:** Sequence pattern matching on infinite streams will not terminate! The `Size()` method is called to determine the number of elements, which requires traversing the entire stream. Always use `Take` or similar limiting operations before sequence pattern matching:
-
-```gala
-// WRONG: Will hang on infinite stream
-val naturals = From(1)
-val result = naturals match {
-    case Stream(a, b, rest...) => a + b  // Never terminates!
-}
-
-// CORRECT: Limit first
-val result = From(1).Take(10) match {
-    case Stream(a, b, rest...) => a + b  // Returns 3
-}
-```
+If you need positional or index-based matching, first collect a bounded prefix (e.g. with
+`Take`) into an `Array`, which *is* a finite `Seq` and supports sequence/rest patterns.
 
 ---
 
@@ -549,14 +513,6 @@ val first10 = fibs.Take(10).ToArray()
 | `GetOption(n)` | Element at index as Option |
 | `IsEmpty()` | Check if empty |
 | `NonEmpty()` | Check if non-empty |
-
-### Seq Interface (Sequence Pattern Matching)
-
-| Method | Description |
-|--------|-------------|
-| `Size()` | Number of elements (same as Count) |
-| `Get(n)` | Element at index (panics if out of bounds) |
-| `SeqDrop(n)` | Drop first n elements (returns Stream) |
 
 ### Pattern Matching
 

--- a/website/features/ide-support.md
+++ b/website/features/ide-support.md
@@ -62,7 +62,7 @@ The plugin provides a **structure view** panel showing the outline of your GALA 
 
 <img src="{{ '/assets/images/ide/structure-view.png' | relative_url }}" alt="GALA structure view showing sealed type Shape with Circle, Rectangle, Triangle variants and their fields" style="max-width: 100%; border: 1px solid #e1e4e8; border-radius: 6px; margin: 1rem 0;">
 
-The structure view displays sealed type `Shape` with its variants (`Circle`, `Rectangle`, `Triangle`), each variant's fields, and auto-generated methods like `IsCircle()`, `IsRectangle()`, `IsTriangle()`.
+The structure view displays sealed type `Shape` with its variants (`Circle`, `Rectangle`, `Triangle`), each variant's fields, and the auto-generated `Apply`/`Unapply` companion methods.
 
 ---
 

--- a/website/features/sealed-types.md
+++ b/website/features/sealed-types.md
@@ -24,7 +24,6 @@ With sealed types you get:
 - **Exhaustive pattern matching** — the compiler rejects incomplete matches
 - **Auto-generated constructors** — companion objects with `Apply` methods
 - **Auto-generated extractors** — `Unapply` methods for pattern matching
-- **Discriminator methods** — `IsXxx()` boolean checks on every instance
 
 ---
 
@@ -60,15 +59,7 @@ val r = Rectangle(10.0, 20.0)
 val p = Point()
 ```
 
-**Unapply methods** — Each companion gets an `Unapply` method for use in pattern matching. You never need to call these directly; the `match` expression uses them behind the scenes.
-
-**IsXxx discriminators** — Methods on the parent type to test which variant an instance is:
-
-```gala
-val c = Circle(3.14)
-Println(c.IsCircle())      // true
-Println(c.IsRectangle())   // false
-```
+**Unapply methods** — Each companion gets an `Unapply` method for use in pattern matching. You never need to call these directly; the `match` expression uses them behind the scenes. To test which variant a value is, `match` on it (see [Pattern Matching](pattern-matching.md)) — that's the idiomatic approach, and it stays exhaustive.
 
 **Copy and Equal** — Like all GALA structs, sealed types get `Copy()` and `Equal()` for free.
 
@@ -103,7 +94,7 @@ val success = Ok(42)
 val failure = Err[int](fmt.Errorf("oops"))
 ```
 
-Generic sealed types work exactly like non-generic ones — you get companion objects, `Apply`/`Unapply`, `IsXxx()`, and exhaustive matching, all parameterized by the type argument.
+Generic sealed types work exactly like non-generic ones — you get companion objects, `Apply`/`Unapply`, and exhaustive matching, all parameterized by the type argument.
 
 ---
 


### PR DESCRIPTION
## Summary
Corrects three places where the docs promised behavior the implementation doesn't provide. Each was verified against the repo; the implementations are intentional, so these are doc-only corrections (removals/prose — no new code snippets).

### 1. Sealed discriminators — no public `IsXxx()`
Docs advertised public `IsCircle()`/`IsRectangle()`/`IsPoint()` methods, but the transpiler generates them **unexported** (`isCircle()`) for internal use — `c.IsCircle()` fails to compile. Removed the public-method claims; point to pattern matching (idiomatic + exhaustive). Files: `docs/GALA.MD`, `website/features/sealed-types.md`, `website/features/ide-support.md`.

### 2. `Stream` ≠ `Seq`
Docs claimed `Stream` implements `Seq[T]` and supported `case Stream(a, b, rest...)`. In reality `Stream.Get` returns `Option[T]` (not `T`) and there's no `SeqDrop`, so a Stream isn't a finite `Seq` — the rest pattern errors with `rest pattern (...) requires a sequence type ... Got 'stream.Stream[int]'`. Replaced with head/tail matching via the working `StreamCons`/`StreamNil` extractors, plus guidance to collect a bounded prefix into an `Array` for positional matching. Removed the inaccurate Seq method tables. File: `website/docs/streams.md`.

### 3. `make(chan/map)`
The docs both said `make()` is unsupported (correct) **and** showed `make(map[string]int)` + a `make(T, ...)` builtin-table row; the grammar rejects typed `make` (`no viable alternative at input '(chanint'`). Removed the contradictory example and row. File: `docs/GALA.MD`.

## Verification
Each drift reproduced against the repo before editing (`c.IsCircle()` → undefined; `case Stream(a,b,rest...)` → rest-pattern semantic error; `make(chan int, 10)`/`make(map[string]int)` → syntax error). Edits are removals/prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)