### PR TITLE
feat(diagnostics): Rust-style framed compile errors with source snippet + caret

### DIFF
--- a/cmd/gala/commands/BUILD.bazel
+++ b/cmd/gala/commands/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/gala/commands/worker",
+        "//galaerr",
         "//internal/build",
         "//internal/depman/fetch",
         "//internal/depman/graph",

--- a/cmd/gala/commands/build.go
+++ b/cmd/gala/commands/build.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"martianoff/gala/galaerr"
 	"martianoff/gala/internal/build"
 )
 
@@ -79,7 +80,7 @@ func runBuild(cmd *cobra.Command, args []string) {
 	// Run build
 	outputPath, err := builder.Build(buildOutput)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Build failed: %v\n", err)
+		fmt.Fprintln(os.Stderr, galaerr.RenderRich(err, galaerr.Options{Color: galaerr.ColorEnabled()}))
 		os.Exit(1)
 	}
 

--- a/cmd/gala/commands/run.go
+++ b/cmd/gala/commands/run.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"martianoff/gala/galaerr"
 	"martianoff/gala/internal/build"
 )
 
@@ -108,7 +109,7 @@ func runRun(cmd *cobra.Command, args []string) {
 	// Run build with absolute path to workspace
 	outputPath, err := builder.Build(tempOutput)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Build failed: %v\n", err)
+		fmt.Fprintln(os.Stderr, galaerr.RenderRich(err, galaerr.Options{Color: galaerr.ColorEnabled()}))
 		os.Exit(1)
 	}
 

--- a/cmd/gala/commands/transpile.go
+++ b/cmd/gala/commands/transpile.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"martianoff/gala/galaerr"
 	"martianoff/gala/internal/build"
 	"martianoff/gala/internal/depman/mod"
 	"martianoff/gala/internal/transpiler"
