### PR TITLE
Forbid bare defer/go statement keywords; add `use` scoped-resource binding

### DIFF
--- a/.claude/skills/gala-lint/SKILL.md
+++ b/.claude/skills/gala-lint/SKILL.md
@@ -56,6 +56,65 @@ user-defined function that happens to share one of these names (e.g. a local
 The rows below (rule 4a Go-slices, rule 11 error handling) reference these
 replacements; a bare builtin is always the higher-severity `GALA-E0035` finding.
 
+### 0b. Bare Go statement keywords are a HARD ERROR (`GALA-E0036`)
+
+The Go statement keywords `defer`, `go`, `goto`, `fallthrough`, `select`, and
+`chan` are **not** part of GALA's grammar. A bare use is a hard transpile error
+(`GALA-E0036`), not merely "prefer GALA". They only ever appeared to work as an
+accident of the final gofmt pass (which glued the following statement onto the
+keyword), so treat any occurrence as a must-fix. Like rule 0, the check is
+resolver-aware — a symbol the program itself declared is left alone.
+
+| Forbidden statement | Sanctioned replacement |
+|---|---|
+| `defer x.Close()` | a `use x = acquire` binding (closes at block exit, LIFO), or a `resource` combinator — `Using` / `Bracket` / `WithLock` from `martianoff/gala/resource` |
+| `go f()` | `go_interop.Spawn(() => f())` — the sanctioned goroutine primitive |
+| `goto`, `fallthrough` | structured control flow — pattern matching (`match`), recursion, or a `for` loop |
+| `select`, `chan` | the `go_interop` channel helpers |
+
+#### `use` — the RAII scoped-resource idiom (preferred defer replacement)
+
+`use x = acquire` binds `x` for the rest of the enclosing block and guarantees
+`x.Close()` runs when the function returns, on every path (normal or panic).
+Multiple `use` bindings release **LIFO** (last acquired closes first). It lowers
+to Go `x := acquire; defer x.Close()` in the generated code — so Go's `defer`
+survives only as this sanctioned internal lowering, never on the GALA surface.
+The resource must satisfy `Close() error`; no import is needed.
+
+| Issue | Pattern to Flag | Recommended Fix |
+|---|---|---|
+| Bare `defer` for cleanup | `defer f.Close()` — a hard error (`GALA-E0036`) | `use f = open(path)` — closes at block exit |
+| Nested `Using` pyramid for sequential resources | `Using(a, (x) => Using(b, (y) => …))` | flatten to top-to-bottom `use` bindings |
+| Manual close on every exit path | `val f = open(); …; f.Close()` (forgettable, skipped on panic) | `use f = open()` — release is guaranteed |
+
+**Bad pattern** — Go-style `defer`:
+```gala
+func readAll(path string) string {
+    val f = OpenFile(path)
+    defer f.Close()              // GALA-E0036: not a GALA statement
+    f.ReadString()
+}
+```
+
+**Good pattern** — `use` binding (or a `resource` combinator):
+```gala
+// use: closes at block exit, guaranteed on every path
+func copyFile(src string, dst string) Try[Int] = Try(() => {
+    use in  = OpenFile(src)      // in.Close()  runs last
+    use out = CreateFile(dst)    // out.Close() runs first (LIFO)
+    out.Write(in.ReadString())
+})
+
+// resource combinators — for resources without Close() (a mutex, a temp dir),
+// or when the close error must be surfaced (Using discards it):
+val next = WithLock(mu, () => sharedCounter + 1)
+val text = Using(OpenFile(path), (f) => f.ReadString())
+```
+
+For a non-`Closeable` cleanup (e.g. `os.RemoveAll(dir)`), use
+`Bracket(resource, release, body)` — it runs `release` after `body` on every
+exit path.
+
 ### 1. Immutability (HIGH priority)
 
 | Issue | Pattern to Flag | Recommended Fix |

--- a/docs/EXAMPLES.MD
+++ b/docs/EXAMPLES.MD
@@ -1138,6 +1138,37 @@ func total() Future[int] {
 
 Full program: [`examples/bind_notation_future.gala`](../examples/bind_notation_future.gala).
 
+## Scoped Resource Cleanup with `use`
+
+GALA has no `defer` (a bare `defer`/`go` statement is a hard error, **GALA-E0036**). Cleanup is a `use` binding: `use x = acquire` binds `x` for the rest of the block and guarantees `x.Close()` runs when the function returns, on every path. Multiple `use` bindings release **LIFO** (last acquired closes first):
+
+```gala
+type Handle struct {
+    name string
+}
+
+func (h Handle) Close() error {
+    Println(s"close ${h.name}")
+    return nil
+}
+
+func open(name string) Handle {
+    Println(s"open ${name}")
+    return Handle(name = name)
+}
+
+func work() {
+    use a = open("a")   // closes last
+    use b = open("b")   // closes first (LIFO)
+    Println(s"body sees ${a.name} and ${b.name}")
+}
+// Output: open a / open b / body sees a and b / close b / close a
+```
+
+For resources without `Close()` (a mutex, a temp dir), reach for the `resource` combinators — `Bracket(res, release, body)` or `WithLock(mu, () => …)`. A goroutine is `go_interop.Spawn(() => f())`, not a bare `go`.
+
+Full programs: [`examples/use_binding.gala`](../examples/use_binding.gala), [`examples/resource_combinators.gala`](../examples/resource_combinators.gala).
+
 ## More Examples
 
 You can find more examples in the `examples/` directory of the project:

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -2611,6 +2611,45 @@ For guaranteed resource cleanup, prefer the `resource` combinators
 (`Using`/`Bracket`/`WithLock`) over a hand-written `Close()` call — they release
 on every exit path, including panics (see the `resource` package).
 
+### Go statement keywords are forbidden too
+
+The Go statement keywords `defer`, `go`, `goto`, `fallthrough`, `select`, and
+`chan` are **not** part of GALA's grammar. A bare use is a hard transpile error
+(**GALA-E0036**). Historically they appeared to "work" only as an accident of
+the final gofmt pass, which glued the following statement onto the keyword — an
+undocumented, fragile artifact GALA removes. The replacements:
+
+| Forbidden statement | Use instead |
+|---|---|
+| `defer x.Close()` | a `use x = …` binding, or a `resource` combinator (`Using`/`Bracket`/`WithLock`) |
+| `go f()` | `go_interop.Spawn(() => f())` |
+| `goto`, `fallthrough`, `select`, `chan` | structured control flow / pattern matching; `go_interop` channel helpers |
+
+Like the builtin check, this is **resolver-aware**: a symbol the program itself
+declared is left alone.
+
+#### `use` — scoped resource binding
+
+`use x = acquire` binds `x` for the rest of the enclosing block and guarantees
+`x.Close()` runs when the function returns, on every path (normal or panic). It
+is the top-to-bottom replacement for Go's `defer x.Close()` — the resource must
+satisfy `Close() error`. Multiple `use` bindings release **LIFO** (last acquired
+closes first), so nested resources unwind in the right order. No import is
+needed.
+
+```gala
+// Two resources; `out` (acquired last) closes first, `in` closes last.
+func copyFile(src string, dst string) Try[Int] = Try(() => {
+    use in  = OpenFile(src)
+    use out = CreateFile(dst)
+    out.Write(in.ReadString())
+})
+```
+
+`use` lowers to Go `x := acquire` plus `defer x.Close()` in the generated code —
+so Go's own `defer` still exists, but only as this sanctioned internal lowering,
+never on the GALA surface.
+
 ## 12. Immutability Under the Hood
 
 When GALA transpiles to Go, immutable values are wrapped in a `std.Immutable[T]` container to ensure safety and provide consistent semantics, especially for struct fields and global variables.

--- a/docs/GALA_BEST_PRACTICES.MD
+++ b/docs/GALA_BEST_PRACTICES.MD
@@ -11,6 +11,7 @@ A scannable rule list for writing idiomatic GALA — useful as both a learning c
 - **No special-casing `std`.** The standard library uses the same import/resolution mechanism as any other library.
 - **Concrete types only.** Never emit `any`/`interface{}` unless the GALA source explicitly asks for it.
 - **No bare Go builtins.** `append`, `make`, `new`, `cap`, `copy`, `delete`, `close`, `complex`, `real`, `imag`, `panic`, `recover`, and `len` are a hard error (GALA-E0035). Use the GALA-native form or the sanctioned interop wrapper (see *Length & size* and *Resource cleanup* below). A user-defined function that happens to share one of these names is fine — only the builtin is forbidden.
+- **No Go statement keywords.** `defer`, `go`, `goto`, `fallthrough`, `select`, and `chan` are not GALA statements — a bare use is a hard error (GALA-E0036). Use a `use` binding or the `resource` combinators for cleanup, and `go_interop.Spawn(...)` for goroutines (see *Resource cleanup* below).
 
 ---
 
@@ -78,7 +79,19 @@ func readAll(path string) string =
     Using(OpenFile(path), (f) => f.ReadString())  // Close() guaranteed
 ```
 
-`panic` → `go_builtins.Panic(...)` for a truly unrecoverable invariant; prefer `Option`/`Try`/`Either`. `go_interop.Spawn(() => f())` is the sanctioned goroutine primitive.
+- **`use x = acquire`** — the top-to-bottom binding form (no nesting pyramid): `x` is bound for the rest of the block and `x.Close()` runs when the function returns, on every path. Multiple `use` bindings release LIFO. No import needed.
+
+```gala
+func copyFile(src string, dst string) Try[Int] = Try(() => {
+    use in  = OpenFile(src)     // in.Close()  runs last
+    use out = CreateFile(dst)   // out.Close() runs first (LIFO)
+    out.Write(in.ReadString())
+})
+```
+
+**No `defer`, no bare `go`.** `defer` and `go` are not GALA statements — a bare use is a hard error (GALA-E0036). Cleanup is a `use` binding or a `resource` combinator; a goroutine is `go_interop.Spawn(() => f())`.
+
+`panic` → `go_builtins.Panic(...)` for a truly unrecoverable invariant; prefer `Option`/`Try`/`Either`.
 
 ---
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1753,6 +1753,13 @@ gala_exec_test(
     ],
 )
 
+# Verification: `use x = ...` scoped-resource binding (LIFO Close on block exit)
+gala_exec_test(
+    name = "use_binding",
+    src = "use_binding.gala",
+    expected = "use_binding.out",
+)
+
 # Verification: ergonomic free-function `strings` package — every
 # heavy-hitter from gala_team's call sites at least once.
 gala_exec_test(

--- a/examples/use_binding.gala
+++ b/examples/use_binding.gala
@@ -1,0 +1,35 @@
+package main
+
+// Verifies the `use` scoped-resource binding. `use x = acquire` binds x for the
+// rest of the enclosing block and guarantees x.Close() runs when the function
+// returns — on every path, LIFO across multiple `use` bindings. It is the
+// GALA-native, non-forgettable replacement for Go's `defer x.Close()` (which is
+// forbidden on the GALA surface); it lowers to Go `defer` in the generated code.
+
+// A Closeable resource that announces open/close so ordering is observable.
+type Handle struct {
+    name string
+}
+
+func (h Handle) Close() error {
+    Println(s"close ${h.name}")
+    return nil
+}
+
+func open(name string) Handle {
+    Println(s"open ${name}")
+    return Handle(name = name)
+}
+
+// Two `use` bindings: `a` is acquired first so it closes LAST; `b` is acquired
+// second so it closes FIRST (last-in, first-out).
+func work() {
+    use a = open("a")
+    use b = open("b")
+    Println(s"body sees ${a.name} and ${b.name}")
+}
+
+func main() {
+    work()
+    Println("done")
+}

--- a/examples/use_binding.out
+++ b/examples/use_binding.out
@@ -1,0 +1,6 @@
+open a
+open b
+body sees a and b
+close b
+close a
+done

--- a/fs/BUILD.bazel
+++ b/fs/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
     deps = [
         "//collection_immutable",
         "//go_interop",
+        "//resource",
         "//std",
         "//time_utils",
     ],
@@ -69,6 +70,7 @@ gala_test(
     deps = [
         ":fs",
         "//collection_immutable",
+        "//resource",
         "//time_utils",
     ],
 )
@@ -79,6 +81,7 @@ gala_test(
     deps = [
         ":fs",
         "//collection_immutable",
+        "//resource",
     ],
 )
 
@@ -88,6 +91,7 @@ gala_test(
     deps = [
         ":fs",
         "//collection_immutable",
+        "//resource",
         "//time_utils",
     ],
 )

--- a/fs/dir_ops.gala
+++ b/fs/dir_ops.gala
@@ -5,6 +5,7 @@ import (
     "os"
     "path/filepath"
     . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/resource"
     . "martianoff/gala/std"
 )
 
@@ -24,15 +25,17 @@ struct WalkEntry(
 //
 // Named CopyFile rather than Copy to avoid colliding with std.Copy,
 // the generic deep-copy helper exported as a prelude symbol.
+//
+// Each handle is released by resource.Using (GALA has no `defer`): the
+// close is guaranteed on every exit path and, being nested, runs LIFO —
+// dst closes before src.
 func CopyFile(src string, dst string, mode int) Try[bool] =
-    Try(os.Open(src)).FlatMap((srcF) => {
-        defer srcF.Close()
-        return Try(os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(mode)))
-            .FlatMap((dstF) => {
-                defer dstF.Close()
-                return Try(io.Copy(dstF, srcF)).Map((_) => true)
-            })
-    })
+    Try(os.Open(src)).FlatMap((srcF) =>
+        Using(srcF, (in) =>
+            Try(os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(mode)))
+                .FlatMap((dstF) =>
+                    Using(dstF, (out) =>
+                        Try(io.Copy(out, in)).Map((_) => true)))))
 
 // Rename moves src to dst by delegating to os.Rename. Atomic on the
 // same filesystem; will fail across filesystems. Callers that need

--- a/fs/dir_ops_test.gala
+++ b/fs/dir_ops_test.gala
@@ -4,19 +4,22 @@ import (
     . "martianoff/gala/test"
     . "martianoff/gala/std"
     . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/resource"
     "martianoff/gala/fs"
     "os"
     "path/filepath"
 )
 
-// scratchDir creates a fresh temp dir per-test so tests are isolated.
-// Each test cleans up via fs.RemoveAll / defer os.RemoveAll.
-func scratchDirDirOps(prefix string) string = Try(os.MkdirTemp("", prefix)).Get()
+// withScratch creates a fresh temp dir per-test (so tests are isolated), runs
+// `body` over it, and removes the dir on every exit path — normal return or
+// panic — via resource.Bracket. This is the GALA-native replacement for the
+// imperative `defer os.RemoveAll(dir)`.
+func withScratch[A any](prefix string, body func(string) A) A {
+    val dir = Try(os.MkdirTemp("", prefix)).Get()
+    return Bracket(dir, (d) => { fs.RemoveAll(d) }, body)
+}
 
-func TestCopyFile(t T) T {
-    val dir = scratchDirDirOps("fs_copy")
-    defer os.RemoveAll(dir)
-
+func TestCopyFile(t T) T = withScratch("fs_copy", (dir) => {
     val src = filepath.Join(dir, "src.txt")
     val dst = filepath.Join(dir, "dst.txt")
     val payload = "stream me byte by byte"
@@ -28,21 +31,15 @@ func TestCopyFile(t T) T {
     val read = fs.ReadFileString(dst)
     val t3 = IsTrue(t2, read.IsSuccess())
     return Eq(t3, read.Get(), payload)
-}
+})
 
-func TestCopyMissingSource(t T) T {
-    val dir = scratchDirDirOps("fs_copy_missing")
-    defer os.RemoveAll(dir)
-
+func TestCopyMissingSource(t T) T = withScratch("fs_copy_missing", (dir) => {
     val dst = filepath.Join(dir, "dst.txt")
     val r = fs.CopyFile(filepath.Join(dir, "nope.txt"), dst, 0o644)
     return IsTrue(t, r.IsFailure())
-}
+})
 
-func TestRename(t T) T {
-    val dir = scratchDirDirOps("fs_rename")
-    defer os.RemoveAll(dir)
-
+func TestRename(t T) T = withScratch("fs_rename", (dir) => {
     val src = filepath.Join(dir, "before.txt")
     val dst = filepath.Join(dir, "after.txt")
     val payload = "rename me"
@@ -54,12 +51,9 @@ func TestRename(t T) T {
     val t3 = IsTrue(t2, fs.Exists(dst))
     val read = fs.ReadFileString(dst)
     return Eq(t3, read.Get(), payload)
-}
+})
 
-func TestWalk(t T) T {
-    val dir = scratchDirDirOps("fs_walk")
-    defer os.RemoveAll(dir)
-
+func TestWalk(t T) T = withScratch("fs_walk", (dir) => {
     // root/{a.txt, b.txt, sub/{c.txt}}
     fs.WriteFileString(filepath.Join(dir, "a.txt"), "1", 0o644)
     fs.WriteFileString(filepath.Join(dir, "b.txt"), "22", 0o644)
@@ -87,17 +81,14 @@ func TestWalk(t T) T {
         tn = IsTrue(tn, found)
     }
     return tn
-}
+})
 
 func TestWalkMissingRoot(t T) T {
     val r = fs.Walk("/this/path/should/never/exist/qqq")
     return IsTrue(t, r.IsFailure())
 }
 
-func TestGlob(t T) T {
-    val dir = scratchDirDirOps("fs_glob")
-    defer os.RemoveAll(dir)
-
+func TestGlob(t T) T = withScratch("fs_glob", (dir) => {
     fs.WriteFileString(filepath.Join(dir, "a.txt"), "1", 0o644)
     fs.WriteFileString(filepath.Join(dir, "b.txt"), "22", 0o644)
     fs.WriteFileString(filepath.Join(dir, "c.md"), "333", 0o644)
@@ -105,16 +96,13 @@ func TestGlob(t T) T {
     val r = fs.Glob(filepath.Join(dir, "*.txt"))
     val t1 = IsTrue(t, r.IsSuccess())
     return Eq(t1, r.Get().Size(), 2)
-}
+})
 
-func TestGlobNoMatches(t T) T {
-    val dir = scratchDirDirOps("fs_glob_empty")
-    defer os.RemoveAll(dir)
-
+func TestGlobNoMatches(t T) T = withScratch("fs_glob_empty", (dir) => {
     val r = fs.Glob(filepath.Join(dir, "*.nothing"))
     val t1 = IsTrue(t, r.IsSuccess())
     return Eq(t1, r.Get().Size(), 0)
-}
+})
 
 func TestGlobMalformed(t T) T {
     val r = fs.Glob("[invalid")

--- a/fs/fs_test.gala
+++ b/fs/fs_test.gala
@@ -4,20 +4,22 @@ import (
     . "martianoff/gala/test"
     . "martianoff/gala/std"
     . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/resource"
     "martianoff/gala/fs"
     "os"
     "path/filepath"
 )
 
-// scratchDir creates a fresh temp dir per-test so tests are isolated
-// and don't depend on /tmp shape. The caller is responsible for
-// removing it (Defer-equivalent: tests call fs.RemoveAll at the end).
-func scratchDir(prefix string) string = Try(os.MkdirTemp("", prefix)).Get()
+// withScratch creates a fresh temp dir per-test (so tests are isolated and
+// don't depend on /tmp shape), runs `body` over it, and removes the dir on
+// every exit path — normal return or panic — via resource.Bracket. This is
+// the GALA-native replacement for the imperative `defer os.RemoveAll(dir)`.
+func withScratch[A any](prefix string, body func(string) A) A {
+    val dir = Try(os.MkdirTemp("", prefix)).Get()
+    return Bracket(dir, (d) => { fs.RemoveAll(d) }, body)
+}
 
-func TestWriteAndReadFile(t T) T {
-    val dir = scratchDir("fs_write_read")
-    defer os.RemoveAll(dir)
-
+func TestWriteAndReadFile(t T) T = withScratch("fs_write_read", (dir) => {
     val target = filepath.Join(dir, "hello.txt")
     val payload = "hello, world"
     val w = fs.WriteFileString(target, payload, 0o644)
@@ -26,12 +28,9 @@ func TestWriteAndReadFile(t T) T {
     val r = fs.ReadFileString(target)
     val t2 = IsTrue(t1, r.IsSuccess())
     return Eq(t2, r.Get(), payload)
-}
+})
 
-func TestReadFileBytesRoundTrip(t T) T {
-    val dir = scratchDir("fs_bytes")
-    defer os.RemoveAll(dir)
-
+func TestReadFileBytesRoundTrip(t T) T = withScratch("fs_bytes", (dir) => {
     val target = filepath.Join(dir, "bytes.bin")
     val data = ArrayOf(byte(1), byte(2), byte(3), byte(255))
     val w = fs.WriteFile(target, data, 0o644)
@@ -40,17 +39,14 @@ func TestReadFileBytesRoundTrip(t T) T {
     val r = fs.ReadFile(target)
     val t2 = IsTrue(t1, r.IsSuccess())
     return Eq(t2, r.Get().Size(), data.Size())
-}
+})
 
 func TestReadFileMissing(t T) T {
     val r = fs.ReadFile("/this/path/should/never/exist/xyz")
     return IsTrue(t, r.IsFailure())
 }
 
-func TestStat(t T) T {
-    val dir = scratchDir("fs_stat")
-    defer os.RemoveAll(dir)
-
+func TestStat(t T) T = withScratch("fs_stat", (dir) => {
     val target = filepath.Join(dir, "info.txt")
     fs.WriteFileString(target, "abcdef", 0o644)
 
@@ -60,34 +56,25 @@ func TestStat(t T) T {
     val t2 = Eq(t1, fi.Name, "info.txt")
     val t3 = Eq(t2, fi.Size, int64(6))
     return IsFalse(t3, fi.IsDir)
-}
+})
 
-func TestStatDirectoryFlag(t T) T {
-    val dir = scratchDir("fs_stat_dir")
-    defer os.RemoveAll(dir)
-
+func TestStatDirectoryFlag(t T) T = withScratch("fs_stat_dir", (dir) => {
     val info = fs.Stat(dir)
     val t1 = IsTrue(t, info.IsSuccess())
     return IsTrue(t1, info.Get().IsDir)
-}
+})
 
-func TestExists(t T) T {
-    val dir = scratchDir("fs_exists")
-    defer os.RemoveAll(dir)
-
+func TestExists(t T) T = withScratch("fs_exists", (dir) => {
     val t1 = IsTrue(t, fs.Exists(dir))
     return IsFalse(t1, fs.Exists(filepath.Join(dir, "nope")))
-}
+})
 
-func TestMkdirAll(t T) T {
-    val dir = scratchDir("fs_mkdir")
-    defer os.RemoveAll(dir)
-
+func TestMkdirAll(t T) T = withScratch("fs_mkdir", (dir) => {
     val nested = filepath.Join(dir, "a", "b", "c")
     val r = fs.MkdirAll(nested, 0o755)
     val t1 = IsTrue(t, r.IsSuccess())
     return IsTrue(t1, fs.Exists(nested))
-}
+})
 
 func TestMkdirTemp(t T) T {
     val r = fs.MkdirTemp("", "fs_mkdirtemp_")
@@ -99,7 +86,8 @@ func TestMkdirTemp(t T) T {
 }
 
 func TestRemoveAll(t T) T {
-    val dir = scratchDir("fs_remove")
+    // No withScratch here: this test exercises fs.RemoveAll as the cleanup.
+    val dir = Try(os.MkdirTemp("", "fs_remove")).Get()
     val nested = filepath.Join(dir, "x", "y")
     fs.MkdirAll(nested, 0o755)
     fs.WriteFileString(filepath.Join(nested, "f.txt"), "data", 0o644)
@@ -117,10 +105,7 @@ func TestRemoveAllMissingIsSuccess(t T) T {
     return IsTrue(t, r.IsSuccess())
 }
 
-func TestReadDir(t T) T {
-    val dir = scratchDir("fs_readdir")
-    defer os.RemoveAll(dir)
-
+func TestReadDir(t T) T = withScratch("fs_readdir", (dir) => {
     fs.WriteFileString(filepath.Join(dir, "a.txt"), "1", 0o644)
     fs.WriteFileString(filepath.Join(dir, "b.txt"), "22", 0o644)
     fs.MkdirAll(filepath.Join(dir, "sub"), 0o755)
@@ -129,7 +114,7 @@ func TestReadDir(t T) T {
     val t1 = IsTrue(t, r.IsSuccess())
     val entries = r.Get()
     return Eq(t1, entries.Size(), 3)
-}
+})
 
 // ReadDir over a missing directory must report Failure — guards that the
 // FlatMap-composed form still surfaces the os.ReadDir error (a never-failing

--- a/fs/streaming.gala
+++ b/fs/streaming.gala
@@ -6,6 +6,7 @@ import (
     "strings"
     . "martianoff/gala/collection_immutable"
     . "martianoff/gala/go_interop"
+    . "martianoff/gala/resource"
     . "martianoff/gala/std"
 )
 
@@ -50,18 +51,20 @@ func splitLines(data []byte) Array[string] {
 // The underlying bufio.Scanner is configured with a 1 MiB max line
 // length so long lines don't trip bufio.ErrTooLong; the default 64 KiB
 // is too tight for many real inputs.
+// The file handle is released by resource.Using (GALA has no `defer`):
+// Close() is guaranteed on every exit path, including an early stop.
 func ForEachLine(path string, fn func(string) bool) Try[bool] =
-    Try(os.Open(path)).FlatMap((f) => {
-        defer f.Close()
-        val scanner = bufio.NewScanner(f)
-        scanner.Buffer(SliceWithCapacity[byte](scannerInitialBufBytes), scannerMaxLineBytes)
-        for scanner.Scan() {
-            if !fn(scanner.Text()) {
-                return Success[bool](false)
+    Try(os.Open(path)).FlatMap((f) =>
+        Using(f, (file) => {
+            val scanner = bufio.NewScanner(file)
+            scanner.Buffer(SliceWithCapacity[byte](scannerInitialBufBytes), scannerMaxLineBytes)
+            for scanner.Scan() {
+                if !fn(scanner.Text()) {
+                    return Success[bool](false)
+                }
             }
-        }
-        return FromError(scanner.Err()).Map((_) => true)
-    })
+            return FromError(scanner.Err()).Map((_) => true)
+        }))
 
 // WriteLines writes `lines` to `path` joined by "\n" with a trailing
 // newline appended after the last line. Existing contents at `path`

--- a/fs/streaming_test.gala
+++ b/fs/streaming_test.gala
@@ -4,20 +4,23 @@ import (
     . "martianoff/gala/test"
     . "martianoff/gala/std"
     . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/resource"
     "martianoff/gala/fs"
     "os"
     "path/filepath"
 )
 
-// scratchStreamDir mirrors fs_test.scratchDir; redeclared here to keep
-// each test file self-contained (GALA's gala_go_test compiles each
-// _test.gala into its own package main).
-func scratchStreamDir(prefix string) string = Try(os.MkdirTemp("", prefix)).Get()
+// withScratch creates a fresh temp dir per-test, runs `body` over it, and
+// removes the dir on every exit path — normal return or panic — via
+// resource.Bracket. Redeclared here to keep each test file self-contained
+// (GALA's gala_test compiles each _test.gala into its own package main). This
+// is the GALA-native replacement for the imperative `defer os.RemoveAll(dir)`.
+func withScratch[A any](prefix string, body func(string) A) A {
+    val dir = Try(os.MkdirTemp("", prefix)).Get()
+    return Bracket(dir, (d) => { fs.RemoveAll(d) }, body)
+}
 
-func TestReadLinesRoundTrip(t T) T {
-    val dir = scratchStreamDir("fs_readlines_rt")
-    defer os.RemoveAll(dir)
-
+func TestReadLinesRoundTrip(t T) T = withScratch("fs_readlines_rt", (dir) => {
     val target = filepath.Join(dir, "lines.txt")
     val lines = ArrayOf("alpha", "beta", "gamma")
     val w = fs.WriteLines(target, lines, 0o644)
@@ -30,24 +33,18 @@ func TestReadLinesRoundTrip(t T) T {
     val t4 = Eq(t3, read.Get(0), "alpha")
     val t5 = Eq(t4, read.Get(1), "beta")
     return Eq(t5, read.Get(2), "gamma")
-}
+})
 
-func TestReadLinesEmptyFile(t T) T {
-    val dir = scratchStreamDir("fs_readlines_empty")
-    defer os.RemoveAll(dir)
-
+func TestReadLinesEmptyFile(t T) T = withScratch("fs_readlines_empty", (dir) => {
     val target = filepath.Join(dir, "empty.txt")
     fs.WriteFileString(target, "", 0o644)
 
     val r = fs.ReadLines(target)
     val t1 = IsTrue(t, r.IsSuccess())
     return Eq(t1, r.Get().Size(), 0)
-}
+})
 
-func TestReadLinesNoTrailingNewline(t T) T {
-    val dir = scratchStreamDir("fs_readlines_notrail")
-    defer os.RemoveAll(dir)
-
+func TestReadLinesNoTrailingNewline(t T) T = withScratch("fs_readlines_notrail", (dir) => {
     val target = filepath.Join(dir, "lines.txt")
     fs.WriteFileString(target, "one\ntwo\nthree", 0o644)
 
@@ -56,12 +53,9 @@ func TestReadLinesNoTrailingNewline(t T) T {
     val read = r.Get()
     val t2 = Eq(t1, read.Size(), 3)
     return Eq(t2, read.Get(2), "three")
-}
+})
 
-func TestForEachLineVisitsAll(t T) T {
-    val dir = scratchStreamDir("fs_foreach_all")
-    defer os.RemoveAll(dir)
-
+func TestForEachLineVisitsAll(t T) T = withScratch("fs_foreach_all", (dir) => {
     val target = filepath.Join(dir, "lines.txt")
     fs.WriteLines(target, ArrayOf("a", "b", "c"), 0o644)
 
@@ -75,12 +69,9 @@ func TestForEachLineVisitsAll(t T) T {
     val t3 = Eq(t2, seen.Get(0), "a")
     val t4 = Eq(t3, seen.Get(1), "b")
     return Eq(t4, seen.Get(2), "c")
-}
+})
 
-func TestForEachLineEarlyStop(t T) T {
-    val dir = scratchStreamDir("fs_foreach_stop")
-    defer os.RemoveAll(dir)
-
+func TestForEachLineEarlyStop(t T) T = withScratch("fs_foreach_stop", (dir) => {
     val target = filepath.Join(dir, "lines.txt")
     fs.WriteLines(target, ArrayOf("a", "b", "c", "d"), 0o644)
 
@@ -92,17 +83,14 @@ func TestForEachLineEarlyStop(t T) T {
     val t1 = IsTrue(t, r.IsSuccess())
     // Callback returned false on line 2, so iteration stopped there.
     return Eq(t1, seen.Size(), 2)
-}
+})
 
 func TestForEachLineMissingFileFails(t T) T {
     val r = fs.ForEachLine("/this/path/should/never/exist/abcxyz", (line) => true)
     return IsTrue(t, r.IsFailure())
 }
 
-func TestAppendStringRoundTrip(t T) T {
-    val dir = scratchStreamDir("fs_append_str")
-    defer os.RemoveAll(dir)
-
+func TestAppendStringRoundTrip(t T) T = withScratch("fs_append_str", (dir) => {
     val target = filepath.Join(dir, "log.txt")
     val w1 = fs.AppendString(target, "a\n", 0o644)
     val t1 = IsTrue(t, w1.IsSuccess())
@@ -112,12 +100,9 @@ func TestAppendStringRoundTrip(t T) T {
     val r = fs.ReadFileString(target)
     val t3 = IsTrue(t2, r.IsSuccess())
     return Eq(t3, r.Get(), "a\nb\n")
-}
+})
 
-func TestAppendStringCreatesFile(t T) T {
-    val dir = scratchStreamDir("fs_append_create")
-    defer os.RemoveAll(dir)
-
+func TestAppendStringCreatesFile(t T) T = withScratch("fs_append_create", (dir) => {
     val target = filepath.Join(dir, "fresh.txt")
     val t1 = IsFalse(t, fs.Exists(target))
     val w = fs.AppendString(target, "hello", 0o644)
@@ -126,12 +111,9 @@ func TestAppendStringCreatesFile(t T) T {
 
     val r = fs.ReadFileString(target)
     return Eq(t3, r.Get(), "hello")
-}
+})
 
-func TestAppendBytesRoundTrip(t T) T {
-    val dir = scratchStreamDir("fs_append_bytes")
-    defer os.RemoveAll(dir)
-
+func TestAppendBytesRoundTrip(t T) T = withScratch("fs_append_bytes", (dir) => {
     val target = filepath.Join(dir, "bytes.bin")
     val payload1 = ArrayOf(byte(1), byte(2))
     val payload2 = ArrayOf(byte(3), byte(4))
@@ -143,4 +125,4 @@ func TestAppendBytesRoundTrip(t T) T {
     val r = fs.ReadFile(target)
     val t3 = IsTrue(t2, r.IsSuccess())
     return Eq(t3, r.Get().Size(), 4)
-}
+})

--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -277,6 +277,16 @@ const (
 	// resolver-aware: a user-defined function of the same name (e.g. a local
 	// `func delete(...)`) is not a builtin and is left untouched.
 	CodeForbiddenGoBuiltin ErrorCode = "GALA-E0035"
+
+	// E0036: a Go-only statement keyword (defer, go, goto, fallthrough, select,
+	// chan) appeared as a bare identifier statement. These are not part of
+	// GALA's grammar; they only "worked" as an accident of the final gofmt pass
+	// re-absorbing the following statement (e.g. `defer` + `f.Close()` gluing
+	// into a Go DeferStmt). GALA expresses cleanup with the `resource`
+	// combinators (Using/Bracket/WithLock, or a `use` binding) and goroutines
+	// with go_interop.Spawn, so the bare keywords are a hard error. The check is
+	// resolver-aware: a user binding of the same name is left untouched.
+	CodeForbiddenStatementKeyword ErrorCode = "GALA-E0036"
 )
 
 // MultiError collects multiple GALA errors.

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -236,7 +236,7 @@ func methodCompletions(richAST *transpiler.RichAST) []lsp.CompletionItem {
 
 func keywordCompletions() []lsp.CompletionItem {
 	keywords := []string{
-		"package", "import", "val", "var", "bind", "also", "func", "type", "struct",
+		"package", "import", "val", "var", "bind", "also", "use", "func", "type", "struct",
 		"interface", "sealed", "embed", "if", "else", "for", "range",
 		"return", "match", "case", "true", "false", "nil", "map",
 	}

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -4319,7 +4319,7 @@ func TestDefinition_MethodDeclNavigation_Repro(t *testing.T) {
 	// defined in a different file than the usage.
 	dir := createTestProject(t, []testProjectFile{
 		{Name: "lib.gala", Src: "package mylib\n\ntype Box[T any] struct {\n    val value T\n}\n\nfunc (b Box[T]) Tail() Box[T] {\n    return b\n}\n\nfunc (b Box[T]) Filter(f func(T) bool) Box[T] {\n    return b\n}\n"},
-		{Name: "main.gala", Src: "package mylib\n\nfunc use(b Box[int]) Box[int] {\n    val t = b.Tail()\n    val f = b.Filter((x) => x > 0)\n    return t\n}\n"},
+		{Name: "main.gala", Src: "package mylib\n\nfunc project(b Box[int]) Box[int] {\n    val t = b.Tail()\n    val f = b.Filter((x) => x > 0)\n    return t\n}\n"},
 	})
 	openProjectFile(t, harness, dir, "lib.gala")
 	uri := openProjectFile(t, harness, dir, "main.gala")
@@ -4409,12 +4409,12 @@ func TestDefinition_StructFieldNotInComment(t *testing.T) {
 		"\n" +
 		"struct SSEEvent(Event string, Data string, Id string, Retry int)\n" +
 		"\n" +
-		"func use(e SSEEvent) string = e.Data\n"
+		"func render(e SSEEvent) string = e.Data\n"
 	uri := openFileOnDisk(t, harness, src)
 	time.Sleep(200 * time.Millisecond)
 
-	lineIdx := 8 // `func use(e SSEEvent) string = e.Data`
-	line := "func use(e SSEEvent) string = e.Data"
+	lineIdx := 8 // `func render(e SSEEvent) string = e.Data`
+	line := "func render(e SSEEvent) string = e.Data"
 	dataCol := strings.Index(line, "e.Data") + 2 // column of D in Data
 	locs, err := harness.Definition(uri, lineIdx, dataCol)
 	if err != nil {

--- a/internal/parser/grammar/gala.g4
+++ b/internal/parser/grammar/gala.g4
@@ -32,6 +32,7 @@ declaration
     | varDeclaration
     | bindDeclaration
     | alsoDeclaration
+    | useDeclaration
     | functionDeclaration
     | typeDeclaration
     | importDeclaration
@@ -62,6 +63,13 @@ varDeclaration: 'var' (tuplePattern | identifierList) (type)? ('=' expressionLis
 // ordering is enforced in the transformer, not the grammar, for better errors.
 bindDeclaration: BIND identifier (type)? '=' expression;
 alsoDeclaration: ALSO identifier (type)? '=' expression;
+
+// Scoped resource binding (RAII). `use x = acquire` binds x for the rest of the
+// enclosing block and guarantees x.Close() runs when the block exits, on every
+// path — the GALA-native replacement for Go's `defer x.Close()`. Multiple `use`
+// bindings in a block close in reverse (LIFO) order. Desugared in the
+// transformer to nested resource.Using scopes; the resource must be Closeable.
+useDeclaration: USE identifier (type)? '=' expression;
 
 // Tuple pattern for destructuring: val (a, b) = tuple
 tuplePattern: '(' identifierList ')';
@@ -245,6 +253,7 @@ VAL: 'val';
 VAR: 'var';
 BIND: 'bind';
 ALSO: 'also';
+USE: 'use';
 FUNC: 'func';
 TYPE: 'type';
 STRUCT: 'struct';

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -123,6 +123,7 @@ go_test(
         "tuple_return_arity_test.go",
         "type_inference_regression_test.go",
         "type_inference_test.go",
+        "use_binding_test.go",
         "user_get_method_test.go",
         "variables_test.go",
         "zero_field_struct_ctor_test.go",

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -70,6 +70,7 @@ go_test(
         "expected_arg_stack_test.go",
         "expected_type_sealed_variant_overlap_test.go",
         "forbidden_builtins_test.go",
+        "forbidden_statement_keywords_test.go",
         "func_phantom_typearg_test.go",
         "functions_test.go",
         "generated_format_test.go",

--- a/internal/transpiler/transformer/bind.go
+++ b/internal/transpiler/transformer/bind.go
@@ -68,6 +68,23 @@ func alsoDeclFromStatement(stmtCtx grammar.IStatementContext) grammar.IAlsoDecla
 	return nil
 }
 
+// useDeclFromStatement returns the UseDeclaration context if the statement is a
+// `use name = expr`, else nil.
+func useDeclFromStatement(stmtCtx grammar.IStatementContext) grammar.IUseDeclarationContext {
+	sc, ok := stmtCtx.(*grammar.StatementContext)
+	if !ok || sc == nil {
+		return nil
+	}
+	dc, ok := sc.Declaration().(*grammar.DeclarationContext)
+	if !ok || dc == nil {
+		return nil
+	}
+	if ud := dc.UseDeclaration(); ud != nil {
+		return ud
+	}
+	return nil
+}
+
 // trailingBindValueExpr extracts the value expression from a block's trailing
 // statement (e.g. `Success(...)`), or nil if the statement is not a bare
 // expression.

--- a/internal/transpiler/transformer/bind.go
+++ b/internal/transpiler/transformer/bind.go
@@ -311,7 +311,13 @@ func (t *galaASTTransformer) buildSequential(prepped []preppedBind, rest []gramm
 			return nil, err
 		}
 	}
-	body.List = append([]ast.Stmt{t.bindRebindStmt(p.name, rawParam)}, body.List...)
+	// A `_`-named bind sequences the monadic effect but discards its value, so
+	// there is no val to rebind — emitting `_ := NewImmutable(...)` would be
+	// invalid Go ("no new variables on left side of :="). The raw FlatMap
+	// callback param stays unused (legal for a Go func parameter).
+	if p.name != "_" {
+		body.List = append([]ast.Stmt{t.bindRebindStmt(p.name, rawParam)}, body.List...)
+	}
 
 	lambda := t.bindLambda(rawParam, p.elemType, resultType, body)
 	return t.emitGenericMethodFreeFunc("FlatMap", p.recvExpr, p.recvType, p.lookupBaseName, t.resultElemTypeArgs(resultType), nil, []ast.Expr{lambda}, false), nil
@@ -380,6 +386,12 @@ func (t *galaASTTransformer) buildAlsoZip(prepped []preppedBind, rest []grammar.
 		// what makes reads emit `.Get()`, unwrapping the field exactly once; a raw
 		// var would leave the field Immutable-wrapped and a downstream constructor
 		// would wrap it a second time (Immutable[Immutable[T]]).
+		// A `_`-named clause contributes its effect to the Zip but discards its
+		// value, so we skip extracting the tuple field — `_ := _zip.Vi` would be
+		// invalid Go ("no new variables on left side of :=").
+		if p.name == "_" {
+			continue
+		}
 		t.addVal(p.name, p.elemType)
 		lambdaBody.List = append(lambdaBody.List, &ast.AssignStmt{
 			Lhs: []ast.Expr{ast.NewIdent(p.name)},

--- a/internal/transpiler/transformer/bind_test.go
+++ b/internal/transpiler/transformer/bind_test.go
@@ -302,3 +302,27 @@ func run() Box[int] {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "FlatMap")
 }
+
+// A `bind _ = <effect>` sequences a monadic effect (e.g. FromError of a Go
+// error-only call) but discards its value. The lowering must NOT emit
+// `_ := std.NewImmutable(...)` — that is invalid Go ("no new variables on left
+// side of :="). The FlatMap still threads the chain; the callback param is left
+// unused (legal for a Go func parameter).
+func TestBindDiscardNameEmitsNoInvalidAssign(t *testing.T) {
+	trans := newBindTranspiler()
+	input := `package main
+
+func eff() Try[bool] = Success(true)
+
+func run() Try[int] {
+    bind _ = eff()
+    Success(42)
+}
+`
+	got, err := trans.Transpile(input, "")
+	assert.NoError(t, err)
+	assert.NotContains(t, got, "_ :=",
+		"a discard bind must not emit an invalid `_ := ...` assignment:\n%s", got)
+	assert.Contains(t, got, "FlatMap",
+		"the discard bind should still lower to a FlatMap chain:\n%s", got)
+}

--- a/internal/transpiler/transformer/coverage_regression_test.go
+++ b/internal/transpiler/transformer/coverage_regression_test.go
@@ -176,8 +176,8 @@ func TestIfExpressionStringInterpolationIIFEReturnType(t *testing.T) {
 	trans := newTranspiler()
 	input := `package main
 
-func makeLabel(use bool, name string) string {
-    val label = if (use) s">> $name" else s"-- $name"
+func makeLabel(arrow bool, name string) string {
+    val label = if (arrow) s">> $name" else s"-- $name"
     return label
 }
 

--- a/internal/transpiler/transformer/cross_module_matrix_test.go
+++ b/internal/transpiler/transformer/cross_module_matrix_test.go
@@ -291,7 +291,7 @@ func buildConsumerSource(modulePath string, dep crossModDep, cons crossModConsum
 	b.WriteString("package consumer\n\n")
 	b.WriteString(importLine)
 	b.WriteString("\n\n")
-	fmt.Fprintf(&b, "func use() Int = %s%s()\n", q, dep.exportedFunc)
+	fmt.Fprintf(&b, "func callDep() Int = %s%s()\n", q, dep.exportedFunc)
 
 	// If the dep exports a type with a constructor, exercise that too.
 	if dep.constructorCall != nil {
@@ -299,6 +299,6 @@ func buildConsumerSource(modulePath string, dep crossModDep, cons crossModConsum
 			q, dep.exportedType, dep.constructorCall(q))
 	}
 
-	b.WriteString("\nfunc main() { Println(use()) }\n")
+	b.WriteString("\nfunc main() { Println(callDep()) }\n")
 	return b.String()
 }

--- a/internal/transpiler/transformer/dot_import_test.go
+++ b/internal/transpiler/transformer/dot_import_test.go
@@ -398,7 +398,7 @@ import (
     . "github.com/example/galatui/harness"
 )
 
-func use(p Program) Harness = NewHarness(p)
+func consume(p Program) Harness = NewHarness(p)
 func makeFrame(s SessionInstance) string = PrintHarnessFrame(s)
 `
 

--- a/internal/transpiler/transformer/forbidden_statement_keywords_test.go
+++ b/internal/transpiler/transformer/forbidden_statement_keywords_test.go
@@ -1,0 +1,64 @@
+package transformer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestForbiddenStatementKeywordsAreHardErrors verifies that the Go-only
+// statement keywords GALA does not have in its grammar (defer, go, goto,
+// fallthrough, select, chan) are rejected with GALA-E0036 when they appear as
+// a bare identifier statement. Historically these "worked" only as an accident
+// of the final gofmt pass re-absorbing the following statement (e.g. `defer` +
+// `f.Close()` gluing into a Go DeferStmt); forbidding them removes that silent
+// Go leakage.
+func TestForbiddenStatementKeywordsAreHardErrors(t *testing.T) {
+	trans := newForbiddenBuiltinTranspiler()
+
+	rejected := []struct {
+		name  string
+		input string
+	}{
+		{"defer", "package main\n\nfunc f() {\n    defer Println(\"x\")\n    Println(\"y\")\n}"},
+		{"go", "package main\n\nfunc f() {\n    go Println(\"x\")\n    Println(\"y\")\n}"},
+		{"goto", "package main\n\nfunc f() {\n    goto Println(\"x\")\n    Println(\"y\")\n}"},
+		{"fallthrough", "package main\n\nfunc f() {\n    fallthrough Println(\"x\")\n    Println(\"y\")\n}"},
+		{"select", "package main\n\nfunc f() {\n    select Println(\"x\")\n    Println(\"y\")\n}"},
+		{"chan", "package main\n\nfunc f() {\n    chan Println(\"x\")\n    Println(\"y\")\n}"},
+	}
+	for _, tc := range rejected {
+		tc := tc
+		t.Run("rejects_bare_"+tc.name, func(t *testing.T) {
+			_, err := trans.Transpile(tc.input, "")
+			require.Error(t, err, "expected bare %q statement to be rejected", tc.name)
+			require.Contains(t, err.Error(), "GALA-E0036",
+				"expected the forbidden-statement-keyword error code for %q, got: %v", tc.name, err)
+		})
+	}
+}
+
+// TestOrdinaryIdentifierStatementsAreLegal verifies the check does not fire for
+// normal statements. It only targets a bare identifier equal to a forbidden Go
+// keyword; a function call (which has a `(...)` postfix), or an identifier that
+// merely *starts* with a forbidden word, must transpile cleanly.
+func TestOrdinaryIdentifierStatementsAreLegal(t *testing.T) {
+	trans := newForbiddenBuiltinTranspiler()
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		// A call to a user function whose name starts with a forbidden word.
+		{"deferred_call", "package main\n\nfunc deferred() {}\n\nfunc f() {\n    deferred()\n}"},
+		// A plain call statement — not a bare identifier.
+		{"plain_call", "package main\n\nfunc f() {\n    Println(\"y\")\n}"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := trans.Transpile(tc.input, "")
+			require.NoError(t, err, "%s must be legal", tc.name)
+		})
+	}
+}

--- a/internal/transpiler/transformer/phantom_reexport_funconly_test.go
+++ b/internal/transpiler/transformer/phantom_reexport_funconly_test.go
@@ -95,7 +95,7 @@ import (
     . "github.com/example/funconly/sub"
 )
 
-func use() Int = helper() + PhantomHelper()
+func consume() Int = helper() + PhantomHelper()
 `), 0644)
 	assert.NoError(t, err)
 

--- a/internal/transpiler/transformer/statements.go
+++ b/internal/transpiler/transformer/statements.go
@@ -7,6 +7,7 @@ import (
 	"go/token"
 	"martianoff/gala/galaerr"
 	"martianoff/gala/internal/parser/grammar"
+	"martianoff/gala/internal/transpiler"
 )
 
 func (t *galaASTTransformer) transformSimpleStatement(ctx grammar.ISimpleStatementContext) (ast.Stmt, error) {
@@ -388,6 +389,18 @@ func (t *galaASTTransformer) transformBlock(ctx *grammar.BlockContext) (*ast.Blo
 			}
 			return block, nil
 		}
+		// A `use x = acquire` scoped-resource binding lowers to `x := acquire`
+		// plus `defer x.Close()`; the binding stays in scope for the rest of
+		// this block and releases (LIFO) when the function returns. Emitted
+		// inline so subsequent statements see `x`.
+		if useDecl := useDeclFromStatement(stmtCtx); useDecl != nil {
+			useStmts, err := t.transformUseDeclaration(useDecl)
+			if err != nil {
+				return nil, err
+			}
+			block.List = append(block.List, useStmts...)
+			continue
+		}
 		// A bare `subject match { ... }` whose value is discarded by the
 		// surrounding ExprStmt must be lowered as a void IIFE; otherwise
 		// arms calling void Go functions (e.g. `d.Skip()`) get wrapped in
@@ -427,6 +440,65 @@ func (t *galaASTTransformer) transformBlock(ctx *grammar.BlockContext) (*ast.Blo
 		block.List = append(block.List, stmt)
 	}
 	return block, nil
+}
+
+// transformUseDeclaration lowers a `use x = acquire` scoped-resource binding to
+// the two Go statements that implement it: `x := acquire` and `defer x.Close()`.
+// The resource is bound for the rest of the enclosing block and released — via
+// its Close() method — when the function returns, on every path (normal or
+// panic), LIFO with any other `use`/defer. This is the GALA-native, non-
+// forgettable replacement for the (now-forbidden) bare Go `defer x.Close()`;
+// emitting Go `defer` here is the sanctioned internal lowering — it lives in the
+// generated Go, never on the GALA surface.
+//
+// The binding is registered with its concrete resource type (not wrapped in
+// Immutable), so `x` and `x.Close()` read as plain Go and no `.Get()` unwrap is
+// injected. Acquisition is a single-value expression; a fallible Go acquire that
+// returns `(resource, error)` should be error-checked first (or use the
+// resource combinators directly).
+func (t *galaASTTransformer) transformUseDeclaration(ctx grammar.IUseDeclarationContext) ([]ast.Stmt, error) {
+	name := ctx.Identifier().GetText()
+	acquire, err := t.transformExpression(ctx.Expression())
+	if err != nil {
+		return nil, err
+	}
+	acquire = t.unwrapImmutable(acquire)
+
+	// Register the binding with its concrete type so downstream references and
+	// the Close() call resolve directly (no Immutable unwrapping). Prefer an
+	// explicit annotation when present; otherwise infer from the acquire expr.
+	resType := t.getExprTypeName(acquire)
+	if typeCtx := ctx.Type_(); typeCtx != nil {
+		if typeExpr, terr := t.transformType(typeCtx); terr == nil {
+			if annotated := t.astTypeToTranspilerType(typeExpr); annotated != nil && !annotated.IsNil() {
+				resType = annotated
+			}
+		}
+	}
+	// The binding holds the plain resource (`x := acquire`), not an Immutable
+	// wrapper, so strip any inferred Immutable[T] to T and register it with
+	// mutable-storage (addVar) semantics. A `val` binding is always
+	// Immutable-wrapped, so every read of it is rewritten to `x.Get()`
+	// (transformPrimary); `use` stores the resource directly, so its reads and
+	// `x.Close()` must stay plain — addVar gives exactly that.
+	if t.isImmutableType(resType) {
+		if gen, ok := resType.(transpiler.GenericType); ok && len(gen.Params) > 0 {
+			resType = gen.Params[0]
+		}
+	}
+	t.addVar(name, resType)
+
+	assign := &ast.AssignStmt{
+		Lhs: []ast.Expr{ast.NewIdent(name)},
+		Tok: token.DEFINE,
+		Rhs: []ast.Expr{acquire},
+	}
+	deferStmt := &ast.DeferStmt{
+		Call: &ast.CallExpr{
+			Fun: &ast.SelectorExpr{X: ast.NewIdent(name), Sel: ast.NewIdent("Close")},
+		},
+	}
+	return []ast.Stmt{assign, deferStmt}, nil
 }
 
 // stmtIsBareMatchExpression reports whether a statement is just a bare

