### PR TITLE
feat(concurrent): structured concurrency + cancellation for Future

### DIFF
--- a/concurrent/execution_context.go
+++ b/concurrent/execution_context.go
@@ -35,29 +35,22 @@ var NewSingleThreadEC = go_interop.NewSingleThreadEC
 var Spawn = go_interop.Spawn
 
 // === Cancellation ===
-// Re-exported from go_interop so GALA code can build structured, cancellable
-// computations without importing go_interop directly.
+// Re-exported from go_interop so GALA code can build cancellable computations
+// without importing go_interop directly. Cancellation is API-level: a Future
+// carries a token internally; user code triggers it via Future.Cancel /
+// WithTimeout and never handles a token itself.
 
-// CancelToken is an opaque cancellation handle observed by a Future's body.
+// CancelToken is the opaque cancellation handle a Future carries internally.
 type CancelToken = go_interop.CancelToken
 
 // NewCancelToken creates a CancelToken that stays live until Cancel is called.
 var NewCancelToken = go_interop.NewCancelToken
 
-// NewTimeoutToken creates a CancelToken that auto-cancels after the duration.
-var NewTimeoutToken = go_interop.NewTimeoutToken
-
-// Cancel cancels a token, closing its CancelDone Signal.
+// Cancel cancels a token.
 var Cancel = go_interop.Cancel
 
-// IsCancelled reports whether a token has been cancelled or timed out.
+// IsCancelled reports whether a token has been cancelled.
 var IsCancelled = go_interop.IsCancelled
-
-// CancelDone returns a Signal that closes when the token is cancelled.
-var CancelDone = go_interop.CancelDone
 
 // CancelErr returns the reason a token was cancelled, or nil if still live.
 var CancelErr = go_interop.CancelErr
-
-// WaitSignal blocks until a Signal (such as CancelDone) is closed.
-var WaitSignal = go_interop.WaitSignal

--- a/concurrent/execution_context.go
+++ b/concurrent/execution_context.go
@@ -51,6 +51,3 @@ var Cancel = go_interop.Cancel
 
 // IsCancelled reports whether a token has been cancelled.
 var IsCancelled = go_interop.IsCancelled
-
-// CancelErr returns the reason a token was cancelled, or nil if still live.
-var CancelErr = go_interop.CancelErr

--- a/concurrent/execution_context.go
+++ b/concurrent/execution_context.go
@@ -33,3 +33,31 @@ var NewSingleThreadEC = go_interop.NewSingleThreadEC
 // Spawn starts a new goroutine executing the given function.
 // Re-exported from go_interop for convenience with async operations.
 var Spawn = go_interop.Spawn
+
+// === Cancellation ===
+// Re-exported from go_interop so GALA code can build structured, cancellable
+// computations without importing go_interop directly.
+
+// CancelToken is an opaque cancellation handle observed by a Future's body.
+type CancelToken = go_interop.CancelToken
+
+// NewCancelToken creates a CancelToken that stays live until Cancel is called.
+var NewCancelToken = go_interop.NewCancelToken
+
+// NewTimeoutToken creates a CancelToken that auto-cancels after the duration.
+var NewTimeoutToken = go_interop.NewTimeoutToken
+
+// Cancel cancels a token, closing its CancelDone Signal.
+var Cancel = go_interop.Cancel
+
+// IsCancelled reports whether a token has been cancelled or timed out.
+var IsCancelled = go_interop.IsCancelled
+
+// CancelDone returns a Signal that closes when the token is cancelled.
+var CancelDone = go_interop.CancelDone
+
+// CancelErr returns the reason a token was cancelled, or nil if still live.
+var CancelErr = go_interop.CancelErr
+
+// WaitSignal blocks until a Signal (such as CancelDone) is closed.
+var WaitSignal = go_interop.WaitSignal

--- a/concurrent/future.gala
+++ b/concurrent/future.gala
@@ -16,6 +16,10 @@ type FutureState[T any] struct {
     var mu       *go_interop.RWMutex
     var complete bool
     var ec       go_interop.ExecutionContext
+    // cancel carries the cancellation handle for computations started via
+    // FutureCancellable. It is None for ordinary Futures, which keeps this
+    // addition non-breaking — Cancel is then a no-op.
+    var cancel   Option[go_interop.CancelToken]
 }
 
 // Future represents an asynchronous computation that will eventually produce
@@ -65,7 +69,8 @@ func NewPromise[T any](ec go_interop.ExecutionContext = nil) Promise[T] {
             once = go_interop.NewOnce(),
             mu = go_interop.NewRWMutex(),
             complete = false,
-            ec = resolvedEc
+            ec = resolvedEc,
+            cancel = None[go_interop.CancelToken]()
         )
     )
     return Promise[T](future = f)
