### PR TITLE
fix(website): render code literally on vs-go page (disable font ligatures)

### DIFF
--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -168,6 +168,14 @@
       font-family: 'Cascadia Code', 'SF Mono', 'Consolas', Menlo, monospace;
       font-size: 0.86rem;
     }
+    /* Render code literally: fonts like Cascadia Code otherwise apply ligatures
+       and contextual alternates that rewrite source glyphs (=> becomes an arrow,
+       != a not-equal sign, and on some browsers * a mid-dot or ... an ellipsis),
+       which misrepresents the exact syntax this page is teaching. */
+    pre, code {
+      font-variant-ligatures: none;
+      font-feature-settings: "liga" 0, "clig" 0, "calt" 0, "dlig" 0;
+    }
     /* Keep INLINE code (prose) light + subtle — kramdown tags it
        `language-plaintext`, which the Prism theme would otherwise darken. */
     :not(pre) > code[class*="language-"] {


### PR DESCRIPTION
## Problem

The Go "functional options" example on https://gala.fyi/vs-go/ rendered with `*` and `...` collapsed to single dots.

The page content and HTML are correct — verified the served bytes and reproduced Prism 1.29.0 tokenization, which preserves every character. The cause is the code font (`Cascadia Code`): its ligatures / contextual alternates rewrite source glyphs. Confirmed in a headless render of the live page:

- `=>` → `⇒`
- `!=` → `≠`
- `<=` → `≤`
- `*` → mid-dot and `...` → ellipsis (browser/font-build dependent — what the report showed)

## Fix

Disable `liga`/`clig`/`calt`/`dlig` on `pre`/`code` in the shared layout so every glyph renders as its literal source character.

**Verified**: injected the CSS into a copy of the live page and re-rendered — the default-params block is clean and operators show literally (`=>`, `!=`, `*`).

## Note

This also changes GALA blocks' `=>` from the decorative `⇒` arrow to a literal `=>`. For a syntax-comparison page that's more accurate; if the arrow was intentional, the fix can be scoped to keep it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)