--- a/internal/transpiler/transformer/statements.go
+++ b/internal/transpiler/transformer/statements.go
@@ -30,6 +30,9 @@ func (t *galaASTTransformer) transformSimpleStatementWithMutability(ctx grammar.
 		return t.transformShortVarDeclWithMutability(shortCtx.(*grammar.ShortVarDeclContext), mutable)
 	}
 	if exprCtx := ctx.Expression(); exprCtx != nil {
+		if err := t.checkForbiddenStatementKeyword(exprCtx); err != nil {
+			return nil, err
+		}
 		expr, err := t.transformExpression(exprCtx)
 		if err != nil {
 			return nil, err
@@ -37,6 +40,71 @@ func (t *galaASTTransformer) transformSimpleStatementWithMutability(ctx grammar.
 		return &ast.ExprStmt{X: expr}, nil
 	}
 	return nil, nil
+}
+
+// forbiddenStatementKeywordSuggestions maps each Go-only statement keyword that
+// GALA does NOT have in its grammar to an actionable replacement. None of these
+// are GALA keywords, so the parser accepts them as a bare identifier
+// expression-statement; they only ever produced working Go by accident of the
+// final gofmt pass, which re-absorbs the following statement into a real Go
+// DeferStmt/GoStmt/etc. (`defer` + `f.Close()` glue into one DeferStmt). That is
+// undocumented, ungrammatical, and fragile, so a bare use is a hard error.
+var forbiddenStatementKeywordSuggestions = map[string]string{
+	"defer":       "GALA has no `defer`; use the `resource` combinators — `Using` / `Bracket` / `WithLock` from martianoff/gala/resource (or a `use x = ...` binding) — which guarantee cleanup on every exit path",
+	"go":          "GALA has no bare `go` statement; use `go_interop.Spawn(() => ...)` to start a goroutine",
+	"goto":        "GALA has no `goto`; use structured control flow — pattern matching, recursion, or a `for` loop",
+	"fallthrough": "GALA has no `fallthrough`; `match` arms never fall through — combine patterns with `|` or restructure the match",
+	"select":      "GALA has no `select` statement; use the go_interop channel helpers",
+	"chan":        "GALA has no bare `chan` statement; use the go_interop channel helpers to build and operate on channels",
+}
+
+// checkForbiddenStatementKeyword rejects a bare Go-only statement keyword
+// (`defer`, `go`, `goto`, `fallthrough`, `select`, `chan`) that the parser
+// accepted as a lone identifier expression-statement. Such statements only
+// "work" as an accident of the final gofmt round-trip (see
+// forbiddenStatementKeywordSuggestions); GALA has native replacements, so this
+// is a hard error (GALA-E0036).
+//
+// It is resolver-aware, mirroring checkForbiddenGoBuiltinCall: the name is only
+// forbidden when it is a bare identifier that does NOT resolve to a
+// user-defined function, a local binding (val/var/param), or a declared
+// type/struct — so a program that legitimately named something after one of
+// these words is left untouched.
+func (t *galaASTTransformer) checkForbiddenStatementKeyword(exprCtx grammar.IExpressionContext) error {
+	// Only a bare identifier statement (`defer`) is the accident; anything with
+	// a postfix (`x.defer()`), operator, or arguments is a normal expression.
+	if !t.isDirectVariableExpression(exprCtx) {
+		return nil
+	}
+	pc := t.getPrimaryFromExpression(exprCtx)
+	if pc == nil || pc.Identifier() == nil {
+		return nil
+	}
+	name := pc.Identifier().GetText()
+	suggestion, isKeyword := forbiddenStatementKeywordSuggestions[name]
+	if !isKeyword {
+		return nil
+	}
+	// Resolver-aware guards: a name the author actually declared is that
+	// declaration, not the leaked Go keyword.
+	if t.getFunction(name) != nil {
+		return nil
+	}
+	if !t.getType(name).IsNil() {
+		return nil
+	}
+	if t.getTypeMeta(name) != nil {
+		return nil
+	}
+	if _, ok := t.structFields[name]; ok {
+		return nil
+	}
+	return galaerr.NewCodedSemanticError(
+		galaerr.CodeForbiddenStatementKeyword,
+		exprCtx.GetStart().GetLine(), exprCtx.GetStart().GetColumn(),
+		fmt.Sprintf("bare Go statement keyword %q is not part of GALA's surface", name),
+		suggestion,
+	)
 }
 
 func (t *galaASTTransformer) transformIncDecStmt(ctx *grammar.IncDecStmtContext) (ast.Stmt, error) {

--- a/internal/transpiler/transformer/use_binding_test.go
+++ b/internal/transpiler/transformer/use_binding_test.go
@@ -1,0 +1,56 @@
+package transformer_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// useProgram wraps a `use` body in a minimal Closeable-providing program so the
+// desugaring can be exercised end to end through the transpiler.
+func useProgram(body string) string {
+	return "package main\n\n" +
+		"type Handle struct {\n    name string\n}\n\n" +
+		"func (h Handle) Close() error {\n    return nil\n}\n\n" +
+		"func open(name string) Handle = Handle(name = name)\n\n" +
+		"func work() {\n" + body + "\n}\n"
+}
+
+// TestUseBindingLowersToAssignPlusDefer verifies `use x = acquire` desugars to
+// `x := acquire` followed by `defer x.Close()` — the sanctioned internal Go
+// `defer` lowering that replaces the (forbidden) bare `defer` on the surface.
+func TestUseBindingLowersToAssignPlusDefer(t *testing.T) {
+	trans := newForbiddenBuiltinTranspiler()
+
+	out, err := trans.Transpile(useProgram("    use a = open(\"a\")\n    a.Close()"), "")
+	require.NoError(t, err)
+	require.Contains(t, out, "a := open(\"a\")", "use binding should emit a plain := assignment:\n%s", out)
+	require.Contains(t, out, "defer a.Close()", "use binding should emit a deferred Close:\n%s", out)
+}
+
+// TestUseBindingReadsArePlain verifies a `use` binding is stored plainly, so
+// reads of it are NOT rewritten to `x.Get()` the way an Immutable `val` is.
+func TestUseBindingReadsArePlain(t *testing.T) {
+	trans := newForbiddenBuiltinTranspiler()
+
+	out, err := trans.Transpile(useProgram("    use a = open(\"a\")\n    Println(a.name)"), "")
+	require.NoError(t, err)
+	require.NotContains(t, out, "a.Get()",
+		"a `use` binding is not Immutable-wrapped; reads must stay plain:\n%s", out)
+}
+
+// TestMultipleUseBindingsCloseLIFO verifies that two `use` bindings emit their
+// defers in source order, so Go runs them last-in-first-out (b closes before a).
+func TestMultipleUseBindingsCloseLIFO(t *testing.T) {
+	trans := newForbiddenBuiltinTranspiler()
+
+	out, err := trans.Transpile(useProgram("    use a = open(\"a\")\n    use b = open(\"b\")\n    Println(a.name)"), "")
+	require.NoError(t, err)
+	ia := strings.Index(out, "defer a.Close()")
+	ib := strings.Index(out, "defer b.Close()")
+	require.Greater(t, ia, -1, "expected defer a.Close():\n%s", out)
+	require.Greater(t, ib, -1, "expected defer b.Close():\n%s", out)
+	require.Less(t, ia, ib,
+		"defer a.Close() must be emitted before defer b.Close() so Go closes b first (LIFO):\n%s", out)
+}

--- a/subprocess/BUILD.bazel
+++ b/subprocess/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go_interop",
+        "//resource",
         "//std",
     ],
 )