@@ -186,7 +187,11 @@ func runTranspile(cmd *cobra.Command, args []string) {
 	// Transpile
 	goCode, err := t.Transpile(string(content), inputPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: transpilation failed: %v\n", err)
+		fmt.Fprintln(os.Stderr, galaerr.RenderRich(err, galaerr.Options{
+			FallbackPath:   inputPath,
+			FallbackSource: string(content),
+			Color:          galaerr.ColorEnabled(),
+		}))
 		os.Exit(1)
 	}
 

--- a/galaerr/BUILD.bazel
+++ b/galaerr/BUILD.bazel
@@ -2,16 +2,23 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "galaerr",
-    srcs = ["errors.go"],
+    srcs = [
+        "errors.go",
+        "render.go",
+    ],
     importpath = "martianoff/gala/galaerr",
     visibility = ["//visibility:public"],
 )
 
 go_test(
     name = "galaerr_test",
-    srcs = ["errors_test.go"],
+    srcs = [
+        "errors_test.go",
+        "render_test.go",
+    ],
     deps = [
         ":galaerr",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -1,6 +1,7 @@
 package galaerr
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -58,6 +59,33 @@ type SemanticError struct {
 	FilePath string
 	Code     ErrorCode // optional stable error code; empty = uncoded
 	Hint     string    // optional remediation hint shown after the message
+
+	// EndColumn is an OPTIONAL exact end for the error's source span, given as
+	// a 0-based rune index that is EXCLUSIVE of the last character (i.e. one
+	// past the final rune of the offending token). It is additive: the point
+	// (Line, Column) still identifies where the error starts, and the zero
+	// value leaves the span unset. A value strictly greater than Column marks
+	// a real span whose width is EndColumn-Column; anything else (0, or <=
+	// Column) means "no exact span — let the renderer derive one by scanning
+	// the token on the source line". Error() ignores this field so existing
+	// text output is unchanged; only the rich CLI renderer consumes it.
+	EndColumn int
+}
+
+// HasSpan reports whether an exact source span was recorded on the error.
+func (e *SemanticError) HasSpan() bool {
+	return e.EndColumn > e.Column
+}
+
+// WithSpan records an exact end column (0-based, exclusive rune index) for the
+// error's source span and returns the receiver for fluent construction. It is
+// additive — the error's start point (Line, Column) and every other field are
+// left untouched — so callers that do not set a span keep the previous
+// derive-at-render behavior. Passing an endColumn that is not strictly greater
+// than Column leaves the span unset.
+func (e *SemanticError) WithSpan(endColumn int) *SemanticError {
+	e.EndColumn = endColumn
+	return e
 }
 
 func (e *SemanticError) Error() string {
@@ -346,6 +374,38 @@ func NewSemanticErrorInFile(filePath string, line, column int, msg string) *Sema
 		Line:     line,
 		Column:   column,
 		FilePath: filePath,
+	}
+}
+
+// WithFilePath stamps a source file path onto any SemanticError reachable from
+// err (directly, through the standard unwrap chain, or inside a MultiError)
+// that does not already carry one. It is used by the transpiler pipeline to
+// attach the file being compiled to errors raised deep in the transformer /
+// analyzer, so the CLI's rich renderer can re-read that file for the snippet.
+// Errors that already have a FilePath, and non-SemanticError values, are left
+// untouched. The original err is returned so callers can `return WithFilePath(...)`.
+func WithFilePath(err error, path string) error {
+	if err == nil || path == "" {
+		return err
+	}
+	stampFilePath(err, path)
+	return err
+}
+
+func stampFilePath(err error, path string) {
+	if err == nil {
+		return
+	}
+	var multi *MultiError
+	if errors.As(err, &multi) {
+		for _, sub := range multi.Errors {
+			stampFilePath(sub, path)
+		}
+		return
+	}
+	var se *SemanticError
+	if errors.As(err, &se) && se.FilePath == "" {
+		se.FilePath = path
 	}
 }
 

--- a/galaerr/render.go
+++ b/galaerr/render.go
@@ -1,0 +1,313 @@
+package galaerr
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// This file holds the Rust/Elm-style compile-error renderer used by the CLI.
+// It is intentionally CLI-only: SemanticError.Error() / SyntaxError.Error()
+// still produce the terse single-line form the LSP and tests depend on, and
+// RenderRich here layers a framed source snippet on top for humans reading a
+// terminal. It adds no third-party dependency — color is hand-written ANSI.
+//
+// Approved layout (color off):
+//
+//	error[GALA-E0035]: bare `len` is forbidden
+//	  --> foo.gala:12:13
+//	   |
+//	12 |     val n = len(s)
+//	   |             ^^^ use .Size() / .ByteSize() instead
+//	   |
+//	   = hint: GALA strings & collections expose .Size()
+
+// ANSI escapes, hand-written so the renderer stays dependency-free. Red+bold
+// for the error header and the caret, dim for the frame gutter, cyan for the
+// hint label. When color is off none of these are emitted and the output is
+// byte-identical plain text.
+const (
+	ansiReset   = "\x1b[0m"
+	ansiRedBold = "\x1b[1;31m"
+	ansiDim     = "\x1b[2m"
+	ansiCyan    = "\x1b[36m"
+)
+
+// Options controls how RenderRich resolves source and colorizes output.
+type Options struct {
+	// FallbackPath is the path shown in the locus (and used to match
+	// FallbackSource) when a diagnostic carries no FilePath of its own.
+	FallbackPath string
+	// FallbackSource is the source text used for the snippet when the
+	// diagnostic has no readable FilePath. The CLI supplies the file it is
+	// currently compiling so single-file transpiles still frame the snippet.
+	FallbackSource string
+	// Color enables ANSI colorization. Callers typically pass ColorEnabled().
+	Color bool
+}
+
+// ColorEnabled reports whether colorized diagnostics should be emitted: only
+// when stderr is a character device (a TTY) and NO_COLOR is unset. It adds no
+// dependency — the TTY probe is a plain os.Stderr.Stat() mode check.
+func ColorEnabled() bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	stat, err := os.Stderr.Stat()
+	if err != nil {
+		return false
+	}
+	return stat.Mode()&os.ModeCharDevice != 0
+}
+
+// diagnostic is the renderer's normalized view of a single typed error.
+type diagnostic struct {
+	code      ErrorCode
+	msg       string
+	hint      string
+	filePath  string
+	line      int // 1-based; 0 means "no position"
+	column    int // 0-based rune index of the span start
+	endColumn int // 0-based exclusive rune index; <=column means "unset"
+}
+
+// RenderRich renders err as one or more framed diagnostics. A *MultiError is
+// unwrapped and each contained error rendered in turn (blank line between).
+// Errors that are not GALA typed errors — notably `go build` failures — are
+// passed through verbatim (err.Error()), never framed.
+func RenderRich(err error, opts Options) string {
+	if err == nil {
+		return ""
+	}
+
+	var multi *MultiError
+	if errors.As(err, &multi) && multi != nil {
+		parts := make([]string, 0, len(multi.Errors))
+		for _, sub := range multi.Errors {
+			parts = append(parts, RenderRich(sub, opts))
+		}
+		return strings.Join(parts, "\n\n")
+	}
+
+	d, ok := toDiagnostic(err)
+	if !ok {
+		// Not a GALA diagnostic (e.g. a wrapped `go build` error). Pass the
+		// underlying text through unchanged so generated-file references and
+		// the Go compiler's own framing survive intact.
+		return err.Error()
+	}
+	return renderDiagnostic(d, opts)
+}
+
+// toDiagnostic extracts a normalized diagnostic from the first GALA typed error
+// reachable through the unwrap chain. Returns ok=false for anything else.
+func toDiagnostic(err error) (diagnostic, bool) {
+	var se *SemanticError
+	if errors.As(err, &se) {
+		return diagnostic{
+			code:      se.Code,
+			msg:       se.Msg,
+			hint:      se.Hint,
+			filePath:  se.FilePath,
+			line:      se.Line,
+			column:    se.Column,
+			endColumn: se.EndColumn,
+		}, true
+	}
+	var sy *SyntaxError
+	if errors.As(err, &sy) {
+		// SyntaxError has no FilePath/Code/Hint; the CLI supplies the source
+		// via the fallback path so its snippet can still be framed.
+		return diagnostic{
+			msg:    sy.Msg,
+			line:   sy.Line,
+			column: sy.Column,
+		}, true
+	}
+	return diagnostic{}, false
+}
+
+func renderDiagnostic(d diagnostic, opts Options) string {
+	var b strings.Builder
+	b.WriteString(renderHeader(d, opts))
+
+	src := resolveSource(d.filePath, opts)
+	lines := strings.Split(src, "\n")
+
+	// No usable position or no source: header (+ hint) only, never a frame.
+	if d.line <= 0 || src == "" || d.line-1 >= len(lines) {
+		if d.hint != "" {
+			b.WriteString("\n")
+			b.WriteString(renderFooter(d.hint, opts.Color))
+		}
+		return b.String()
+	}
+
+	displayPath := d.filePath
+	if displayPath == "" {
+		if opts.FallbackPath != "" {
+			displayPath = opts.FallbackPath
+		} else {
+			displayPath = "<input>"
+		}
+	}
+
+	srcLine := lines[d.line-1]
+	gutter := strconv.Itoa(d.line)
+	gw := len(gutter)
+	pad := strings.Repeat(" ", gw)
+	pipe := colorize("|", ansiDim, opts.Color)
+
+	// Locus: 1-based column shown to the user (stored 0-based).
+	arrow := colorize("-->", ansiDim, opts.Color)
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("  %s %s:%d:%d", arrow, displayPath, d.line, d.column+1))
+
+	// Frame: blank line, source row, caret row, blank line.
+	b.WriteString("\n")
+	b.WriteString(pad + " " + pipe)
+
+	b.WriteString("\n")
+	b.WriteString(gutter + " " + pipe + " " + srcLine)
+
+	width := spanWidth(srcLine, d.column, d.endColumn)
+	carets := colorize(strings.Repeat("^", width), ansiRedBold, opts.Color)
+	caretRow := pad + " " + pipe + " " + caretIndent(srcLine, d.column) + carets
+	if ann := terseHint(d.hint); ann != "" {
+		caretRow += " " + ann
+	}
+	b.WriteString("\n")
+	b.WriteString(caretRow)
+
+	b.WriteString("\n")
+	b.WriteString(pad + " " + pipe)
+
+	if d.hint != "" {
+		b.WriteString("\n")
+		b.WriteString(pad + " " + renderFooter(d.hint, opts.Color))
+	}
+	return b.String()
+}
+
+// renderHeader builds the `error[CODE]: message` (or `error: message`) line.
+func renderHeader(d diagnostic, opts Options) string {
+	label := "error"
+	if d.code != "" {
+		label = "error[" + string(d.code) + "]"
+	}
+	return colorize(label, ansiRedBold, opts.Color) + ": " + d.msg
+}
+
+// renderFooter builds the `= hint: <hint>` footer (without the leading pad,
+// which the caller aligns to the gutter width).
+func renderFooter(hint string, color bool) string {
+	return "= " + colorize("hint:", ansiCyan, color) + " " + hint
+}
+
+// resolveSource returns the source text for the snippet: the diagnostic's own
+// file if readable, else the caller-provided fallback when it applies.
+func resolveSource(filePath string, opts Options) string {
+	if filePath != "" {
+		if data, err := os.ReadFile(filePath); err == nil {
+			return string(data)
+		}
+	}
+	if opts.FallbackSource != "" && (filePath == "" || filePath == opts.FallbackPath) {
+		return opts.FallbackSource
+	}
+	return ""
+}
+
+// caretIndent produces the whitespace that positions the caret under column
+// (0-based rune index) of srcLine. Non-tab characters become spaces while tabs
+// are preserved, so the caret lines up with tab-expanded source in the terminal.
+func caretIndent(srcLine string, column int) string {
+	runes := []rune(srcLine)
+	var b strings.Builder
+	for i := 0; i < column; i++ {
+		if i < len(runes) && runes[i] == '\t' {
+			b.WriteByte('\t')
+		} else {
+			b.WriteByte(' ')
+		}
+	}
+	return b.String()
+}
+
+// spanWidth computes the caret width. When an exact end is set (endColumn >
+// column) it is used (clamped to the line); otherwise the width is derived by
+// scanning the token at column: an identifier run, a quoted string/backtick to
+// its closing delimiter, or a single character.
+func spanWidth(srcLine string, column, endColumn int) int {
+	runes := []rune(srcLine)
+	if endColumn > column {
+		end := endColumn
+		if end > len(runes) {
+			end = len(runes)
+		}
+		if end > column {
+			return end - column
+		}
+		return 1
+	}
+	if column < 0 || column >= len(runes) {
+		return 1
+	}
+	ch := runes[column]
+	if ch == '"' || ch == '`' {
+		for j := column + 1; j < len(runes); j++ {
+			if runes[j] == ch {
+				return j - column + 1
+			}
+		}
+		return len(runes) - column
+	}
+	if isIdentRune(ch) {
+		j := column
+		for j < len(runes) && isIdentRune(runes[j]) {
+			j++
+		}
+		return j - column
+	}
+	return 1
+}
+
+func isIdentRune(r rune) bool {
+	return r == '_' ||
+		(r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z') ||
+		(r >= '0' && r <= '9')
+}
+
+// terseHint reduces a full hint to a short inline annotation for the caret row:
+// the first clause (before " (", "; " or ". "), trimmed and capped in length.
+// The full hint is still shown in the footer.
+func terseHint(hint string) string {
+	if hint == "" {
+		return ""
+	}
+	cut := len(hint)
+	for _, sep := range []string{" (", "; ", ". "} {
+		if i := strings.Index(hint, sep); i >= 0 && i < cut {
+			cut = i
+		}
+	}
+	s := strings.TrimSpace(hint[:cut])
+	const maxLen = 60
+	if r := []rune(s); len(r) > maxLen {
+		s = strings.TrimSpace(string(r[:maxLen])) + "…"
+	}
+	if s == "" {
+		return strings.TrimSpace(hint)
+	}
+	return s
+}
+
+func colorize(s, code string, color bool) string {
+	if !color {
+		return s
+	}
+	return code + s + ansiReset
+}

--- a/galaerr/render_test.go
+++ b/galaerr/render_test.go
@@ -1,0 +1,155 @@
+package galaerr_test
+
+import (
+	"strings"
+	"testing"
+
+	"martianoff/gala/galaerr"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// caretLineOf returns the frame line containing the caret run (the first line
+// with a '^'), or "" if none. Used to assert caret column and width.
+func caretLineOf(out string) string {
+	for _, ln := range strings.Split(out, "\n") {
+		if strings.Contains(ln, "^") {
+			return ln
+		}
+	}
+	return ""
+}
+
+// afterPipe returns the substring following the first "| " on a frame line,
+// i.e. the content aligned with the source text (or caret indent).
+func afterPipe(line string) string {
+	if i := strings.Index(line, "| "); i >= 0 {
+		return line[i+2:]
+	}
+	return ""
+}
+
+const multiLineSrc = `package main
+
+func main() {
+    val n = len(s)
+}
+`
+
+func TestRenderRich(t *testing.T) {
+	t.Run("coded semantic error with hint and multi-line source", func(t *testing.T) {
+		// `len` starts at 0-based rune column 12 on line 4; exact span 12..15.
+		err := galaerr.NewCodedSemanticError(
+			galaerr.CodeForbiddenGoBuiltin, 4, 12,
+			"bare `len` is forbidden",
+			"GALA strings & collections expose .Size()",
+		).WithSpan(15)
+
+		out := galaerr.RenderRich(err, galaerr.Options{FallbackPath: "foo.gala", FallbackSource: multiLineSrc})
+
+		assert.Contains(t, out, "error[GALA-E0035]: bare `len` is forbidden")
+		assert.Contains(t, out, "  --> foo.gala:4:13") // 0-based col 12 shown as 13
+		assert.Contains(t, out, "4 |     val n = len(s)")
+		assert.Contains(t, out, "= hint: GALA strings & collections expose .Size()")
+
+		caret := caretLineOf(out)
+		require.NotEmpty(t, caret, "expected a caret line")
+		// 12 spaces of indent then a 3-wide caret under `len`.
+		assert.Equal(t, strings.Repeat(" ", 12)+"^^^ GALA strings & collections expose .Size()", afterPipe(caret))
+	})
+
+	t.Run("exact-span caret width equals the token", func(t *testing.T) {
+		// Point at `n` (a 1-char name) but set an exact span covering `len` (3).
+		err := galaerr.NewCodedSemanticError(galaerr.CodeForbiddenGoBuiltin, 4, 12, "m", "h").WithSpan(15)
+		out := galaerr.RenderRich(err, galaerr.Options{FallbackSource: multiLineSrc})
+		assert.Contains(t, afterPipe(caretLineOf(out)), "^^^")
+		assert.NotContains(t, afterPipe(caretLineOf(out)), "^^^^") // exactly 3
+	})
+
+	t.Run("derived-span caret width scans the identifier", func(t *testing.T) {
+		// No exact span: width is derived by scanning the identifier run `len`.
+		err := galaerr.NewCodedSemanticError(galaerr.CodeForbiddenGoBuiltin, 4, 12, "m", "h")
+		out := galaerr.RenderRich(err, galaerr.Options{FallbackSource: multiLineSrc})
+		assert.Equal(t, strings.Repeat(" ", 12)+"^^^ h", afterPipe(caretLineOf(out)))
+	})
+
+	t.Run("derived string span reaches closing quote", func(t *testing.T) {
+		src := `    val s = "hello"` + "\n"
+		// `"` starts at rune column 12; span should cover `"hello"` (7 chars).
+		err := galaerr.NewSemanticErrorAt(1, 12, "unexpected string")
+		out := galaerr.RenderRich(err, galaerr.Options{FallbackSource: src})
+		assert.Contains(t, afterPipe(caretLineOf(out)), "^^^^^^^") // 7 carets
+	})
+
+	t.Run("no position renders header and hint only", func(t *testing.T) {
+		err := galaerr.NewCodedSemanticError(galaerr.CodeUndefinedVariable, 0, 0, "undefined variable x", "check the spelling")
+		out := galaerr.RenderRich(err, galaerr.Options{FallbackSource: multiLineSrc})
+		assert.Contains(t, out, "error[GALA-E0023]: undefined variable x")
+		assert.Contains(t, out, "= hint: check the spelling")
+		assert.NotContains(t, out, "-->")
+		assert.NotContains(t, out, "^")
+		assert.NotContains(t, out, "|")
+	})
+
+	t.Run("uncoded error omits the bracketed code", func(t *testing.T) {
+		err := galaerr.NewSemanticErrorAt(0, 0, "something went wrong")
+		out := galaerr.RenderRich(err, galaerr.Options{})
+		assert.True(t, strings.HasPrefix(out, "error: something went wrong"),
+			"want plain `error:` header, got %q", out)
+		assert.NotContains(t, out, "error[")
+	})
+
+	t.Run("multi-error renders each diagnostic", func(t *testing.T) {
+		e1 := galaerr.NewCodedSemanticError(galaerr.CodeForbiddenGoBuiltin, 4, 12, "first", "h1").WithSpan(15)
+		e2 := galaerr.NewCodedSemanticError(galaerr.CodeForbiddenGoBuiltin, 4, 12, "second", "h2").WithSpan(15)
+		multi := &galaerr.MultiError{Errors: []error{e1, e2}}
+		out := galaerr.RenderRich(multi, galaerr.Options{FallbackSource: multiLineSrc})
+		assert.Contains(t, out, "error[GALA-E0035]: first")
+		assert.Contains(t, out, "error[GALA-E0035]: second")
+		assert.Equal(t, 2, strings.Count(out, "^^^"), "expected two caret frames")
+		assert.Contains(t, out, "\n\n", "expected a blank line between diagnostics")
+	})
+
+	t.Run("tab-indented source keeps the caret aligned", func(t *testing.T) {
+		src := "\tval n = len(s)\n" // `len` at rune column 9 (tab + "val n = ")
+		err := galaerr.NewCodedSemanticError(galaerr.CodeForbiddenGoBuiltin, 1, 9, "bare len", "h").WithSpan(12)
+		out := galaerr.RenderRich(err, galaerr.Options{FallbackSource: src})
+		// The caret indent replicates the leading tab, then 8 spaces, then ^^^.
+		assert.Equal(t, "\t"+strings.Repeat(" ", 8)+"^^^ h", afterPipe(caretLineOf(out)))
+		// The snippet keeps the literal tab.
+		assert.Contains(t, out, "1 | \tval n = len(s)")
+	})
+
+	t.Run("multi-byte column keeps the caret aligned", func(t *testing.T) {
+		// `é` is one rune but two bytes; rune-indexed column must not misalign.
+		src := "val café = len(x)\n" // `len` at rune column 11
+		err := galaerr.NewCodedSemanticError(galaerr.CodeForbiddenGoBuiltin, 1, 11, "bare len", "h").WithSpan(14)
+		out := galaerr.RenderRich(err, galaerr.Options{FallbackSource: src})
+		assert.Equal(t, strings.Repeat(" ", 11)+"^^^ h", afterPipe(caretLineOf(out)))
+	})
+
+	t.Run("color off emits zero ANSI escapes", func(t *testing.T) {
+		err := galaerr.NewCodedSemanticError(galaerr.CodeForbiddenGoBuiltin, 4, 12, "bare len", "h").WithSpan(15)
+		out := galaerr.RenderRich(err, galaerr.Options{FallbackSource: multiLineSrc, Color: false})
+		assert.NotContains(t, out, "\x1b[")
+	})
+
+	t.Run("color on includes ANSI escapes", func(t *testing.T) {
+		err := galaerr.NewCodedSemanticError(galaerr.CodeForbiddenGoBuiltin, 4, 12, "bare len", "h").WithSpan(15)
+		out := galaerr.RenderRich(err, galaerr.Options{FallbackSource: multiLineSrc, Color: true})
+		assert.Contains(t, out, "\x1b[1;31m") // red+bold header/caret
+		assert.Contains(t, out, "\x1b[0m")    // reset
+	})
+
+	t.Run("non-GALA error passes through verbatim", func(t *testing.T) {
+		err := assertError("go build: ./main.gen.go:9:2: undefined: Foo")
+		out := galaerr.RenderRich(err, galaerr.Options{})
+		assert.Equal(t, err.Error(), out)
+	})
+}
+
+// assertError is a tiny error wrapper for the passthrough test.
+type assertError string
+
+func (e assertError) Error() string { return string(e) }

--- a/internal/transpiler/BUILD.bazel
+++ b/internal/transpiler/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "martianoff/gala/internal/transpiler",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//galaerr",
         "//internal/parser",
         "//internal/transpiler/profiler",
         "@com_github_antlr4_go_antlr_v4//:antlr",

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -1263,6 +1263,10 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 				if ctx.Signature().Type_() != nil {
 					funcMeta.ReturnType = a.resolveTypeWithParams(ctx.Signature().Type_().GetText(), pkgName, funcMeta.TypeParams)
 				}
+				// Source spans of each default expression, keyed by param index.
+				// Used to give the E0014 (default type mismatch) diagnostic an
+				// exact caret span over the offending default value.
+				var defaultSpans map[int]defaultExprSpan
 				if ctx.Signature().Parameters() != nil {
 					pCtx := ctx.Signature().Parameters().(*grammar.ParametersContext)
 					if pList := pCtx.ParameterList(); pList != nil {
@@ -1290,13 +1294,18 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 									funcMeta.DefaultExprs = make(map[int]string)
 								}
 								defaultCtx := paramCtx.ParamDefault().(*grammar.ParamDefaultContext)
-								funcMeta.DefaultExprs[i] = defaultCtx.Expression().GetText()
+								exprCtx := defaultCtx.Expression()
+								funcMeta.DefaultExprs[i] = exprCtx.GetText()
+								if defaultSpans == nil {
+									defaultSpans = make(map[int]defaultExprSpan)
+								}
+								defaultSpans[i] = spanOfCtx(exprCtx)
 							}
 						}
 					}
 				}
 				// Validate default parameter rules
