### PR TITLE
fix(stdlib): embed collection_mutable treemap in the CLI stdlib snapshot

### DIFF
--- a/internal/stdlib/BUILD.bazel
+++ b/internal/stdlib/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 # Generate embedded stdlib Go file from transpiled sources and GALA source files.
 # This uses gala_bootstrap (not gala) to avoid circular dependency.
@@ -75,12 +75,14 @@ genrule(
         "//collection_mutable:hashmap_go",
         "//collection_mutable:hashset_go",
         "//collection_mutable:treeset_go",
+        "//collection_mutable:treemap_go",
         # collection_mutable package - GALA source
         "//collection_mutable:array.gala",
         "//collection_mutable:list.gala",
         "//collection_mutable:hashmap.gala",
         "//collection_mutable:hashset.gala",
         "//collection_mutable:treeset.gala",
+        "//collection_mutable:treemap.gala",
         # concurrent package - transpiled Go
         "//concurrent:future_go",
         "//concurrent:event_bus_go",
@@ -157,4 +159,10 @@ go_library(
     ],
     importpath = "martianoff/gala/internal/stdlib",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "stdlib_test",
+    srcs = ["embed_collections_test.go"],
+    embed = [":stdlib"],
 )

--- a/internal/stdlib/embed_collections_test.go
+++ b/internal/stdlib/embed_collections_test.go
@@ -1,0 +1,51 @@
+package stdlib
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCollectionFilesEmbedded guards against a stdlib source file existing in the
+// repo but being forgotten in the embed srcs list (internal/stdlib/BUILD.bazel's
+// generate_embedded genrule). That drift is invisible to `bazel test` — which
+// builds examples against the repo's stdlib tree — but breaks the released CLI,
+// whose analyzer/build only sees the embedded snapshot.
+//
+// Concretely: `collection_mutable`'s treemap was present in the repo but missing
+// from the embed, so `gala build` reported `undefined: TreeMapOf` (the analyzer
+// couldn't resolve the symbol, dropped the import, and Go compilation failed)
+// even though the bazel example suite passed.
+func TestCollectionFilesEmbedded(t *testing.T) {
+	// The immutable and mutable collection packages both provide the full set of
+	// collection types; each must be embedded as GALA source (for the analyzer)
+	// and transpiled Go (for compilation).
+	collections := []string{"array", "list", "hashmap", "hashset", "treeset", "treemap"}
+	for _, pkg := range []string{"collection_immutable", "collection_mutable"} {
+		files, ok := EmbeddedPackages[pkg]
+		if !ok {
+			t.Fatalf("package %q is not embedded at all", pkg)
+		}
+		for _, c := range collections {
+			for _, name := range []string{c + ".gala", c + ".gen.go"} {
+				if _, ok := files[name]; !ok {
+					t.Errorf("%s embed is missing %q — add it to the generate_embedded srcs in internal/stdlib/BUILD.bazel", pkg, name)
+				}
+			}
+		}
+	}
+}
+
+// TestCollectionConstructorsEmbedded is a symbol-level sanity check: the embedded
+// GALA source for treemap actually carries its public constructor, so a content
+// regression (not just a missing filename) is caught too.
+func TestCollectionConstructorsEmbedded(t *testing.T) {
+	for _, pkg := range []string{"collection_immutable", "collection_mutable"} {
+		content, ok := GetPackageContent(pkg, "treemap.gala")
+		if !ok {
+			t.Fatalf("%s: treemap.gala not embedded", pkg)
+		}
+		if !strings.Contains(content, "func TreeMapOf") {
+			t.Errorf("%s treemap.gala embed does not define func TreeMapOf", pkg)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Follow-up to the drift list in #410. `collection_mutable`'s treemap existed in the repo but was **missing from the embedded stdlib snapshot** the CLI ships with, so `gala build` of a program using `EmptyTreeMap`/`TreeMapOf` failed with `undefined: TreeMapOf` on the released CLI — while the bazel example suite (which builds against the repo stdlib tree, not the embed) passed. That's why it looked fine in CI but broke in the playground.

## Root cause
The CLI's analyzer/build only see the embedded snapshot generated by `internal/stdlib/BUILD.bazel`'s `generate_embedded` genrule. `collection_mutable`'s `treemap_go` + `treemap.gala` weren't in the srcs list. Result at build time: the analyzer couldn't resolve `TreeMapOf` → dropped the `collection_mutable` import as unused → Go reported `undefined: TreeMapOf`.

## Fix
Add the two treemap targets to the embed list (mirrors the immutable-treemap and mutable-treeset entries).

Verified end-to-end with a branch-built CLI after clearing the stale `~/.gala/stdlib` extraction and `~/.gala/build` workspace caches (the stale caches are what made this look intermittent during investigation): `TreeMapOf(("b", 2), ("a", 1))` now builds and runs (`size=2 first=a`), and the generated Go correctly emits `import . "martianoff/gala/collection_mutable"`.

## Regression test
Adds `internal/stdlib` tests asserting **both** collection packages embed every collection type's `.gala` + `.gen.go`, plus a symbol-level check that the embedded treemap source defines `TreeMapOf`. This class of "file in repo but not in embed" drift is otherwise invisible to `bazel test`.

Also unblocks the mutable-`TreeMap` examples in `website/docs/mutable-collections.md` on the released CLI (once a release ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)