--- a/subprocess/subprocess.gala
+++ b/subprocess/subprocess.gala
@@ -54,30 +54,31 @@ func Spawn(opts SpawnOpts) Try[Process] {
     if opts.Cmd == "" {
         return Failure[Process](errors.New("subprocess.Spawn: empty Cmd"))
     }
-    return Try[Process](() => {
-        val c = exec.Command(opts.Cmd, opts.Args...)
-        if opts.Dir != "" {
-            c.Dir = opts.Dir
-        }
-        if opts.Env.Size() > 0 {
-            // Append rather than overwrite — replace mode would be a footgun
-            // (forgetting PATH breaks every spawn).
-            c.Env = go_interop.SliceAppendAll(c.Environ(), opts.Env)
-        }
-        val sin = Try(c.StdinPipe()).Get()
-        val sout = Try(c.StdoutPipe()).Get()
-        val serr = Try(c.StderrPipe()).Get()
-        FromError(c.Start()).Get()
-        return Process(state = &processState(
-            cmd        = c,
-            stdin      = sin,
-            stdoutScan = newLineScanner(sout),
-            stderrScan = newLineScanner(serr),
-            stdinMu    = go_interop.NewMutex(),
-            waitOnce   = go_interop.NewOnce(),
-            waitDone   = go_interop.NewSignal(),
-        ))
-    })
+    val c = exec.Command(opts.Cmd, opts.Args...)
+    if opts.Dir != "" {
+        c.Dir = opts.Dir
+    }
+    if opts.Env.Size() > 0 {
+        // Append rather than overwrite — replace mode would be a footgun
+        // (forgetting PATH breaks every spawn).
+        c.Env = go_interop.SliceAppendAll(c.Environ(), opts.Env)
+    }
+    // Monadic do-notation: each fallible step threads through the next, so a
+    // pipe or start failure short-circuits to Failure — no `.Get()` re-raising.
+    // Start() runs last (after the pipes are wired, per Go's exec contract);
+    // its Void result is mapped straight into the Process.
+    bind sin = Try(c.StdinPipe())
+    bind sout = Try(c.StdoutPipe())
+    bind serr = Try(c.StderrPipe())
+    FromError(c.Start()).Map((_) => Process(state = &processState(
+        cmd        = c,
+        stdin      = sin,
+        stdoutScan = newLineScanner(sout),
+        stderrScan = newLineScanner(serr),
+        stdinMu    = go_interop.NewMutex(),
+        waitOnce   = go_interop.NewOnce(),
+        waitDone   = go_interop.NewSignal(),
+    )))
 }
 
 // WriteLine writes s + "\n" to the child's stdin, flushing immediately.