@@ -150,6 +155,35 @@ func (f Future[T]) Apply(body func() T) Future[T] = runAsync[T](body, go_interop
 // If body panics, the Future is completed with a Failure.
 func FutureOn[T any](body func() T, ec go_interop.ExecutionContext) Future[T] = runAsync[T](body, ec)
 
+// FutureCancellable runs body asynchronously and hands it a CancelToken so the
+// computation can observe cancellation and stop cooperatively. The body polls
+// IsCancelled(tok) or blocks on WaitSignal(CancelDone(tok)); when the returned
+// Future is cancelled (via its Cancel method, WithTimeout firing, or losing a
+// Race), the token is triggered and the body can return early.
+//
+// It runs on the given ExecutionContext; a nil ec (the default) means GlobalEC().
+// If body panics, the Future is completed with a Failure. This is additive:
+// ordinary Futures created without a token treat Cancel as a no-op.
+func FutureCancellable[T any](body func(go_interop.CancelToken) T, ec go_interop.ExecutionContext = nil) Future[T] {
+    val resolvedEc = if (ec == nil) go_interop.GlobalEC() else ec
+    val token = go_interop.NewCancelToken()
+    val f = fut[T](
+        state = &FutureState[T](
+            done = go_interop.NewSignal(),
+            once = go_interop.NewOnce(),
+            mu = go_interop.NewRWMutex(),
+            complete = false,
+            ec = resolvedEc,
+            cancel = Some(token)
+        )
+    )
+    val p = Promise[T](future = f)
+    val onSuccess = () => { p.Success(body(token)) }
+    val onPanic = (r any) => { p.Failure(go_interop.PanicToError(r)) }
+    resolvedEc.ExecuteWithRecover(onSuccess, onPanic)
+    return p.Future()
+}
+
 // FutureError is a custom error type for Future-related errors.
 struct FutureError(Message string)
 
@@ -200,13 +234,25 @@ func (f Future[T]) AwaitFor(timeout Duration) Option[Try[T]] {
     return None[Try[T]]()
 }
 
+// Cancel triggers this Future's cancellation token, if it has one. Futures
+// created with FutureCancellable observe the token and can stop cooperatively;
+// for any other Future this is a no-op. Cancel does not itself complete the
+// Future — the body decides how to respond (e.g., return a sentinel value).
+func (f Future[T]) Cancel() {
+    if f.state != nil && f.state.cancel.IsDefined() {
+        go_interop.Cancel(f.state.cancel.Get())
+    }
+}
+
 // WithTimeout returns a new Future that completes with this Future's result
 // if it arrives before the timeout, or fails with TimeoutError if the timeout
 // expires first. The returned Future inherits this Future's ExecutionContext.
 //
-// WithTimeout does not cancel the underlying computation — side effects still
-// run in the background after a timeout fires. Make async work cancellable
-// (e.g., honor context.Context) if that matters.
+// When the timeout fires, WithTimeout also cancels this Future's cancellation
+// token (if it has one, e.g. it was created with FutureCancellable), so a
+// cooperating computation can stop instead of running to completion in the
+// background. For Futures without a token this is a no-op and behaviour is
+// unchanged.
 func (f Future[T]) WithTimeout(timeout Duration) Future[T] {
     val p = NewPromise[T](f.state.ec)
     f.OnComplete((r Try[T]) => {
@@ -215,7 +261,11 @@ func (f Future[T]) WithTimeout(timeout Duration) Future[T] {
     f.state.ec.Execute(() => {
         val received = go_interop.WaitSignalTimeout(f.state.done, timeout.ToGoDuration())
         if !received {
+            // Fail the bounded Future first so the timeout result wins the
+            // single-assignment race; only then cancel the token so a
+            // cooperating body stops (its later completion becomes a no-op).
             p.Failure(TimeoutError(Timeout = timeout))
+            f.Cancel()
         }
     })
     return p.Future()
@@ -541,6 +591,32 @@ func FirstCompletedOf[T any](futures Array[Future[T]]) Future[T] {
     futures.ForEach((fut Future[T]) => {
         fut.OnComplete((r Try[T]) => {
             p.Complete(r)
+        })
+    })
+
+    return p.Future()
+}
+
+// Race returns a Future that completes with the result of the first Future to
+// finish, then cancels the losers via their cancellation tokens. It is the
+// structured-concurrency form of FirstCompletedOf: the winner's result is kept
+// and every other Future is asked to stop.
+//
+// Cancellation is cooperative — a loser stops promptly only if it was created
+// with FutureCancellable and observes its token. Losers without a token simply
+// run to completion in the background (their results are discarded), exactly as
+// with FirstCompletedOf.
+func Race[T any](futures Array[Future[T]]) Future[T] {
+    val p = NewPromise[T]()
+
+    futures.ForEach((fut Future[T]) => {
+        fut.OnComplete((r Try[T]) => {
+            val won = p.Complete(r)
+            if won {
+                futures.ForEach((other Future[T]) => {
+                    other.Cancel()
+                })
+            }
         })
     })
 

--- a/concurrent/future.gala
+++ b/concurrent/future.gala
@@ -17,9 +17,10 @@ type FutureState[T any] struct {
     var complete bool
     var ec       go_interop.ExecutionContext
     // cancel carries the Future's cancellation token, shared across every stage
-    // derived from it. Root constructors create a fresh token; combinators inherit
+    // derived from it. It is always present (newPromiseWith resolves it to a
+    // concrete token); root constructors create a fresh one, combinators inherit
     // the parent's. Cancelling it short-circuits pending downstream stages.
-    var cancel   Option[go_interop.CancelToken]
+    var cancel   go_interop.CancelToken
 }
 
 // Future represents an asynchronous computation that will eventually produce
@@ -72,13 +73,16 @@ func NewPromise[T any](ec go_interop.ExecutionContext = nil) Promise[T] {
 }
 
 // newPromiseWith builds a Promise on the given ExecutionContext (nil → GlobalEC())
-// with an explicit cancellation token: an already-defined token is reused so a
-// derived stage shares its parent's token, while None means "fresh root token".
-// Combinators call this with cancel = f.state.cancel so the whole derived chain
-// shares one token and a single Cancel short-circuits every pending stage.
+// with an explicit cancellation token. The Option param is the one place the
+// fresh-vs-inherit distinction is real: Some(parent) reuses the parent's token so
+// a derived stage shares its scope, while None opens a FRESH scope with a new
+// token. Token-scope rule: linear combinators inherit (pass Some(f.state.cancel)
+// via `derive`); aggregation / scope constructors (Race, Sequence,
+// FirstCompletedOf, WithTimeout) intentionally open a fresh scope (pass None,
+// which is what NewPromise does).
 func newPromiseWith[T any](ec go_interop.ExecutionContext, cancel Option[go_interop.CancelToken]) Promise[T] {
     val resolvedEc = if (ec == nil) go_interop.GlobalEC() else ec
-    val resolvedCancel = if (cancel.IsDefined()) cancel else Some(go_interop.NewCancelToken())
+    val resolvedCancel = if (cancel.IsDefined()) cancel.Get() else go_interop.NewCancelToken()
     val f = fut[T](
         state = &FutureState[T](
             done = go_interop.NewSignal(),
@@ -191,10 +195,10 @@ struct CancellationError(Message string)
 func (e CancellationError) Error() string = e.Message
 
 // checkCancelled fails p with a CancellationError and returns true when tok is
-// defined and already cancelled, signalling the caller to skip the now-pointless
-// stage. It returns false (and does nothing) when there is nothing to cancel.
-func checkCancelled[U any](p Promise[U], tok Option[go_interop.CancelToken]) bool {
-    if tok.IsDefined() && go_interop.IsCancelled(tok.Get()) {
+// already cancelled, signalling the caller to skip the now-pointless stage. It
+// returns false (and does nothing) when the token is still live.
+func checkCancelled[U any](p Promise[U], tok go_interop.CancelToken) bool {
+    if go_interop.IsCancelled(tok) {
         p.Failure(CancellationError(Message = "future cancelled"))
         return true
     }
@@ -248,8 +252,8 @@ func (f Future[T]) AwaitFor(timeout Duration) Option[Try[T]] {
 // Cancel does not itself complete this Future, and cancelling an already
 // completed Future has no effect on its stored result.
 func (f Future[T]) Cancel() {
-    if f.state != nil && f.state.cancel.IsDefined() {
-        go_interop.Cancel(f.state.cancel.Get())
+    if f.state != nil {
+        go_interop.Cancel(f.state.cancel)
     }
 }
 
@@ -324,117 +328,92 @@ func (f Future[T]) OnFailure(callback func(error)) {
     })
 }
 
-// Map transforms the successful value of this Future using the given function.
-// If this Future fails, the resulting Future will also fail with the same error.
-// The resulting Future inherits this Future's ExecutionContext and cancellation
-// token; if the token is cancelled before this stage runs, it short-circuits.
-func (f Future[T]) Map[U any](fn func(T) U) Future[U] {
-    val p = newPromiseWith[U](f.state.ec, f.state.cancel)
+// derive builds a new Future stage that inherits this Future's ExecutionContext
+// and cancellation token. Once this Future completes it runs handle(p, r) on the
+// EC, but only after the shared-token boundary check: if the token is already
+// cancelled the derived stage short-circuits with a CancellationError and handle
+// never runs. Every linear combinator below is expressed through it, so the
+// promise-creation + OnComplete + cancellation-guard scaffold lives in one place.
+func (f Future[T]) derive[U any](handle func(Promise[U], Try[T])) Future[U] {
+    val p = newPromiseWith[U](f.state.ec, Some(f.state.cancel))
     f.OnComplete((r Try[T]) => {
         if !checkCancelled(p, f.state.cancel) {
-            p.Complete(r.Map[U](fn))
+            handle(p, r)
         }
     })
     return p.Future()
 }
 
+// Map transforms the successful value of this Future using the given function.
+// If this Future fails, the resulting Future will also fail with the same error.
+// The resulting Future inherits this Future's ExecutionContext and cancellation
+// token; if the token is cancelled before this stage runs, it short-circuits.
+func (f Future[T]) Map[U any](fn func(T) U) Future[U] =
+    f.derive[U]((p, r) => { p.Complete(r.Map[U](fn)) })
+
 // FlatMap transforms the successful value of this Future using a function
 // that returns another Future. This allows chaining asynchronous operations.
 // The resulting Future inherits this Future's ExecutionContext.
-func (f Future[T]) FlatMap[U any](fn func(T) Future[U]) Future[U] {
-    val p = newPromiseWith[U](f.state.ec, f.state.cancel)
-    f.OnComplete((r Try[T]) => {
-        if !checkCancelled(p, f.state.cancel) {
-            r match {
-                case Success(v) => fn(v).OnComplete((innerResult Try[U]) => {
-                    p.Complete(innerResult)
-                })
-                case Failure(e) => p.Failure(e)
-            }
+func (f Future[T]) FlatMap[U any](fn func(T) Future[U]) Future[U] =
+    f.derive[U]((p, r) => {
+        r match {
+            case Success(v) => fn(v).OnComplete((innerResult Try[U]) => {
+                p.Complete(innerResult)
+            })
+            case Failure(e) => p.Failure(e)
         }
     })
-    return p.Future()
-}
 
 // Filter returns a new Future that contains the value only if it satisfies
 // the predicate. If the predicate returns false, the Future fails with
 // NoSuchElementError.
 // The resulting Future inherits this Future's ExecutionContext.
-func (f Future[T]) Filter(predicate func(T) bool) Future[T] {
-    val p = newPromiseWith[T](f.state.ec, f.state.cancel)
-    f.OnComplete((r Try[T]) => {
-        if !checkCancelled(p, f.state.cancel) {
-            p.Complete(r.Filter(predicate))
-        }
-    })
-    return p.Future()
-}
+func (f Future[T]) Filter(predicate func(T) bool) Future[T] =
+    f.derive[T]((p, r) => { p.Complete(r.Filter(predicate)) })
 
 // Recover handles failures by applying a recovery function.
 // If this Future fails, the recovery function is applied to the error
 // to produce a successful value.
 // The resulting Future inherits this Future's ExecutionContext.
-func (f Future[T]) Recover(pf func(error) T) Future[T] {
-    val p = newPromiseWith[T](f.state.ec, f.state.cancel)
-    f.OnComplete((r Try[T]) => {
-        if !checkCancelled(p, f.state.cancel) {
-            p.Complete(r.Recover(pf))
-        }
-    })
-    return p.Future()
-}
+func (f Future[T]) Recover(pf func(error) T) Future[T] =
+    f.derive[T]((p, r) => { p.Complete(r.Recover(pf)) })
 
 // RecoverWith handles failures by applying a recovery function
 // that returns another Future.
 // The resulting Future inherits this Future's ExecutionContext.
-func (f Future[T]) RecoverWith(pf func(error) Future[T]) Future[T] {
-    val p = newPromiseWith[T](f.state.ec, f.state.cancel)
-    f.OnComplete((r Try[T]) => {
-        if !checkCancelled(p, f.state.cancel) {
-            r match {
-                case Success(v) => p.Success(v)
-                case Failure(e) => pf(e).OnComplete((recovered Try[T]) => {
-                    p.Complete(recovered)
-                })
-            }
+func (f Future[T]) RecoverWith(pf func(error) Future[T]) Future[T] =
+    f.derive[T]((p, r) => {
+        r match {
+            case Success(v) => p.Success(v)
+            case Failure(e) => pf(e).OnComplete((recovered Try[T]) => {
+                p.Complete(recovered)
+            })
         }
     })
-    return p.Future()
-}
 
 // Transform applies success or failure function based on the result.
 // The resulting Future inherits this Future's ExecutionContext.
-func (f Future[T]) Transform[U any](s func(T) Try[U], fn func(error) Try[U]) Future[U] {
-    val p = newPromiseWith[U](f.state.ec, f.state.cancel)
-    f.OnComplete((r Try[T]) => {
-        if !checkCancelled(p, f.state.cancel) {
-            r match {
-                case Success(v) => p.Complete(s(v))
-                case Failure(e) => p.Complete(fn(e))
-            }
+func (f Future[T]) Transform[U any](s func(T) Try[U], fn func(error) Try[U]) Future[U] =
+    f.derive[U]((p, r) => {
+        r match {
+            case Success(v) => p.Complete(s(v))
+            case Failure(e) => p.Complete(fn(e))
         }
     })
-    return p.Future()
-}
 
 // TransformWith applies success or failure function that returns a Future.
 // The resulting Future inherits this Future's ExecutionContext.
-func (f Future[T]) TransformWith[U any](s func(T) Future[U], fn func(error) Future[U]) Future[U] {
-    val p = newPromiseWith[U](f.state.ec, f.state.cancel)
-    f.OnComplete((r Try[T]) => {
-        if !checkCancelled(p, f.state.cancel) {
-            r match {
-                case Success(v) => s(v).OnComplete((res Try[U]) => {
-                    p.Complete(res)
-                })
-                case Failure(e) => fn(e).OnComplete((res Try[U]) => {
-                    p.Complete(res)
-                })
-            }
+func (f Future[T]) TransformWith[U any](s func(T) Future[U], fn func(error) Future[U]) Future[U] =
+    f.derive[U]((p, r) => {
+        r match {
+            case Success(v) => s(v).OnComplete((res Try[U]) => {
+                p.Complete(res)
+            })
+            case Failure(e) => fn(e).OnComplete((res Try[U]) => {
+                p.Complete(res)
+            })
         }
     })
-    return p.Future()
-}
 
 // Zip combines two Futures into a Future of a tuple.
 // The resulting Future inherits this Future's ExecutionContext. Zip, ZipWith,
@@ -538,16 +517,11 @@ func (f Future[T]) Fallback(that Future[T]) Future[T] {
 // AndThen registers a callback and returns a new Future that completes
 // with the same result after the callback executes.
 // The resulting Future inherits this Future's ExecutionContext.
-func (f Future[T]) AndThen(callback func(Try[T])) Future[T] {
-    val p = newPromiseWith[T](f.state.ec, f.state.cancel)
-    f.OnComplete((r Try[T]) => {
-        if !checkCancelled(p, f.state.cancel) {
-            callback(r)
-            p.Complete(r)
-        }
+func (f Future[T]) AndThen(callback func(Try[T])) Future[T] =
+    f.derive[T]((p, r) => {
+        callback(r)
+        p.Complete(r)
     })
-    return p.Future()
-}
 
 // ToTry converts the Future to a Try by blocking until completion.
 func (f Future[T]) ToTry() Try[T] = f.Await()

--- a/concurrent/future.gala
+++ b/concurrent/future.gala
@@ -16,9 +16,9 @@ type FutureState[T any] struct {
     var mu       *go_interop.RWMutex
     var complete bool
     var ec       go_interop.ExecutionContext
-    // cancel carries the cancellation handle for computations started via
-    // FutureCancellable. It is None for ordinary Futures, which keeps this
-    // addition non-breaking — Cancel is then a no-op.
+    // cancel carries the Future's cancellation token, shared across every stage
+    // derived from it. Root constructors create a fresh token; combinators inherit
+    // the parent's. Cancelling it short-circuits pending downstream stages.
     var cancel   Option[go_interop.CancelToken]
 }
 
@@ -61,8 +61,24 @@ struct Promise[T any](future Future[T])
 // The default is a bare nil rather than GlobalEC() so the injected default at
 // each call site carries no package qualifier — callers need not import the
 // ExecutionContext's defining package.
+//
+// Every Promise carries a cancellation token: NewPromise creates a fresh one, so
+// each root Future gets its own. The public signature keeps only the `ec` default
+// (a bare nil that injects no package qualifier at call sites); the token plumbing
+// lives in the package-private newPromiseWith so callers outside this package
+// never have go_interop leaked into their generated code.
 func NewPromise[T any](ec go_interop.ExecutionContext = nil) Promise[T] {
+    return newPromiseWith[T](ec, None[go_interop.CancelToken]())
+}
+
+// newPromiseWith builds a Promise on the given ExecutionContext (nil → GlobalEC())
+// with an explicit cancellation token: an already-defined token is reused so a
+// derived stage shares its parent's token, while None means "fresh root token".
+// Combinators call this with cancel = f.state.cancel so the whole derived chain
+// shares one token and a single Cancel short-circuits every pending stage.
+func newPromiseWith[T any](ec go_interop.ExecutionContext, cancel Option[go_interop.CancelToken]) Promise[T] {
     val resolvedEc = if (ec == nil) go_interop.GlobalEC() else ec
+    val resolvedCancel = if (cancel.IsDefined()) cancel else Some(go_interop.NewCancelToken())
     val f = fut[T](
         state = &FutureState[T](
             done = go_interop.NewSignal(),
@@ -70,7 +86,7 @@ func NewPromise[T any](ec go_interop.ExecutionContext = nil) Promise[T] {
             mu = go_interop.NewRWMutex(),
             complete = false,
             ec = resolvedEc,
-            cancel = None[go_interop.CancelToken]()
+            cancel = resolvedCancel
         )
     )
     return Promise[T](future = f)
@@ -155,35 +171,6 @@ func (f Future[T]) Apply(body func() T) Future[T] = runAsync[T](body, go_interop
 // If body panics, the Future is completed with a Failure.
 func FutureOn[T any](body func() T, ec go_interop.ExecutionContext) Future[T] = runAsync[T](body, ec)
 
-// FutureCancellable runs body asynchronously and hands it a CancelToken so the
-// computation can observe cancellation and stop cooperatively. The body polls
-// IsCancelled(tok) or blocks on WaitSignal(CancelDone(tok)); when the returned
-// Future is cancelled (via its Cancel method, WithTimeout firing, or losing a
-// Race), the token is triggered and the body can return early.
-//
-// It runs on the given ExecutionContext; a nil ec (the default) means GlobalEC().
-// If body panics, the Future is completed with a Failure. This is additive:
-// ordinary Futures created without a token treat Cancel as a no-op.
-func FutureCancellable[T any](body func(go_interop.CancelToken) T, ec go_interop.ExecutionContext = nil) Future[T] {
-    val resolvedEc = if (ec == nil) go_interop.GlobalEC() else ec
-    val token = go_interop.NewCancelToken()
-    val f = fut[T](
-        state = &FutureState[T](
-            done = go_interop.NewSignal(),
-            once = go_interop.NewOnce(),
-            mu = go_interop.NewRWMutex(),
-            complete = false,
-            ec = resolvedEc,
-            cancel = Some(token)
-        )
-    )
-    val p = Promise[T](future = f)
-    val onSuccess = () => { p.Success(body(token)) }
-    val onPanic = (r any) => { p.Failure(go_interop.PanicToError(r)) }
-    resolvedEc.ExecuteWithRecover(onSuccess, onPanic)
-    return p.Future()
-}
-
 // FutureError is a custom error type for Future-related errors.
 struct FutureError(Message string)
 
@@ -193,6 +180,26 @@ func (e FutureError) Error() string = e.Message
 struct TimeoutError(Timeout Duration)
 
 func (e TimeoutError) Error() string = s"future timed out after ${e.Timeout}"
+
+// CancellationError is returned by a derived Future whose pending stage was
+// short-circuited because the shared cancellation token was triggered (via
+// Future.Cancel, WithTimeout firing, or losing a Race). It never aborts an
+// already-running body — Go has no goroutine interruption — it only prevents a
+// not-yet-started downstream stage from running.
+struct CancellationError(Message string)
+
+func (e CancellationError) Error() string = e.Message
+
+// checkCancelled fails p with a CancellationError and returns true when tok is
+// defined and already cancelled, signalling the caller to skip the now-pointless
+// stage. It returns false (and does nothing) when there is nothing to cancel.
+func checkCancelled[U any](p Promise[U], tok Option[go_interop.CancelToken]) bool {
+    if tok.IsDefined() && go_interop.IsCancelled(tok.Get()) {
+        p.Failure(CancellationError(Message = "future cancelled"))
+        return true
+    }
+    return false
+}
 
 // IsCompleted returns true if the Future has been completed (success or failure).
 func (f Future[T]) IsCompleted() bool {
@@ -234,10 +241,12 @@ func (f Future[T]) AwaitFor(timeout Duration) Option[Try[T]] {
     return None[Try[T]]()
 }
 
-// Cancel triggers this Future's cancellation token, if it has one. Futures
-// created with FutureCancellable observe the token and can stop cooperatively;
-// for any other Future this is a no-op. Cancel does not itself complete the
-// Future — the body decides how to respond (e.g., return a sentinel value).
+// Cancel triggers this Future's cancellation token, which is shared by every
+// stage derived from it. Any pending downstream combinator (Map, FlatMap, etc.)
+// that has not yet started short-circuits with a CancellationError; an
+// already-running body is not interrupted (Go has no goroutine interruption).
+// Cancel does not itself complete this Future, and cancelling an already
+// completed Future has no effect on its stored result.
 func (f Future[T]) Cancel() {
     if f.state != nil && f.state.cancel.IsDefined() {
         go_interop.Cancel(f.state.cancel.Get())
@@ -248,11 +257,10 @@ func (f Future[T]) Cancel() {
 // if it arrives before the timeout, or fails with TimeoutError if the timeout
 // expires first. The returned Future inherits this Future's ExecutionContext.
 //
-// When the timeout fires, WithTimeout also cancels this Future's cancellation
-// token (if it has one, e.g. it was created with FutureCancellable), so a
-// cooperating computation can stop instead of running to completion in the
-// background. For Futures without a token this is a no-op and behaviour is
-// unchanged.
+// When the timeout fires, WithTimeout also cancels this Future's shared
+// cancellation token, so pending downstream stages short-circuit instead of
+// running after the deadline. The bounded Future is failed first so the timeout
+// result wins the single-assignment race.
 func (f Future[T]) WithTimeout(timeout Duration) Future[T] {
     val p = NewPromise[T](f.state.ec)
     f.OnComplete((r Try[T]) => {
@@ -318,11 +326,14 @@ func (f Future[T]) OnFailure(callback func(error)) {
 
 // Map transforms the successful value of this Future using the given function.
 // If this Future fails, the resulting Future will also fail with the same error.
-// The resulting Future inherits this Future's ExecutionContext.
+// The resulting Future inherits this Future's ExecutionContext and cancellation
+// token; if the token is cancelled before this stage runs, it short-circuits.
 func (f Future[T]) Map[U any](fn func(T) U) Future[U] {
-    val p = NewPromise[U](f.state.ec)
+    val p = newPromiseWith[U](f.state.ec, f.state.cancel)
     f.OnComplete((r Try[T]) => {
-        p.Complete(r.Map[U](fn))
+        if !checkCancelled(p, f.state.cancel) {
+            p.Complete(r.Map[U](fn))
+        }
     })
     return p.Future()
 }
@@ -331,13 +342,15 @@ func (f Future[T]) Map[U any](fn func(T) U) Future[U] {
 // that returns another Future. This allows chaining asynchronous operations.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) FlatMap[U any](fn func(T) Future[U]) Future[U] {
-    val p = NewPromise[U](f.state.ec)
+    val p = newPromiseWith[U](f.state.ec, f.state.cancel)
     f.OnComplete((r Try[T]) => {
-        r match {
-            case Success(v) => fn(v).OnComplete((innerResult Try[U]) => {
-                p.Complete(innerResult)
-            })
-            case Failure(e) => p.Failure(e)
+        if !checkCancelled(p, f.state.cancel) {
+            r match {
+                case Success(v) => fn(v).OnComplete((innerResult Try[U]) => {
+                    p.Complete(innerResult)
+                })
+                case Failure(e) => p.Failure(e)
+            }
         }
     })
     return p.Future()
@@ -348,9 +361,11 @@ func (f Future[T]) FlatMap[U any](fn func(T) Future[U]) Future[U] {
 // NoSuchElementError.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) Filter(predicate func(T) bool) Future[T] {
-    val p = NewPromise[T](f.state.ec)
+    val p = newPromiseWith[T](f.state.ec, f.state.cancel)
     f.OnComplete((r Try[T]) => {
-        p.Complete(r.Filter(predicate))
+        if !checkCancelled(p, f.state.cancel) {
+            p.Complete(r.Filter(predicate))
+        }
     })
     return p.Future()
 }
@@ -360,9 +375,11 @@ func (f Future[T]) Filter(predicate func(T) bool) Future[T] {
 // to produce a successful value.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) Recover(pf func(error) T) Future[T] {
-    val p = NewPromise[T](f.state.ec)
+    val p = newPromiseWith[T](f.state.ec, f.state.cancel)
     f.OnComplete((r Try[T]) => {
-        p.Complete(r.Recover(pf))
+        if !checkCancelled(p, f.state.cancel) {
+            p.Complete(r.Recover(pf))
+        }
     })
     return p.Future()
 }
@@ -371,13 +388,15 @@ func (f Future[T]) Recover(pf func(error) T) Future[T] {
 // that returns another Future.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) RecoverWith(pf func(error) Future[T]) Future[T] {
-    val p = NewPromise[T](f.state.ec)
+    val p = newPromiseWith[T](f.state.ec, f.state.cancel)
     f.OnComplete((r Try[T]) => {
-        r match {
-            case Success(v) => p.Success(v)
-            case Failure(e) => pf(e).OnComplete((recovered Try[T]) => {
-                p.Complete(recovered)
-            })
+        if !checkCancelled(p, f.state.cancel) {
+            r match {
+                case Success(v) => p.Success(v)
+                case Failure(e) => pf(e).OnComplete((recovered Try[T]) => {
+                    p.Complete(recovered)
+                })
+            }
         }
     })
     return p.Future()
@@ -386,11 +405,13 @@ func (f Future[T]) RecoverWith(pf func(error) Future[T]) Future[T] {
 // Transform applies success or failure function based on the result.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) Transform[U any](s func(T) Try[U], fn func(error) Try[U]) Future[U] {
-    val p = NewPromise[U](f.state.ec)
+    val p = newPromiseWith[U](f.state.ec, f.state.cancel)
     f.OnComplete((r Try[T]) => {
-        r match {
-            case Success(v) => p.Complete(s(v))
-            case Failure(e) => p.Complete(fn(e))
+        if !checkCancelled(p, f.state.cancel) {
+            r match {
+                case Success(v) => p.Complete(s(v))
+                case Failure(e) => p.Complete(fn(e))
+            }
         }
     })
     return p.Future()
@@ -399,22 +420,26 @@ func (f Future[T]) Transform[U any](s func(T) Try[U], fn func(error) Try[U]) Fut
 // TransformWith applies success or failure function that returns a Future.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) TransformWith[U any](s func(T) Future[U], fn func(error) Future[U]) Future[U] {
-    val p = NewPromise[U](f.state.ec)
+    val p = newPromiseWith[U](f.state.ec, f.state.cancel)
     f.OnComplete((r Try[T]) => {
-        r match {
-            case Success(v) => s(v).OnComplete((res Try[U]) => {
-                p.Complete(res)
-            })
-            case Failure(e) => fn(e).OnComplete((res Try[U]) => {
-                p.Complete(res)
-            })
+        if !checkCancelled(p, f.state.cancel) {
+            r match {
+                case Success(v) => s(v).OnComplete((res Try[U]) => {
+                    p.Complete(res)
+                })
+                case Failure(e) => fn(e).OnComplete((res Try[U]) => {
+                    p.Complete(res)
+                })
+            }
         }
     })
     return p.Future()
 }
 
 // Zip combines two Futures into a Future of a tuple.
-// The resulting Future inherits this Future's ExecutionContext.
+// The resulting Future inherits this Future's ExecutionContext. Zip, ZipWith,
+// Zip2..Zip10 and Fallback are defined in terms of FlatMap/Map/RecoverWith, so
+// they inherit this Future's cancellation token and boundary check transitively.
 func (f Future[T]) Zip[U any](other Future[U]) Future[Tuple[T, U]] {
     return f.FlatMap[Tuple[T, U]]((t T) => {
         return other.Map[Tuple[T, U]]((u U) => (t, u))
@@ -514,10 +539,12 @@ func (f Future[T]) Fallback(that Future[T]) Future[T] {
 // with the same result after the callback executes.
 // The resulting Future inherits this Future's ExecutionContext.
 func (f Future[T]) AndThen(callback func(Try[T])) Future[T] {
-    val p = NewPromise[T](f.state.ec)
+    val p = newPromiseWith[T](f.state.ec, f.state.cancel)
     f.OnComplete((r Try[T]) => {
-        callback(r)
-        p.Complete(r)
+        if !checkCancelled(p, f.state.cancel) {
+            callback(r)
+            p.Complete(r)
+        }
     })
     return p.Future()
 }
@@ -600,12 +627,13 @@ func FirstCompletedOf[T any](futures Array[Future[T]]) Future[T] {
 // Race returns a Future that completes with the result of the first Future to
 // finish, then cancels the losers via their cancellation tokens. It is the
 // structured-concurrency form of FirstCompletedOf: the winner's result is kept
-// and every other Future is asked to stop.
+// and every other Future's shared token is cancelled, so their pending
+// downstream stages short-circuit instead of running on.
 //
-// Cancellation is cooperative — a loser stops promptly only if it was created
-// with FutureCancellable and observes its token. Losers without a token simply
-// run to completion in the background (their results are discarded), exactly as
-// with FirstCompletedOf.
+// Cancellation is coarse and cooperative: a loser's already-running body is not
+// interrupted (Go has no goroutine interruption), but any stage derived from it
+// that has not yet started fails with a CancellationError. The Race result
+// itself carries a fresh token and is unaffected.
 func Race[T any](futures Array[Future[T]]) Future[T] {
     val p = NewPromise[T]()
 

--- a/concurrent/future_test.gala
+++ b/concurrent/future_test.gala
@@ -461,3 +461,79 @@ func TestPoolShutdownGraceful(t T) T {
     val t3 = Eq(t2, r2.Get(), 20)
     return Eq(t3, r3.Get(), 30)
 }
+
+// === Cancellation Tests ===
+
+// A cancellable future whose body blocks on its token observes the cancellation
+// and stops, completing with the sentinel it returns after the signal.
+func TestFutureCancellableObservesCancellation(t T) T {
+    val f = FutureCancellable[string]((tok) => {
+        WaitSignal(CancelDone(tok))
+        "cancelled"
+    })
+    Sleep(Milliseconds(20))
+    f.Cancel()
+    val result = f.Await()
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), "cancelled")
+}
+
+// IsCancelled reflects the token state before and after Cancel.
+func TestIsCancelledReflectsState(t T) T {
+    val tok = NewCancelToken()
+    val before = IsCancelled(tok)
+    Cancel(tok)
+    // Give the monitor goroutine a beat; IsCancelled itself does not block.
+    Sleep(Milliseconds(10))
+    val after = IsCancelled(tok)
+    val t1 = IsFalse(t, before)
+    return IsTrue(t1, after)
+}
+
+// WithTimeout now cancels the underlying token when it fires, so a cooperating
+// computation stops instead of leaking. The bounded Future fails with a timeout,
+// and the original Future subsequently completes with its cancellation sentinel.
+func TestWithTimeoutSignalsToken(t T) T {
+    val f = FutureCancellable[string]((tok) => {
+        WaitSignal(CancelDone(tok))
+        "stopped"
+    })
+    val bounded = f.WithTimeout(Milliseconds(50))
+    val timedOut = bounded.Await()
+    val t1 = IsFailure(t, timedOut)
+    val t2 = Contains(t1, timedOut.Err.Error(), "timed out")
+    // The token was cancelled by WithTimeout, so the body unblocks and completes.
+    val inner = f.Await()
+    val t3 = IsSuccess(t2, inner)
+    return Eq(t3, inner.Get(), "stopped")
+}
+
+// Race returns the first result and cancels the loser, which then completes with
+// its cancellation sentinel.
+func TestRaceCancelsLoser(t T) T {
+    val winner = FutureCancellable[string]((tok) => {
+        Sleep(Milliseconds(20))
+        "winner"
+    })
+    val loser = FutureCancellable[string]((tok) => {
+        WaitSignal(CancelDone(tok))
+        "loser-cancelled"
+    })
+    val racy = Race[string](ArrayOf[Future[string]](winner, loser))
+    val result = racy.Await()
+    val t1 = IsSuccess(t, result)
+    val t2 = Eq(t1, result.Get(), "winner")
+    // The loser was cancelled by Race and unblocks with its sentinel.
+    val loserResult = loser.Await()
+    val t3 = IsSuccess(t2, loserResult)
+    return Eq(t3, loserResult.Get(), "loser-cancelled")
+}
+
+// Ordinary (non-cancellable) Futures ignore Cancel — it is a safe no-op.
+func TestCancelNoOpOnPlainFuture(t T) T {
+    val f = FutureOf(42)
+    f.Cancel()
+    val result = f.Await()
+    val t1 = IsSuccess(t, result)
+    return Eq(t1, result.Get(), 42)
+}

--- a/concurrent/future_test.gala
+++ b/concurrent/future_test.gala
@@ -464,76 +464,63 @@ func TestPoolShutdownGraceful(t T) T {
 
 // === Cancellation Tests ===
 
-// A cancellable future whose body blocks on its token observes the cancellation
-// and stops, completing with the sentinel it returns after the signal.
-func TestFutureCancellableObservesCancellation(t T) T {
-    val f = FutureCancellable[string]((tok) => {
-        WaitSignal(CancelDone(tok))
-        "cancelled"
-    })
-    Sleep(Milliseconds(20))
-    f.Cancel()
-    val result = f.Await()
-    val t1 = IsSuccess(t, result)
-    return Eq(t1, result.Get(), "cancelled")
+// Cancelling a chain before a pending stage runs short-circuits that stage with
+// a CancellationError. A Promise gate keeps the root pending until after Cancel,
+// so the Map boundary check is guaranteed to observe the cancellation.
+func TestCancelShortCircuitsPendingStage(t T) T {
+    val gate = NewPromise[int]()
+    val mapped = gate.Future().Map((x) => x * 2)
+    // Cancel the shared chain before the gate opens and the Map can run.
+    mapped.Cancel()
+    gate.Success(5)
+    val result = mapped.Await()
+    val t1 = IsFailure(t, result)
+    return Contains(t1, result.Err.Error(), "cancelled")
 }
 
-// IsCancelled reflects the token state before and after Cancel.
-func TestIsCancelledReflectsState(t T) T {
-    val tok = NewCancelToken()
-    val before = IsCancelled(tok)
-    Cancel(tok)
-    // Give the monitor goroutine a beat; IsCancelled itself does not block.
-    Sleep(Milliseconds(10))
-    val after = IsCancelled(tok)
-    val t1 = IsFalse(t, before)
-    return IsTrue(t1, after)
+// WithTimeout fires TimeoutError and cancels the shared token, so a stage chained
+// off the underlying Future short-circuits after the deadline.
+func TestWithTimeoutFiresAndCancels(t T) T {
+    val gate = NewPromise[int]()
+    val root = gate.Future()
+    val bounded = root.WithTimeout(Milliseconds(50))
+    val boundedResult = bounded.Await()
+    val t1 = IsFailure(t, boundedResult)
+    val t2 = Contains(t1, boundedResult.Err.Error(), "timed out")
+    // Let the timeout goroutine finish cancelling the shared token.
+    Sleep(Milliseconds(30))
+    val downstream = root.Map((x) => x + 1)
+    gate.Success(1)
+    val dr = downstream.Await()
+    val t3 = IsFailure(t2, dr)
+    return Contains(t3, dr.Err.Error(), "cancelled")
 }
 
-// WithTimeout now cancels the underlying token when it fires, so a cooperating
-// computation stops instead of leaking. The bounded Future fails with a timeout,
-// and the original Future subsequently completes with its cancellation sentinel.
-func TestWithTimeoutSignalsToken(t T) T {
-    val f = FutureCancellable[string]((tok) => {
-        WaitSignal(CancelDone(tok))
-        "stopped"
-    })
-    val bounded = f.WithTimeout(Milliseconds(50))
-    val timedOut = bounded.Await()
-    val t1 = IsFailure(t, timedOut)
-    val t2 = Contains(t1, timedOut.Err.Error(), "timed out")
-    // The token was cancelled by WithTimeout, so the body unblocks and completes.
-    val inner = f.Await()
-    val t3 = IsSuccess(t2, inner)
-    return Eq(t3, inner.Get(), "stopped")
-}
-
-// Race returns the first result and cancels the loser, which then completes with
-// its cancellation sentinel.
+// Race returns the first result and cancels the losers, so a stage chained off a
+// loser short-circuits with a CancellationError.
 func TestRaceCancelsLoser(t T) T {
-    val winner = FutureCancellable[string]((tok) => {
-        Sleep(Milliseconds(20))
-        "winner"
-    })
-    val loser = FutureCancellable[string]((tok) => {
-        WaitSignal(CancelDone(tok))
-        "loser-cancelled"
-    })
-    val racy = Race[string](ArrayOf[Future[string]](winner, loser))
+    val winnerGate = NewPromise[int]()
+    val loserGate = NewPromise[int]()
+    val winner = winnerGate.Future()
+    val loser = loserGate.Future()
+    winnerGate.Success(1)
+    val racy = Race[int](ArrayOf[Future[int]](winner, loser))
     val result = racy.Await()
     val t1 = IsSuccess(t, result)
-    val t2 = Eq(t1, result.Get(), "winner")
-    // The loser was cancelled by Race and unblocks with its sentinel.
-    val loserResult = loser.Await()
-    val t3 = IsSuccess(t2, loserResult)
-    return Eq(t3, loserResult.Get(), "loser-cancelled")
+    val t2 = Eq(t1, result.Get(), 1)
+    // Let Race finish cancelling the losers' tokens.
+    Sleep(Milliseconds(30))
+    val downstream = loser.Map((x) => x + 1)
+    loserGate.Success(99)
+    val dr = downstream.Await()
+    val t3 = IsFailure(t2, dr)
+    return Contains(t3, dr.Err.Error(), "cancelled")
 }
 
-// Ordinary (non-cancellable) Futures ignore Cancel — it is a safe no-op.
-func TestCancelNoOpOnPlainFuture(t T) T {
-    val f = FutureOf(42)
-    f.Cancel()
+// A chain that is never cancelled completes normally (non-breaking regression).
+func TestNoCancellationCompletesNormally(t T) T {
+    val f = FutureOf(42).Map((x) => x + 1).Map((x) => x * 2)
     val result = f.Await()
     val t1 = IsSuccess(t, result)
-    return Eq(t1, result.Get(), 42)
+    return Eq(t1, result.Get(), 86)
 }

--- a/docs/CONCURRENT.MD
+++ b/docs/CONCURRENT.MD
@@ -77,14 +77,56 @@ val bounded = slow.WithTimeout(Milliseconds(500))
 val maybe = slow.AwaitFor(Milliseconds(500))      // None on timeout
 ```
 
-`WithTimeout` does not cancel the underlying computation — side effects still run after the timeout fires. Make async work cancellable (e.g., honor `context.Context`) if that matters.
+When the timeout fires, `WithTimeout` also cancels the underlying Future's
+cancellation token, if it has one (i.e. it was created with `FutureCancellable`),
+so a cooperating computation can stop instead of running to completion in the
+background. For a plain Future without a token this is a no-op and behaviour is
+unchanged — the body keeps running and its result is discarded. See
+[Cancellation](#cancellation) for how to make a Future observe its token.
 
 ### Combining Futures
 
 ```gala
 val zipped = f1.Zip(f2)               // Future[Tuple[int, string]]
 val first = f1.Fallback(f2)          // First success or last failure
+val winner = Race[int](ArrayOf[Future[int]](a, b))  // first result, cancels losers
 ```
+
+`Race` is the structured-concurrency form of `FirstCompletedOf`: it completes
+with the first Future to finish and then cancels the losers via their
+cancellation tokens (cooperative — a loser stops promptly only if it was created
+with `FutureCancellable`).
+
+### Cancellation
+
+`FutureCancellable` hands the computation an opaque `CancelToken` so it can
+observe cancellation without threading a raw `context.Context` through GALA. The
+token is triggered by the Future's `Cancel()` method, by `WithTimeout` firing, or
+by losing a `Race`. Cancellation is cooperative: the body decides how to respond.
+
+```gala
+// Poll IsCancelled, or block on the token's done Signal via WaitSignal.
+val f = FutureCancellable[string]((tok) => {
+    WaitSignal(CancelDone(tok))     // unblocks when the token is cancelled
+    "cancelled"                     // or return a partial/sentinel result
+})
+
+f.Cancel()                          // trigger cancellation
+Println(f.Get())                    // "cancelled"
+```
+
+Token API (re-exported from `go_interop` into the `concurrent` namespace):
+
+- `CancelToken` — opaque handle wrapping a context and its cancel function.
+- `NewCancelToken() CancelToken` — a token that stays live until `Cancel`.
+- `NewTimeoutToken(goDuration) CancelToken` — auto-cancels after the duration.
+- `Cancel(tok)` — cancel the token (safe to call more than once).
+- `IsCancelled(tok) bool` — non-blocking check.
+- `CancelDone(tok) Signal` — a Signal that closes on cancel; block on it with `WaitSignal`.
+- `CancelErr(tok) error` — cancellation reason, or nil while live.
+
+`Cancel()` on a plain Future (one created without a token) is a safe no-op, so
+this is fully additive to existing code.
 
 ---
 

--- a/docs/CONCURRENT.MD
+++ b/docs/CONCURRENT.MD
@@ -78,11 +78,10 @@ val maybe = slow.AwaitFor(Milliseconds(500))      // None on timeout
 ```
 
 When the timeout fires, `WithTimeout` also cancels the underlying Future's
-cancellation token, if it has one (i.e. it was created with `FutureCancellable`),
-so a cooperating computation can stop instead of running to completion in the
-background. For a plain Future without a token this is a no-op and behaviour is
-unchanged — the body keeps running and its result is discarded. See
-[Cancellation](#cancellation) for how to make a Future observe its token.
+cancellation token, so pending downstream stages short-circuit instead of running
+after the deadline (see [Cancellation](#cancellation)). The bounded Future is
+failed with `TimeoutError` first, so that result wins even though cancellation
+also unblocks the chain.
 
 ### Combining Futures
 
@@ -93,40 +92,41 @@ val winner = Race[int](ArrayOf[Future[int]](a, b))  // first result, cancels los
 ```
 
 `Race` is the structured-concurrency form of `FirstCompletedOf`: it completes
-with the first Future to finish and then cancels the losers via their
-cancellation tokens (cooperative — a loser stops promptly only if it was created
-with `FutureCancellable`).
+with the first Future to finish and then cancels the losing Futures' shared
+tokens, so their pending downstream stages short-circuit.
 
 ### Cancellation
 
-`FutureCancellable` hands the computation an opaque `CancelToken` so it can
-observe cancellation without threading a raw `context.Context` through GALA. The
-token is triggered by the Future's `Cancel()` method, by `WithTimeout` firing, or
-by losing a `Race`. Cancellation is cooperative: the body decides how to respond.
+Cancellation is **API-level**: you cancel a Future with `.Cancel()` (or let
+`.WithTimeout()` / `Race` cancel it for you). There is no token in user code — a
+Future carries an opaque cancellation token internally.
 
 ```gala
-// Poll IsCancelled, or block on the token's done Signal via WaitSignal.
-val f = FutureCancellable[string]((tok) => {
-    WaitSignal(CancelDone(tok))     // unblocks when the token is cancelled
-    "cancelled"                     // or return a partial/sentinel result
-})
-
-f.Cancel()                          // trigger cancellation
-Println(f.Get())                    // "cancelled"
+val chain = source.Map((v) => step1(v)).FlatMap((v) => step2(v))
+chain.Cancel()   // pending stages that haven't started fail with CancellationError
 ```
 
-Token API (re-exported from `go_interop` into the `concurrent` namespace):
+Three properties define the semantics:
 
-- `CancelToken` — opaque handle wrapping a context and its cancel function.
-- `NewCancelToken() CancelToken` — a token that stays live until `Cancel`.
-- `NewTimeoutToken(goDuration) CancelToken` — auto-cancels after the duration.
-- `Cancel(tok)` — cancel the token (safe to call more than once).
-- `IsCancelled(tok) bool` — non-blocking check.
-- `CancelDone(tok) Signal` — a Signal that closes on cancel; block on it with `WaitSignal`.
-- `CancelErr(tok) error` — cancellation reason, or nil while live.
+- **Checked at combinator boundaries.** Each derived stage (`Map`, `FlatMap`,
+  `Filter`, `Recover`, `RecoverWith`, `Transform`, `TransformWith`, `AndThen`,
+  and the `Zip*`/`Fallback` built on them) checks the token *before* it runs.
+  Cancelling short-circuits any stage that has not started yet, failing it with a
+  `CancellationError`. A single already-running body cannot be preempted — Go has
+  no goroutine interruption — so cancellation does not abort work that is
+  in-flight; it only prevents downstream stages from running.
+- **Graph-level and coarse.** A derived chain shares one token, so cancelling any
+  node cancels the whole shared computation. Per-node / sub-tree scoping is future
+  work.
+- **Never on success.** Successful completion does not cancel the token, so
+  `.Cancel()` after a Future has completed has no effect on its stored result.
 
-`Cancel()` on a plain Future (one created without a token) is a safe no-op, so
-this is fully additive to existing code.
+`.Cancel()` is always safe: on a chain that is already complete, or one with no
+pending stages, it simply does nothing observable. This makes the whole feature
+additive — existing code that never calls `.Cancel()` behaves exactly as before.
+
+Interrupting a long in-flight body (true preemption) is intentionally out of
+scope here and would be achieved by other means later.
 
 ---
 

--- a/docs/CONCURRENT.MD
+++ b/docs/CONCURRENT.MD
@@ -117,7 +117,9 @@ Three properties define the semantics:
   in-flight; it only prevents downstream stages from running.
 - **Graph-level and coarse.** A derived chain shares one token, so cancelling any
   node cancels the whole shared computation. Per-node / sub-tree scoping is future
-  work.
+  work. Scope rule: linear combinators inherit the parent's token, while the
+  aggregation / scope constructors (`Race`, `Sequence`, `FirstCompletedOf`,
+  `WithTimeout`) intentionally open a fresh token scope.
 - **Never on success.** Successful completion does not cancel the token, so
   `.Cancel()` after a Future has completed has no effect on its stored result.
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1334,6 +1334,18 @@ gala_exec_test(
 )
 
 gala_exec_test(
+    name = "doc_verify_concurrent_cancellation",
+    src = "doc_verify/concurrent_cancellation.gala",
+    expected = "doc_verify/concurrent_cancellation.out",
+    deps = [
+        "//collection_immutable",
+        "//concurrent",
+        "//go_interop",
+        "//time_utils",
+    ],
+)
+
+gala_exec_test(
     name = "doc_verify_strings_md",
     src = "doc_verify/strings_md.gala",
     expected = "doc_verify/strings_md.out",

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1340,7 +1340,6 @@ gala_exec_test(
     deps = [
         "//collection_immutable",
         "//concurrent",
-        "//go_interop",
         "//time_utils",
     ],
 )

--- a/examples/doc_verify/concurrent_cancellation.gala
+++ b/examples/doc_verify/concurrent_cancellation.gala
@@ -7,46 +7,39 @@ import (
     . "martianoff/gala/time_utils"
 )
 
-// Verifies the cancellation additions documented in CONCURRENT.MD.
+// Verifies the API-level cancellation added to CONCURRENT.MD. User code never
+// touches a token — it cancels via Future.Cancel / WithTimeout / Race.
 
-// A cancellable Future receives a CancelToken and stops when it is cancelled.
-func testCancellable() {
-    val f = FutureCancellable[string]((tok) => {
-        WaitSignal(CancelDone(tok))
-        "cancelled"
-    })
-    f.Cancel()
-    Println(s"Cancellable=${f.Get()}")
+// Cancelling a chain short-circuits its pending stages with a CancellationError.
+// A Promise gate holds the root pending until after Cancel, so the Map boundary
+// deterministically observes the cancellation.
+func testCancelChain() {
+    val gate = NewPromise[int]()
+    val mapped = gate.Future().Map((x) => x * 2)
+    mapped.Cancel()
+    gate.Success(21)
+    val result = mapped.Await()
+    Println(s"Cancelled failure=${result.IsFailure()}")
 }
 
-// WithTimeout now cancels the underlying token, so a cooperating body stops.
-func testTimeoutCancels() {
-    val f = FutureCancellable[string]((tok) => {
-        WaitSignal(CancelDone(tok))
-        "stopped"
-    })
-    val bounded = f.WithTimeout(Milliseconds(50))
+// WithTimeout fails the bounded Future and cancels the underlying chain.
+func testTimeout() {
+    val gate = NewPromise[int]()
+    val bounded = gate.Future().WithTimeout(Milliseconds(50))
     Println(s"Timeout failed=${bounded.Await().IsFailure()}")
-    Println(s"Underlying=${f.Get()}")
 }
 
 // Race returns the first result and cancels the losers.
 func testRace() {
-    val winner = FutureCancellable[string]((tok) => {
-        Sleep(Milliseconds(20))
-        "fast"
-    })
-    val loser = FutureCancellable[string]((tok) => {
-        WaitSignal(CancelDone(tok))
-        "slow-cancelled"
-    })
-    val first = Race[string](ArrayOf[Future[string]](winner, loser))
+    val winnerGate = NewPromise[string]()
+    val loserGate = NewPromise[string]()
+    winnerGate.Success("fast")
+    val first = Race[string](ArrayOf[Future[string]](winnerGate.Future(), loserGate.Future()))
     Println(s"Race winner=${first.Get()}")
-    Println(s"Loser=${loser.Get()}")
 }
 
 func main() {
-    testCancellable()
-    testTimeoutCancels()
+    testCancelChain()
+    testTimeout()
     testRace()
 }

--- a/examples/doc_verify/concurrent_cancellation.gala
+++ b/examples/doc_verify/concurrent_cancellation.gala
@@ -1,0 +1,52 @@
+package main
+
+import (
+    . "martianoff/gala/std"
+    . "martianoff/gala/concurrent"
+    . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/time_utils"
+)
+
+// Verifies the cancellation additions documented in CONCURRENT.MD.
+
+// A cancellable Future receives a CancelToken and stops when it is cancelled.
+func testCancellable() {
+    val f = FutureCancellable[string]((tok) => {
+        WaitSignal(CancelDone(tok))
+        "cancelled"
+    })
+    f.Cancel()
+    Println(s"Cancellable=${f.Get()}")
+}
+
+// WithTimeout now cancels the underlying token, so a cooperating body stops.
+func testTimeoutCancels() {
+    val f = FutureCancellable[string]((tok) => {
+        WaitSignal(CancelDone(tok))
+        "stopped"
+    })
+    val bounded = f.WithTimeout(Milliseconds(50))
+    Println(s"Timeout failed=${bounded.Await().IsFailure()}")
+    Println(s"Underlying=${f.Get()}")
+}
+
+// Race returns the first result and cancels the losers.
+func testRace() {
+    val winner = FutureCancellable[string]((tok) => {
+        Sleep(Milliseconds(20))
+        "fast"
+    })
+    val loser = FutureCancellable[string]((tok) => {
+        WaitSignal(CancelDone(tok))
+        "slow-cancelled"
+    })
+    val first = Race[string](ArrayOf[Future[string]](winner, loser))
+    Println(s"Race winner=${first.Get()}")
+    Println(s"Loser=${loser.Get()}")
+}
+
+func main() {
+    testCancellable()
+    testTimeoutCancels()
+    testRace()
+}

--- a/examples/doc_verify/concurrent_cancellation.out
+++ b/examples/doc_verify/concurrent_cancellation.out
@@ -1,0 +1,5 @@
+Cancellable=cancelled
+Timeout failed=true
+Underlying=stopped
+Race winner=fast
+Loser=slow-cancelled

--- a/examples/doc_verify/concurrent_cancellation.out
+++ b/examples/doc_verify/concurrent_cancellation.out
@@ -1,5 +1,3 @@
-Cancellable=cancelled
+Cancelled failure=true
 Timeout failed=true
-Underlying=stopped
 Race winner=fast
-Loser=slow-cancelled

--- a/go_interop/types.go
+++ b/go_interop/types.go
@@ -10,6 +10,7 @@
 package go_interop
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -318,6 +319,93 @@ func WaitSignalTimeout(s Signal, timeout time.Duration) bool {
 	case <-time.After(timeout):
 		return false
 	}
+}
+
+// === Cancellation ===
+
+// CancelToken is an opaque cancellation handle. It wraps a context.Context and
+// its cancel function so GALA code can observe and trigger cancellation without
+// threading a raw context.Context through the transpiler (a historically fragile
+// codegen path).
+//
+// CancelToken is a value type (handle pattern): its fields are reference types
+// (context, func, channel), so a copy shares the same underlying cancellation
+// state and can be passed by value without loss of identity.
+type CancelToken struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// newCancelToken bridges a context's Done channel onto a bidirectional Signal so
+// GALA can WaitSignal on it. A single monitor goroutine is the only closer of
+// done, which fires for both manual Cancel and context deadline expiry, so there
+// is no double-close race. For a timeout token the goroutine exits when the
+// deadline elapses; for a plain token it exits once Cancel is called.
+func newCancelToken(ctx context.Context, cancel context.CancelFunc) CancelToken {
+	tok := CancelToken{
+		ctx:    ctx,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	go func() {
+		<-ctx.Done()
+		close(tok.done)
+	}()
+	return tok
+}
+
+// NewCancelToken creates a CancelToken backed by context.WithCancel. The token
+// stays live until Cancel is called.
+func NewCancelToken() CancelToken {
+	ctx, cancel := context.WithCancel(context.Background())
+	return newCancelToken(ctx, cancel)
+}
+
+// NewTimeoutToken creates a CancelToken that auto-cancels after d elapses. It is
+// built on context.WithTimeout and accepts the same time.Duration that the
+// concurrent package's duration helpers produce via Duration.ToGoDuration().
+func NewTimeoutToken(d time.Duration) CancelToken {
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	return newCancelToken(ctx, cancel)
+}
+
+// Cancel cancels the token, releasing its context resources and closing the
+// Signal returned by CancelDone. Calling Cancel more than once is safe.
+func Cancel(tok CancelToken) {
+	if tok.cancel != nil {
+		tok.cancel()
+	}
+}
+
+// IsCancelled reports whether the token has been cancelled or timed out. It never
+// blocks. A zero CancelToken (nil context) is reported as not cancelled.
+func IsCancelled(tok CancelToken) bool {
+	if tok.ctx == nil {
+		return false
+	}
+	select {
+	case <-tok.ctx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+// CancelDone returns a Signal that closes when the token is cancelled. GALA code
+// can WaitSignal (or WaitSignalTimeout) on it to block until cancellation, or
+// select on it inside a computation.
+func CancelDone(tok CancelToken) Signal {
+	return tok.done
+}
+
+// CancelErr returns the reason the token was cancelled: context.Canceled after
+// Cancel, context.DeadlineExceeded after a timeout, or nil if still live.
+func CancelErr(tok CancelToken) error {
+	if tok.ctx == nil {
+		return nil
+	}
+	return tok.ctx.Err()
 }
 
 // Mutex wraps sync.Mutex for GALA compatibility.

--- a/go_interop/types.go
+++ b/go_interop/types.go
@@ -367,15 +367,6 @@ func IsCancelled(tok CancelToken) bool {
 	}
 }
 
-// CancelErr returns the reason the token was cancelled (context.Canceled after
-// Cancel), or nil if it is still live.
-func CancelErr(tok CancelToken) error {
-	if tok.ctx == nil {
-		return nil
-	}
-	return tok.ctx.Err()
-}
-
 // Mutex wraps sync.Mutex for GALA compatibility.
 type Mutex struct {
 	mu sync.Mutex

--- a/go_interop/types.go
+++ b/go_interop/types.go
@@ -324,62 +324,37 @@ func WaitSignalTimeout(s Signal, timeout time.Duration) bool {
 // === Cancellation ===
 
 // CancelToken is an opaque cancellation handle. It wraps a context.Context and
-// its cancel function so GALA code can observe and trigger cancellation without
-// threading a raw context.Context through the transpiler (a historically fragile
-// codegen path).
+// its cancel function so GALA code can trigger and observe cancellation at the
+// API level (Future.Cancel / WithTimeout) without threading a raw
+// context.Context through the transpiler (a historically fragile codegen path).
 //
-// CancelToken is a value type (handle pattern): its fields are reference types
-// (context, func, channel), so a copy shares the same underlying cancellation
-// state and can be passed by value without loss of identity.
+// CancelToken is a value type (handle pattern): both fields are reference types
+// (context, func), so a copy shares the same underlying cancellation state and
+// can be passed by value without loss of identity. There is no monitor goroutine
+// and nothing to leak — a token that is never cancelled holds only a plain
+// cancellable context.
 type CancelToken struct {
 	ctx    context.Context
 	cancel context.CancelFunc
-	done   chan struct{}
-}
-
-// newCancelToken bridges a context's Done channel onto a bidirectional Signal so
-// GALA can WaitSignal on it. A single monitor goroutine is the only closer of
-// done, which fires for both manual Cancel and context deadline expiry, so there
-// is no double-close race. For a timeout token the goroutine exits when the
-// deadline elapses; for a plain token it exits once Cancel is called.
-func newCancelToken(ctx context.Context, cancel context.CancelFunc) CancelToken {
-	tok := CancelToken{
-		ctx:    ctx,
-		cancel: cancel,
-		done:   make(chan struct{}),
-	}
-	go func() {
-		<-ctx.Done()
-		close(tok.done)
-	}()
-	return tok
 }
 
 // NewCancelToken creates a CancelToken backed by context.WithCancel. The token
 // stays live until Cancel is called.
 func NewCancelToken() CancelToken {
 	ctx, cancel := context.WithCancel(context.Background())
-	return newCancelToken(ctx, cancel)
+	return CancelToken{ctx: ctx, cancel: cancel}
 }
 
-// NewTimeoutToken creates a CancelToken that auto-cancels after d elapses. It is
-// built on context.WithTimeout and accepts the same time.Duration that the
-// concurrent package's duration helpers produce via Duration.ToGoDuration().
-func NewTimeoutToken(d time.Duration) CancelToken {
-	ctx, cancel := context.WithTimeout(context.Background(), d)
-	return newCancelToken(ctx, cancel)
-}
-
-// Cancel cancels the token, releasing its context resources and closing the
-// Signal returned by CancelDone. Calling Cancel more than once is safe.
+// Cancel cancels the token, releasing its context resources. Calling Cancel on a
+// zero token, or more than once, is safe.
 func Cancel(tok CancelToken) {
 	if tok.cancel != nil {
 		tok.cancel()
 	}
 }
 
-// IsCancelled reports whether the token has been cancelled or timed out. It never
-// blocks. A zero CancelToken (nil context) is reported as not cancelled.
+// IsCancelled reports whether the token has been cancelled. It never blocks. A
+// zero CancelToken (nil context) is reported as not cancelled.
 func IsCancelled(tok CancelToken) bool {
 	if tok.ctx == nil {
 		return false
@@ -392,15 +367,8 @@ func IsCancelled(tok CancelToken) bool {
 	}
 }
 
-// CancelDone returns a Signal that closes when the token is cancelled. GALA code
-// can WaitSignal (or WaitSignalTimeout) on it to block until cancellation, or
-// select on it inside a computation.
-func CancelDone(tok CancelToken) Signal {
-	return tok.done
-}
-
-// CancelErr returns the reason the token was cancelled: context.Canceled after
-// Cancel, context.DeadlineExceeded after a timeout, or nil if still live.
+// CancelErr returns the reason the token was cancelled (context.Canceled after
+// Cancel), or nil if it is still live.
 func CancelErr(tok CancelToken) error {
 	if tok.ctx == nil {
 		return nil


### PR DESCRIPTION
Structured concurrency + cancellation for `Future` — **default, API-level path only** (no body token, non-breaking). Redesigned per review discussion.

## Model
Cancellation is stored in the Future and driven entirely through the API — bodies stay `() => T`, so **no existing call site changes**. This mirrors how Monix/cats-effect expose cancellation (the token is not threaded through user code); Scala's stdlib `Future` isn't cancellable at all.

**Go backing (`go_interop/types.go`)** — minimal opaque handle:
```go
type CancelToken struct { ctx context.Context; cancel context.CancelFunc }
```
`NewCancelToken()`, `Cancel` (nil-safe), `IsCancelled` (non-blocking), `CancelErr`. No monitor goroutine, no `done` channel → nothing to leak (the earlier draft's goroutine-lifetime concern is gone).

**GALA (`concurrent/future.gala`)**
- Every root future gets a token; derived futures **inherit the parent's token exactly like they inherit the ExecutionContext** (via a package-private `newPromiseWith(ec, cancel)`, so `NewPromise`'s public signature is unchanged and no `go_interop` leaks into callers).
- `Map`, `FlatMap`, `Filter`, `Recover`, `RecoverWith`, `Transform`, `TransformWith`, `AndThen` check `IsCancelled` at their boundary and complete with `CancellationError` instead of running the stage; `Zip`/`ZipWith`/`Zip2..10`/`Fallback` inherit transitively.
- `f.Cancel()` short-circuits all pending downstream stages sharing the token. `WithTimeout` cancels the token when it fires (keeps fail-first-then-cancel ordering). `Race` cancels losers. No cancel-on-success.

## Honest semantics (documented in `docs/CONCURRENT.MD`)
- Cancellation short-circuits **pending** stages. It does **not** abort an already-running body — Go has no goroutine preemption. Interrupting a long in-flight body is explicitly out of scope (to be achieved differently later); there is deliberately **no token-in-body API**.
- Cancellation is graph-level/coarse: a derived chain shares one token. Per-node scoping is future work.

## Tests / verification
- API-level tests in `concurrent/future_test.gala` (cancel short-circuits a chain → `CancellationError`; `WithTimeout` fires + cancels; `Race` cancels losers; plain future completes normally).
- The pre-existing `concurrent_md` example and all prior `future_test` cases pass **unchanged** (proves non-breaking).
- `bazel build //...` passes; `bazel test //concurrent/... //examples:doc_verify_concurrent_cancellation //examples:doc_verify_concurrent_md` passes; timing robustness checked at `--runs_per_test=8` (16/16). Independently re-verified.

Part of the feature-gap roadmap; TCO (#4) is PR #430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)