### PR TITLE
fix(lsp): go-to-definition on Size()/ByteSize() sugar jumps to a random method

### DIFF
--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -63,6 +63,17 @@ func (h *GalaHandler) Definition(ctx context.Context, params *lsp.DefinitionPara
 		}
 	}
 
+	// A member access (`receiver.Member` / `pkg.Symbol`) can only resolve to a
+	// member of its receiver or a package symbol — both handled above. If none
+	// matched, stop here: the global by-name scans below match on the bare name
+	// and would jump to an unrelated same-named symbol. This is what made
+	// clicking a Go primitive's `.Size()` / `.ByteSize()` sugar (which has no
+	// source definition — the transpiler lowers it to len()/utf8.RuneCountInString)
+	// land in some random type's Size() method.
+	if isDottedMemberAccess(text, line, char) {
+		return nil, nil
+	}
+
 	// Check sealed variants FIRST (Success, Failure, Some, None, etc.)
 	// Must run before the type check because companion types (e.g., "Success")
 	// would match the generic type handler and navigate to the wrong location.
@@ -234,6 +245,27 @@ func (h *GalaHandler) Definition(ctx context.Context, params *lsp.DefinitionPara
 	}
 
 	return nil, nil
+}
+
+// isDottedMemberAccess reports whether the identifier at (line, char) is a
+// member access — immediately preceded by a '.' once any partial identifier to
+// its left is walked over. Such a reference resolves only to a receiver member
+// or a package symbol; when those handlers miss, Definition must not fall
+// through to the global by-name scans.
+func isDottedMemberAccess(text string, line, char int) bool {
+	lines := strings.Split(text, "\n")
+	if line < 0 || line >= len(lines) {
+		return false
+	}
+	l := lines[line]
+	if char > len(l) {
+		char = len(l)
+	}
+	i := char
+	for i > 0 && isIdentChar(l[i-1]) {
+		i--
+	}
+	return i > 0 && l[i-1] == '.'
 }
 
 // patternBindingDefinition checks if the word at the cursor is a pattern binding

--- a/internal/lsp/size_sugar_integration_test.go
+++ b/internal/lsp/size_sugar_integration_test.go
@@ -221,6 +221,42 @@ func TestCompletion_SizeSugarOnSlice(t *testing.T) {
 	}
 }
 
+// TestDefinition_SizeSugarNoStrayJump verifies that go-to-definition on a Go
+// primitive's `.Size()` sugar does NOT jump into an unrelated type's Size()
+// method. The magic method has no source definition (the transpiler lowers it
+// to len()), so it must resolve to no location rather than falling through to a
+// global by-name scan that lands in a random same-named method.
+func TestDefinition_SizeSugarNoStrayJump(t *testing.T) {
+	h := newHarness(t)
+	src := "package main\n" +
+		"\n" +
+		"type Box struct {\n" +
+		"    val n int\n" +
+		"}\n" +
+		"func (b Box) Size() int {\n" +
+		"    return b.n\n" +
+		"}\n" +
+		"func main() {\n" +
+		"    val s = \"hello\"\n" +
+		"    val k = s.Size()\n" +
+		"    Println(k)\n" +
+		"}\n"
+	uri := openFileOnDisk(t, h, src)
+	// Cursor on "Size" of `s.Size()` — line 10 (0-indexed), col 15.
+	locs, err := h.Definition(uri, 10, 15)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range locs {
+		if l.Range.Start.Line == 5 {
+			t.Fatalf("string .Size() wrongly jumped into Box.Size() at line 5; locs=%v", locs)
+		}
+	}
+	if len(locs) != 0 {
+		t.Errorf("string .Size() should resolve to no location (magic method), got: %v", locs)
+	}
+}
+
 // hasErrorContaining reports whether any error-severity diagnostic message
 // contains substr.
 func hasErrorContaining(diags []lsp.Diagnostic, substr string) bool {


### PR DESCRIPTION
## Problem

The GALA LSP **does** auto-suggest the recently added `.Size()` / `.ByteSize()` magic methods in completion (verified: `TestCompletion_SizeSugarOnString` / `TestCompletion_SizeSugarOnSlice` pass). But **go-to-definition** on those methods was broken: clicking `.Size()` on a Go primitive (string/slice/map) jumped into an unrelated type's `Size()` method — a *different* class each time.

## Root cause

The size-sugar magic methods have no source definition — the transpiler lowers them to `len(...)` / `utf8.RuneCountInString(...)`. So `dotMethodDefinition` correctly resolved nothing. But `Definition` then fell through to a **global by-name scan of every type's method set** (`for ... range richAST.Types { if method, ok := typeMeta.Methods[word]; ok ... }`). With multiple types defining `Size`, Go's randomized map iteration picked an arbitrary same-named method — hence the "jumps into random different Size methods across different classes" symptom.

## Fix

After the qualified-reference handlers (`receiver.Member`, `pkg.Symbol`) have had their chance, short-circuit any dotted member access instead of falling through to the global scans:

```go
if isDottedMemberAccess(text, line, char) {
    return nil, nil
}
```

A dotted reference can only legitimately resolve to a receiver member or a package symbol — both handled above — so it must never match a bare same-named symbol elsewhere. This also hardens go-to-definition for any unresolved `receiver.member`, not just the size sugar.

## Tests

- Added `TestDefinition_SizeSugarNoStrayJump` (reproduces the stray jump, now returns no location).
- Full `//internal/lsp/...` suite passes — no regressions in existing method / field / Go-stdlib / third-party definition tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)