### PR TITLE
fix(lsp): go-to-definition + completion for Go interop and native types

### DIFF
--- a/internal/lsp/BUILD.bazel
+++ b/internal/lsp/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
     ],
     data = [
         "//collection_immutable:gala_sources",
+        "//go_interop:types.go",
         "//std:gala_sources",
     ],
     embed = [":lsp"],

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -534,6 +534,10 @@ func typeSpecificCompletions(richAST *transpiler.RichAST, typeName string) []lsp
 
 	tm := findType(richAST, typeName)
 	if tm == nil {
+		// No GALA TypeMetadata — the receiver may be a Go type (e.g. a value
+		// returned from an imported Go package like bytes.Buffer or hash.Hash).
+		// Surface its method set from the analyzer's Go type info.
+		items = append(items, goTypeCompletions(richAST, typeName)...)
 		return items
 	}
 
@@ -584,6 +588,114 @@ func typeSpecificCompletions(richAST *transpiler.RichAST, typeName string) []lsp
 	})
 
 	return items
+}
+
+// goTypeCompletions surfaces the method set and fields of a Go type (struct or
+// interface) recorded in richAST.GoTypeInfo. It backs dot completion on values
+// whose type comes from an imported Go package and therefore has no GALA
+// TypeMetadata — e.g. `val b = bytes.NewBufferString("x"); b.` or a hash.Hash.
+func goTypeCompletions(richAST *transpiler.RichAST, typeName string) []lsp.CompletionItem {
+	items := make([]lsp.CompletionItem, 0)
+	gi := richAST.GoTypeInfo
+	if gi == nil {
+		return items
+	}
+
+	// Normalize the receiver type to the "pkg.Name" key used by GoTypeInfo:
+	// drop a leading pointer star and any generic arguments.
+	key := stripTypeParams(strings.TrimPrefix(strings.TrimSpace(typeName), "*"))
+
+	td := gi.Types[key]
+	if td == nil {
+		// Follow a single Go type-alias hop (type X = Y).
+		if under := gi.TypeAliases[key]; under != nil {
+			td = gi.Types[stripTypeParams(strings.TrimPrefix(under.String(), "*"))]
+		}
+	}
+	if td == nil {
+		return items
+	}
+
+	seen := make(map[string]bool, len(td.Methods))
+	for name, sig := range td.Methods {
+		if !isExported(name) || seen[name] {
+			continue
+		}
+		seen[name] = true
+		items = append(items, goMethodCompletion(name, sig))
+	}
+	for _, fn := range td.FieldOrder {
+		if !isExported(fn) {
+			continue
+		}
+		items = append(items, lsp.CompletionItem{
+			Label:  fn,
+			Kind:   kindPtr(lsp.CompletionItemKindField),
+			Detail: goTypeString(td.Fields[fn]),
+		})
+	}
+	return items
+}
+
+// goMethodCompletion builds a completion item for a Go method from its
+// signature, mirroring the parenthesis-insertion behavior of GALA methods.
+func goMethodCompletion(name string, sig *transpiler.GoFuncSignature) lsp.CompletionItem {
+	label := name + goFuncSigString(sig)
+	insertText := name + "("
+	if sig == nil || len(sig.Params) == 0 {
+		insertText = name + "()"
+	}
+	return lsp.CompletionItem{
+		Label:      label,
+		Kind:       kindPtr(lsp.CompletionItemKindMethod),
+		Detail:     goFuncSigString(sig),
+		InsertText: insertText,
+		FilterText: name,
+		SortText:   name,
+	}
+}
+
+// goFuncSigString renders a Go function/method signature like "(w []byte) int".
+func goFuncSigString(sig *transpiler.GoFuncSignature) string {
+	if sig == nil {
+		return "()"
+	}
+	var b strings.Builder
+	b.WriteString("(")
+	for i, p := range sig.Params {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		if p.Name != "" {
+			b.WriteString(p.Name)
+			b.WriteString(" ")
+		}
+		b.WriteString(goTypeString(p.Type))
+	}
+	b.WriteString(")")
+	switch len(sig.Returns) {
+	case 0:
+	case 1:
+		b.WriteString(" " + goTypeString(sig.Returns[0]))
+	default:
+		b.WriteString(" (")
+		for i, r := range sig.Returns {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(goTypeString(r))
+		}
+		b.WriteString(")")
+	}
+	return b.String()
+}
+
+// goTypeString renders a Go type for display, tolerating a nil type.
+func goTypeString(t transpiler.Type) string {
+	if t == nil || t.IsNil() {
+		return "any"
+	}
+	return t.String()
 }
 
 func formatMethodSig(meta *transpiler.MethodMetadata) string {

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -9,6 +9,7 @@ import (
 	"github.com/owenrumney/go-lsp/lsp"
 
 	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
 )
 
 func (h *GalaHandler) Definition(ctx context.Context, params *lsp.DefinitionParams) ([]lsp.Location, error) {
@@ -39,6 +40,27 @@ func (h *GalaHandler) Definition(ctx context.Context, params *lsp.DefinitionPara
 	// Check if it's a dot-accessed method/field: receiver.Method or receiver.Field
 	if loc := h.dotMethodDefinition(text, word, uri, line, char, richAST, varTypeMap); loc != nil {
 		return []lsp.Location{*loc}, nil
+	}
+
+	// Imported-package navigation. Parse imports from the document because
+	// Go-only packages (e.g. go_interop, which ships only .go sources) never
+	// appear in richAST.Packages — the analyzer records a package name only
+	// when it finds GALA sources to attach it to.
+	imports := parseGalaImports(text)
+
+	// pkg.Symbol — clicking a member qualified by an imported package name
+	// navigates to that symbol's definition in the package's source files.
+	if loc := h.packageMemberDefinition(text, word, uri, line, char, imports); loc != nil {
+		return []lsp.Location{*loc}, nil
+	}
+
+	// Clicking the imported package name itself navigates to the package.
+	if importPath, ok := imports[word]; ok {
+		if dir := h.resolveImportDir(uri, importPath); dir != "" {
+			if loc := packageFileLocation(dir); loc != nil {
+				return []lsp.Location{*loc}, nil
+			}
+		}
 	}
 
 	// Check sealed variants FIRST (Success, Failure, Some, None, etc.)
@@ -306,7 +328,9 @@ func (h *GalaHandler) dotMethodDefinition(text, word, uri string, curLine, curCh
 	// Find the type metadata for this receiver
 	tm := findType(richAST, receiverType)
 	if tm == nil {
-		return nil
+		// The receiver may be a Go type (e.g. b : *bytes.Buffer). Try to
+		// resolve the method in the Go type's package source.
+		return h.goMethodDefinition(text, uri, receiverType, word, richAST)
 	}
 
 	// Check methods first
@@ -364,6 +388,381 @@ func (h *GalaHandler) dotMethodDefinition(text, word, uri string, curLine, curCh
 	}
 
 	return nil
+}
+
+// parseGalaImports scans the document text for import declarations and returns
+// a map of local package name -> import path. This captures Go-only packages
+// (e.g. go_interop) that never surface in richAST.Packages because they have
+// no .gala sources for the analyzer to attach a package name to. The local
+// name is the alias when one is given (e.g. `im "path"`), otherwise the final
+// path segment. Dot imports (`. "path"`) contribute no qualified name and are
+// skipped.
+func parseGalaImports(text string) map[string]string {
+	imports := make(map[string]string)
+	inBlock := false
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "//") {
+			continue
+		}
+		if !inBlock {
+			if strings.HasPrefix(line, "import (") {
+				inBlock = true
+				continue
+			}
+			if strings.HasPrefix(line, "import ") {
+				addImportSpec(imports, strings.TrimSpace(strings.TrimPrefix(line, "import")))
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ")") {
+			inBlock = false
+			continue
+		}
+		addImportSpec(imports, line)
+	}
+	return imports
+}
+
+// addImportSpec parses a single import spec ("path", `alias "path"`, or
+// `. "path"`) and records the local-name -> path mapping.
+func addImportSpec(imports map[string]string, spec string) {
+	q := strings.Index(spec, "\"")
+	if q < 0 {
+		return
+	}
+	rest := spec[q+1:]
+	end := strings.Index(rest, "\"")
+	if end < 0 {
+		return
+	}
+	path := rest[:end]
+	if path == "" {
+		return
+	}
+	alias := strings.TrimSpace(spec[:q])
+	switch {
+	case alias == ".":
+		return // dot import: symbols are unqualified, no package name to click
+	case alias != "":
+		imports[alias] = path
+	default:
+		local := path
+		if idx := strings.LastIndex(path, "/"); idx >= 0 {
+			local = path[idx+1:]
+		}
+		imports[local] = path
+	}
+}
+
+// resolveImportDir resolves an import path to a filesystem directory using the
+// same search-path strategy the analyzer's resolver applies: internal
+// martianoff/gala/* paths map to a directory relative to a search path with
+// the module prefix stripped; everything else is tried as-is.
+func (h *GalaHandler) resolveImportDir(uri, importPath string) string {
+	relPath := strings.TrimPrefix(importPath, "martianoff/gala/")
+	for _, sp := range h.getSearchPaths(uriToPath(uri)) {
+		for _, cand := range []string{relPath, importPath} {
+			dir := filepath.Join(sp, cand)
+			if info, err := os.Stat(dir); err == nil && info.IsDir() {
+				if abs, err := filepath.Abs(dir); err == nil {
+					return abs
+				}
+				return dir
+			}
+		}
+	}
+	// Not on a GALA search path — fall back to the Go SDK source tree so
+	// definitions in Go stdlib packages (bytes, crypto/sha256, ...) resolve.
+	return analyzer.GoPackageSourceDir(importPath)
+}
+
+// packageMemberDefinition resolves a `pkg.Symbol` reference where `pkg` is an
+// imported package name, navigating to Symbol's definition in the package's
+// source files (.gala or .go). This is what makes go_interop.SliceAppend and
+// similar Go-interop calls clickable.
+func (h *GalaHandler) packageMemberDefinition(text, word, uri string, curLine, curChar int, imports map[string]string) *lsp.Location {
+	lines := strings.Split(text, "\n")
+	if curLine >= len(lines) {
+		return nil
+	}
+	l := lines[curLine]
+
+	// The word must be immediately preceded by a dot.
+	start := curChar
+	if start > len(l) {
+		start = len(l)
+	}
+	for start > 0 && isIdentChar(l[start-1]) {
+		start--
+	}
+	if start == 0 || l[start-1] != '.' {
+		return nil
+	}
+
+	// The identifier before that dot is the (candidate) package name. It must
+	// itself not be preceded by a dot — `x.pkg.Symbol` means `pkg` is a field,
+	// not an imported package.
+	pkgEnd := start - 1
+	pkgStart := pkgEnd
+	for pkgStart > 0 && isIdentChar(l[pkgStart-1]) {
+		pkgStart--
+	}
+	if pkgStart == pkgEnd || (pkgStart > 0 && l[pkgStart-1] == '.') {
+		return nil
+	}
+	importPath, ok := imports[l[pkgStart:pkgEnd]]
+	if !ok {
+		return nil
+	}
+	dir := h.resolveImportDir(uri, importPath)
+	if dir == "" {
+		return nil
+	}
+	return dirSymbolLocation(dir, word)
+}
+
+// dirSymbolLocation searches the .gala and .go files in dir for a top-level
+// definition of name. GALA files use the keyword-pattern search; Go files use
+// goSymbolLocation.
+func dirSymbolLocation(dir, name string) *lsp.Location {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var goFiles []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := e.Name()
+		if strings.HasSuffix(n, ".gala") && !strings.HasSuffix(n, "_test.gala") {
+			if loc := fileLocationBroad(filepath.Join(dir, n), name); loc != nil {
+				return loc
+			}
+		} else if strings.HasSuffix(n, ".go") && !strings.HasSuffix(n, "_test.go") {
+			goFiles = append(goFiles, filepath.Join(dir, n))
+		}
+	}
+	for _, gf := range goFiles {
+		if loc := goSymbolLocation(gf, name); loc != nil {
+			return loc
+		}
+	}
+	return nil
+}
+
+// goSymbolLocation searches a .go file for a top-level func/type/const/var
+// declaration of name and returns the location of its identifier. Methods
+// (func with a receiver) are skipped — a package-qualified reference resolves
+// to a package-level symbol, not a method.
+func goSymbolLocation(filePath, name string) *lsp.Location {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil
+	}
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil
+	}
+	uri := pathToURI(absPath)
+	keywords := []string{"func ", "type ", "const ", "var "}
+	for i, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		for _, kw := range keywords {
+			if !strings.HasPrefix(trimmed, kw) {
+				continue
+			}
+			rest := trimmed[len(kw):]
+			if strings.HasPrefix(rest, "(") {
+				continue // func with receiver — a method, not a package symbol
+			}
+			end := 0
+			for end < len(rest) && isIdentChar(rest[end]) {
+				end++
+			}
+			if rest[:end] != name {
+				continue
+			}
+			col := findWholeWord(line, name)
+			if col < 0 {
+				col = strings.Index(line, name)
+			}
+			if col < 0 {
+				col = 0
+			}
+			return &lsp.Location{
+				URI: lsp.DocumentURI(uri),
+				Range: lsp.Range{
+					Start: lsp.Position{Line: i, Character: col},
+					End:   lsp.Position{Line: i, Character: col + len(name)},
+				},
+			}
+		}
+	}
+	return nil
+}
+
+// packageFileLocation returns a location at the `package` declaration of a
+// representative source file in dir — a .gala file when present, else a .go
+// file. Used to navigate to a package from its imported name.
+func packageFileLocation(dir string) *lsp.Location {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var goFallback string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := e.Name()
+		if strings.HasSuffix(n, ".gala") && !strings.HasSuffix(n, "_test.gala") {
+			return packageDeclLocation(filepath.Join(dir, n))
+		}
+		if goFallback == "" && strings.HasSuffix(n, ".go") && !strings.HasSuffix(n, "_test.go") {
+			goFallback = filepath.Join(dir, n)
+		}
+	}
+	if goFallback != "" {
+		return packageDeclLocation(goFallback)
+	}
+	return nil
+}
+
+// packageDeclLocation points at the `package X` line of filePath, falling back
+// to the file's start when no package clause is found.
+func packageDeclLocation(filePath string) *lsp.Location {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil
+	}
+	uri := lsp.DocumentURI(pathToURI(absPath))
+	if data, err := os.ReadFile(absPath); err == nil {
+		for i, line := range strings.Split(string(data), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "package ") {
+				return &lsp.Location{URI: uri, Range: lsp.Range{
+					Start: lsp.Position{Line: i, Character: 0},
+					End:   lsp.Position{Line: i, Character: 0},
+				}}
+			}
+		}
+	}
+	return &lsp.Location{URI: uri, Range: zeroRange()}
+}
+
+// goMethodDefinition resolves a method call on a value whose type comes from a
+// Go package (e.g. b.WriteString where b : *bytes.Buffer) by locating the
+// method in the Go type's package source. Best-effort: the type's package must
+// be one the document imports so its import path — hence source directory — is
+// known, and the method must be declared as `func (recv Type) Method` (struct
+// methods) or as an interface method in `type Type interface { ... }`.
+func (h *GalaHandler) goMethodDefinition(text, uri, receiverType, method string, richAST *transpiler.RichAST) *lsp.Location {
+	if richAST == nil || richAST.GoTypeInfo == nil {
+		return nil
+	}
+	key := stripTypeParams(strings.TrimPrefix(strings.TrimSpace(receiverType), "*"))
+	td := richAST.GoTypeInfo.Types[key]
+	if td == nil {
+		return nil
+	}
+	if _, ok := td.Methods[method]; !ok {
+		return nil
+	}
+	dot := strings.LastIndex(key, ".")
+	if dot < 0 {
+		return nil
+	}
+	pkgName, typeName := key[:dot], key[dot+1:]
+	importPath, ok := parseGalaImports(text)[pkgName]
+	if !ok {
+		return nil
+	}
+	dir := h.resolveImportDir(uri, importPath)
+	if dir == "" {
+		return nil
+	}
+	return goMethodInDir(dir, typeName, method)
+}
+
+// goMethodInDir searches the non-test .go files in dir for a declaration of
+// method on typeName.
+func goMethodInDir(dir, typeName, method string) *lsp.Location {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		if loc := goMethodInFile(filepath.Join(dir, e.Name()), typeName, method); loc != nil {
+			return loc
+		}
+	}
+	return nil
+}
+
+// goMethodInFile looks for `func (recv [*]typeName[...]) method(` in a .go file
+// and returns the location of the method identifier.
+func goMethodInFile(filePath, typeName, method string) *lsp.Location {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil
+	}
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil
+	}
+	uri := pathToURI(absPath)
+	for i, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "func (") {
+			continue
+		}
+		closeParen := strings.Index(trimmed, ")")
+		if closeParen < 0 {
+			continue
+		}
+		if !receiverMatchesType(trimmed[len("func ("):closeParen], typeName) {
+			continue
+		}
+		rest := strings.TrimSpace(trimmed[closeParen+1:])
+		end := 0
+		for end < len(rest) && isIdentChar(rest[end]) {
+			end++
+		}
+		if rest[:end] != method {
+			continue
+		}
+		col := findWholeWord(line, method)
+		if col < 0 {
+			col = 0
+		}
+		return &lsp.Location{
+			URI: lsp.DocumentURI(uri),
+			Range: lsp.Range{
+				Start: lsp.Position{Line: i, Character: col},
+				End:   lsp.Position{Line: i, Character: col + len(method)},
+			},
+		}
+	}
+	return nil
+}
+
+// receiverMatchesType reports whether a Go method receiver clause (the text
+// between the parens in `func (b *Buffer) ...`) is a receiver for typeName,
+// tolerating a pointer star and generic type parameters.
+func receiverMatchesType(recv, typeName string) bool {
+	parts := strings.Fields(strings.TrimSpace(recv))
+	if len(parts) == 0 {
+		return false
+	}
+	typ := strings.TrimPrefix(parts[len(parts)-1], "*")
+	if idx := strings.IndexByte(typ, '['); idx >= 0 {
+		typ = typ[:idx]
+	}
+	return typ == typeName
 }
 
 // searchPackageDirs searches the type's package directory and search paths for a definition.

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -344,6 +344,178 @@ func TestCompletion_DotOnStruct(t *testing.T) {
 }
 
 // ====================================================================
