### PR TITLE
fix(release): bump version files to 0.71.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ module(
     # release-script tag and gala.mod so `bazel_dep(name = "gala",
     # version = X)` always matches the published binary the registry
     # serves for that version.
-    version = "0.70.1",
+    version = "0.71.0",
 )
 
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/gala.mod
+++ b/gala.mod
@@ -1,3 +1,3 @@
 module martianoff/gala
 
-gala 0.70.1
+gala 0.71.0


### PR DESCRIPTION
Mechanical release-prep bump for 0.71.0 (gala.mod + MODULE.bazel). Tag follows.