-				if err := validateDefaultParams(funcMeta, ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(), filePath); err != nil {
+				if err := validateDefaultParams(funcMeta, ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(), filePath, defaultSpans); err != nil {
 					return nil, err
 				}
 				// Reject redeclaration of a top-level function within the same
@@ -3686,11 +3695,41 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 }
 
 
+// defaultExprSpan is the source span of a parameter's default expression,
+// captured while collecting metadata so a later validation error can point an
+// exact caret at the offending default value. Columns are 0-based rune indices;
+// endCol is exclusive.
+type defaultExprSpan struct {
+	line     int
+	startCol int
+	endCol   int
+}
+
+// spanOfCtx returns the source span covering an ANTLR rule context, from the
+// start token's position to one past the stop token. Columns are 0-based;
+// endCol is exclusive. When the context spans multiple lines the renderer
+// clamps the caret to the start line, so only line/startCol matter there.
+func spanOfCtx(ctx antlr.ParserRuleContext) defaultExprSpan {
+	start := ctx.GetStart()
+	stop := ctx.GetStop()
+	sp := defaultExprSpan{line: start.GetLine(), startCol: start.GetColumn()}
+	if stop != nil {
+		sp.endCol = stop.GetColumn() + len([]rune(stop.GetText()))
+	} else {
+		sp.endCol = sp.startCol
+	}
+	return sp
+}
+
 // validateDefaultParams checks that default parameter values follow the rules:
 // 1. Parameters with defaults must come after all required parameters
 // 2. Variadic parameters cannot have defaults
 // 3. Default expression types must be compatible with parameter types (for literals)