+// Completion: dot completion on a `bind`-defined variable resolves the
+// unwrapped monad element type (bind o = fetchOrder(id) -> o : Order).
+// ====================================================================
+
+func TestCompletion_DotOnBindVar(t *testing.T) {
+	h := newHarness(t)
+	valid := "package main\n" +
+		"\n" +
+		"struct Order(Id int, Amount int)\n" +
+		"func fetchOrder(id int) Try[Order] =\n" +
+		"    if (id > 0) Success(Order(id, 100))\n" +
+		"    else Failure[Order](NoSuchElementError(Message = \"no order\"))\n" +
+		"func process(id int) Try[Order] {\n" +
+		"    bind o = fetchOrder(id)\n" +
+		"    Success(o)\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, valid)
+	time.Sleep(300 * time.Millisecond)
+
+	broken := "package main\n" +
+		"\n" +
+		"struct Order(Id int, Amount int)\n" +
+		"func fetchOrder(id int) Try[Order] =\n" +
+		"    if (id > 0) Success(Order(id, 100))\n" +
+		"    else Failure[Order](NoSuchElementError(Message = \"no order\"))\n" +
+		"func process(id int) Try[Order] {\n" +
+		"    bind o = fetchOrder(id)\n" +
+		"    o.\n" +
+		"    Success(o)\n" +
+		"}\n"
+	if err := h.DidChange(uri, 1, broken); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	// "    o." on line 8, col 6
+	list, err := h.Completion(uri, 8, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list == nil {
+		t.Fatal("dot completion returned nil for bind var")
+	}
+	labels := collectLabels(list)
+	if !labels["Id"] && !labels["Amount"] {
+		t.Errorf("expected Order fields (Id/Amount) for bind var completion, got %v", labelSlice(list))
+	}
+}
+
+// Mid-typing reality: the bind has no continuation yet — the dot line is the
+// only statement after it. This is the state the file is in the instant the
+// user types "o." and expects completion.
+func TestCompletion_DotOnBindVar_NoContinuation(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"struct Order(Id int, Amount int)\n" +
+		"func fetchOrder(id int) Try[Order] =\n" +
+		"    if (id > 0) Success(Order(id, 100))\n" +
+		"    else Failure[Order](NoSuchElementError(Message = \"no order\"))\n" +
+		"func process(id int) Try[Order] {\n" +
+		"    bind o = fetchOrder(id)\n" +
+		"    o.\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(300 * time.Millisecond)
+
+	list, err := h.Completion(uri, 8, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list == nil {
+		t.Fatal("dot completion returned nil for bind var (no continuation)")
+	}
+	labels := collectLabels(list)
+	if !labels["Id"] && !labels["Amount"] {
+		t.Errorf("expected Order fields (Id/Amount) for bind var completion, got %v", labelSlice(list))
+	}
+}
+
+// Completion on a value whose type comes from a Go package (go_interop.Mutex
+// has Lock/Unlock methods defined in Go). Reproduces the "no suggestions on Go
+// native types" report.
+func TestCompletion_DotOnGoInteropType(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"import \"martianoff/gala/go_interop\"\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val m = go_interop.NewMutex()\n" +
+		"    m.\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(300 * time.Millisecond)
+
+	// "    m." on line 6, col 6
+	list, err := h.Completion(uri, 6, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list == nil {
+		t.Fatal("dot completion returned nil for go_interop Mutex value")
+	}
+	t.Logf("go_interop.Mutex dot completion: %v", labelSlice(list))
+	labels := collectLabels(list)
+	if !labels["Lock"] && !labels["Unlock"] {
+		t.Errorf("expected Mutex methods (Lock/Unlock), got %v", labelSlice(list))
+	}
+}
+
+// Completion on a value typed by an EXTERNAL Go stdlib package. bytes.Buffer's
+// methods live in the same package that is imported, so the method set is
+// available in richAST.GoTypeInfo — completion should surface them.
+func TestCompletion_DotOnExternalGoType_SamePkg(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"import \"bytes\"\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val b = bytes.NewBufferString(\"hi\")\n" +
+		"    b.\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(300 * time.Millisecond)
+
+	list, err := h.Completion(uri, 6, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list == nil {
+		t.Fatal("dot completion returned nil for bytes.Buffer value")
+	}
+	t.Logf("bytes.Buffer dot completion: %v", labelSlice(list))
+	labels := collectLabels(list)
+	if !labels["String"] && !labels["Len"] && !labels["Write"] {
+		t.Errorf("expected *bytes.Buffer methods (String/Len/Write), got %v", labelSlice(list))
+	}
+}
+
+// Completion on a value whose type is returned CROSS-PACKAGE: sha256.New()
+// returns hash.Hash (interface in package `hash`, not crypto/sha256). The
+// method set lives in a package that was never imported.
+func TestCompletion_DotOnExternalGoType_CrossPkg(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"import \"crypto/sha256\"\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val d = sha256.New()\n" +
+		"    d.\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(300 * time.Millisecond)
+
+	list, err := h.Completion(uri, 6, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list == nil {
+		t.Fatal("dot completion returned nil for sha256.New() value")
+	}
+	t.Logf("sha256.New() (hash.Hash) dot completion: %v", labelSlice(list))
+	labels := collectLabels(list)
+	if !labels["Write"] && !labels["Sum"] && !labels["Reset"] {
+		t.Errorf("expected hash.Hash methods (Write/Sum/Reset), got %v", labelSlice(list))
+	}
+}
+
+// ====================================================================
 // Completion: Dot completion should NOT include keywords
 // ====================================================================
 
@@ -712,6 +884,92 @@ func TestDefinition_PatternBinding(t *testing.T) {
 	// Should point to the binding "r" in "case Circle(r)"
 	if locs[0].Range.Start.Line != 7 {
 		t.Errorf("expected pattern binding definition on line 7, got line %d", locs[0].Range.Start.Line)
+	}
+}
+
+// ====================================================================
+// Definition: Go interop package name + functions navigate to the
+// package's .go source (go_interop is a pure-Go stdlib package).
+// ====================================================================
+
+func TestDefinition_GoInteropPackageAndFunc(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"import \"martianoff/gala/go_interop\"\n" +
+		"\n" +
+		"func main() {\n" +
+		"    var elems = go_interop.SliceWithCapacity[int](4)\n" +
+		"    elems = go_interop.SliceAppend(elems, 1)\n" +
+		"    Println(elems)\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+
+	// Click on the package name "go_interop" at line 5, col 20
+	pkgLocs, err := h.Definition(uri, 5, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pkgLocs) == 0 {
+		t.Errorf("no definition found for go_interop package name")
+	} else if !strings.Contains(strings.ToLower(string(pkgLocs[0].URI)), "go_interop") {
+		t.Errorf("expected package definition in go_interop dir, got %s", pkgLocs[0].URI)
+	}
+
+	// Click on the function "SliceAppend" at line 6, col 26
+	fnLocs, err := h.Definition(uri, 6, 26)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fnLocs) == 0 {
+		t.Errorf("no definition found for go_interop.SliceAppend")
+	} else if !strings.Contains(strings.ToLower(string(fnLocs[0].URI)), "go_interop") {
+		t.Errorf("expected SliceAppend definition in go_interop dir, got %s", fnLocs[0].URI)
+	}
+}
+
+// ====================================================================
+// Definition: external Go stdlib package name, function, and method all
+// navigate into the Go SDK source tree.
+// ====================================================================
+
+func TestDefinition_ExternalGoStdlib(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"import \"bytes\"\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val b = bytes.NewBufferString(\"hi\")\n" +
+		"    b.WriteString(\"x\")\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(300 * time.Millisecond)
+
+	isBytesGoFile := func(u lsp.DocumentURI) bool {
+		s := strings.ToLower(string(u))
+		return strings.Contains(s, "/bytes/") && strings.HasSuffix(s, ".go")
+	}
+
+	// Package name "bytes" at line 5, col 12
+	if locs, err := h.Definition(uri, 5, 12); err != nil {
+		t.Fatal(err)
+	} else if len(locs) == 0 || !isBytesGoFile(locs[0].URI) {
+		t.Errorf("bytes package name: expected a Go file under bytes/, got %v", locs)
+	}
+
+	// Package function "NewBufferString" at line 5, col 22
+	if locs, err := h.Definition(uri, 5, 22); err != nil {
+		t.Fatal(err)
+	} else if len(locs) == 0 || !isBytesGoFile(locs[0].URI) {
+		t.Errorf("bytes.NewBufferString: expected a Go file under bytes/, got %v", locs)
+	}
+
+	// Method "WriteString" on *bytes.Buffer at line 6, col 8
+	if locs, err := h.Definition(uri, 6, 8); err != nil {
+		t.Fatal(err)
+	} else if len(locs) == 0 || !isBytesGoFile(locs[0].URI) {
+		t.Errorf("bytes.Buffer.WriteString: expected a Go file under bytes/, got %v", locs)
 	}
 }
 

--- a/internal/transpiler/analyzer/go_types.go
+++ b/internal/transpiler/analyzer/go_types.go
@@ -415,6 +415,12 @@ func extractPackageInfo(pkg *types.Package, info *transpiler.GoTypeInfo) {
 		case *types.Func:
 			sig := obj.Type().(*types.Signature)
 			info.Functions[qualName] = convertSignature(sig)
+			// A function often returns a named type defined in another package
+			// (e.g. sha256.New() returns hash.Hash). Record that type's method
+			// set under its canonical "pkg.Name" key so a value bound to the
+			// call has completions even though the defining package (hash) was
+			// never directly imported.
+			registerReturnNamedTypes(sig, info)
 
 		case *types.TypeName:
 			if obj.IsAlias() {
@@ -474,6 +480,75 @@ func registerAliasTargetType(aliasType types.Type, aliasQualName string, info *t
 		return
 	}
 	info.Types[canonical] = extractTypeData(tn, "")
+}
+
+// registerReturnNamedTypes records, for each of a function's return values, the
+// method set of any named type reached (unwrapping pointer/slice/array layers)
+// that is defined in another package. This mirrors
+// registerAliasTargetType but for return positions, so completion and type
+// inference can find methods on values produced by a call into an imported
+// package even when the value's own type lives in a package that was never
+// directly imported (the classic case: a constructor returning an interface,
+// like sha256.New() -> hash.Hash).
+func registerReturnNamedTypes(sig *types.Signature, info *transpiler.GoTypeInfo) {
+	if sig == nil {
+		return
+	}
+	res := sig.Results()
+	for i := 0; i < res.Len(); i++ {
+		registerNamedTypeClosure(res.At(i).Type(), info)
+	}
+}
+
+// registerNamedTypeClosure unwraps common type constructors (pointer, slice,
+// array, map, chan) to find a named type and records its GoTypeData under the
+// canonical "pkgName.TypeName" key. It is a no-op when the type is not a
+// package-scoped named type or when an entry already exists (which also bounds
+// the recursion).
+func registerNamedTypeClosure(t types.Type, info *transpiler.GoTypeInfo) {
+	switch tt := t.(type) {
+	case *types.Pointer:
+		registerNamedTypeClosure(tt.Elem(), info)
+	case *types.Slice:
+		registerNamedTypeClosure(tt.Elem(), info)
+	case *types.Array:
+		registerNamedTypeClosure(tt.Elem(), info)
+	case *types.Chan:
+		registerNamedTypeClosure(tt.Elem(), info)
+	case *types.Map:
+		registerNamedTypeClosure(tt.Key(), info)
+		registerNamedTypeClosure(tt.Elem(), info)
+	case *types.Named:
+		tn := tt.Obj()
+		if tn == nil || tn.Pkg() == nil {
+			return
+		}
+		canonical := tn.Pkg().Name() + "." + tn.Name()
+		if _, exists := info.Types[canonical]; exists {
+			return
+		}
+		info.Types[canonical] = extractTypeData(tn, "")
+	}
+}
+
+// GoPackageSourceDir resolves a Go import path to its on-disk source directory.
+// It covers the standard library (under GOROOT/src), which is what the LSP needs
+// to offer go-to-definition into Go source for stdlib calls. Returns "" when the
+// directory can't be located (e.g. no Go SDK, or a third-party module that isn't
+// unpacked under GOROOT).
+func GoPackageSourceDir(importPath string) string {
+	if importPath == "" {
+		return ""
+	}
+	goroot := findGOROOT()
+	if goroot == "" {
+		return ""
+	}
+	dir := filepath.Join(goroot, "src", filepath.FromSlash(importPath))
+	if info, err := os.Stat(dir); err == nil && info.IsDir() {
+		return dir
+	}
+	return ""
 }
 
 // extractTypeData creates GoTypeData for a types.TypeName.

--- a/internal/transpiler/analyzer/go_types_test.go
+++ b/internal/transpiler/analyzer/go_types_test.go
@@ -1,6 +1,8 @@
 package analyzer_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"martianoff/gala/internal/transpiler"
@@ -14,6 +16,30 @@ func skipIfNoGoSDK(t *testing.T) {
 	t.Helper()
 	if !analyzer.GoImporterAvailable() {
 		t.Skip("Go SDK not available (Bazel sandbox)")
+	}
+}
+
+// A function whose return type reaches a cross-package named type through a map
+// or chan layer must still register that type's method set, so downstream
+// completion/type-inference can see its methods even though the defining
+// package was never directly imported.
+func TestAnalyzeGoFiles_RegistersMapAndChanElementTypes(t *testing.T) {
+	skipIfNoGoSDK(t)
+	dir := t.TempDir()
+	src := "package sample\n\n" +
+		"import \"bytes\"\n\n" +
+		"func MapReturn() map[string]bytes.Buffer { return nil }\n" +
+		"func ChanReturn() chan bytes.Reader { return nil }\n"
+	if err := os.WriteFile(filepath.Join(dir, "sample.go"), []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	info := analyzer.AnalyzeGoFiles(dir)
+	require.NotNil(t, info)
+	if info.Types["bytes.Buffer"] == nil {
+		t.Error("expected bytes.Buffer registered via map value type")
+	}
+	if info.Types["bytes.Reader"] == nil {
+		t.Error("expected bytes.Reader registered via chan element type")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes three IntelliJ/LSP gaps for Go-backed code, reported while working in `gala-server`:

1. **`go_interop` (and any Go-only package) not clickable.** These packages ship only `.go` sources, so the analyzer never records a package name in `richAST.Packages` and go-to-definition had no path. `Definition` now parses imports from the document, resolves the package directory, and navigates to the package (package-name click) or the symbol's declaration in `.gala`/`.go` (`pkg.Symbol` click).

2. **No dot completion on Go-typed values** (e.g. `val b = bytes.NewBufferString(...); b.`, or a `go_interop.Mutex`). External Go types get `GoTypeInfo` but no GALA `TypeMetadata`, so the method list was empty. `typeSpecificCompletions` now falls back to the Go type's method set / fields from `richAST.GoTypeInfo`.

3. **Cross-package return types had no method set.** `sha256.New()` returns `hash.Hash` (defined in `hash`, never imported). The analyzer now records the method set of named types reached through a function's return values, unwrapping pointer/slice/array/map/chan.

Also adds **go-to-definition into the Go SDK source tree** for external stdlib: package name, package function, and struct methods resolve via `analyzer.GoPackageSourceDir` (`GOROOT/src`).

## Changes
- `internal/lsp/definition.go` — import parsing, package/member/name navigation, Go stdlib source resolution, Go struct-method go-to-def.
- `internal/lsp/completion.go` — `GoTypeInfo` fallback for dot completion on Go types.
- `internal/transpiler/analyzer/go_types.go` — `registerReturnNamedTypes`/`registerNamedTypeClosure` (pointer/slice/array/map/chan) + exported `GoPackageSourceDir`.
- `internal/lsp/BUILD.bazel` — add `//go_interop:types.go` to test data.
- Tests in `server_test.go` and `go_types_test.go`.

## Tests
New, all passing: go_interop navigation, bind-var completion (already worked — locked in as regression), same-package (`bytes.Buffer`) and cross-package (`sha256`→`hash.Hash`) completion, external stdlib go-to-def (package/function/method), and map/chan element-type registration.

Verified locally:
- `//internal/lsp`, `//internal/transpiler/transformer`, `//internal/transpiler` — PASS
- `//internal/transpiler/analyzer` — only the pre-existing `TestGorootFromGoBinarySymlink` Windows symlink-privilege failure (unrelated)
- `bazel build //internal/... //cmd/...` — PASS

## Known limitations
- Method go-to-def is struct-only; interface methods via embedding (e.g. `hash.Hash.Write`) and cross-package interface types whose defining package isn't imported won't resolve to source (completion still lists them).
- `GoPackageSourceDir` covers `GOROOT/src` only; third-party module-cache resolution isn't wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)