### PR TITLE
refactor(stdlib): functional pattern-matching over guarded .Get() unwraps

### DIFF
--- a/collection_immutable/array.gala
+++ b/collection_immutable/array.gala
@@ -899,11 +899,9 @@ func (a Array[T]) PartitionMap[A any, B any](f func(T) Either[A, B]) Tuple[Array
     var leftBuilder = newArrayBuilder[A]()
     var rightBuilder = newArrayBuilder[B]()
     for i := 0; i < a.length; i++ {
-        val either = f(a.Get(i))
-        if either.IsLeft() {
-            leftBuilder.Add(either.GetLeft())
-        } else {
-            rightBuilder.Add(either.GetRight())
+        f(a.Get(i)) match {
+            case Left(l) => leftBuilder.Add(l)
+            case Right(r) => rightBuilder.Add(r)
         }
     }
     return (leftBuilder.Result(), rightBuilder.Result())

--- a/collection_immutable/list.gala
+++ b/collection_immutable/list.gala
@@ -546,11 +546,9 @@ func (l List[T]) PartitionMap[A any, B any](f func(T) Either[A, B]) Tuple[List[A
     var rights = emptyList[B]()
     var current = l
     for !current.isEmpty {
-        val either = f(current.head)
-        if either.IsLeft() {
-            lefts = lefts.Append(either.GetLeft())
-        } else {
-            rights = rights.Append(either.GetRight())
+        f(current.head) match {
+            case Left(l) => lefts = lefts.Append(l)
+            case Right(r) => rights = rights.Append(r)
         }
         current = *current.tail
     }

--- a/stream/stream.gala
+++ b/stream/stream.gala
@@ -320,8 +320,13 @@ func (s Stream[T]) ToArray() Array[T] {
     var result = EmptyArray[T]()
     var current = s
     for current.NonEmpty() {
-        result = result.Append(current.Head().Get())
-        current = current.Tail()
+        current match {
+            case StreamCons(h, tail) => {
+                result = result.Append(h)
+                current = tail
+            }
+            case _ => {}
+        }
     }
     return result
 }
@@ -332,8 +337,13 @@ func (s Stream[T]) ToList() List[T] {
     var result = EmptyList[T]()
     var current = s
     for current.NonEmpty() {
-        result = result.Append(current.Head().Get())
-        current = current.Tail()
+        current match {
+            case StreamCons(h, tail) => {
+                result = result.Append(h)
+                current = tail
+            }
+            case _ => {}
+        }
     }
     return result
 }
@@ -343,8 +353,13 @@ func (s Stream[T]) ToList() List[T] {
 func (s Stream[T]) ForEach(f func(T)) {
     var current = s
     for current.NonEmpty() {
-        f(current.Head().Get())
-        current = current.Tail()
+        current match {
+            case StreamCons(h, tail) => {
+                f(h)
+                current = tail
+            }
+            case _ => {}
+        }
     }
 }
 
@@ -354,8 +369,13 @@ func (s Stream[T]) Fold[U any](zero U, f func(U, T) U) U {
     var acc = zero
     var current = s
     for current.NonEmpty() {
-        acc = f(acc, current.Head().Get())
-        current = current.Tail()
+        current match {
+            case StreamCons(h, tail) => {
+                acc = f(acc, h)
+                current = tail
+            }
+            case _ => {}
+        }
     }
     return acc
 }
@@ -374,11 +394,15 @@ func (s Stream[T]) Reduce(f func(T, T) T) Option[T] {
 func (s Stream[T]) Find(p func(T) bool) Option[T] {
     var current = s
     for current.NonEmpty() {
-        val h = current.Head().Get()
-        if p(h) {
-            return Some(h)
+        current match {
+            case StreamCons(h, tail) => {
+                if p(h) {
+                    return Some(h)
+                }
+                current = tail
+            }
+            case _ => {}
         }
-        current = current.Tail()
     }
     return None[T]()
 }
@@ -391,10 +415,15 @@ func (s Stream[T]) Exists(p func(T) bool) bool = s.Find(p).IsDefined()
 func (s Stream[T]) ForAll(p func(T) bool) bool {
     var current = s
     for current.NonEmpty() {
-        if !p(current.Head().Get()) {
-            return false
+        current match {
+            case StreamCons(h, tail) => {
+                if !p(h) {
+                    return false
+                }
+                current = tail
+            }
+            case _ => {}
         }
-        current = current.Tail()
     }
     return true
 }
@@ -424,12 +453,17 @@ func (s Stream[T]) MkString(sep string) string {
     var first = true
     var current = s
     for current.NonEmpty() {
-        if !first {
-            result = result + sep
+        current match {
+            case StreamCons(h, tail) => {
+                if !first {
+                    result = result + sep
+                }
+                result = result + s"${h}"
+                first = false
+                current = tail
+            }
+            case _ => {}
         }
-        result = result + s"${current.Head().Get()}"
-        first = false
-        current = current.Tail()
     }
     return result
 }
@@ -494,10 +528,15 @@ func (s Stream[T]) Partition(p func(T) bool) Tuple[Stream[T], Stream[T]] = (s.Fi
 func (s Stream[T]) Contains(elem T) bool {
     var current = s
     for current.NonEmpty() {
-        if Equal(current.Head().Get(), elem) {
-            return true
+        current match {
+            case StreamCons(h, tail) => {
+                if Equal(h, elem) {
+                    return true
+                }
+                current = tail
+            }
+            case _ => {}
         }
-        current = current.Tail()
     }
     return false
 }
@@ -508,11 +547,16 @@ func (s Stream[T]) IndexOf(elem T) int {
     var idx = 0
     var current = s
     for current.NonEmpty() {
-        if Equal(current.Head().Get(), elem) {
-            return idx
+        current match {
+            case StreamCons(h, tail) => {
+                if Equal(h, elem) {
+                    return idx
+                }
+                idx = idx + 1
+                current = tail
+            }
+            case _ => {}
         }
-        idx = idx + 1
-        current = current.Tail()
     }
     return -1
 }
@@ -523,11 +567,16 @@ func (s Stream[T]) IndexWhere(p func(T) bool) int {
     var idx = 0
     var current = s
     for current.NonEmpty() {
-        if p(current.Head().Get()) {
-            return idx
+        current match {
+            case StreamCons(h, tail) => {
+                if p(h) {
+                    return idx
+                }
+                idx = idx + 1
+                current = tail
+            }
+            case _ => {}
         }
-        idx = idx + 1
-        current = current.Tail()
     }
     return -1
 }


### PR DESCRIPTION
## What

Makes the GALA stdlib more exemplary-functional by replacing **safe-but-imperative** unwraps with idiomatic destructuring pattern matches. These sites were already guarded (not crashing), just not maximally functional. No behavior change.

Stacked on top of #416 (`feature/ide-gala-surface`).

### Converted

**1. `collection_immutable` PartitionMap — Either match (Array + List)**

Before:
```gala
val either = f(a.Get(i))
if either.IsLeft() {
    leftBuilder.Add(either.GetLeft())
} else {
    rightBuilder.Add(either.GetRight())
}
```
After:
```gala
f(a.Get(i)) match {
    case Left(l) => leftBuilder.Add(l)
    case Right(r) => rightBuilder.Add(r)
}
```
`Either` is sealed, so the match is exhaustive — `GetLeft()`/`GetRight()` are gone and the value is bound by the pattern.

**2. `stream/stream.gala` — `Head().Get()` → `StreamCons(h, tail)` (10 sites)**

`ToArray`, `ToList`, `ForEach`, `Fold`, `Find`, `ForAll`, `MkString`, `Contains`, `IndexOf`, `IndexWhere`.

Before:
```gala
for current.NonEmpty() {
    ... current.Head().Get() ...
    current = current.Tail()
}
```
After:
```gala
for current.NonEmpty() {
    current match {
        case StreamCons(h, tail) => {
            ... use h ...
            current = tail
        }
        case _ => {}
    }
}
```
Uses the pre-existing `StreamCons` extractor (`Unapply` calls `Head()`/`Tail()` — identical work to the original body), dropping the unsafe `.Get()`.

### Preserve iteration, no recursion

Streams can be large/lazy, so termination and laziness were held constant: the `for current.NonEmpty()` guard is **kept** in every case — no iterative loop was turned into unbounded recursion. The change is purely destructuring the head+tail via the pattern instead of `Head().Get()` + `Tail()`. The `case _ => {}` arm is required for extractor-match exhaustiveness and is unreachable given the `NonEmpty()` guard.

### Deliberately left

- **`Stream.Count`** — already only calls `Tail()` (no `Head().Get()`), so nothing to convert.
- Out of scope per task: crypto/fs (unsafe `Try().Get()`, handled in a different PR), strings (Immutable unwraps), io (intentional `UnsafeRun`), std/try.gala, examples, grammar.

## Test evidence

- `bazel test //collection_immutable/... //stream/...` → **9/9 pass** (suites unchanged).
- `bazel test //...` → **373 pass**, only failure is the known unrelated Windows symlink test `TestGorootFromGoBinarySymlink` (`A required privilege is not held by the client`).
- `bazel run //:gazelle` → clean, no BUILD changes.
- Sweep: `grep -nE "GetLeft\(\)|GetRight\(\)" collection_immutable/*.gala` and `grep -nE "Head\(\)\.Get\(\)" stream/stream.gala` → both empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01UibquB523iZL6QozbKA8kV