### PR TITLE
fix(analyzer): detect duplicate methods and functions across files in a package

### DIFF
--- a/docs/errors/GALA-E0011.md
+++ b/docs/errors/GALA-E0011.md
@@ -4,23 +4,61 @@
 same name is declared more than once in the same package (across any
 combination of files).
 
-**Minimal repro.**
+**Minimal repro — two files.**
 
 ```gala
 // a.gala
 package main
-type User struct { Name string }
 
+type User struct {
+    Name string
+}
+```
+
+```gala
 // b.gala
 package main
-type User struct { Email string }   // redefines User
+
+type User struct {
+    Email string
+}
 ```
 
 **Error output.**
 
 ```
-[SemanticError GALA-E0011] b.gala:2:5 type "User" in package "main" redefined (first defined in a.gala) (hint: remove the duplicate declaration or rename one of the types)
+Error transpiling a.gala: [SemanticError GALA-E0011] a.gala:3:5 type "User" in package "main" redefined (also declared at b.gala:3) (hint: remove the duplicate declaration or rename one of the types)
+Error transpiling b.gala: [SemanticError GALA-E0011] b.gala:3:5 type "User" in package "main" redefined (also declared at a.gala:3) (hint: remove the duplicate declaration or rename one of the types)
 ```
+
+Every file of the package is compiled, so both declarations are reported,
+each naming the *other* one. Batch analysis order is not source order, so
+the message does not claim either declaration came first — it points at the
+other declaration site and leaves the choice of which to delete to you.
+
+**Minimal repro — one file.**
+
+```gala
+// a.gala
+package main
+
+type User struct {
+    Name string
+}
+
+type User struct {
+    Email string
+}
+```
+
+**Error output.**
+
+```
+Error transpiling a.gala: [SemanticError GALA-E0011] a.gala:7:0 type "User" in package "main" redefined (also declared at line 3) (hint: remove the duplicate declaration or rename one of the types)
+```
+
+When the other declaration is in the file the error is reported against, the
+message gives its line instead of repeating the file name.
 
 **Fix.** Delete one of the declarations, merge their fields, or rename one
 of the types so both can coexist.

--- a/docs/errors/GALA-E0012.md
+++ b/docs/errors/GALA-E0012.md
@@ -3,28 +3,73 @@
 **When it fires.** A method with the same name is declared twice on the same
 type (across any combination of files).
 
-**Minimal repro.**
+**Minimal repro — two files.** A method may be declared in a different file
+from its receiver type, so the duplicate here is only visible once the whole
+package is on the table.
 
 ```gala
 // a.gala
 package main
-type User struct { Name string }
-func (u User) Greet() string = "hello"
 
+type User struct {
+    Name string
+}
+
+func (u User) Greet() string = "hello"
+```
+
+```gala
 // b.gala
 package main
+
 func (u User) Greet() string = "hola"   // duplicate
 ```
 
 **Error output.**
 
 ```
-[SemanticError GALA-E0012] b.gala:2:5 method "Greet" on type "User" in package "main" redefined (first defined in a.gala) (hint: remove the duplicate method or rename it)
+Error transpiling a.gala: [SemanticError GALA-E0012] a.gala:7:14 method "Greet" on type "User" in package "main" redefined (also declared at b.gala:3) (hint: remove the duplicate method or rename it)
+Error transpiling b.gala: [SemanticError GALA-E0012] b.gala:3:14 method "Greet" on type "User" in package "main" redefined (also declared at a.gala:7) (hint: remove the duplicate method or rename it)
 ```
+
+Every file of the package is compiled, so both definitions are reported, each
+naming the *other* one. Batch analysis order is not source order, so the
+message does not claim either definition came first — it points at the other
+definition site and leaves the choice of which to delete to you.
+
+Declaring a method in a different file from its receiver type is otherwise
+fine, and stays fine: only a second definition of the *same* method name on
+the same type is rejected.
+
+**Minimal repro — one file.**
+
+```gala
+// a.gala
+package main
+
+type User struct {
+    Name string
+}
+
+func (u User) Greet() string = "hello"
+
+func (u User) Greet() string = "hola"
+```
+
+**Error output.**
+
+```
+Error transpiling a.gala: [SemanticError GALA-E0012] a.gala:9:0 method "Greet" on type "User" in package "main" redefined (also declared at line 7) (hint: remove the duplicate method or rename it)
+```
+
+When the other definition is in the file the error is reported against, the
+message gives its line instead of repeating the file name.
 
 **Fix.** Delete one of the definitions or rename the second method.
 
 **Rationale.** Method resolution uses a single map keyed by method name; a
 second declaration would silently replace the first, making the behavior
 order-of-loading dependent and hard to debug. This also mirrors Go's own
