### PR TITLE
feat(website): GA4 conversion events + center vs-go CTA

### DIFF
--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -368,5 +368,25 @@
       Prism.highlightAll();
     })();
   </script>
+
+  <!-- GA4 conversion tracking: one delegated listener fires named events for
+       high-intent clicks (Playground, GitHub, Getting Started, downloads).
+       Covers every current and future link. Mark these as key events in GA4. -->
+  <script>
+    (function () {
+      document.addEventListener('click', function (e) {
+        var a = e.target.closest ? e.target.closest('a[href]') : null;
+        if (!a || typeof gtag !== 'function') return;
+        var href = a.href || '';
+        var text = (a.textContent || '').trim().slice(0, 80);
+        var name = null;
+        if (/gala-playground\.fly\.dev/.test(href) || /\/playground\/?([?#]|$)/.test(href)) name = 'playground_open';
+        else if (/github\.com\/martianoff\/gala\/releases/.test(href)) name = 'download_click';
+        else if (/github\.com\/martianoff\/gala/.test(href)) name = 'github_click';
+        else if (/\/getting-started\/?([?#]|$)/.test(href)) name = 'getting_started_click';
+        if (name) gtag('event', name, { link_url: href, link_text: text });
+      }, true);
+    })();
+  </script>
 </body>
 </html>

--- a/website/vs-go.md
+++ b/website/vs-go.md
@@ -18,7 +18,7 @@ GALA is not replacing Go -- it is adding expressiveness on top of it. GALA trans
 
 This page shows real code comparisons between GALA and the equivalent idiomatic Go. Every GALA snippet on this page uses only syntax from the language specification.
 
-<p style="margin:1.5rem 0 0.5rem;">
+<p style="margin:1.5rem 0 0.5rem;text-align:center;">
   <a class="cta" href="https://gala-playground.fly.dev">▶ Run GALA in the Playground</a>
   <a class="cta cta-secondary" href="https://github.com/martianoff/gala">View the code on GitHub</a>
 </p>


### PR DESCRIPTION
## What

1. **GA4 conversion events** (`website/_layouts/default.html`) — one delegated click listener fires named events for high-intent clicks:
   - `playground_open` — Playground app (`gala-playground.fly.dev`) or `/playground/` page
   - `github_click` — the repo
   - `download_click` — `/releases`
   - `getting_started_click` — `/getting-started/`
   
   Delegation via `closest('a[href]')` covers nested markup and **every current and future link** with no per-link tagging. Reuses the `gtag` already on the page.

2. **Center the vs-go top CTA row** to match the centered closing CTA.

## Validation

- Href→event routing unit-tested (10 cases incl. `releases` beating the general github rule, and the `gala-playground` repo correctly routing to `github_click`).
- Full script verified end-to-end in a headless browser: 6 clicks fired the right events, nested-element clicks resolve to the anchor, and control links fire nothing.

## Follow-up (in GA4 console, not code)

Mark `playground_open`, `github_click`, `download_click`, `getting_started_click` as **key events** in Admin → Events to count them as conversions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)