-func validateDefaultParams(funcMeta *transpiler.FunctionMetadata, line, column int, filePath string) error {
+//
+// defaultSpans (optional, keyed by param index) carries each default
+// expression's source span so the type-mismatch diagnostic can render an exact
+// caret over the offending value.
+func validateDefaultParams(funcMeta *transpiler.FunctionMetadata, line, column int, filePath string, defaultSpans map[int]defaultExprSpan) error {
 	_ = filePath // filePath is retained for future use; position info now travels via the coded error
 	if len(funcMeta.DefaultExprs) == 0 {
 		return nil
@@ -3734,12 +3773,22 @@ func validateDefaultParams(funcMeta *transpiler.FunctionMetadata, line, column i
 			if i < len(funcMeta.ParamNames) {
 				paramName = funcMeta.ParamNames[i]
 			}
-			return galaerr.NewCodedSemanticError(
+			// Point the diagnostic at the default expression itself (with an
+			// exact caret span) when we captured its position; otherwise fall
+			// back to the function-declaration start.
+			errLine, errCol := line, column
+			derr := galaerr.NewCodedSemanticError(
 				galaerr.CodeParamDefaultTypeMismatch,
-				line, column,
+				errLine, errCol,
 				fmt.Sprintf("default for parameter %q has type %s, expected %s", paramName, literalType, paramType),
 				"fix the default expression or change the parameter type",
 			)
+			if sp, ok := defaultSpans[i]; ok && sp.line > 0 {
+				derr.Line = sp.line
+				derr.Column = sp.startCol
+				derr = derr.WithSpan(sp.endCol)
+			}
+			return derr
 		}
 	}
 

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -104,6 +104,7 @@ go_test(
         "qualified_namedarg_shadow_test.go",
         "recursive_immutable_test.go",
         "resource_inference_test.go",
+        "rich_diagnostics_test.go",
         "sealed_apply_dispatch_test.go",
         "sealed_call_arg_widen_test.go",
         "sealed_equal_synth_test.go",

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -61,7 +61,14 @@ func ForbiddenGoBuiltins() map[string]bool {
 // (examples/method_default_params.gala) — while forbidding the builtins
 // themselves. A selector call (`x.copy()`) is never a bare builtin and is not
 // checked. Returns nil when the call is allowed.
-func (t *galaASTTransformer) checkForbiddenGoBuiltinCall(fun ast.Expr, line, col int) error {
+// checkForbiddenGoBuiltinCall's line/col identify the callee identifier's start.
+// When exactStart is true the position is the real primary-expression token
+// (via primaryStartOf), so the diagnostic can carry an EXACT span covering the
+// whole identifier — the caret in the rich CLI renderer then underlines `len`
+// itself rather than a single derived character. When exactStart is false the
+// caller only had an approximate position, so the span is left for the renderer
+// to derive.
+func (t *galaASTTransformer) checkForbiddenGoBuiltinCall(fun ast.Expr, line, col int, exactStart bool) error {
 	id, ok := fun.(*ast.Ident)
 	if !ok {
 		return nil
@@ -84,12 +91,35 @@ func (t *galaASTTransformer) checkForbiddenGoBuiltinCall(fun ast.Expr, line, col
 	if _, ok := t.structFields[id.Name]; ok { // struct layout used as a constructor
 		return nil
 	}
-	return galaerr.NewCodedSemanticError(
+	err := galaerr.NewCodedSemanticError(
 		galaerr.CodeForbiddenGoBuiltin,
 		line, col,
 		fmt.Sprintf("bare Go builtin %q is not part of GALA's surface", id.Name+"(...)"),
 		suggestion,
 	)
+	if exactStart {
+		// The callee is a single identifier token on one line, so its exact
+		// end is the start column plus the identifier's rune length.
+		err = err.WithSpan(col + len([]rune(id.Name)))
+	}
+	return err
+}
+
+// primaryStartOf walks up from an ANTLR node inside a postfix call chain to the
+// enclosing postfixExpr and returns the start token of its primary expression —
+// i.e. the callee identifier (`len` in `len(s)`). This is the position the
+// forbidden-builtin diagnostic should point at, rather than the argument list.
+func primaryStartOf(node antlr.Tree) (line, col int, ok bool) {
+	for n := node; n != nil; n = n.GetParent() {
+		if pe, isPE := n.(*grammar.PostfixExprContext); isPE {
+			if prim := pe.PrimaryExpr(); prim != nil {
+				tok := prim.GetStart()
+				return tok.GetLine(), tok.GetColumn(), true
+			}
+			return 0, 0, false
+		}
+	}
+	return 0, 0, false
 }
 
 func (t *galaASTTransformer) applyCallSuffix(base ast.Expr, suffix *grammar.PostfixSuffixContext) (ast.Expr, error) {
@@ -299,8 +329,14 @@ func (t *galaASTTransformer) applyCallSuffix(base ast.Expr, suffix *grammar.Post
 				return &ast.CompositeLit{Type: base}, nil
 			}
 		}
-		// Zero-argument bare builtin (e.g. `recover()`) is forbidden too.
-		if err := t.checkForbiddenGoBuiltinCall(base, suffix.GetStart().GetLine(), suffix.GetStart().GetColumn()); err != nil {
+		// Zero-argument bare builtin (e.g. `recover()`) is forbidden too. Point
+		// the diagnostic at the callee identifier (the primary expr) so the
+		// caret underlines the builtin name, not the empty argument list.
+		bl, bc, exact := primaryStartOf(suffix)
+		if !exact {
+			bl, bc = suffix.GetStart().GetLine(), suffix.GetStart().GetColumn()
+		}
+		if err := t.checkForbiddenGoBuiltinCall(base, bl, bc, exact); err != nil {
 			return nil, err
 		}
 		return &ast.CallExpr{Fun: base, Args: nil}, nil
@@ -1720,7 +1756,13 @@ func (t *galaASTTransformer) transformCallWithArgsCtx(fun ast.Expr, argListCtx *
 	// Bare Go builtins (append, len, panic, ...) are a hard error: they are the
 	// last symbols that resolve with no import and no GALA declaration. Reject
 	// them here where the call target and the symbol tables are both available.
-	if err := t.checkForbiddenGoBuiltinCall(fun, argListCtx.GetStart().GetLine(), argListCtx.GetStart().GetColumn()); err != nil {
+	// Report at the callee identifier (the primary expr) so the caret spans the
+	// builtin name; fall back to the argument list start if the walk-up fails.
+	fl, fc, exact := primaryStartOf(argListCtx)
+	if !exact {
+		fl, fc = argListCtx.GetStart().GetLine(), argListCtx.GetStart().GetColumn()
+	}
+	if err := t.checkForbiddenGoBuiltinCall(fun, fl, fc, exact); err != nil {
 		return nil, err
 	}
 

--- a/internal/transpiler/transformer/rich_diagnostics_test.go
+++ b/internal/transpiler/transformer/rich_diagnostics_test.go
@@ -1,0 +1,56 @@
+package transformer_test
+
+import (
+	"strings"
+	"testing"
+
+	"martianoff/gala/galaerr"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRichDiagnostic_ForbiddenBuiltin drives a real bare-`len` program through
+// the full transpiler pipeline and feeds the resulting error to the CLI's rich
+// renderer, asserting the framed snippet, the GALA-E0035 code, and a caret that
+// underlines the `len` token exactly (exact-span upgrade).
+func TestRichDiagnostic_ForbiddenBuiltin(t *testing.T) {
+	trans := newForbiddenBuiltinTranspiler()
+
+	src := "package main\n\nfunc f(s string) int = len(s)"
+	_, err := trans.Transpile(src, "")
+	require.Error(t, err, "expected bare len(...) to be rejected")
+
+	out := galaerr.RenderRich(err, galaerr.Options{
+		FallbackPath:   "prog.gala",
+		FallbackSource: src,
+	})
+
+	require.Contains(t, out, "GALA-E0035", "rendered output must carry the code:\n%s", out)
+	require.Contains(t, out, "  --> prog.gala:", "rendered output must show the locus:\n%s", out)
+	require.Contains(t, out, "^^^", "rendered output must draw a caret:\n%s", out)
+	require.Contains(t, out, "len(s)", "rendered output must frame the source line:\n%s", out)
+
+	// The caret must sit exactly under `len`: the caret indent length equals
+	// the index of `len` on the framed source line.
+	var snippet, caret string
+	for _, ln := range strings.Split(out, "\n") {
+		if strings.Contains(ln, "len(s)") && strings.Contains(ln, "| ") {
+			snippet = ln
+		}
+		if strings.Contains(ln, "^^^") {
+			caret = ln
+		}
+	}
+	require.NotEmpty(t, snippet, "no framed source line found:\n%s", out)
+	require.NotEmpty(t, caret, "no caret line found:\n%s", out)
+
+	snippetBody := snippet[strings.Index(snippet, "| ")+2:]
+	caretBody := caret[strings.Index(caret, "| ")+2:]
+	indent := len(caretBody) - len(strings.TrimLeft(caretBody, " "))
+	require.GreaterOrEqual(t, len(snippetBody), indent+3)
+	require.Equal(t, "len", snippetBody[indent:indent+3],
+		"caret is not aligned under `len`:\nsnippet=%q\ncaret=%q", snippetBody, caretBody)
+	// Exact span: three carets, no more.
+	require.Contains(t, caretBody, "^^^")
+	require.NotContains(t, caretBody, "^^^^")
+}

--- a/internal/transpiler/transpiler.go
+++ b/internal/transpiler/transpiler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/antlr4-go/antlr/v4"
 
+	"martianoff/gala/galaerr"
 	"martianoff/gala/internal/transpiler/profiler"
 )
 
@@ -404,7 +405,9 @@ func (t *GalaToGoTranspiler) Transpile(input string, filePath string) (string, e
 	richAST, err := t.analyzer.Analyze(tree, filePath)
 	done()
 	if err != nil {
-		return "", err
+		// Stamp the file being compiled onto any positional error that lacks
+		// one, so the CLI's rich renderer can re-read the source for a snippet.
+		return "", galaerr.WithFilePath(err, filePath)
 	}
 	richAST.FilePath = filePath
 	richAST.SourceContent = input
@@ -413,7 +416,7 @@ func (t *GalaToGoTranspiler) Transpile(input string, filePath string) (string, e
 	fset, file, err := t.transformer.Transform(richAST)
 	done()
 	if err != nil {
-		return "", err
+		return "", galaerr.WithFilePath(err, filePath)
 	}
 
 	done = prof.Phase("generate")


### PR DESCRIPTION
Continues the DX line (after source-mapped stack traces): compile errors now render a **framed source snippet with a caret** instead of bare `line:col` numbers.

## Before / after
```
# before
Error: transpilation failed: [SemanticError GALA-E0035] foo.gala:5:13 bare Go builtin "len(...)" ... (hint: ...)

# after
error[GALA-E0035]: bare Go builtin "len(...)" is not part of GALA's surface
  --> foo.gala:5:13
  |
5 |     val n = len(s)
  |             ^^^ use `.Size()`
  |
  = hint: use `.Size()` (logical size — characters for strings) or `.ByteSize()` (raw bytes) instead of `len(...)`
```
(Verified end-to-end through the real `gala transpile` binary — caret sits exactly under `len`.)

## Design (locked with the requester)
- **Rust-style gutter** layout: `error[CODE]: msg` header, `--> file:line:col` locus, line-number gutter, caret row with a terse inline annotation, `= hint:` footer.
- **Hybrid spans:** the caret width is derived at render time by scanning the token; PLUS an *additive, optional* `SemanticError.EndColumn` for exact spans. `GALA-E0035` (forbidden builtin) and `GALA-E0014` (default-param type mismatch) are upgraded to exact spans from the parser's stop token, so `^^^` covers the whole real token.
- **CLI-only:** the renderer lives in a new `galaerr/render.go`, wired into the `build`/`run`/`transpile` print sites. `Error()` and the entire LSP path are untouched (their tests don't move; LSP tests pass).
- **Auto color, no new dependency:** gated on `NO_COLOR` + `os.Stderr` being a char device; hand-written ANSI; byte-identical plain text when off.

## Correctness (reviewed)
- No crashes: caret math bounds-checks every `[]rune`/line index; no-position errors (type-inference, line 0) render header+hint only; `go build` errors are passed through verbatim (never framed).
- `WithFilePath` stamping only fills errors that lack a path — it never clobbers a cross-file/imported-package error's own file.
- Rune-based columns + tab-preserving caret indent (aligns regardless of tab width); LSP still reads `Line`/`Column` and its diagnostics are unchanged.

## Tests
- `galaerr/render_test.go` — exact vs derived spans, tab & unicode alignment, no-position, uncoded header, MultiError, color on/off, non-GALA passthrough.
- `internal/transpiler/transformer/rich_diagnostics_test.go` — drives a real `len(...)` program end-to-end and asserts the frame + `^^^` aligned under `len` + `GALA-E0035`.
- Full `//...` builds; the only red is the pre-existing unrelated `TestGorootFromGoBinarySymlink` Windows symlink flake. No `go.mod` change.

## Known cosmetic follow-ups (non-blocking)
- An E0014 default expression whose span crosses lines renders a clamped (non-crashing) over-long caret.
- CRLF source lines render fine (`\r\n` is a normal break); a trailing-`\r` strip would be tidier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)