-rule — Go forbids duplicate methods on the same receiver.
+rule — Go forbids duplicate methods on the same receiver. Reporting it here
+means the duplicate is named in GALA source terms rather than reaching the Go
+compiler as `method User.Greet already declared` against generated code.

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2781,6 +2781,8 @@ gala_library(
     name = "multifile_lib_regress",
     srcs = [
         "multifile_lib_regress/consult_end.gala",
+        "multifile_lib_regress/cross_file_methods.gala",
+        "multifile_lib_regress/cross_file_methods_ext.gala",
         "multifile_lib_regress/directive_chain.gala",
         "multifile_lib_regress/events_pipe.gala",
         "multifile_lib_regress/go_interop.gala",

--- a/examples/multifile_lib_regress/cross_file_methods.gala
+++ b/examples/multifile_lib_regress/cross_file_methods.gala
@@ -1,0 +1,12 @@
+package multifile_lib_regress
+
+// --- Regression: methods on one type spread across files of a package ---
+// Ledger is declared here and carries one of its methods; the rest live in
+// cross_file_methods_ext.gala. The analyzer merges a package's files into a
+// single method set per type, and the duplicate-method check that guards
+// that set must count a sibling's contribution as one declaration, not two.
+// This only exercises the batch (--package-files) path, so a single-file
+// test cannot stand in for it.
+struct Ledger(Owner string)
+
+func (l Ledger) OwnedBy() string = l.Owner

--- a/examples/multifile_lib_regress/cross_file_methods_ext.gala
+++ b/examples/multifile_lib_regress/cross_file_methods_ext.gala
@@ -1,0 +1,8 @@
+package multifile_lib_regress
+
+// Continuation of Ledger's method set, in a different file of the same
+// package than the struct declaration (see cross_file_methods.gala).
+
+func (l Ledger) Tagged() string = s"ledger:${l.Owner}"
+
+func LedgerFor(owner string) Ledger = Ledger(Owner = owner)

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -350,4 +350,13 @@ func main() {
         case Some(c) => Println(c.String())
         case None()  => Println("<no cookie>")
     }
+
+    // --- Regression: one type's methods declared across two files of the
+    // package. Ledger and OwnedBy live in cross_file_methods.gala, Tagged
+    // and LedgerFor in cross_file_methods_ext.gala. Both methods must reach
+    // the generated Go exactly once: the duplicate-method check runs over
+    // the merged sibling metadata, so a sibling contributing a method to a
+    // type declared elsewhere must not read as a redefinition.
+    val ledger = multifile_lib_regress.LedgerFor("nina")
+    Println(s"ledger=${ledger.OwnedBy()}/${ledger.Tagged()}")
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -78,3 +78,4 @@ cfgs(1).Lead=Theo
 processed-42
 Cookie(session=session, path=/)
 Cookie(opt=opt, path=/)
+ledger=nina/ledger:nina

--- a/internal/transpiler/analyzer/BUILD.bazel
+++ b/internal/transpiler/analyzer/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
         "multipackage_panic_test.go",
         "parallel_parse_test.go",
         "parsedfile_cache_test.go",
+        "redefinition_cross_file_test.go",
         "test_exports_test.go",
         "test_helper_test.go",
         "validation_test.go",

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -828,12 +828,9 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 				// Error if type is being redefined from a DIFFERENT file.
 				// Skip if DefinedIn is empty (cache) or same file (re-analysis from analyzePackage).
 				if existing.DefinedIn != "" && hasTypeDefinition(existing) && !(existing.DefinedIn != filePath && isSameFile(existing.DefinedIn, absFilePath)) {
-					return nil, galaerr.NewCodedSemanticError(
-						galaerr.CodeTypeRedefinition,
+					return nil, typeRedefinedError(typeName, pkgName,
 						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-						fmt.Sprintf("type %q in package %q redefined (also declared at %s)", typeName, pkgName, declSiteRef(existing.DefinedIn, filePath, existing.Pos)),
-						"remove the duplicate declaration or rename one of the types",
-					)
+						existing.DefinedIn, filePath, existing.Pos)
 				}
 				meta = existing
 				// Clear fields to avoid duplicates if re-analyzing
@@ -980,12 +977,9 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 			pos := transpiler.PosFromToken(ctx.Identifier().GetStart())
 			if existing, ok := richAST.Types[fullTypeName]; ok && existing.Package == pkgName {
 				if existing.DefinedIn != "" && hasTypeDefinition(existing) && !(existing.DefinedIn != filePath && isSameFile(existing.DefinedIn, absFilePath)) {
-					return nil, galaerr.NewCodedSemanticError(
-						galaerr.CodeTypeRedefinition,
+					return nil, typeRedefinedError(typeName, pkgName,
 						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-						fmt.Sprintf("type %q in package %q redefined (also declared at %s)", typeName, pkgName, declSiteRef(existing.DefinedIn, filePath, existing.Pos)),
-						"remove the duplicate declaration or rename one of the types",
-					)
+						existing.DefinedIn, filePath, existing.Pos)
 				}
 				meta = existing
 				meta.Fields = make(map[string]transpiler.Type)
@@ -1071,12 +1065,9 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 			}
 			// Check for redefinition (skip if DefinedIn is empty — type came from cache)
 			if existing, ok := richAST.Types[fullSealedName]; ok && existing.DefinedIn != "" && hasTypeDefinition(existing) && !(existing.DefinedIn != filePath && isSameFile(existing.DefinedIn, absFilePath)) {
-				return nil, galaerr.NewCodedSemanticError(
-					galaerr.CodeTypeRedefinition,
+				return nil, typeRedefinedError(sealedName, pkgName,
 					ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-					fmt.Sprintf("type %q in package %q redefined (also declared at %s)", sealedName, pkgName, declSiteRef(existing.DefinedIn, filePath, existing.Pos)),
-					"remove the duplicate declaration or rename one of the types",
-				)
+					existing.DefinedIn, filePath, existing.Pos)
 			}
 			if err := a.analyzeSealedType(ctx, pkgName, richAST); err != nil {
 				return nil, err
@@ -1228,12 +1219,9 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 						if existing, exists := typeMeta.Methods[methodName]; exists {
 							// Error if method already has a user-defined implementation
 							if existing.DefinedIn != "" && !(existing.DefinedIn != filePath && isSameFile(existing.DefinedIn, absFilePath)) {
-								return nil, galaerr.NewCodedSemanticError(
-									galaerr.CodeMethodRedefinition,
+								return nil, methodRedefinedError(methodName, baseType, pkgName,
 									ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-									fmt.Sprintf("method %q on type %q in package %q redefined (also declared at %s)", methodName, baseType, pkgName, declSiteRef(existing.DefinedIn, filePath, existing.Pos)),
-									"remove the duplicate method or rename it",
-								)
+									existing.DefinedIn, filePath, existing.Pos)
 							}
 							// Merge IsGeneric: preserve a pre-populated flag (e.g. from a
 							// sibling-metadata pass) without clobbering a fresh true that
@@ -1263,13 +1251,9 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 					// check above sees only a placeholder entry whose
 					// DefinedIn is still empty, and would let it through.
 					if prev, dup := decls.recordMethod(fullBaseType+"."+methodName, filePath, methodMeta.Pos); dup {
-						return nil, galaerr.NewCodedSemanticError(
-							galaerr.CodeMethodRedefinition,
+						return nil, methodRedefinedError(methodName, baseType, pkgName,
 							ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-							fmt.Sprintf("method %q on type %q in package %q redefined (also declared at %s)",
-								methodName, baseType, pkgName, declSiteRef(prev.file, filePath, prev.pos)),
-							"remove the duplicate method or rename it",
-						)
+							prev.file, filePath, prev.pos)
 					}
 				}
 			} else {
@@ -1358,25 +1342,18 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 				// (re-analysis of the same source).
 				if existing, ok := richAST.Functions[fullFuncName]; ok {
 					if existing.DefinedIn != "" && !(existing.DefinedIn != filePath && isSameFile(existing.DefinedIn, absFilePath)) {
-						return nil, galaerr.NewCodedSemanticError(
-							galaerr.CodeFunctionRedeclared,
+						return nil, funcRedeclaredError(funcName, pkgName,
 							ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-							fmt.Sprintf("function %q in package %q redeclared (also declared at %s)", funcName, pkgName, declSiteRef(existing.DefinedIn, filePath, existing.Pos)),
-							"remove the duplicate declaration or rename one of the functions",
-						)
+							existing.DefinedIn, filePath, existing.Pos)
 					}
 				}
 				// Record the declaration so the sibling pass can detect a
 				// second definition of this function in another file of the
 				// package.
 				if prev, dup := decls.recordFunc(fullFuncName, filePath, funcMeta.Pos); dup {
-					return nil, galaerr.NewCodedSemanticError(
-						galaerr.CodeFunctionRedeclared,
+					return nil, funcRedeclaredError(funcName, pkgName,
 						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-						fmt.Sprintf("function %q in package %q redeclared (also declared at %s)",
-							funcName, pkgName, declSiteRef(prev.file, filePath, prev.pos)),
-						"remove the duplicate declaration or rename one of the functions",
-					)
+						prev.file, filePath, prev.pos)
 				}
 				richAST.Functions[fullFuncName] = funcMeta
 			}
@@ -2676,12 +2653,9 @@ func (a *galaAnalyzer) analyzePackage(relPath string) (*transpiler.RichAST, erro
 					}
 					if existingMeta, ok := pkgAST.Types[typeName]; ok {
 						if hasTypeDefinition(existingMeta) && existingMeta.DefinedIn != "" && !sameAsFilePath(existingMeta.DefinedIn) {
-							return nil, galaerr.NewCodedSemanticError(
-								galaerr.CodeTypeRedefinition,
+							return nil, typeRedefinedError(newMeta.Name, res.PackageName,
 								newMeta.Pos.Line, newMeta.Pos.Column,
-								fmt.Sprintf("type %q in package %q redefined (also declared at %s)", newMeta.Name, res.PackageName, declSiteRef(existingMeta.DefinedIn, filePath, existingMeta.Pos)),
-								"remove the duplicate declaration or rename one of the types",
-							)
+								existingMeta.DefinedIn, filePath, existingMeta.Pos)
 						}
 					}
 				}
@@ -3442,6 +3416,42 @@ func declSiteRef(otherFile, errorFile string, pos transpiler.SourcePos) string {
 	return otherFile
 }
 
+// typeRedefinedError, methodRedefinedError and funcRedeclaredError build the
+// GALA-E0011 / E0012 / E0027 diagnostics. Every site that reports a duplicate
+// declaration goes through one of these, so the wording cannot drift between
+// the same-file, cross-file and sibling paths that all raise the same code —
+// docs/errors/GALA-E0011.md and GALA-E0012.md quote this output verbatim.
+//
+// line/column place the caret. (otherFile, otherPos) is the *other*
+// declaration the message points at, spelled relative to errorFile — the file
+// the diagnostic is rendered against — by declSiteRef.
+func typeRedefinedError(typeName, pkgName string, line, column int, otherFile, errorFile string, otherPos transpiler.SourcePos) *galaerr.SemanticError {
+	return galaerr.NewCodedSemanticError(
+		galaerr.CodeTypeRedefinition, line, column,
+		fmt.Sprintf("type %q in package %q redefined (also declared at %s)",
+			typeName, pkgName, declSiteRef(otherFile, errorFile, otherPos)),
+		"remove the duplicate declaration or rename one of the types",
+	)
+}
+
+func methodRedefinedError(methodName, baseType, pkgName string, line, column int, otherFile, errorFile string, otherPos transpiler.SourcePos) *galaerr.SemanticError {
+	return galaerr.NewCodedSemanticError(
+		galaerr.CodeMethodRedefinition, line, column,
+		fmt.Sprintf("method %q on type %q in package %q redefined (also declared at %s)",
+			methodName, baseType, pkgName, declSiteRef(otherFile, errorFile, otherPos)),
+		"remove the duplicate method or rename it",
+	)
+}
+
+func funcRedeclaredError(funcName, pkgName string, line, column int, otherFile, errorFile string, otherPos transpiler.SourcePos) *galaerr.SemanticError {
+	return galaerr.NewCodedSemanticError(
+		galaerr.CodeFunctionRedeclared, line, column,
+		fmt.Sprintf("function %q in package %q redeclared (also declared at %s)",
+			funcName, pkgName, declSiteRef(otherFile, errorFile, otherPos)),
+		"remove the duplicate declaration or rename one of the functions",
+	)
+}
+
 // siblingTypeRedefinedError builds the E0011 diagnostic for a type that a
 // sibling file declares a second time. The diagnostic is rendered against the
 // file being analyzed, so when the earlier declaration lives there the caret
@@ -3453,18 +3463,10 @@ func declSiteRef(otherFile, errorFile string, pos transpiler.SourcePos) string {
 // quotes it the same way the build driver named the file rather than as an
 // absolute path next to a relative caret.
 func siblingTypeRedefinedError(typeName, pkgName string, existing *transpiler.TypeMetadata, sibPath string, sibPos transpiler.SourcePos, mainFile string) *galaerr.SemanticError {
-	line, column := sibPos.Line, sibPos.Column
-	other := declSiteRef(existing.DefinedIn, mainFile, existing.Pos)
 	if isSameFile(existing.DefinedIn, mainFile) {
-		line, column = existing.Pos.Line, existing.Pos.Column
-		other = declSiteRef(sibPath, mainFile, sibPos)
+		return typeRedefinedError(typeName, pkgName, existing.Pos.Line, existing.Pos.Column, sibPath, mainFile, sibPos)
 	}
-	return galaerr.NewCodedSemanticError(
-		galaerr.CodeTypeRedefinition,
-		line, column,
-		fmt.Sprintf("type %q in package %q redefined (also declared at %s)", typeName, pkgName, other),
-		"remove the duplicate declaration or rename one of the types",
-	)
+	return typeRedefinedError(typeName, pkgName, sibPos.Line, sibPos.Column, existing.DefinedIn, mainFile, existing.Pos)
 }
 
 // extractSiblingFullMetadata extracts full type metadata from a sibling .gala file.
@@ -3766,16 +3768,11 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 				// diagnostic is rendered against. A collision between two
 				// siblings is left to the Analyze call for one of those two
 				// files, which sees it as this same main-file case.
-				if prev, dup := decls.recordMethod(fullBaseType+"."+methodName, absSibPath, sibPos); dup {
-					if isSameFile(prev.file, decls.mainFile) {
-						return galaerr.NewCodedSemanticError(
-							galaerr.CodeMethodRedefinition,
-							prev.pos.Line, prev.pos.Column,
-							fmt.Sprintf("method %q on type %q in package %q redefined (also declared at %s)",
-								methodName, baseType, pkgName, declSiteRef(sibDisplay, decls.mainFile, sibPos)),
-							"remove the duplicate method or rename it",
-						)
-					}
+				prev, dup := decls.recordMethod(fullBaseType+"."+methodName, absSibPath, sibPos)
+				if dup && isSameFile(prev.file, decls.mainFile) {
+					return methodRedefinedError(methodName, baseType, pkgName,
+						prev.pos.Line, prev.pos.Column,
+						sibDisplay, decls.mainFile, sibPos)
 				}
 
 				methodMeta := &transpiler.MethodMetadata{
@@ -3874,16 +3871,11 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 				// Same rule as for methods above: a top-level function the
 				// analyzed file already declares is a redeclaration, and was
 				// previously dropped here without a word.
-				if prev, dup := decls.recordFunc(fullFuncName, absSibPath, sibPos); dup {
-					if isSameFile(prev.file, decls.mainFile) {
-						return galaerr.NewCodedSemanticError(
-							galaerr.CodeFunctionRedeclared,
-							prev.pos.Line, prev.pos.Column,
-							fmt.Sprintf("function %q in package %q redeclared (also declared at %s)",
-								funcName, pkgName, declSiteRef(sibDisplay, decls.mainFile, sibPos)),
-							"remove the duplicate declaration or rename one of the functions",
-						)
-					}
+				prev, dup := decls.recordFunc(fullFuncName, absSibPath, sibPos)
+				if dup && isSameFile(prev.file, decls.mainFile) {
+					return funcRedeclaredError(funcName, pkgName,
+						prev.pos.Line, prev.pos.Column,
+						sibDisplay, decls.mainFile, sibPos)
 				}
 				if _, ok := richAST.Functions[fullFuncName]; !ok {
 					funcMeta := &transpiler.FunctionMetadata{

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -831,7 +831,7 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 					return nil, galaerr.NewCodedSemanticError(
 						galaerr.CodeTypeRedefinition,
 						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-						fmt.Sprintf("type %q in package %q redefined (first defined in %s)", typeName, pkgName, existing.DefinedIn),
+						fmt.Sprintf("type %q in package %q redefined (also declared at %s)", typeName, pkgName, declSiteRef(existing.DefinedIn, filePath, existing.Pos)),
 						"remove the duplicate declaration or rename one of the types",
 					)
 				}
@@ -983,7 +983,7 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 					return nil, galaerr.NewCodedSemanticError(
 						galaerr.CodeTypeRedefinition,
 						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-						fmt.Sprintf("type %q in package %q redefined (first defined in %s)", typeName, pkgName, existing.DefinedIn),
+						fmt.Sprintf("type %q in package %q redefined (also declared at %s)", typeName, pkgName, declSiteRef(existing.DefinedIn, filePath, existing.Pos)),
 						"remove the duplicate declaration or rename one of the types",
 					)
 				}
@@ -1074,7 +1074,7 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 				return nil, galaerr.NewCodedSemanticError(
 					galaerr.CodeTypeRedefinition,
 					ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-					fmt.Sprintf("type %q in package %q redefined (first defined in %s)", sealedName, pkgName, existing.DefinedIn),
+					fmt.Sprintf("type %q in package %q redefined (also declared at %s)", sealedName, pkgName, declSiteRef(existing.DefinedIn, filePath, existing.Pos)),
 					"remove the duplicate declaration or rename one of the types",
 				)
 			}
@@ -1138,6 +1138,13 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 			)
 		}
 	}
+
+	// decls remembers which file of this package declared each method and each
+	// top-level function, for the duration of this call. Section 2 below fills
+	// it from the file being analyzed; the sibling-metadata pass (section 2.5)
+	// adds the siblings and rejects any declaration that collides with one
+	// already recorded from another file.
+	decls := newPackageDecls(filePath)
 
 	// 2. Collect methods and functions
 	for _, topDecl := range sourceFile.AllTopLevelDeclaration() {
@@ -1224,7 +1231,7 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 								return nil, galaerr.NewCodedSemanticError(
 									galaerr.CodeMethodRedefinition,
 									ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-									fmt.Sprintf("method %q on type %q in package %q redefined (first defined in %s)", methodName, baseType, pkgName, existing.DefinedIn),
+									fmt.Sprintf("method %q on type %q in package %q redefined (also declared at %s)", methodName, baseType, pkgName, declSiteRef(existing.DefinedIn, filePath, existing.Pos)),
 									"remove the duplicate method or rename it",
 								)
 							}
@@ -1248,6 +1255,21 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 							Methods: map[string]*transpiler.MethodMetadata{methodName: methodMeta},
 							Fields:  make(map[string]transpiler.Type),
 						}