--- a/subprocess/subprocess.gala
+++ b/subprocess/subprocess.gala
@@ -54,32 +54,30 @@ func Spawn(opts SpawnOpts) Try[Process] {
     if opts.Cmd == "" {
         return Failure[Process](errors.New("subprocess.Spawn: empty Cmd"))
     }
-    val c = exec.Command(opts.Cmd, opts.Args...)
-    if opts.Dir != "" {
-        c.Dir = opts.Dir
-    }
-    if opts.Env.Size() > 0 {
-        // Append rather than overwrite — replace mode would be a footgun
-        // (forgetting PATH breaks every spawn).
-        c.Env = go_interop.SliceAppendAll(c.Environ(), opts.Env)
-    }
-    val sin, sErr = c.StdinPipe()
-    if sErr != nil { return Failure[Process](sErr) }
-    val sout, oErr = c.StdoutPipe()
-    if oErr != nil { return Failure[Process](oErr) }
-    val serr, eErr = c.StderrPipe()
-    if eErr != nil { return Failure[Process](eErr) }
-    val startErr = c.Start()
-    if startErr != nil { return Failure[Process](startErr) }
-    return Success(Process(state = &processState(
-        cmd        = c,
-        stdin      = sin,
-        stdoutScan = newLineScanner(sout),
-        stderrScan = newLineScanner(serr),
-        stdinMu    = go_interop.NewMutex(),
-        waitOnce   = go_interop.NewOnce(),
-        waitDone   = go_interop.NewSignal(),
-    )))
+    return Try[Process](() => {
+        val c = exec.Command(opts.Cmd, opts.Args...)
+        if opts.Dir != "" {
+            c.Dir = opts.Dir
+        }
+        if opts.Env.Size() > 0 {
+            // Append rather than overwrite — replace mode would be a footgun
+            // (forgetting PATH breaks every spawn).
+            c.Env = go_interop.SliceAppendAll(c.Environ(), opts.Env)
+        }
+        val sin = Try(c.StdinPipe()).Get()
+        val sout = Try(c.StdoutPipe()).Get()
+        val serr = Try(c.StderrPipe()).Get()
+        FromError(c.Start()).Get()
+        return Process(state = &processState(
+            cmd        = c,
+            stdin      = sin,
+            stdoutScan = newLineScanner(sout),
+            stderrScan = newLineScanner(serr),
+            stdinMu    = go_interop.NewMutex(),
+            waitOnce   = go_interop.NewOnce(),
+            waitDone   = go_interop.NewSignal(),
+        ))
+    })
 }
 
 // WriteLine writes s + "\n" to the child's stdin, flushing immediately.

