### PR TITLE
feat(ide): recognize .Size()/.ByteSize() magic methods, use keyword, E0035/E0036 diagnostics

### DIFF
--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaAnnotator.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaAnnotator.kt
@@ -63,11 +63,17 @@ class GalaAnnotator : Annotator {
 
         // Built-in functions available without import. Keep in sync with the
         // LSP server's builtinFuncs in internal/lsp/completion.go.
+        //
+        // The bare Go builtins (len/append/make/new/cap/copy/delete/close/
+        // complex/real/imag/panic/recover) are deliberately NOT here: they are
+        // forbidden on GALA's surface (GALA-E0035, see
+        // forbiddenGoBuiltinSuggestions in
+        // internal/transpiler/transformer/calls.go), so highlighting them as
+        // available builtins would contradict the compiler. Use `.Size()` /
+        // `.ByteSize()` or the go_interop wrappers instead.
         private val BUILTIN_FUNCTION_NAMES = setOf(
             "Println", "Print",
             "SliceOf",
-            "len", "cap", "make", "append", "copy", "delete",
-            "close", "panic", "recover",
             // Auto-imported std prelude constructors / converters (distinctive
             // names — see internal/transpiler/registry/std.go and std/*.gala)
             "NewImmutable", "NewConstPtr", "NewEmbeddedFS",

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaDocumentationProvider.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaDocumentationProvider.kt
@@ -68,6 +68,7 @@ class GalaDocumentationProvider : AbstractDocumentationProvider() {
             is VarDeclarationNode -> "var"
             is BindDeclarationNode -> "bind"
             is AlsoDeclarationNode -> "also"
+            is UseDeclarationNode -> "use"
             is StructShorthandDeclarationNode -> "struct"
             is MethodSpecNode -> "method"
             else -> "declaration"
@@ -111,6 +112,10 @@ class GalaDocumentationProvider : AbstractDocumentationProvider() {
                 text.substringBefore("=").trim()
             }
             is AlsoDeclarationNode -> {
+                val text = element.text.trim()
+                text.substringBefore("=").trim()
+            }
+            is UseDeclarationNode -> {
                 val text = element.text.trim()
                 text.substringBefore("=").trim()
             }

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaFindUsagesProvider.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaFindUsagesProvider.kt
@@ -37,6 +37,7 @@ class GalaFindUsagesProvider : FindUsagesProvider {
             is VarDeclarationNode -> "variable"
             is BindDeclarationNode -> "value"
             is AlsoDeclarationNode -> "value"
+            is UseDeclarationNode -> "value"
             is StructShorthandDeclarationNode -> "struct"
             is MethodSpecNode -> "method"
             else -> "symbol"

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaParserDefinition.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaParserDefinition.kt
@@ -67,6 +67,7 @@ class GalaParserDefinition : ParserDefinition {
             GalaTokenTypes.RULE_VAR_DECLARATION -> VarDeclarationNode(node)
             GalaTokenTypes.RULE_BIND_DECLARATION -> BindDeclarationNode(node)
             GalaTokenTypes.RULE_ALSO_DECLARATION -> AlsoDeclarationNode(node)
+            GalaTokenTypes.RULE_USE_DECLARATION -> UseDeclarationNode(node)
             GalaTokenTypes.RULE_STRUCT_SHORTHAND_DECLARATION -> StructShorthandDeclarationNode(node)
             GalaTokenTypes.RULE_IMPORT_DECLARATION -> ImportDeclarationNode(node)
             GalaTokenTypes.RULE_BLOCK -> BlockNode(node)

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaSyntaxHighlighter.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/GalaSyntaxHighlighter.kt
@@ -58,6 +58,7 @@ class GalaSyntaxHighlighter : SyntaxHighlighterBase() {
             galaLexer.VAR,
             galaLexer.BIND,
             galaLexer.ALSO,
+            galaLexer.USE,
             galaLexer.FUNC,
             galaLexer.TYPE,
             galaLexer.STRUCT,

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/psi/GalaPsiNodes.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/psi/GalaPsiNodes.kt
@@ -168,6 +168,24 @@ class AlsoDeclarationNode(node: ASTNode) : GalaPsiNode(node), PsiNameIdentifierO
 }
 
 /**
+ * PSI node for use declarations (scoped-resource binding: `use x = acquire`).
+ * The bound name behaves exactly like a val: it is a name-owner so it is
+ * clickable (go-to-definition), find-usages/rename anchor, and gets a tooltip.
+ */
+class UseDeclarationNode(node: ASTNode) : GalaPsiNode(node), PsiNameIdentifierOwner {
+    override fun getName(): String? = nameIdentifier?.text
+
+    override fun getNameIdentifier(): PsiElement? {
+        for (child in children) {
+            if (child.node.elementType == GalaTokenTypes.RULE_IDENTIFIER) return child
+        }
+        return null
+    }
+
+    override fun setName(name: String): PsiElement = this
+}
+
+/**
  * PSI node for struct shorthand declarations.
  */
 class StructShorthandDeclarationNode(node: ASTNode) : GalaPsiNode(node), PsiNameIdentifierOwner {

--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/psi/GalaTokenTypes.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/psi/GalaTokenTypes.kt
@@ -62,6 +62,7 @@ object GalaTokenTypes {
     val RULE_VAR_DECLARATION: IElementType get() = ruleIElementTypes[galaParser.RULE_varDeclaration]
     val RULE_BIND_DECLARATION: IElementType get() = ruleIElementTypes[galaParser.RULE_bindDeclaration]
     val RULE_ALSO_DECLARATION: IElementType get() = ruleIElementTypes[galaParser.RULE_alsoDeclaration]
+    val RULE_USE_DECLARATION: IElementType get() = ruleIElementTypes[galaParser.RULE_useDeclaration]
     val RULE_STRUCT_SHORTHAND_DECLARATION: IElementType get() = ruleIElementTypes[galaParser.RULE_structShorthandDeclaration]
     val RULE_IMPORT_DECLARATION: IElementType get() = ruleIElementTypes[galaParser.RULE_importDeclaration]
     val RULE_PACKAGE_CLAUSE: IElementType get() = ruleIElementTypes[galaParser.RULE_packageClause]

--- a/internal/lsp/BUILD.bazel
+++ b/internal/lsp/BUILD.bazel
@@ -38,6 +38,8 @@ go_test(
         "repro_gala_mcp_test.go",
         "server_test.go",
         "signature_help_test.go",
+        "size_sugar_integration_test.go",
+        "size_sugar_test.go",
         "typeatpos_test.go",
         "uri_internal_test.go",
     ],

--- a/internal/lsp/BUILD.bazel
+++ b/internal/lsp/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
     tags = ["no-sandbox"],
     deps = [
         "//internal/transpiler",
+        "//internal/transpiler/transformer",
         "@com_github_owenrumney_go_lsp//lsp",
         "@com_github_owenrumney_go_lsp//servertest",
         "@rules_go//go/tools/bazel",

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -8,6 +8,7 @@ import (
 	"github.com/owenrumney/go-lsp/lsp"
 
 	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/transformer"
 )
 
 func (h *GalaHandler) Completion(ctx context.Context, params *lsp.CompletionParams) (*lsp.CompletionList, error) {
@@ -240,10 +241,13 @@ func keywordCompletions() []lsp.CompletionItem {
 		"interface", "sealed", "embed", "if", "else", "for", "range",
 		"return", "match", "case", "true", "false", "nil", "map",
 	}
+	// Only genuinely-available names belong here. The bare Go builtins
+	// (len/append/make/…) are forbidden on GALA's surface (GALA-E0035), so
+	// suggesting them would complete code the compiler rejects — use `.Size()`
+	// / `.ByteSize()` (offered as method completions) or the go_interop
+	// wrappers (ordinary symbols) instead.
 	builtinFuncs := []string{
 		"Println", "Print", "SliceOf",
-		"len", "cap", "make", "append", "copy", "delete",
-		"close", "panic", "recover",
 		// Auto-imported std prelude constructors / converters
 		// (see internal/transpiler/registry/std.go and std/*.gala).
 		"NewImmutable", "NewConstPtr", "NewEmbeddedFS",
@@ -253,7 +257,13 @@ func keywordCompletions() []lsp.CompletionItem {
 	for _, kw := range keywords {
 		items = append(items, lsp.CompletionItem{Label: kw, Kind: kindPtr(lsp.CompletionItemKindKeyword)})
 	}
+	// Defensive filter against the authoritative forbidden set so this list can
+	// never drift back into suggesting an E0035 builtin.
+	forbidden := transformer.ForbiddenGoBuiltins()
 	for _, fn := range builtinFuncs {
+		if forbidden[fn] {
+			continue
+		}
 		items = append(items, lsp.CompletionItem{Label: fn, Kind: kindPtr(lsp.CompletionItemKindFunction), Detail: "builtin"})
 	}
 	return items

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -482,9 +482,45 @@ func kindPtr(k lsp.CompletionItemKind) *lsp.CompletionItemKind { return &k }
 // --- Type-Aware Completion ---
 // Type resolution logic is in typeatpos.go
 
+// goSizeSugarCompletions returns the `.Size()` / `.ByteSize()` completion items
+// that apply to a Go primitive receiver (string, slice, or map). `ByteSize()` is
+// only offered on strings. Mirrors the transpiler's tryTransformSizeSugar
+// (internal/transpiler/transformer/methods.go). These are surfaced even though
+// the receiver has no GALA TypeMetadata, because the transpiler lowers them to
+// len(...) / utf8.RuneCountInString(...) at compile time.
+func goSizeSugarCompletions(typeName string) []lsp.CompletionItem {
+	if !isGoSizeableType(typeName) {
+		return nil
+	}
+	items := []lsp.CompletionItem{{
+		Label:      "Size()",
+		Kind:       kindPtr(lsp.CompletionItemKindMethod),
+		Detail:     "() int",
+		InsertText: "Size()",
+		FilterText: "Size",
+		SortText:   "Size",
+	}}
+	if typeName == "string" {
+		items = append(items, lsp.CompletionItem{
+			Label:      "ByteSize()",
+			Kind:       kindPtr(lsp.CompletionItemKindMethod),
+			Detail:     "() int",
+			InsertText: "ByteSize()",
+			FilterText: "ByteSize",
+			SortText:   "ByteSize",
+		})
+	}
+	return items
+}
+
 // typeSpecificCompletions returns methods and fields for a specific type.
 func typeSpecificCompletions(richAST *transpiler.RichAST, typeName string) []lsp.CompletionItem {
 	items := make([]lsp.CompletionItem, 0)
+
+	// GALA's `.Size()` / `.ByteSize()` sugar is available on Go primitive
+	// receivers (string/slice/map) that have no GALA TypeMetadata. Offer it up
+	// front so it shows up even when findType below returns nil.
+	items = append(items, goSizeSugarCompletions(typeName)...)
 
 	tm := findType(richAST, typeName)
 	if tm == nil {

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -295,9 +295,17 @@ func TestCompletion_BuiltinFunctions(t *testing.T) {
 	}
 
 	labels := collectLabels(list)
-	for _, fn := range []string{"Println", "Print", "SliceOf", "len", "cap", "make", "append", "panic"} {
+	// Genuinely-available names must be offered.
+	for _, fn := range []string{"Println", "Print", "SliceOf"} {
 		if !labels[fn] {
 			t.Errorf("missing built-in function: %s", fn)
+		}
+	}
+	// Bare Go builtins are forbidden on GALA's surface (GALA-E0035); the LSP
+	// must NOT suggest code the compiler rejects.
+	for _, fn := range []string{"len", "cap", "make", "new", "append", "copy", "delete", "close", "complex", "real", "imag", "panic", "recover"} {
+		if labels[fn] {
+			t.Errorf("forbidden Go builtin %q should NOT be offered in completion (GALA-E0035)", fn)
 		}
 	}
 }

--- a/internal/lsp/size_sugar_integration_test.go
+++ b/internal/lsp/size_sugar_integration_test.go
@@ -1,0 +1,192 @@
+package lsp_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/owenrumney/go-lsp/lsp"
+)
+
+// errorDiags returns only the error-severity diagnostics.
+func errorDiags(diags []lsp.Diagnostic) []lsp.Diagnostic {
+	out := make([]lsp.Diagnostic, 0)
+	for _, d := range diags {
+		if d.Severity != nil && *d.Severity == lsp.SeverityError {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// TestDiagnostics_SizeSugarNoFalseError verifies that `.Size()` / `.ByteSize()`
+// on Go primitive receivers (string, slice) raise NO diagnostic — the transpiler
+// lowers them to len()/utf8.RuneCountInString(), so the LSP must not flag them as
+// unresolved methods.
+func TestDiagnostics_SizeSugarNoFalseError(t *testing.T) {
+	_, diags := getDiags(t, `package main
+
+func main() {
+    val s = "hello"
+    val n = s.Size()
+    val b = s.ByteSize()
+    val xs = SliceOf(1, 2, 3)
+    val m = xs.Size()
+    Println(n)
+    Println(b)
+    Println(m)
+}
+`)
+	errs := errorDiags(diags)
+	if len(errs) != 0 {
+		for _, d := range errs {
+			t.Errorf("unexpected error on .Size()/.ByteSize(): line=%d msg=%s", d.Range.Start.Line, d.Message)
+		}
+	}
+}
+
+// TestDiagnostics_ForbiddenBuiltin verifies bare `len(...)` raises GALA-E0035
+// with its fix suggestion, in-editor.
+func TestDiagnostics_ForbiddenBuiltin(t *testing.T) {
+	_, diags := getDiags(t, `package main
+
+func main() {
+    val s = "hello"
+    val n = len(s)
+    Println(n)
+}
+`)
+	if !hasErrorContaining(diags, "GALA-E0035") {
+		t.Errorf("expected GALA-E0035 for bare len(...); diagnostics: %s", diagSummary(diags))
+	}
+	// The actionable suggestion (use .Size()/.ByteSize()) must reach the editor.
+	if !hasErrorContaining(diags, ".Size()") {
+		t.Errorf("expected the E0035 suggestion to mention .Size(); diagnostics: %s", diagSummary(diags))
+	}
+}
+
+// TestDiagnostics_ForbiddenStatementKeyword verifies bare `defer ...` raises
+// GALA-E0036 in-editor.
+func TestDiagnostics_ForbiddenStatementKeyword(t *testing.T) {
+	_, diags := getDiags(t, `package main
+
+func main() {
+    defer Println("x")
+    Println("y")
+}
+`)
+	if !hasErrorContaining(diags, "GALA-E0036") {
+		t.Errorf("expected GALA-E0036 for bare defer; diagnostics: %s", diagSummary(diags))
+	}
+}
+
+// TestDiagnostics_UseBindingNoError verifies a `use x = ...` scoped-resource
+// binding and the bound name raise NO diagnostic.
+func TestDiagnostics_UseBindingNoError(t *testing.T) {
+	_, diags := getDiags(t, `package main
+
+type Handle struct {
+    name string
+}
+
+func (h Handle) Close() error {
+    return nil
+}
+
+func open(name string) Handle {
+    return Handle(name = name)
+}
+
+func work() {
+    use a = open("a")
+    Println(a.name)
+}
+
+func main() {
+    work()
+}
+`)
+	errs := errorDiags(diags)
+	if len(errs) != 0 {
+		for _, d := range errs {
+			t.Errorf("unexpected error on `use` binding: line=%d msg=%s", d.Range.Start.Line, d.Message)
+		}
+	}
+}
+
+// TestCompletion_SizeSugarOnString verifies dot completion on a string receiver
+// offers Size() and ByteSize().
+func TestCompletion_SizeSugarOnString(t *testing.T) {
+	h := newHarness(t)
+	// GALA requires a blank line after the package clause. Cursor is right after
+	// "s." in `    val n = s.` on line 4 (0-indexed), col 14.
+	uri := openFileOnDisk(t, h, "package main\n\nfunc main() {\n    val s = \"hello\"\n    val n = s.\n    Println(n)\n}\n")
+	list, err := h.Completion(uri, 4, 14)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list == nil {
+		t.Fatal("completion returned nil for string receiver")
+	}
+	labels := collectLabels(list)
+	if labels["val"] {
+		t.Fatalf("got keyword fallback — analyzer did not produce type-aware completion; items: %v", labelSlice(list))
+	}
+	if !labels["Size()"] {
+		t.Errorf("string dot completion missing Size(); got: %v", labelSlice(list))
+	}
+	if !labels["ByteSize()"] {
+		t.Errorf("string dot completion missing ByteSize(); got: %v", labelSlice(list))
+	}
+}
+
+// TestCompletion_SizeSugarOnSlice verifies dot completion on a Go slice receiver
+// offers Size() but NOT ByteSize().
+func TestCompletion_SizeSugarOnSlice(t *testing.T) {
+	h := newHarness(t)
+	// Blank line after package; cursor right after "xs." in `    val n = xs.`
+	// on line 4 (0-indexed), col 15.
+	uri := openFileOnDisk(t, h, "package main\n\nfunc main() {\n    val xs = SliceOf(1, 2, 3)\n    val n = xs.\n    Println(n)\n}\n")
+	list, err := h.Completion(uri, 4, 15)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list == nil {
+		t.Fatal("completion returned nil for slice receiver")
+	}
+	labels := collectLabels(list)
+	if labels["val"] {
+		t.Fatalf("got keyword fallback — analyzer did not produce type-aware completion; items: %v", labelSlice(list))
+	}
+	if !labels["Size()"] {
+		t.Errorf("slice dot completion missing Size(); got: %v", labelSlice(list))
+	}
+	if labels["ByteSize()"] {
+		t.Errorf("slice dot completion should NOT offer ByteSize(); got: %v", labelSlice(list))
+	}
+}
+
+// hasErrorContaining reports whether any error-severity diagnostic message
+// contains substr.
+func hasErrorContaining(diags []lsp.Diagnostic, substr string) bool {
+	for _, d := range diags {
+		if d.Severity == nil || *d.Severity != lsp.SeverityError {
+			continue
+		}
+		if strings.Contains(d.Message, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func diagSummary(diags []lsp.Diagnostic) string {
+	if len(diags) == 0 {
+		return "(none)"
+	}
+	var b strings.Builder
+	for _, d := range diags {
+		fmt.Fprintf(&b, "\n  line=%d msg=%s", d.Range.Start.Line, d.Message)
+	}
+	return b.String()
+}

--- a/internal/lsp/size_sugar_integration_test.go
+++ b/internal/lsp/size_sugar_integration_test.go
@@ -114,6 +114,61 @@ func main() {
 	}
 }
 
+// TestDiagnostics_GoBuiltinsPanicResolves verifies the LSP resolves the
+// go_builtins package and its Panic function — the sanctioned replacement for
+// the forbidden bare `panic(...)` — without a false "unresolved" diagnostic.
+func TestDiagnostics_GoBuiltinsPanicResolves(t *testing.T) {
+	_, diags := getDiags(t, `package main
+
+import . "martianoff/gala/go_builtins"
+
+func main() {
+    Panic("boom")
+}
+`)
+	errs := errorDiags(diags)
+	if len(errs) != 0 {
+		for _, d := range errs {
+			t.Errorf("unexpected error importing/using go_builtins.Panic: line=%d msg=%s", d.Range.Start.Line, d.Message)
+		}
+	}
+}
+
+// TestDiagnostics_ResourcePackageResolves verifies the LSP resolves the
+// resource package (Closeable / Using / Bracket / WithLock) without false
+// errors. Mirrors examples/resource_combinators.gala.
+func TestDiagnostics_ResourcePackageResolves(t *testing.T) {
+	_, diags := getDiags(t, `package main
+
+import . "martianoff/gala/resource"
+import . "martianoff/gala/go_interop"
+
+type Handle struct {
+    name string
+}
+
+func (h Handle) Close() error {
+    return nil
+}
+
+func main() {
+    val n = Using(Handle(name = "log.txt"), (h) => h.name.Size())
+    val doubled = Bracket(21, (r) => Println(r), (r) => r * 2)
+    val mu = NewMutex()
+    val guarded = WithLock(mu, () => 7 + 1)
+    Println(n)
+    Println(doubled)
+    Println(guarded)
+}
+`)
+	errs := errorDiags(diags)
+	if len(errs) != 0 {
+		for _, d := range errs {
+			t.Errorf("unexpected error importing/using resource combinators: line=%d msg=%s", d.Range.Start.Line, d.Message)
+		}
+	}
+}
+
 // TestCompletion_SizeSugarOnString verifies dot completion on a string receiver
 // offers Size() and ByteSize().
 func TestCompletion_SizeSugarOnString(t *testing.T) {

--- a/internal/lsp/size_sugar_test.go
+++ b/internal/lsp/size_sugar_test.go
@@ -4,7 +4,35 @@ import (
 	"testing"
 
 	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/transformer"
 )
+
+// TestKeywordCompletions_NoForbiddenBuiltins verifies that keyword/builtin
+// completion never offers a bare Go builtin the compiler forbids (GALA-E0035),
+// cross-checking against the authoritative set in the transformer so the two
+// cannot drift. The sanctioned names (Println/Print/SliceOf) must still appear.
+func TestKeywordCompletions_NoForbiddenBuiltins(t *testing.T) {
+	forbidden := transformer.ForbiddenGoBuiltins()
+	if len(forbidden) == 0 {
+		t.Fatal("expected a non-empty forbidden-builtin set from the transformer")
+	}
+
+	offered := make(map[string]bool)
+	for _, item := range keywordCompletions() {
+		offered[item.Label] = true
+	}
+
+	for name := range forbidden {
+		if offered[name] {
+			t.Errorf("keywordCompletions offers forbidden Go builtin %q (GALA-E0035)", name)
+		}
+	}
+	for _, want := range []string{"Println", "Print", "SliceOf"} {
+		if !offered[want] {
+			t.Errorf("keywordCompletions missing sanctioned builtin %q", want)
+		}
+	}
+}
 
 // TestResolveMethodReturn_SizeSugar verifies that GALA's `.Size()` / `.ByteSize()`
 // magic methods on Go primitive receivers (string, slice, map) type-resolve to

--- a/internal/lsp/size_sugar_test.go
+++ b/internal/lsp/size_sugar_test.go
@@ -1,0 +1,112 @@
+package lsp
+
+import (
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+)
+
+// TestResolveMethodReturn_SizeSugar verifies that GALA's `.Size()` / `.ByteSize()`
+// magic methods on Go primitive receivers (string, slice, map) type-resolve to
+// int in the LSP, mirroring the transpiler's tryTransformSizeSugar. These
+// receivers have no GALA TypeMetadata, so resolveMethodReturn must special-case
+// them before the findType lookup.
+func TestResolveMethodReturn_SizeSugar(t *testing.T) {
+	// Empty RichAST: string/slice/map are Go primitives, never GALA types, so
+	// the result must come purely from the size-sugar path.
+	richAST := &transpiler.RichAST{
+		Types:     map[string]*transpiler.TypeMetadata{},
+		Functions: map[string]*transpiler.FunctionMetadata{},
+	}
+
+	tests := []struct {
+		name     string
+		typeName string
+		method   string
+		want     string
+	}{
+		{"string Size", "string", "Size", "int"},
+		{"string ByteSize", "string", "ByteSize", "int"},
+		{"slice Size", "[]int", "Size", "int"},
+		{"slice of struct Size", "[]Person", "Size", "int"},
+		{"map Size (stripped)", "map", "Size", "int"},
+		{"map Size (spelled)", "map[string]int", "Size", "int"},
+		// ByteSize is string-only: slices/maps must NOT resolve it.
+		{"slice ByteSize not resolved", "[]int", "ByteSize", ""},
+		{"map ByteSize not resolved", "map", "ByteSize", ""},
+		// A non-primitive receiver with no metadata resolves to nothing.
+		{"unknown type Size", "Person", "Size", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveMethodReturn(richAST, tt.typeName, tt.method)
+			if got != tt.want {
+				t.Errorf("resolveMethodReturn(%q, %q) = %q, want %q",
+					tt.typeName, tt.method, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGoSizeSugarCompletions verifies the completion items offered on Go
+// primitive receivers: Size() on string/slice/map, ByteSize() only on string.
+func TestGoSizeSugarCompletions(t *testing.T) {
+	hasLabel := func(items []completionLabel, want string) bool {
+		for _, it := range items {
+			if it.label == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	toLabels := func(typeName string) []completionLabel {
+		var out []completionLabel
+		for _, it := range goSizeSugarCompletions(typeName) {
+			out = append(out, completionLabel{label: it.Label, detail: it.Detail})
+		}
+		return out
+	}
+
+	// string: Size() and ByteSize(), both typed () int.
+	strItems := toLabels("string")
+	if !hasLabel(strItems, "Size()") {
+		t.Errorf("string: missing Size() completion, got %v", strItems)
+	}
+	if !hasLabel(strItems, "ByteSize()") {
+		t.Errorf("string: missing ByteSize() completion, got %v", strItems)
+	}
+	for _, it := range strItems {
+		if it.detail != "() int" {
+			t.Errorf("string %s: detail = %q, want %q", it.label, it.detail, "() int")
+		}
+	}
+
+	// slice: Size() only, no ByteSize().
+	sliceItems := toLabels("[]int")
+	if !hasLabel(sliceItems, "Size()") {
+		t.Errorf("slice: missing Size() completion, got %v", sliceItems)
+	}
+	if hasLabel(sliceItems, "ByteSize()") {
+		t.Errorf("slice: ByteSize() should NOT be offered, got %v", sliceItems)
+	}
+
+	// map: Size() only.
+	mapItems := toLabels("map")
+	if !hasLabel(mapItems, "Size()") {
+		t.Errorf("map: missing Size() completion, got %v", mapItems)
+	}
+	if hasLabel(mapItems, "ByteSize()") {
+		t.Errorf("map: ByteSize() should NOT be offered, got %v", mapItems)
+	}
+
+	// non-sizeable receiver: nothing.
+	if items := toLabels("Person"); len(items) != 0 {
+		t.Errorf("Person: expected no size-sugar completions, got %v", items)
+	}
+}
+
+type completionLabel struct {
+	label  string
+	detail string
+}

--- a/internal/lsp/typeatpos.go
+++ b/internal/lsp/typeatpos.go
@@ -342,8 +342,51 @@ func skipTrailingWhitespace(text string, start int) int {
 	return j
 }
 
+// goSizeSugarReturn resolves the result type of GALA's `.Size()` / `.ByteSize()`
+// magic methods when the receiver is a Go primitive (string, slice, or map).
+// These zero-arg methods are transpiler sugar (see
+// internal/transpiler/transformer/methods.go tryTransformSizeSugar): they lower
+// to len(...) / utf8.RuneCountInString(...) and always yield int, even though
+// the receiver has no GALA TypeMetadata in the RichAST. Mirrored rule:
+//
+//	.Size()     on string / []T / map[K]V  -> int
+//	.ByteSize() on string                   -> int
+//
+// It returns ("", false) for any other receiver/method so normal method
+// dispatch (e.g. a GALA Array/List/HashMap, which have their own Size()) is
+// unaffected.
+func goSizeSugarReturn(typeName, methodName string) (string, bool) {
+	switch methodName {
+	case "Size":
+		if isGoSizeableType(typeName) {
+			return "int", true
+		}
+	case "ByteSize":
+		if typeName == "string" {
+			return "int", true
+		}
+	}
+	return "", false
+}
+
+// isGoSizeableType reports whether typeName is a Go string, slice, or map — the
+// receivers on which `.Size()` sugar is defined. Slice types arrive as "[]T";
+// map types arrive either fully spelled ("map[K]V") or reduced to "map" by
+// stripTypeParams.
+func isGoSizeableType(typeName string) bool {
+	return typeName == "string" ||
+		strings.HasPrefix(typeName, "[]") ||
+		typeName == "map" || strings.HasPrefix(typeName, "map[")
+}
+
 // resolveMethodReturn finds the return type of a method on a given type.
 func resolveMethodReturn(richAST *transpiler.RichAST, typeName, methodName string) string {
+	// GALA's `.Size()` / `.ByteSize()` sugar resolves to int on Go primitive
+	// receivers (string/slice/map) that have no GALA TypeMetadata; check it
+	// before findType so the magic methods type-resolve like the transpiler.
+	if ret, ok := goSizeSugarReturn(typeName, methodName); ok {
+		return ret
+	}
 	tm := findType(richAST, typeName)
 	if tm == nil {
 		return ""

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -39,6 +39,19 @@ var forbiddenGoBuiltinSuggestions = map[string]string{
 	"recover": "`recover` is not available on the GALA surface; `Try` captures panics — use `Try(() => ...)` / `TryApply`",
 }
 
+// ForbiddenGoBuiltins returns the set of bare Go builtins that GALA forbids on
+// its surface (GALA-E0035), keyed by name. It is the exported view of
+// forbiddenGoBuiltinSuggestions so downstream tooling — notably the LSP
+// completion provider — can avoid suggesting a builtin the compiler will
+// reject, without re-declaring a list that could drift out of sync.
+func ForbiddenGoBuiltins() map[string]bool {
+	out := make(map[string]bool, len(forbiddenGoBuiltinSuggestions))
+	for name := range forbiddenGoBuiltinSuggestions {
+		out[name] = true
+	}
+	return out
+}
+
 // checkForbiddenGoBuiltinCall rejects a call to a bare Go builtin as a hard
 // error (GALA-E0035). It is resolver-aware: the name is only forbidden when it
 // is a bare identifier that does NOT resolve to a user-defined function, a


### PR DESCRIPTION
Syncs the GALA LSP server and IntelliJ plugin with the new language surface added by the two stacked PRs below it (bare builtins forbidden + `.Size()`/`.ByteSize()` sugar + `resource`/`go_builtins`; `defer`/`go`/`goto`/`fallthrough`/`select`/`chan` forbidden + `use` binding).

Stacked on `feature/forbid-defer-go` (PR #415), which is itself stacked on PR #414.

## What the IDE now resolves

### `.Size()` / `.ByteSize()` magic methods (headline)
The transpiler lowers `.Size()` / `.ByteSize()` on Go primitive receivers (string, slice, map) to `len(...)` / `utf8.RuneCountInString(...)` (`internal/transpiler/transformer/methods.go` `tryTransformSizeSugar`). These receivers have no GALA `TypeMetadata`, so the LSP previously offered no completion and no type for them. The LSP now mirrors the transpiler's rule:

- **Type resolution** (`internal/lsp/typeatpos.go`): `resolveMethodReturn` returns `int` for `.Size()` on string/slice/map and `.ByteSize()` on string, checked before the `findType` lookup. New helpers `goSizeSugarReturn` / `isGoSizeableType`.
- **Completion** (`internal/lsp/completion.go`): `typeSpecificCompletions` offers `Size()` on string/slice/map and `ByteSize()` only on string, surfaced even when the receiver has no `TypeMetadata` (`goSizeSugarCompletions`).
- **No false diagnostic**: the transpiler resolves these at compile time, so no "unresolved method" is raised — now asserted by a test.

### `use` keyword
- IntelliJ `GalaSyntaxHighlighter` highlights the `USE` token as a keyword.
- New `UseDeclarationNode` (PsiNameIdentifierOwner, mirrors bind/also) so the bound name is clickable, a find-usages/rename anchor, and gets a tooltip; wired via `RULE_USE_DECLARATION` in `GalaTokenTypes`, `GalaParserDefinition`, `GalaDocumentationProvider`, `GalaFindUsagesProvider`.
- Keyword completion for `use` already comes from the LSP (`keywordCompletions`), so no LSP change was needed there.

### GALA-E0035 / GALA-E0036 diagnostics
These already flow into the editor automatically: the LSP runs the transformer (`TransformForLSP`), whose `checkForbiddenGoBuiltinCall` (E0035) and `checkForbiddenStatementKeyword` (E0036) surface as diagnostics with their fix suggestions. This PR adds tests asserting bare `len(...)` → E0035 (with the `.Size()` hint) and bare `defer ...` → E0036, and that a `use x = ...` binding raises none.

### `resource` / `go_builtins` awareness
Resolved dynamically by the analyzer via imports. Tests assert `go_builtins.Panic` and the `resource` combinators (Closeable / Using / Bracket / WithLock) resolve without false errors.

## Verification
- `bazel test //internal/lsp/...` green. New tests:
  - `TestResolveMethodReturn_SizeSugar` — `.Size()` on string/slice/map and `.ByteSize()` on string resolve to `int`; `.ByteSize()` is string-only.
  - `TestGoSizeSugarCompletions` — completion set per receiver.
  - `TestDiagnostics_SizeSugarNoFalseError` — `.Size()`/`.ByteSize()` raise no diagnostic.
  - `TestCompletion_SizeSugarOnString` / `OnSlice` — dot completion offers `Size()` (+ `ByteSize()` for string).
  - `TestDiagnostics_ForbiddenBuiltin` (E0035 + hint), `TestDiagnostics_ForbiddenStatementKeyword` (E0036), `TestDiagnostics_UseBindingNoError`, `TestDiagnostics_GoBuiltinsPanicResolves`, `TestDiagnostics_ResourcePackageResolves`.
- IntelliJ plugin builds via Gradle (`bazel build //ide/intellij:plugin` → `BUILD SUCCESSFUL`), compiling against the ANTLR-generated `galaLexer.USE` / `galaParser.RULE_useDeclaration`.
- `bazel build //...` green; `bazel test //...` green except the known Windows-env failure `TestGorootFromGoBinarySymlink` (unrelated symlink test). `bazel run //:gazelle` clean.

## Not runnable here
- The IntelliJ plugin's Gradle *unit tests* (`GalaParsingTest.kt`) are not compiled by the current `build.gradle.kts` (test kotlin srcDirs set to empty; `compileTestKotlin NO-SOURCE`), so no plugin unit test was run — only the full compile + instrument + package pipeline, which passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UibquB523iZL6QozbKA8kV