+					}
+					// Record the declaration so the sibling pass can detect a
+					// second definition of this method in another file of the
+					// package. This also catches a duplicate within this file
+					// when the receiver type is declared in a sibling: the
+					// check above sees only a placeholder entry whose
+					// DefinedIn is still empty, and would let it through.
+					if prev, dup := decls.recordMethod(fullBaseType+"."+methodName, filePath, methodMeta.Pos); dup {
+						return nil, galaerr.NewCodedSemanticError(
+							galaerr.CodeMethodRedefinition,
+							ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+							fmt.Sprintf("method %q on type %q in package %q redefined (also declared at %s)",
+								methodName, baseType, pkgName, declSiteRef(prev.file, filePath, prev.pos)),
+							"remove the duplicate method or rename it",
+						)
 					}
 				}
 			} else {
@@ -1339,10 +1361,22 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 						return nil, galaerr.NewCodedSemanticError(
 							galaerr.CodeFunctionRedeclared,
 							ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-							fmt.Sprintf("function %q in package %q redeclared (first defined in %s)", funcName, pkgName, existing.DefinedIn),
+							fmt.Sprintf("function %q in package %q redeclared (also declared at %s)", funcName, pkgName, declSiteRef(existing.DefinedIn, filePath, existing.Pos)),
 							"remove the duplicate declaration or rename one of the functions",
 						)
 					}