--- a/subprocess/subprocess.gala
+++ b/subprocess/subprocess.gala
@@ -6,6 +6,7 @@ import (
     "io"
     "os/exec"
     . "martianoff/gala/std"
+    . "martianoff/gala/resource"
     "martianoff/gala/go_interop"
 )
 
@@ -88,13 +89,13 @@ func Spawn(opts SpawnOpts) Try[Process] {
 // child closed stdin or exited; Failure carries the underlying io error.
 func (p Process) WriteLine(s string) Try[bool] {
     val st = p.state
-    st.stdinMu.Lock()
-    defer st.stdinMu.Unlock()
-    val _, e1 = io.WriteString(st.stdin, s)
-    if e1 != nil { return Failure[bool](e1) }
-    val _, e2 = io.WriteString(st.stdin, "\n")
-    if e2 != nil { return Failure[bool](e2) }
-    return Success(true)
+    return WithLock(st.stdinMu, () => {
+        val _, e1 = io.WriteString(st.stdin, s)
+        if e1 != nil { return Failure[bool](e1) }
+        val _, e2 = io.WriteString(st.stdin, "\n")
+        if e2 != nil { return Failure[bool](e2) }
+        return Success(true)
+    })
 }
 
 // CloseStdin closes the child's stdin pipe. Required for children
@@ -109,10 +110,10 @@ func (p Process) WriteLine(s string) Try[bool] {
 // mutex so a write in flight isn't truncated.
 func (p Process) CloseStdin() Try[bool] {
     val st = p.state
-    st.stdinMu.Lock()
-    defer st.stdinMu.Unlock()
-    st.stdin.Close()
-    return Success(true)
+    return WithLock(st.stdinMu, () => {
+        st.stdin.Close()
+        return Success(true)
+    })
 }
 
 // ReadLine blocks until the child writes a complete line on stdout, then


### PR DESCRIPTION
Stacked on #414 (base: `feature/go-builtins-interop`). Removes the last two silent Go-leakage surfaces after the bare-builtins work: the accidental `defer`/`go` statements, and adds the `use` scoped-resource binding as the GALA-native cleanup form.

## The gofmt accident (why `defer`/`go` "worked")

`defer`, `go`, `goto`, `fallthrough`, `select`, and `chan` are **not** in GALA's grammar. The parser accepts each as a bare identifier expression-statement, and Go's parser does not insert a semicolon after these keywords at line end, so the final `format.Source` (gofmt) pass re-absorbs the *following* statement into a real Go `DeferStmt`/`GoStmt`/etc. So `defer` + `f.Close()` (two GALA statements) silently glued into one Go `defer f.Close()`. Control: `frobnicate Println("x")` stays two statements — only real Go keywords merge. Undocumented, ungrammatical, and fragile.

## What shipped

**B3 — forbid the statement-keyword accidents (hard error, GALA-E0036).** A resolver-aware check (mirrors `checkForbiddenGoBuiltinCall`) rejects a bare `defer`/`go`/`goto`/`fallthrough`/`select`/`chan` identifier-statement with an actionable suggestion (cleanup → `resource`/`use`; goroutine → `go_interop.Spawn`). A name the program itself declared is left alone.

**Sweep result:** all six Go-only statement keywords leak through the same gofmt accident, so all six are forbidden consistently. `range` is already a reserved GALA keyword (parse error), so it needed nothing.

**B2 — `use x = acquire` scoped-resource binding.** New `USE` token + `useDeclaration` grammar rule (modeled on `bind`/`also`); the Go/Java parsers are regenerated from `gala.g4` by the existing antlr genrule (the `*.go` outputs are build artifacts, never hand-edited). `use x = acquire` binds `x` for the rest of the block and guarantees `x.Close()` on function exit, every path; multiple bindings release **LIFO**. It lowers to Go `x := acquire; defer x.Close()` — Go's `defer` survives only as this sanctioned internal lowering, never on the GALA surface. `use` is now a reserved word.

**Migration (in-repo `defer` users).** The task assumed zero `defer`/`go` in the tree, but `fs/` and `subprocess/` used the accident. Migrated to keep `//...` green:
- `fs.CopyFile` / `fs.ForEachLine`: `defer f.Close()` → `resource.Using`
- `subprocess.WriteLine` / `CloseStdin`: lock + `defer mu.Unlock()` → `resource.WithLock`
- fs tests: `defer os.RemoveAll(dir)` → a `withScratch` helper over `resource.Bracket` (release via `fs.RemoveAll`, which returns `Try` so the cleanup error isn't discarded by a void lambda)

No `defer`/`go` remain in `std`/`examples`.

## Test coverage
- `forbidden_statement_keywords_test.go` — all six keywords rejected with GALA-E0036; ordinary identifiers/calls unaffected.
- `use_binding_test.go` — `use` lowers to assign+defer, reads stay plain (not `x.Get()`), multiple bindings emit defers in LIFO order.
- `examples/use_binding.gala` (+ `.out`) — golden exec test asserting LIFO close order end to end.
- Reserving `use` broke internal fixtures that used it as an identifier (transformer + LSP tests) — renamed; LSP keyword-completion list gains `use`.

## End-to-end (branch CLI `//cmd/gala:gala`, fresh `GALA_HOME`)
- `defer f.Close()` → `GALA-E0036 … use the resource combinators … (or a use x = ... binding)`
- `go something()` → `GALA-E0036 … use go_interop.Spawn(() => ...)`
- `use_binding.gala` runs: `open a / open b / body sees a and b / close b / close a / done` (LIFO confirmed)

## Build/test
`bazel build //...` green. `bazel test //...`: 373/374 pass; the only failure is the known Windows env test `TestGorootFromGoBinarySymlink` (symlink privilege), unrelated. `bazel run //:gazelle` clean.

## Downstream note
Repos using bare `defer`/`go` (e.g. `gala_team`) will need the same migration to `use`/`resource`/`Spawn`. That is handled at the user level — this PR does not touch `gala_team`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UibquB523iZL6QozbKA8kV