### PR TITLE
feat(lsp): completion + go-to-definition for third-party Go modules

### DIFF
--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -281,7 +281,20 @@ func (b *Builder) effectiveDepDir(req mod.Require) string {
 // or none are cached yet (the analyzer then leaves Go resolution to the
 // importer, which is correct for stdlib-only code).
 func (b *Builder) goModuleSrcDirs() map[string]string {
-	reqs := b.galaMod.GoRequires()
+	return GoModuleSrcDirs(b.galaMod, b.config)
+}
+
+// GoModuleSrcDirs maps each Go module required by galaMod to its on-disk .go
+// source directory in the dependency cache. It checks the GALA dep cache (which
+// stores the module path verbatim) and the Go module cache (which case-escapes
+// uppercase letters). Returns nil when there are no Go requires or none resolve
+// to a directory with Go sources. Shared by the CLI builder and the LSP so both
+// resolve third-party Go types the same way.
+func GoModuleSrcDirs(galaMod *mod.File, config *Config) map[string]string {
+	if galaMod == nil || config == nil {
+		return nil
+	}
+	reqs := galaMod.GoRequires()
 	if len(reqs) == 0 {
 		return nil
 	}
@@ -289,8 +302,8 @@ func (b *Builder) goModuleSrcDirs() map[string]string {
 	for _, req := range reqs {
 		// GALA dep cache stores the module path verbatim; the Go module
 		// cache case-escapes it (uppercase letter c -> "!"+lower(c)).
-		galaCand := filepath.Join(b.config.GalaPkgDir, filepath.FromSlash(req.Path)+"@"+req.Version)
-		goCand := filepath.Join(b.config.GoPkgDir, filepath.FromSlash(escapeGoModulePath(req.Path))+"@"+req.Version)
+		galaCand := filepath.Join(config.GalaPkgDir, filepath.FromSlash(req.Path)+"@"+req.Version)
+		goCand := filepath.Join(config.GoPkgDir, filepath.FromSlash(escapeGoModulePath(req.Path))+"@"+req.Version)
 		for _, cand := range []string{galaCand, goCand} {
 			if dirHasGoFiles(cand) {
 				dirs[req.Path] = cand

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -472,8 +472,14 @@ func (h *GalaHandler) resolveImportDir(uri, importPath string) string {
 			}
 		}
 	}
-	// Not on a GALA search path — fall back to the Go SDK source tree so
-	// definitions in Go stdlib packages (bytes, crypto/sha256, ...) resolve.
+	// Not on a GALA search path. Try third-party Go modules wired from the
+	// project's gala.mod (their sources live in the dependency cache), then
+	// fall back to the Go SDK source tree for stdlib (bytes, crypto/sha256, ...).
+	if dir, ok := analyzer.ResolveGoSrcDir(h.goSrcDirs, importPath); ok {
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
+		}
+	}
 	return analyzer.GoPackageSourceDir(importPath)
 }
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -44,8 +44,9 @@ type GalaHandler struct {
 	parser    transpiler.GalaParser
 	generator transpiler.CodeGenerator
 
-	extraSearchPaths []string          // additional search paths (for testing)
-	client           *golsp.Client     // LSP client for sending notifications
+	extraSearchPaths []string      // additional search paths (for testing)
+	goSrcDirs        map[string]string // Go module import-path prefix -> on-disk .go source dir (third-party deps)
+	client           *golsp.Client // LSP client for sending notifications
 
 	mu              sync.Mutex
 	documents       map[string]string              // URI -> source text
@@ -70,6 +71,13 @@ func (h *GalaHandler) SetClient(client *golsp.Client) {
 // SetSearchPaths adds additional search paths for the analyzer (for testing).
 func (h *GalaHandler) SetSearchPaths(paths []string) {
 	h.extraSearchPaths = paths
+}
+
+// SetGoSrcDirs wires the Go module import-path -> source-directory table used to
+// resolve third-party Go types (for testing; in production it is populated from
+// the project's gala.mod by resolveProjectDeps).
+func (h *GalaHandler) SetGoSrcDirs(dirs map[string]string) {
+	h.goSrcDirs = dirs
 }
 
 // SetVersion sets the version reported in the LSP Initialize response.
@@ -314,6 +322,11 @@ func (h *GalaHandler) analyzeFile(uri, filePath, text string) []lsp.Diagnostic {
 
 	searchPaths := h.getSearchPaths(filePath)
 	a := analyzer.NewGalaAnalyzerForLSP(h.parser, searchPaths)
+	if len(h.goSrcDirs) > 0 {
+		if s, ok := a.(interface{ SetGoSrcDirs(map[string]string) }); ok {
+			s.SetGoSrcDirs(h.goSrcDirs)
+		}
+	}
 	richAST, err := a.Analyze(tree, filePath)
 	if err != nil {
 		diagnostics = append(diagnostics, errorsToDiagnostics(err)...)
@@ -412,6 +425,11 @@ func (h *GalaHandler) resolveProjectDeps(rootPath string) {
 			h.extraSearchPaths = append(h.extraSearchPaths, depDir)
 		}
 	}
+	// Wire third-party Go module source directories so the analyzer can resolve
+	// their concrete types (completion) and definition can navigate into them.
+	if dirs := build.GoModuleSrcDirs(galaMod, config); len(dirs) > 0 {
+		h.goSrcDirs = dirs
+	}
 }
 
 // tryAnalyzePartial attempts to analyze an error-recovered ANTLR tree.
@@ -429,6 +447,11 @@ func (h *GalaHandler) tryAnalyzePartial(uri, filePath string, tree antlr.Tree) {
 
 	searchPaths := h.getSearchPaths(filePath)
 	a := analyzer.NewGalaAnalyzerForLSP(h.parser, searchPaths)
+	if len(h.goSrcDirs) > 0 {
+		if s, ok := a.(interface{ SetGoSrcDirs(map[string]string) }); ok {
+			s.SetGoSrcDirs(h.goSrcDirs)
+		}
+	}
 	richAST, err := a.Analyze(tree, filePath)
 	if err != nil || richAST == nil {
 		return
@@ -543,6 +566,11 @@ func (h *GalaHandler) analyzeAndCache(uri, cleanText, caller string) {
 	filePath := uriToPath(uri)
 	searchPaths := h.getSearchPaths(filePath)
 	a := analyzer.NewGalaAnalyzerForLSP(h.parser, searchPaths)
+	if len(h.goSrcDirs) > 0 {
+		if s, ok := a.(interface{ SetGoSrcDirs(map[string]string) }); ok {
+			s.SetGoSrcDirs(h.goSrcDirs)
+		}
+	}
 	richAST, aerr := a.Analyze(tree, filePath)
 	if aerr != nil {
 		fmt.Fprintf(os.Stderr, "[%s] analyze failed: %v\n", caller, aerr)

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -974,6 +974,101 @@ func TestDefinition_ExternalGoStdlib(t *testing.T) {
 }
 
 // ====================================================================
+// Third-party Go module interop: completion + go-to-definition on a
+// value/package whose type comes from a wired Go module source dir.
+// ====================================================================
+
+// writeThirdPartyGoModule writes an import-free Go package to a temp dir and
+// returns it. Import-free means AnalyzeGoFiles never needs the Go SDK, so the
+// fixture is hermetic (mirrors the analyzer's own go_src_dirs_test.go).
+func writeThirdPartyGoModule(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := "package widget\n\n" +
+		"type Widget struct {\n\tName string\n}\n\n" +
+		"func New() Widget { return Widget{} }\n\n" +
+		"func (w Widget) Spin() int { return 1 }\n" +
+		"func (w Widget) Label() string { return w.Name }\n"
+	if err := os.WriteFile(filepath.Join(dir, "widget.go"), []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestCompletion_DotOnThirdPartyGoType(t *testing.T) {
+	h, handler := newHarnessWithHandler(t)
+	goDir := writeThirdPartyGoModule(t)
+	handler.SetGoSrcDirs(map[string]string{"example.test/widget": goDir})
+
+	src := "package main\n" +
+		"\n" +
+		"import \"example.test/widget\"\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val w = widget.New()\n" +
+		"    w.\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(300 * time.Millisecond)
+
+	list, err := h.Completion(uri, 6, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list == nil {
+		t.Fatal("dot completion returned nil for third-party Go type")
+	}
+	t.Logf("third-party widget.Widget dot completion: %v", labelSlice(list))
+	labels := collectLabels(list)
+	if !labels["Spin"] && !labels["Label"] {
+		t.Errorf("expected widget.Widget methods (Spin/Label), got %v", labelSlice(list))
+	}
+}
+
+func TestDefinition_ThirdPartyGoModule(t *testing.T) {
+	h, handler := newHarnessWithHandler(t)
+	goDir := writeThirdPartyGoModule(t)
+	handler.SetGoSrcDirs(map[string]string{"example.test/widget": goDir})
+
+	src := "package main\n" +
+		"\n" +
+		"import \"example.test/widget\"\n" +
+		"\n" +
+		"func main() {\n" +
+		"    val w = widget.New()\n" +
+		"    val s = w.Spin()\n" +
+		"    Println(s)\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(300 * time.Millisecond)
+
+	inWidgetGo := func(u lsp.DocumentURI) bool {
+		return strings.HasSuffix(strings.ToLower(string(u)), "widget.go")
+	}
+
+	// Package name "widget" at line 5, col 14
+	if locs, err := h.Definition(uri, 5, 14); err != nil {
+		t.Fatal(err)
+	} else if len(locs) == 0 || !inWidgetGo(locs[0].URI) {
+		t.Errorf("widget package name: expected widget.go, got %v", locs)
+	}
+
+	// Package function "New" at line 5, col 20
+	if locs, err := h.Definition(uri, 5, 20); err != nil {
+		t.Fatal(err)
+	} else if len(locs) == 0 || !inWidgetGo(locs[0].URI) {
+		t.Errorf("widget.New: expected widget.go, got %v", locs)
+	}
+
+	// Method "Spin" on widget.Widget at line 6, col 16
+	if locs, err := h.Definition(uri, 6, 16); err != nil {
+		t.Fatal(err)
+	} else if len(locs) == 0 || !inWidgetGo(locs[0].URI) {
+		t.Errorf("widget.Widget.Spin: expected widget.go, got %v", locs)
+	}
+}
+
+// ====================================================================
 // Definition: Word boundary (process vs processAll)
 // ====================================================================
 

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -315,14 +315,25 @@ func (a *galaAnalyzer) SetGoSrcDirs(dirs map[string]string) {
 // no prefix matches — in which case the caller leaves Go type resolution to
 // go/importer (correct for stdlib, which is always on GOROOT).
 func (a *galaAnalyzer) resolveGoSrcDir(importPath string) (string, bool) {
-	if len(a.goSrcDirs) == 0 {
+	return ResolveGoSrcDir(a.goSrcDirs, importPath)
+}
+
+// ResolveGoSrcDir maps a Go import path to its on-disk .go source directory
+// using the given module-path -> directory table. It first tries an exact
+// match, then the longest registered import-path prefix (a module path),
+// appending the remaining package subpath. Returns ("", false) when nothing is
+// wired or no prefix matches. Exported so the LSP can resolve third-party Go
+// source directories for go-to-definition using the same table the analyzer
+// uses for type inference.
+func ResolveGoSrcDir(goSrcDirs map[string]string, importPath string) (string, bool) {
+	if len(goSrcDirs) == 0 {
 		return "", false
 	}
-	if dir, ok := a.goSrcDirs[importPath]; ok {
+	if dir, ok := goSrcDirs[importPath]; ok {
 		return dir, true
 	}
 	bestKey := ""
-	for k := range a.goSrcDirs {
+	for k := range goSrcDirs {
 		if len(k) > len(bestKey) && strings.HasPrefix(importPath, k+"/") {
 			bestKey = k
 		}
@@ -331,7 +342,7 @@ func (a *galaAnalyzer) resolveGoSrcDir(importPath string) (string, bool) {
 		return "", false
 	}
 	rel := strings.TrimPrefix(importPath, bestKey+"/")
-	return filepath.Join(a.goSrcDirs[bestKey], filepath.FromSlash(rel)), true
+	return filepath.Join(goSrcDirs[bestKey], filepath.FromSlash(rel)), true
 }
 
 // Analyze walk the ANTLR tree and collects metadata for RichAST.


### PR DESCRIPTION
## Summary

Third-party Go modules (e.g. `github.com/google/uuid`) were unsupported in the IntelliJ/LSP experience. The LSP never wired the module source directories the CLI builder uses, so those types got **no `GoTypeInfo`** (dot completion returned nothing) and **no source directory** (go-to-definition was a no-op). They now resolve the same way stdlib and `go_interop` do.

Follow-up to #425 (which covered `go_interop`, native stdlib types, and cross-package return types).

## Changes
- `internal/build/builder.go` — extract `GoModuleSrcDirs(galaMod, config)` (exported; the `Builder` method delegates) so the LSP maps a Go module import path to its cached `.go` source dir identically to the compiler.
- `internal/transpiler/analyzer/analyzer.go` — export `ResolveGoSrcDir(goSrcDirs, importPath)` (exact match, then longest module-path prefix + subpath); the analyzer method delegates to it.
- `internal/lsp/server.go` — add a `goSrcDirs` table (+ `SetGoSrcDirs`), populate it from the project's `gala.mod` in `resolveProjectDeps`, and wire it into every analyzer the handler creates so `GoTypeInfo` is populated for third-party types → completion.
- `internal/lsp/definition.go` — `resolveImportDir` tries wired module dirs (third-party) before the `GOROOT` stdlib fallback → package name / function / method navigate into the cached module source.

## Tests
Hermetic (import-free Go fixture, no Go SDK needed):
- `TestCompletion_DotOnThirdPartyGoType` — `val w = widget.New(); w.` lists `Spin`/`Label`.
- `TestDefinition_ThirdPartyGoModule` — package name, function, and method all navigate into `widget.go`.

Verified locally:
- `//internal/lsp`, `//internal/build`, `//internal/transpiler/transformer` — PASS
- `//internal/transpiler/analyzer` — only the pre-existing `TestGorootFromGoBinarySymlink` Windows symlink-privilege failure (unrelated)
- `bazel build //internal/... //cmd/...` — PASS

## Notes
- Resolution reads the project's `gala.mod` Go requires and looks in the GALA dep cache / Go module cache (same source-of-truth as `gala build`). A dependency that hasn't been fetched into the cache yet won't resolve until it is.
- Method go-to-def remains struct-only (interface methods via embedding aren't resolved to source); completion still lists them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)