+				}
+				// Record the declaration so the sibling pass can detect a
+				// second definition of this function in another file of the
+				// package.
+				if prev, dup := decls.recordFunc(fullFuncName, filePath, funcMeta.Pos); dup {
+					return nil, galaerr.NewCodedSemanticError(
+						galaerr.CodeFunctionRedeclared,
+						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
+						fmt.Sprintf("function %q in package %q redeclared (also declared at %s)",
+							funcName, pkgName, declSiteRef(prev.file, filePath, prev.pos)),
+						"remove the duplicate declaration or rename one of the functions",
+					)
 				}
 				richAST.Functions[fullFuncName] = funcMeta
 			}
@@ -1364,7 +1398,7 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 			if i < len(siblingPaths) {
 				sibPath = siblingPaths[i]
 			}
-			if err := a.extractSiblingFullMetadata(sibTree, pkgName, richAST, sibPath); err != nil {
+			if err := a.extractSiblingFullMetadata(sibTree, pkgName, richAST, sibPath, decls); err != nil {
 				return nil, err
 			}
 			a.extractPackageVals(sibTree, pkgName, richAST)
@@ -1378,7 +1412,7 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 			if i < len(siblingPaths) {
 				sibPath = siblingPaths[i]
 			}
-			if err := a.extractSiblingFullMetadata(sibTree, pkgName, richAST, sibPath); err != nil {
+			if err := a.extractSiblingFullMetadata(sibTree, pkgName, richAST, sibPath, decls); err != nil {
 				return nil, err
 			}
 			a.extractPackageVals(sibTree, pkgName, richAST)
@@ -2645,7 +2679,7 @@ func (a *galaAnalyzer) analyzePackage(relPath string) (*transpiler.RichAST, erro
 							return nil, galaerr.NewCodedSemanticError(
 								galaerr.CodeTypeRedefinition,
 								newMeta.Pos.Line, newMeta.Pos.Column,
-								fmt.Sprintf("type %q in package %q redefined (first defined in %s)", newMeta.Name, res.PackageName, existingMeta.DefinedIn),
+								fmt.Sprintf("type %q in package %q redefined (also declared at %s)", newMeta.Name, res.PackageName, declSiteRef(existingMeta.DefinedIn, filePath, existingMeta.Pos)),
 								"remove the duplicate declaration or rename one of the types",
 							)
 						}
@@ -3324,12 +3358,134 @@ func getBaseTypeName(ctx grammar.ITypeContext) string {
 	return ""
 }
 
+// packageDeclSite is where one declaration of a package-level symbol was seen.
+type packageDeclSite struct {
+	file string
+	pos  transpiler.SourcePos
+}
+
+// packageDecls records the methods and top-level functions declared by the
+// files of the package under analysis, during a single Analyze call: the file
+// being analyzed plus its sibling files.
+//
+// Only declarations parsed in this call are recorded. Entries that reached
+// richAST some other way — merged from an imported package, restored from the
+// analysis cache, or synthesized from Go metadata — are deliberately excluded:
+// their DefinedIn paths can be spelled differently from the sources on disk
+// (sandbox vs. source tree), and treating those as a second declaration would
+// report a redefinition for a file that only declares the symbol once.
+type packageDecls struct {
+	// mainFile is the file Analyze was called on. Diagnostics are rendered
+	// against this file, so a redefinition is only worth reporting when one
+	// of the two declarations lives here — that is the only case where the
+	// caret can point at real source.
+	mainFile string
+	methods  map[string]packageDeclSite
+	funcs    map[string]packageDeclSite
+}
+
+func newPackageDecls(mainFile string) *packageDecls {
+	return &packageDecls{
+		mainFile: mainFile,
+		methods:  make(map[string]packageDeclSite),
+		funcs:    make(map[string]packageDeclSite),
+	}
+}
+
+// recordDeclSite registers a declaration of key at (file, pos) and returns the
+// previous declaration when the symbol was already declared elsewhere in the
+// package. The first declaration wins: a duplicate never overwrites the
+// recorded site, so every later duplicate is reported against the same
+// original.
+//
+// The very same declaration seen twice — the same position in the same file,
+// which happens when a file is listed more than once among the package files,
+// or is reachable under two path spellings — is not a duplicate.
+func recordDeclSite(sites map[string]packageDeclSite, key, file string, pos transpiler.SourcePos) (packageDeclSite, bool) {
+	prev, ok := sites[key]
+	if !ok {
+		sites[key] = packageDeclSite{file: file, pos: pos}
+		return packageDeclSite{}, false
+	}
+	if prev.pos == pos && isSameFile(prev.file, file) {
+		return packageDeclSite{}, false
+	}
+	return prev, true
+}
+
+// recordMethod registers a method declaration. key is the fully qualified
+// receiver type plus the method name.
+func (d *packageDecls) recordMethod(key, file string, pos transpiler.SourcePos) (packageDeclSite, bool) {
+	return recordDeclSite(d.methods, key, file, pos)
+}
+
+// recordFunc registers a top-level function declaration.
+func (d *packageDecls) recordFunc(key, file string, pos transpiler.SourcePos) (packageDeclSite, bool) {
+	return recordDeclSite(d.funcs, key, file, pos)
+}
+
+// declSiteRef renders the location of the *other* declaration named by a
+// redefinition diagnostic. The message is attached to a caret in errorFile,
+// so a site in that same file is rendered as a bare line number and a site in
+// another file carries the file name — never the file the caret is already
+// pointing at, which would make the message self-referential.
+func declSiteRef(otherFile, errorFile string, pos transpiler.SourcePos) string {
+	if otherFile == "" || isSameFile(otherFile, errorFile) {
+		if pos.Line > 0 {
+			return fmt.Sprintf("line %d", pos.Line)
+		}
+		return "another declaration in this file"
+	}
+	if pos.Line > 0 {
+		return fmt.Sprintf("%s:%d", otherFile, pos.Line)
+	}
+	return otherFile
+}
+
+// siblingTypeRedefinedError builds the E0011 diagnostic for a type that a
+// sibling file declares a second time. The diagnostic is rendered against the
+// file being analyzed, so when the earlier declaration lives there the caret
+// is put on it and the message names the sibling; otherwise the caret falls
+// back to the sibling declaration and the message names the earlier file.
+// Either way the message points somewhere other than the caret.
+//
+// sibPath is the sibling's path as the caller spelled it, so the message
+// quotes it the same way the build driver named the file rather than as an
+// absolute path next to a relative caret.
+func siblingTypeRedefinedError(typeName, pkgName string, existing *transpiler.TypeMetadata, sibPath string, sibPos transpiler.SourcePos, mainFile string) *galaerr.SemanticError {
+	line, column := sibPos.Line, sibPos.Column
+	other := declSiteRef(existing.DefinedIn, mainFile, existing.Pos)
+	if isSameFile(existing.DefinedIn, mainFile) {
+		line, column = existing.Pos.Line, existing.Pos.Column
+		other = declSiteRef(sibPath, mainFile, sibPos)
+	}
+	return galaerr.NewCodedSemanticError(
+		galaerr.CodeTypeRedefinition,
+		line, column,
+		fmt.Sprintf("type %q in package %q redefined (also declared at %s)", typeName, pkgName, other),
+		"remove the duplicate declaration or rename one of the types",
+	)
+}
+
 // extractSiblingFullMetadata extracts full type metadata from a sibling .gala file.
 // This includes struct fields, sealed types, shorthand structs, and all method/function
 // signatures. Used for both --package-files mode and directory-discovered siblings
 // to enable full cross-file type resolution.
-func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileContext, pkgName string, richAST *transpiler.RichAST, sibFilePath string) error {
+//
+// decls carries the declarations already seen for this package in this Analyze
+// call, so a method or function that a sibling declares a second time is
+// rejected here rather than silently overwriting — or being silently dropped
+// by — the first declaration and reaching the Go compiler as "already
+// declared".
+func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileContext, pkgName string, richAST *transpiler.RichAST, sibFilePath string, decls *packageDecls) error {
 	absSibPath, _ := filepath.Abs(sibFilePath)
+	// sibDisplay is how diagnostics name this sibling: the caller's spelling,
+	// which matches how the caret path is printed for the file under
+	// compilation. absSibPath stays the identity used for comparisons.
+	sibDisplay := sibFilePath
+	if sibDisplay == "" {
+		sibDisplay = absSibPath
+	}
 	// 1. Collect struct types with full field info
 	for _, topDecl := range sibTree.AllTopLevelDeclaration() {
 		if typeDecl := topDecl.TypeDeclaration(); typeDecl != nil {
@@ -3344,12 +3500,8 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 			// Skip if DefinedIn is empty — the type came from cache and should be overwritable.
 			if existing, ok := richAST.Types[fullTypeName]; ok && len(existing.FieldNames) > 0 {
 				if existing.DefinedIn != "" && !isSameFile(existing.DefinedIn, absSibPath) {
-					return galaerr.NewCodedSemanticError(
-						galaerr.CodeTypeRedefinition,
-						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-						fmt.Sprintf("type %q in package %q redefined (first defined in %s)", typeName, pkgName, existing.DefinedIn),
-						"remove the duplicate declaration or rename one of the types",
-					)
+					return siblingTypeRedefinedError(typeName, pkgName, existing, sibDisplay,
+						transpiler.PosFromToken(ctx.Identifier().GetStart()), decls.mainFile)
 				}
 				if existing.DefinedIn != "" {
 					continue
@@ -3475,12 +3627,8 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 			}
 			if existing, ok := richAST.Types[fullTypeName]; ok && len(existing.FieldNames) > 0 {
 				if existing.DefinedIn != "" && !isSameFile(existing.DefinedIn, absSibPath) {
-					return galaerr.NewCodedSemanticError(
-						galaerr.CodeTypeRedefinition,
-						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-						fmt.Sprintf("type %q in package %q redefined (first defined in %s)", typeName, pkgName, existing.DefinedIn),
-						"remove the duplicate declaration or rename one of the types",
-					)
+					return siblingTypeRedefinedError(typeName, pkgName, existing, sibDisplay,
+						transpiler.PosFromToken(ctx.Identifier().GetStart()), decls.mainFile)
 				}
 				if existing.DefinedIn != "" {
 					continue
@@ -3561,12 +3709,8 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 			// Skip if DefinedIn is empty — the type came from cache.
 			if existing, ok := richAST.Types[fullTypeName]; ok && existing.IsSealed {
 				if existing.DefinedIn != "" && !isSameFile(existing.DefinedIn, absSibPath) {
-					return galaerr.NewCodedSemanticError(
-						galaerr.CodeTypeRedefinition,
-						ctx.GetStart().GetLine(), ctx.GetStart().GetColumn(),
-						fmt.Sprintf("type %q in package %q redefined (first defined in %s)", typeName, pkgName, existing.DefinedIn),
-						"remove the duplicate declaration or rename one of the types",
-					)
+					return siblingTypeRedefinedError(typeName, pkgName, existing, sibDisplay,
+						transpiler.PosFromToken(ctx.Identifier().GetStart()), decls.mainFile)
 				}
 				if existing.DefinedIn != "" {
 					continue
@@ -3609,10 +3753,35 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 					fullBaseType = pkgName + "." + baseType
 				}
 
+				sibPos := transpiler.PosFromToken(ctx.Identifier().GetStart())
+				// A method the analyzed file (or an earlier sibling) already
+				// declares on the same type is a duplicate. Without this the
+				// duplicate was silently dropped below — the receiver type's
+				// Methods map keeps whichever definition landed first — and
+				// both definitions still reached the generated Go, where the
+				// Go compiler rejected them with "method already declared".
+				//
+				// Reported only when the original is the file being analyzed:
+				// the caret then lands on real source in the file the
+				// diagnostic is rendered against. A collision between two
+				// siblings is left to the Analyze call for one of those two
+				// files, which sees it as this same main-file case.
+				if prev, dup := decls.recordMethod(fullBaseType+"."+methodName, absSibPath, sibPos); dup {
+					if isSameFile(prev.file, decls.mainFile) {
+						return galaerr.NewCodedSemanticError(
+							galaerr.CodeMethodRedefinition,
+							prev.pos.Line, prev.pos.Column,
+							fmt.Sprintf("method %q on type %q in package %q redefined (also declared at %s)",
+								methodName, baseType, pkgName, declSiteRef(sibDisplay, decls.mainFile, sibPos)),
+							"remove the duplicate method or rename it",
+						)
+					}
+				}
+
 				methodMeta := &transpiler.MethodMetadata{
 					Name:         methodName,
 					Package:      pkgName,
-					Pos:          transpiler.PosFromToken(ctx.Identifier().GetStart()),
+					Pos:          sibPos,
 					ReceiverName: recvCtx.Identifier().GetText(),
 					DefinedIn:    absSibPath,
 				}
@@ -3701,11 +3870,26 @@ func (a *galaAnalyzer) extractSiblingFullMetadata(sibTree *grammar.SourceFileCon
 				if pkgName != "" && pkgName != "main" && pkgName != "test" {
 					fullFuncName = pkgName + "." + funcName
 				}
+				sibPos := transpiler.PosFromToken(ctx.Identifier().GetStart())
+				// Same rule as for methods above: a top-level function the
+				// analyzed file already declares is a redeclaration, and was
+				// previously dropped here without a word.
+				if prev, dup := decls.recordFunc(fullFuncName, absSibPath, sibPos); dup {
+					if isSameFile(prev.file, decls.mainFile) {
+						return galaerr.NewCodedSemanticError(
+							galaerr.CodeFunctionRedeclared,
+							prev.pos.Line, prev.pos.Column,
+							fmt.Sprintf("function %q in package %q redeclared (also declared at %s)",
+								funcName, pkgName, declSiteRef(sibDisplay, decls.mainFile, sibPos)),
+							"remove the duplicate declaration or rename one of the functions",
+						)
+					}
+				}
 				if _, ok := richAST.Functions[fullFuncName]; !ok {
 					funcMeta := &transpiler.FunctionMetadata{
 						Name:      funcName,
 						Package:   pkgName,
-						Pos:       transpiler.PosFromToken(ctx.Identifier().GetStart()),
+						Pos:       sibPos,
 						DefinedIn: absSibPath,
 					}
 					if ctx.TypeParameters() != nil {

--- a/internal/transpiler/analyzer/redefinition_cross_file_test.go
+++ b/internal/transpiler/analyzer/redefinition_cross_file_test.go
@@ -1,0 +1,382 @@
+package analyzer_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+)
+
+// writePackage writes each name→source pair into dir and returns the absolute
+// path of every file, keyed by name.
+func writePackage(t *testing.T, dir string, files map[string]string) map[string]string {
+	t.Helper()
+	paths := make(map[string]string, len(files))
+	for name, src := range files {
+		p := filepath.Join(dir, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0755))
+		require.NoError(t, os.WriteFile(p, []byte(src), 0644))
+		paths[name] = p
+	}
+	return paths
+}
+
+// siblingsOf returns every path in paths except the one named self, which is
+// what the transpiler passes as --package-files when compiling self.
+func siblingsOf(paths map[string]string, self string) []string {
+	var out []string
+	for name, p := range paths {
+		if name != self {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// TestRedefinitionAcrossFiles covers duplicate declarations spread over the
+// files of a single package. A duplicate method used to be reported only when
+// both definitions sat in the same file: the sibling-metadata pass, which is
+// what pulls in the other files of the package, dropped a colliding method
+// without a word, so the duplicate reached the generated Go and surfaced as
+// the Go compiler's "method X.Y already declared".
+func TestRedefinitionAcrossFiles(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	searchPaths := getStdSearchPath()
+
+	tests := []struct {
+		name string
+		// files of the package, by file name.
+		files map[string]string
+		// analyze names the file to compile; the others are its siblings.
+		analyze string
+		// wantCode is the error code the analysis must report; empty means
+		// the analysis must succeed.
+		wantCode string
+		// wantContains are substrings the message must carry.
+		wantContains []string
+		// wantNotContains are substrings the message must not carry — used to
+		// pin down that a message never points at the file it is reported
+		// against as if that were a different declaration.
+		wantNotContains []string
+	}{
+		{
+			name: "duplicate method across two files, compiling the first",
+			files: map[string]string{
+				"a.gala": "package dup\n\nstruct User(Name string)\n\nfunc (u User) Greet() string = \"hi\"\n",
+				"b.gala": "package dup\n\nfunc (u User) Greet() string = \"hello\"\n",
+			},
+			analyze:         "a.gala",
+			wantCode:        "GALA-E0012",
+			wantContains:    []string{`method "Greet" on type "User" in package "dup" redefined`, "also declared at", "b.gala:3"},
+			wantNotContains: []string{"at a.gala"},
+		},
+		{
+			name: "duplicate method across two files, compiling the second",
+			files: map[string]string{
+				"a.gala": "package dup\n\nstruct User(Name string)\n\nfunc (u User) Greet() string = \"hi\"\n",
+				"b.gala": "package dup\n\nfunc (u User) Greet() string = \"hello\"\n",
+			},
+			analyze:      "b.gala",
+			wantCode:     "GALA-E0012",
+			wantContains: []string{`method "Greet" on type "User"`, "also declared at", "a.gala:5"},
+		},
+		{
+			name: "duplicate method in one file still reported",
+			files: map[string]string{
+				"a.gala": "package dup\n\nstruct User(Name string)\n\nfunc (u User) Greet() string = \"hi\"\n\nfunc (u User) Greet() string = \"hello\"\n",
+			},
+			analyze:      "a.gala",
+			wantCode:     "GALA-E0012",
+			wantContains: []string{`method "Greet" on type "User"`, "also declared at line 5"},
+		},
+		{
+			name: "duplicate method on a generic type across two files",
+			files: map[string]string{
+				"a.gala": "package dup\n\ntype Box[T any] struct {\n    value T\n}\n\nfunc (b Box[T]) Get() T = b.value\n",
+				"b.gala": "package dup\n\nfunc (b Box[T]) Get() T = b.value\n",
+			},
+			analyze:      "a.gala",
+			wantCode:     "GALA-E0012",
+			wantContains: []string{`method "Get" on type "Box"`, "also declared at", "b.gala:3"},
+		},
+		{
+			name: "duplicate generic method across two files",
+			files: map[string]string{
+				"a.gala": "package dup\n\ntype Box[T any] struct {\n    value T\n}\n\nfunc (b Box[T]) To[U any](u U) U = u\n",
+				"b.gala": "package dup\n\nfunc (b Box[T]) To[U any](u U) U = u\n",
+			},
+			analyze:      "a.gala",
+			wantCode:     "GALA-E0012",
+			wantContains: []string{`method "To" on type "Box"`},
+		},
+		{
+			name: "duplicate top-level function across two files",
+			files: map[string]string{
+				"a.gala": "package dup\n\nfunc Greet() string = \"hi\"\n",
+				"b.gala": "package dup\n\nfunc Greet() string = \"hello\"\n",
+			},
+			analyze:         "a.gala",
+			wantCode:        "GALA-E0027",
+			wantContains:    []string{`function "Greet" in package "dup" redeclared`, "also declared at", "b.gala:3"},
+			wantNotContains: []string{"at a.gala"},
+		},
+		{
+			name: "duplicate type across two files names the sibling, not itself",
+			files: map[string]string{
+				"a.gala": "package dup\n\nstruct Item(Id int)\n",
+				"b.gala": "package dup\n\nstruct Item(Name string)\n",
+			},
+			analyze:         "a.gala",
+			wantCode:        "GALA-E0011",
+			wantContains:    []string{`type "Item" in package "dup" redefined`, "also declared at", "b.gala:3"},
+			wantNotContains: []string{"at a.gala"},
+		},
+		{
+			name: "duplicate sealed type across two files names the sibling",
+			files: map[string]string{
+				"a.gala": "package dup\n\nsealed type Color {\n    case Red()\n    case Blue()\n}\n",
+				"b.gala": "package dup\n\nsealed type Color {\n    case Green()\n}\n",
+			},
+			analyze:         "a.gala",
+			wantCode:        "GALA-E0011",
+			wantContains:    []string{`type "Color" in package "dup" redefined`, "also declared at", "b.gala:3"},
+			wantNotContains: []string{"at a.gala"},
+		},
+
+		// --- negative cases: none of these may report a redefinition ---
+		{
+			name: "same method name on different types",
+			files: map[string]string{
+				"a.gala": "package ok\n\nstruct User(Name string)\n\nfunc (u User) Label() string = u.Name\n",
+				"b.gala": "package ok\n\nstruct Item(Id int)\n\nfunc (i Item) Label() string = \"item\"\n",
+			},
+			analyze: "a.gala",
+		},
+		{
+			name: "method and a same-named top-level function",
+			files: map[string]string{
+				"a.gala": "package ok\n\nstruct User(Name string)\n\nfunc (u User) Label() string = u.Name\n",
+				"b.gala": "package ok\n\nfunc Label() string = \"free function\"\n",
+			},
+			analyze: "a.gala",
+		},
+		{
+			name: "methods on a sibling-declared type",
+			files: map[string]string{
+				"a.gala": "package ok\n\nstruct User(Name string)\n",
+				"b.gala": "package ok\n\nfunc (u User) Greet() string = u.Name\n\nfunc (u User) Shout() string = u.Name\n",
+			},
+			analyze: "a.gala",
+		},
+		{
+			name: "one type with methods spread over three files",
+			files: map[string]string{
+				"a.gala": "package ok\n\nstruct User(Name string)\n\nfunc (u User) First() string = u.Name\n",
+				"b.gala": "package ok\n\nfunc (u User) Second() string = u.Name\n",
+				"c.gala": "package ok\n\nfunc (u User) Third() string = u.Name\n",
+			},
+			analyze: "b.gala",
+		},
+		{
+			name: "methods on companion-object variants of a sibling sealed type",
+			files: map[string]string{
+				"a.gala": "package ok\n\nsealed type Shape {\n    case Circle(r float64)\n    case Square(s float64)\n}\n",
+				"b.gala": "package ok\n\nfunc (c Circle) Area() float64 = c.r * c.r\n\nfunc (s Square) Area() float64 = s.s * s.s\n",
+			},
+			analyze: "a.gala",
+		},
+		{
+			name: "generic methods with distinct names on a sibling generic type",
+			files: map[string]string{
+				"a.gala": "package ok\n\ntype Box[T any] struct {\n    value T\n}\n",
+				"b.gala": "package ok\n\nfunc (b Box[T]) Get() T = b.value\n\nfunc (b Box[T]) To[U any](u U) U = u\n",
+			},
+			analyze: "a.gala",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			paths := writePackage(t, dir, tc.files)
+
+			src, err := os.ReadFile(paths[tc.analyze])
+			require.NoError(t, err)
+			tree, err := p.Parse(string(src))
+			require.NoError(t, err)
+
+			a := analyzer.NewGalaAnalyzerWithPackageFiles(p, searchPaths, siblingsOf(paths, tc.analyze))
+			_, err = a.Analyze(tree, paths[tc.analyze])
+
+			if tc.wantCode == "" {
+				assert.NoError(t, err, "legitimate cross-file declarations must analyze cleanly")
+				return
+			}
+			require.Error(t, err, "duplicate declaration must be rejected by the analyzer")
+			msg := err.Error()
+			assert.Contains(t, msg, tc.wantCode)
+			for _, want := range tc.wantContains {
+				assert.Contains(t, msg, want)
+			}
+			for _, notWant := range tc.wantNotContains {
+				assert.NotContains(t, msg, notWant,
+					"the message must point at the other declaration, not at the file it is reported against")
+			}
+		})
+	}
+}
+
+// TestRedefinitionSameFileListedTwice pins down that presenting one file to the
+// analyzer under two spellings of its path is not a redefinition. The sibling
+// pass records a declaration per file, and a package file list that repeats a
+// file — or reaches it through a path that only cleans down to the same file —
+// must resolve to a single declaration site.
+func TestRedefinitionSameFileListedTwice(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	searchPaths := getStdSearchPath()
+	dir := t.TempDir()
+
+	paths := writePackage(t, dir, map[string]string{
+		"a.gala": "package ok\n\nstruct User(Name string)\n\nfunc (u User) Greet() string = u.Name\n\nfunc Helper() string = \"h\"\n",
+		"c.gala": "package ok\n\nfunc Other() string = \"o\"\n",
+	})
+
+	// Same file, two spellings: the plain path and one routed through a
+	// directory that is immediately backed out of.
+	alias := filepath.Join(dir, "sub", "..", "a.gala")
+
+	src, err := os.ReadFile(paths["c.gala"])
+	require.NoError(t, err)
+	tree, err := p.Parse(string(src))
+	require.NoError(t, err)
+
+	a := analyzer.NewGalaAnalyzerWithPackageFiles(p, searchPaths, []string{paths["a.gala"], alias})
+	_, err = a.Analyze(tree, paths["c.gala"])
+	assert.NoError(t, err, "one file listed twice must not look like two declarations")
+}
+
+// TestRedefinitionSelfListedAsPackageFile pins down that the file being
+// analyzed may also appear in its own package-file list — the build driver
+// passes the whole package in some modes — without its own declarations being
+// counted twice.
+func TestRedefinitionSelfListedAsPackageFile(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	searchPaths := getStdSearchPath()
+	dir := t.TempDir()
+
+	paths := writePackage(t, dir, map[string]string{
+		"a.gala": "package ok\n\nstruct User(Name string)\n\nfunc (u User) Greet() string = u.Name\n\nfunc Helper() string = \"h\"\n",
+		"b.gala": "package ok\n\nfunc (u User) Shout() string = u.Name\n",
+	})
+
+	src, err := os.ReadFile(paths["a.gala"])
+	require.NoError(t, err)
+	tree, err := p.Parse(string(src))
+	require.NoError(t, err)
+
+	self := filepath.Join(dir, "sub", "..", "a.gala")
+	a := analyzer.NewGalaAnalyzerWithPackageFiles(p, searchPaths, []string{self, paths["b.gala"]})
+	_, err = a.Analyze(tree, paths["a.gala"])
+	assert.NoError(t, err, "a file listed among its own package files must not redefine itself")
+}
+
+// TestRedefinitionAcrossPackages pins down that identical type and method
+// names in two different packages never collide, including when both packages
+// are analyzed through the same analyzer instance and therefore share its
+// caches.
+func TestRedefinitionAcrossPackages(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	searchPaths := getStdSearchPath()
+	root := t.TempDir()
+
+	body := "struct Item(Id int)\n\nfunc (i Item) Label() string = \"item\"\n"
+	pkgs := map[string]string{
+		"pkga": "package pkga\n\n" + body,
+		"pkgb": "package pkgb\n\n" + body,
+	}
+
+	a := analyzer.NewGalaAnalyzer(p, searchPaths)
+	for pkg, src := range pkgs {
+		dir := filepath.Join(root, pkg)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		file := filepath.Join(dir, "item.gala")
+		require.NoError(t, os.WriteFile(file, []byte(src), 0644))
+
+		tree, err := p.Parse(src)
+		require.NoError(t, err)
+		_, err = a.Analyze(tree, file)
+		assert.NoError(t, err, "package %s must not collide with the identically shaped sibling package", pkg)
+	}
+}
+
+// TestRedefinitionMessageNamesOtherFile is the message-shape guard for the
+// three redefinition codes: the location a redefinition message names must be
+// a declaration other than the one the caret is on. Naming the file under
+// compilation as the place the symbol was "first defined" told the reader
+// nothing.
+func TestRedefinitionMessageNamesOtherFile(t *testing.T) {
+	p := transpiler.NewAntlrGalaParser()
+	searchPaths := getStdSearchPath()
+
+	tests := []struct {
+		name  string
+		files map[string]string
+		code  string
+	}{
+		{
+			name: "type",
+			files: map[string]string{
+				"first.gala":  "package dup\n\nstruct Item(Id int)\n",
+				"second.gala": "package dup\n\nstruct Item(Name string)\n",
+			},
+			code: "GALA-E0011",
+		},
+		{
+			name: "method",
+			files: map[string]string{
+				"first.gala":  "package dup\n\nstruct Item(Id int)\n\nfunc (i Item) Label() string = \"a\"\n",
+				"second.gala": "package dup\n\nfunc (i Item) Label() string = \"b\"\n",
+			},
+			code: "GALA-E0012",
+		},
+		{
+			name: "function",
+			files: map[string]string{
+				"first.gala":  "package dup\n\nfunc Label() string = \"a\"\n",
+				"second.gala": "package dup\n\nfunc Label() string = \"b\"\n",
+			},
+			code: "GALA-E0027",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			paths := writePackage(t, dir, tc.files)
+
+			src, err := os.ReadFile(paths["first.gala"])
+			require.NoError(t, err)
+			tree, err := p.Parse(string(src))
+			require.NoError(t, err)
+
+			a := analyzer.NewGalaAnalyzerWithPackageFiles(p, searchPaths, siblingsOf(paths, "first.gala"))
+			_, err = a.Analyze(tree, paths["first.gala"])
+			require.Error(t, err)
+
+			msg := err.Error()
+			assert.Contains(t, msg, tc.code)
+			// The named site is the sibling…
+			assert.True(t, strings.Contains(msg, "second.gala"),
+				"message must name the other declaration site, got: %s", msg)
+			// …and never the file the diagnostic is reported against.
+			assert.NotContains(t, msg, "first.gala",
+				"message must not name the file it is reported against, got: %s", msg)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

A duplicate method declared in two files of the same package was not caught by GALA. It reached the Go compiler, which reported `method User.Greet already declared` against *generated* Go. Same-file duplicates were caught correctly.

The same hole existed for duplicate **functions** (GALA-E0027) — despite a source comment claiming otherwise.

## Root cause

Ordering, plus a missing check:

1. Methods and functions of the analyzed file are collected in section 2; the sibling-metadata pass is section 2.5, which runs **later**. At the moment the E0012 guard runs, no sibling has contributed anything, so `existing` can only ever be the same file.
2. The sibling pass then reached the duplicate and **silently dropped it** (`if _, exists := typeMeta.Methods[name]; !exists`). E0011 works cross-file only because the sibling pass's *type* branch has its own explicit error check — the method and function branches never got one.

## Changes

- A per-`Analyze` record of every method and top-level function declared by the analyzed file and each sibling; a second declaration from a different file is rejected. Only declarations parsed in that call participate, so metadata merged from an imported package or restored from cache can never masquerade as a duplicate, and a file reached via two path spellings is not a duplicate of itself.
- **Message rewording.** The old text said `first defined in <file>` and named the file being compiled — self-referential and useless. Batch order is not source order, so no site can honestly be called "first". All three codes now name the *other* site:
  - E0011 `type %q in package %q redefined (also declared at %s)`
  - E0012 `method %q on type %q in package %q redefined (also declared at %s)`
  - E0027 `function %q in package %q redeclared (also declared at %s)`
- Each message is now built in **one place per code** instead of being spelled out at 12 call sites — 12 copies of a format string quoted verbatim by the docs were 12 future drift sites.

## Verification

- `bazel build //...`; `bazel test //...` green apart from the known Windows symlink test.
- `std` (12 files) transpiles with zero false "redefined" errors.
- `examples/multifile_lib_regress/` gains a cross-file-methods case — this is inherently a batch/`transpile-package` bug that single-file tests cannot catch.
- Docs quote real captured CLI output verbatim for all four cases; zero occurrences of `first defined in` remain in the repo.
- Negative coverage: same method name on different types, method vs same-named function, methods spread over three files, companion-object variants, one file listed twice under two path spellings.

## Scope note

When two siblings collide but neither is the file currently being analyzed, it is not reported in that pass — the caret would land in a file the diagnostic isn't rendered against. It is caught when either file is itself analyzed, which every build path does: `gala build`'s cache is all-or-nothing over every `.gala` plus `gala.mod`, and `transpile-package`, the worker, test files and dependency transpilation all loop over every file as `mainFile`. The only gap is the LSP, which analyzes just the open file — not a build gate.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)