### PR TITLE
docs(website): idiomatic best-practice Go in GALA-vs-Go comparisons

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -127,12 +127,12 @@ val msg = shape match {
 
 ```go
 var msg string
-switch shape._variant {
-case Shape_Circle:
-    msg = fmt.Sprintf("r=%.1f", shape.Radius.Get())
-case Shape_Rectangle:
-    msg = fmt.Sprintf("%fx%f", shape.Width.Get(), shape.Height.Get())
-case Shape_Point:
+switch s := shape.(type) {
+case Circle:
+    msg = fmt.Sprintf("r=%.1f", s.Radius)
+case Rectangle:
+    msg = fmt.Sprintf("%.0fx%.0f", s.Width, s.Height)
+case Point:
     msg = "point"
 }
 ```
@@ -188,7 +188,8 @@ type Config struct {
     Host string
     Port int
 }
-updated := Config{Host: config.Host, Port: 8080}
+updated := config     // value copy; both stay mutable
+updated.Port = 8080
 ```
 
 </td>
@@ -255,14 +256,11 @@ val result = divide(10, 2)
 
 ```go
 result, err := divide(10, 2)
+if err == nil {
+    result, err = divide(result*2, 3)
+}
 if err != nil {
     result = 0
-} else {
-    result = result * 2
-    result, err = divide(result, 3)
-    if err != nil {
-        result = 0
-    }
 }
 ```
 

--- a/website/docs/why-gala.md
+++ b/website/docs/why-gala.md
@@ -53,26 +53,23 @@ If you add a new variant -- say `case Triangle(Base float64, Height float64)` --
 ### Equivalent Go
 
 ```go
-type Shape struct {
-    _variant  uint8
-    Radius    float64
-    Width     float64
-    Height    float64
-}
+type Shape interface{ isShape() }
 
-const (
-    Shape_Circle    uint8 = 0
-    Shape_Rectangle uint8 = 1
-    Shape_Point     uint8 = 2
-)
+type Circle struct{ Radius float64 }
+type Rectangle struct{ Width, Height float64 }
+type Point struct{}
+
+func (Circle) isShape()    {}
+func (Rectangle) isShape() {}
+func (Point) isShape()     {}
 
 func describe(s Shape) string {
-    switch s._variant {
-    case Shape_Circle:
-        return fmt.Sprintf("circle with radius %.2f", s.Radius)
-    case Shape_Rectangle:
-        return fmt.Sprintf("rectangle %0.fx%.0f", s.Width, s.Height)
-    case Shape_Point:
+    switch v := s.(type) {
+    case Circle:
+        return fmt.Sprintf("circle with radius=%.2f", v.Radius)
+    case Rectangle:
+        return fmt.Sprintf("rectangle %vx%v", v.Width, v.Height)
+    case Point:
         return "a point"
     default:
         panic("unhandled variant")
@@ -80,7 +77,7 @@ func describe(s Shape) string {
 }
 ```
 
-The Go version is more than twice the length, carries fields that are meaningless for most variants, and relies on a runtime panic for exhaustiveness that the compiler cannot verify.
+This is idiomatic Go, and it works -- but the closed set exists only by convention: every variant needs a marker method (`isShape()`), and the type switch is never checked for completeness. Add `Triangle` and forget a case, and the compiler stays silent; a runtime `panic` in `default` is the only backstop. GALA turns that into a compile error.
 
 ### Why this matters
 
@@ -174,10 +171,11 @@ type Config struct {
     RetryCount int
 }
 
-// No compile-time enforcement of field immutability.
-// Anyone with a reference can modify any field.
-// Copy requires manually listing every field:
-updated := Config{Host: cfg.Host, Port: 9090, RetryCount: cfg.RetryCount}
+// A value copy is concise, but Go enforces nothing:
+// both cfg and updated stay fully mutable, and anyone
+// with a reference can reassign any field at any time.
+updated := cfg
+updated.Port = 9090
 ```
 
 ### Why this matters

--- a/website/features/error-handling.md
+++ b/website/features/error-handling.md
@@ -372,14 +372,11 @@ Compare this to the Go equivalent:
 <td>
 
 <pre><code class="language-go">result, err := divide(10, 2)
+if err == nil {
+    result, err = divide(result*2, 3)
+}
 if err != nil {
     result = 0
-} else {
-    result = result * 2
-    result, err = divide(result, 3)
-    if err != nil {
-        result = 0
-    }
 }</code></pre>
 
 </td>

--- a/website/features/immutability.md
+++ b/website/features/immutability.md
@@ -105,7 +105,7 @@ val updated = base.Copy(Port = 8080)
 // base is unchanged
 ```
 
-This replaces the tedious Go pattern of manually copying every field:
+The idiomatic Go equivalent copies the struct value, then mutates the field in place:
 
 <table>
 <tr><th>GALA</th><th>Go</th></tr>
@@ -122,13 +122,14 @@ val updated = config.Copy(Port = 8080)</code></pre>
     Host string
     Port int
 }
-updated := Config{Host: config.Host, Port: 8080}</code></pre>
+updated := config
+updated.Port = 8080</code></pre>
 
 </td>
 </tr>
 </table>
 
-With two fields the Go version is manageable. With ten fields, `Copy()` saves significant boilerplate and prevents bugs from forgetting to copy a field.
+Go's copy is concise, but `updated` and `config` both stay mutable, and if `Config` holds a slice or map the value copy shares it. GALA's `Copy()` returns a new **immutable** value as an expression -- no temp variable, no in-place mutation, and the original `val` can never be reassigned. It also composes: you can drop `config.Copy(Port = 8080)` straight into a function call or pipeline.
 
 ---
 

--- a/website/features/pattern-matching.md
+++ b/website/features/pattern-matching.md
@@ -348,12 +348,12 @@ val desc = flag match {
 <td>
 
 <pre><code class="language-go">var msg string
-switch shape._variant {
-case Shape_Circle:
-    msg = fmt.Sprintf("r=%.1f", shape.Radius.Get())
-case Shape_Rectangle:
-    msg = fmt.Sprintf("%fx%f", shape.Width.Get(), shape.Height.Get())
-case Shape_Point:
+switch s := shape.(type) {
+case Circle:
+    msg = fmt.Sprintf("r=%.1f", s.Radius)
+case Rectangle:
+    msg = fmt.Sprintf("%.0fx%.0f", s.Width, s.Height)
+case Point:
     msg = "point"
 }</code></pre>
 

--- a/website/index.md
+++ b/website/index.md
@@ -65,7 +65,7 @@ val port = Try(strconv.Atoi("8080")).GetOrElse(80)</code></pre>
 
 ## GALA vs Go — A Quick Look
 
-Pattern matching is one of the most visible differences between GALA and Go. Where Go requires a manual type switch with field accessors, GALA destructures values directly and ensures every case is handled at compile time.
+Pattern matching is one of the most visible differences between GALA and Go. Idiomatic Go handles a closed set with a type switch, but it destructures nothing for you and never checks that every case is covered. GALA destructures values directly and enforces exhaustiveness at compile time.
 
 <div class="comparison">
 <div>
@@ -79,15 +79,14 @@ Pattern matching is one of the most visible differences between GALA and Go. Whe
 <div>
 <p><strong>Go</strong></p>
 <pre><code>var msg string
-switch shape._variant {
-case Shape_Circle:
+switch s := shape.(type) {
+case Circle:
     msg = fmt.Sprintf("r=%.1f",
-        shape.Radius.Get())
-case Shape_Rectangle:
-    msg = fmt.Sprintf("%fx%f",
-        shape.Width.Get(),
-        shape.Height.Get())
-case Shape_Point:
+        s.Radius)
+case Rectangle:
+    msg = fmt.Sprintf("%.0fx%.0f",
+        s.Width, s.Height)
+case Point:
     msg = "point"
 }</code></pre>
 </div>

--- a/website/vs-go.md
+++ b/website/vs-go.md
@@ -22,7 +22,7 @@ This page shows real code comparisons between GALA and the equivalent idiomatic 
 
 ## Pattern Matching vs Switch
 
-GALA sealed types define closed hierarchies. The compiler enforces exhaustive matching -- if you forget a case, it will not compile. Go requires manual variant tracking with constants and field accessors.
+GALA sealed types define closed hierarchies. The compiler enforces exhaustive matching -- if you forget a case, it will not compile. Idiomatic Go models the same closed set with a marker-method interface and a type switch -- but nothing checks that you handled every variant.
 
 <div class="comparison">
 <div>
@@ -41,22 +41,28 @@ val msg = shape match {
 </div>
 <div>
 <p><strong>Go</strong></p>
-<pre><code>var msg string
-switch shape._variant {
-case Shape_Circle:
-    msg = fmt.Sprintf("r=%.1f",
-        shape.Radius.Get())
-case Shape_Rectangle:
-    msg = fmt.Sprintf("%fx%f",
-        shape.Width.Get(),
-        shape.Height.Get())
-case Shape_Point:
+<pre><code>type Shape interface{ isShape() }
+type Circle struct{ Radius float64 }
+type Rectangle struct{ Width, Height float64 }
+type Point struct{}
+func (Circle) isShape()    {}
+func (Rectangle) isShape() {}
+func (Point) isShape()     {}
+
+var msg string
+switch s := shape.(type) {
+case Circle:
+    msg = fmt.Sprintf("r=%.1f", s.Radius)
+case Rectangle:
+    msg = fmt.Sprintf("%.0fx%.0f",
+        s.Width, s.Height)
+case Point:
     msg = "point"
 }</code></pre>
 </div>
 </div>
 
-GALA destructures values directly into named bindings (`r`, `w`, `h`) and produces a compile-time error if you forget a case. Go's `switch` does not enforce exhaustiveness and requires explicit field access through `.Get()` calls.
+GALA destructures values directly into named bindings (`r`, `w`, `h`) and produces a compile-time error if you forget a case. The idiomatic Go equivalent needs a marker-method interface (`isShape()` on every variant) to define the closed set, and its type switch is *not* exhaustiveness-checked -- drop the `Point` case and it still compiles, silently leaving `msg` empty.
 
 ---
 
@@ -91,7 +97,7 @@ val res = opt match {
 
 ---
 
-## Immutable Structs vs Manual Copying
+## Immutable Structs vs Mutable Copies
 
 GALA structs are immutable by default. Fields cannot be reassigned after construction. The compiler auto-generates a `Copy()` method for creating modified copies, and an `Equal()` method for structural comparison.
 
@@ -107,14 +113,14 @@ val updated = config.Copy(Port = 8080)</code></pre>
     Host string
     Port int
 }
-updated := Config{
-    Host: config.Host,
-    Port: 8080,
-}</code></pre>
+updated := config // shallow value copy
+updated.Port = 8080
+// config is still mutable here --
+// nothing stops a later reassignment</code></pre>
 </div>
 </div>
 
-In Go, you must manually copy every field you want to keep. With GALA's `Copy()`, you only specify the fields that change. As your struct grows, the GALA version stays the same size while the Go version grows with every field.
+Go's value copy is concise, but the copy and the original stay fully mutable -- and if `Config` holds a slice or map, the shallow copy shares it. GALA makes immutability the guarantee: fields can never be reassigned, `Copy()` is an expression you can drop straight into a pipeline, and the compiler also generates a structural `Equal()` (Go's `==` breaks the moment a field is a slice or map).
 
 ---
 
@@ -133,19 +139,16 @@ GALA's `Try[T]` type wraps computations that can fail. Instead of checking `if e
 <div>
 <p><strong>Go</strong></p>
 <pre><code>result, err := divide(10, 2)
+if err == nil {
+    result, err = divide(result*2, 3)
+}
 if err != nil {
     result = 0
-} else {
-    result = result * 2
-    result, err = divide(result, 3)
-    if err != nil {
-        result = 0
-    }
 }</code></pre>
 </div>
 </div>
 
-The GALA version reads as a linear pipeline: divide, double, divide again, recover on failure. The Go version nests deeper with each operation. Both compile to equivalent logic, but GALA expresses the intent more clearly.
+The GALA version reads as a linear pipeline: divide, double, divide again, recover on failure. The Go version threads an `err` variable through every step and interleaves the happy path with error checks. Both compile to equivalent logic, but GALA keeps the intent front and center -- and each stage composes, so adding a step is one more `.Map`/`.FlatMap`, not another `if err`.
 
 You can also pattern match on `Try[T]`:
 


### PR DESCRIPTION
## Problem

Several GALA-vs-Go comparison blocks showed **transpiler-generated code** on the "Go" side — `switch shape._variant`, `.Radius.Get()`, flat-struct-with-discriminator — which no Go developer writes by hand. To the exact audience this content targets (Go devs), it reads as a strawman and quietly undercuts the whole page's credibility.

## Fix

Replaced the fake Go with genuinely idiomatic Go, and let GALA win on real, defensible merits:

- **Pattern matching** → sealed marker-method interface + `switch s := shape.(type)`. Prose now makes the honest point: the type switch is *not* exhaustiveness-checked, so a missing case compiles clean and silently returns the zero value.
- **Immutable structs** → value copy (`updated := config; updated.Port = …`) instead of manual field-by-field construction; reframed around GALA's real win (enforced immutability + auto `Equal()`).
- **Error handling** → flat `if err == nil { … }` instead of nested `if/else`.

Kept the comparisons that were already honest best-practice Go (Option/`*T` nil-check, manual collection loop, `json` struct tags, functional-options / options-struct).

## Scope

`README.MD`, `website/vs-go.md`, `website/index.md`, `website/features/{pattern-matching,error-handling,immutability}.md`, `website/docs/why-gala.md`. No GALA snippets changed.

## Validation

Every new Go snippet was compiled and run: `gofmt` clean, `go vet` clean, `go build` clean, correct runtime output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)