### PR TITLE
fix(diagnostics): correct E0018 hint syntax and doc/output message drift

### DIFF
--- a/docs/errors/BUILD.bazel
+++ b/docs/errors/BUILD.bazel
@@ -1,0 +1,9 @@
+# The error-code reference pages are consumed as test data by the
+# doc-verification guard in //internal/transpiler/transformer, which asserts
+# each page quotes the compiler's real output byte-for-byte. Linux CI sandboxes
+# tests, so the pages must be declared as data to be readable there.
+filegroup(
+    name = "error_docs",
+    srcs = glob(["GALA-E*.md"]),
+    visibility = ["//visibility:public"],
+)

--- a/docs/errors/GALA-E0002.md
+++ b/docs/errors/GALA-E0002.md
@@ -3,9 +3,11 @@
 **When it fires.** A `match` expression on a sealed type omits one or more
 variants and has no default (`case _ =>`) fallback.
 
-**Minimal repro.**
+**Minimal repro.** (`main.gala`)
 
 ```gala
+package main
+
 sealed type Color {
     case Red()
     case Green()
@@ -15,15 +17,30 @@ sealed type Color {
 func name(c Color) string = c match {
     case Red()   => "red"
     case Green() => "green"
-    // missing: Blue
+}
+
+func main() {
+    Println(name(Red()))
 }
 ```
 
-**Error output.**
+**Error output.** The caret sits on the *first* case clause: coverage is
+reported against the match as a whole, and the omitted variant has no source
+location of its own to point at. The inline annotation next to the caret is
+the hint truncated to one line; the full hint follows below the frame.
 
+```text
+error[GALA-E0002]: non-exhaustive match: missing cases: Blue
+  --> main.gala:10:5
+   |
+10 |     case Red()   => "red"
+   |     ^^^^ add the missing variant cases, or add a `case _ => ...` defa…
+   |
+   = hint: add the missing variant cases, or add a `case _ => ...` default to cover them
 ```
-[SemanticError GALA-E0002] main.gala:7:28 non-exhaustive match: missing cases: Blue
-```
+
+The `-->` line echoes the source path as the compiler resolved it; the CLI
+prints it absolute.
 
 **Fix.** Either cover every variant explicitly:
 
@@ -52,6 +69,6 @@ as a `switch` with a forgotten case. GALA therefore requires either full
 coverage or an explicit acknowledgment (`case _ =>`) that some variants
 should be grouped.
 
-**Related work.** Exhaustiveness introduced by the boolean / sealed match
-checker in B6 / A8 (PRs #166, #167). The same machinery emits GALA-E0004
-when the *arity* of a variant pattern is wrong.
+**Related work.** The same exhaustiveness machinery emits GALA-E0004 when the
+*arity* of a variant pattern is wrong. GALA-E0003 is the open-type
+counterpart of this check.

--- a/docs/errors/GALA-E0003.md
+++ b/docs/errors/GALA-E0003.md
@@ -49,17 +49,16 @@ func name(n int) string = n match {
 
 If you genuinely want the program to abort on unknown values, be explicit.
 A bare `panic(...)` is a Go builtin that GALA rejects (GALA-E0035), so use
-the sanctioned interop wrapper:
+the sanctioned interop wrapper. `Panic` is void, but in a match-arm tail the
+transpiler lowers it to Go's diverging `panic`, so the arm needs no trailing
+value:
 
 ```gala
 import "martianoff/gala/go_builtins"
 
 func strict(n int) string = n match {
     case 1 => "one"
-    case _ => {
-        go_builtins.Panic(s"unexpected n: $n")
-        ""
-    }
+    case _ => go_builtins.Panic(s"unexpected n: $n")
 }
 ```
 

--- a/docs/errors/GALA-E0003.md
+++ b/docs/errors/GALA-E0003.md
@@ -5,21 +5,37 @@ primitive or a plain struct) has no default branch. Unlike sealed matches,
 the compiler cannot prove exhaustiveness for open types, so a default is
 mandatory.
 
-**Minimal repro.**
+**Minimal repro.** (`main.gala`)
 
 ```gala
+package main
+
 func name(n int) string = n match {
     case 1 => "one"
     case 2 => "two"
-    // missing: case _ => ...
+}
+
+func main() {
+    Println(name(1))
 }
 ```
 
-**Error output.**
+**Error output.** The caret sits on the first case clause — it is the match
+as a whole that lacks a default, so there is no later offending token to
+point at.
 
+```text
+error[GALA-E0003]: match expression must have a default case
+  --> main.gala:4:5
+  |
+4 |     case 1 => "one"
+  |     ^^^^ add `case _ => ...`
+  |
+  = hint: add `case _ => ...`
 ```
-[SemanticError GALA-E0003] main.gala:1:28 match expression must have a default case (hint: add `case _ => ...`)
-```
+
+The `-->` line echoes the source path as the compiler resolved it; the CLI
+prints it absolute.
 
 **Fix.** Add a default case that produces a sensible fallback value:
 
@@ -31,10 +47,20 @@ func name(n int) string = n match {
 }
 ```
 
-If you genuinely want the program to crash on unknown values, be explicit:
+If you genuinely want the program to abort on unknown values, be explicit.
+A bare `panic(...)` is a Go builtin that GALA rejects (GALA-E0035), so use
+the sanctioned interop wrapper:
 
 ```gala
-case _ => panic("unexpected n")
+import "martianoff/gala/go_builtins"
+
+func strict(n int) string = n match {
+    case 1 => "one"
+    case _ => {
+        go_builtins.Panic(s"unexpected n: $n")
+        ""
+    }
+}
 ```
 
 **Rationale.** Non-sealed types have unbounded instance sets — there is no
@@ -43,5 +69,10 @@ the generated Go code would be forced to synthesize one (usually a runtime
 panic), hiding the missing-branch bug from the author. Requiring the default
 to be written explicitly surfaces the decision at the call site.
 
-**Related work.** Introduced alongside B6 / A8 (PRs #166, #167). Sealed
-types get GALA-E0002 instead; GALA-E0003 is the open-type counterpart.
+**Note on wording.** Two places in the transformer lower a `match` — one for
+expression position, one for statement position. They now emit identical text
+for this code; if you are reading an older build, the expression-position
+lowering appended a redundant `(case _ => ...)` to the message.
+
+**Related work.** Sealed types get GALA-E0002 instead; GALA-E0003 is the
+open-type counterpart.

--- a/docs/errors/GALA-E0006.md
+++ b/docs/errors/GALA-E0006.md
@@ -4,35 +4,47 @@
 either multiple `case _ =>` clauses, or a mix of `case _ =>` and a plain
 binding pattern (`case n =>`) that also catches everything.
 
-**Minimal repro.**
+**Minimal repro.** (`main.gala`)
 
 ```gala
+package main
+
 func name(n int) string = n match {
     case 1 => "one"
     case _ => "other"
-    case _ => "also-other"   // error: second default
+    case _ => "also-other"
+}
+
+func main() {
+    Println(name(1))
 }
 ```
 
-**Error output.**
+**Error output.** The caret sits on the *second* default — the first one is
+legal, so the offending token is the duplicate.
 
+```text
+error[GALA-E0006]: multiple default cases in match expression
+  --> main.gala:6:5
+  |
+6 |     case _ => "also-other"
+  |     ^^^^ keep one default case
+  |
+  = hint: keep one default case; combine logic with guards or nested matches if you need sub-cases
 ```
-[SemanticError GALA-E0006] main.gala:3:9 multiple default cases in match expression
-```
+
+The `-->` line echoes the source path as the compiler resolved it; the CLI
+prints it absolute.
 
 **Fix.** Keep exactly one default. If you need to distinguish several
-"other" groups, move the extra logic into the default body with an `if`:
+"other" groups, move the extra logic into the default body with an `if`
+(GALA's `if` condition is parenthesized, and the `if` is an expression that
+yields the branch value):
 
 ```gala
 func name(n int) string = n match {
     case 1 => "one"
-    case _ => {
-        if n > 100 {
-            "big"
-        } else {
-            "other"
-        }
-    }
+    case _ => if (n > 100) { "big" } else { "other" }
 }
 ```
 
@@ -41,6 +53,6 @@ default as the final `else` of the generated if-else chain, so any branch
 after it would be dead code. Making it a compile error means authors notice
 the duplication instead of wondering why a branch never fires.
 
-**Related work.** Introduced as part of A8 / structured error codes
-(PR #167). The check lives in `transformMatchClauses` in `match.go` and
-fires on the second default encountered while walking the case clauses.
+**Related work.** The check fires on the second default encountered while
+walking the case clauses; both the expression-position and statement-position
+match lowerings emit identical text for it.

--- a/docs/errors/GALA-E0006.md
+++ b/docs/errors/GALA-E0006.md
@@ -44,7 +44,7 @@ yields the branch value):
 ```gala
 func name(n int) string = n match {
     case 1 => "one"
-    case _ => if (n > 100) { "big" } else { "other" }
+    case _ => if (n > 100) "big" else "other"
 }
 ```
 

--- a/docs/errors/GALA-E0010.md
+++ b/docs/errors/GALA-E0010.md
@@ -1,22 +1,65 @@
 # GALA-E0010 — Duplicate package name in directory
 
 **When it fires.** Two or more `.gala` files in the same directory declare
-different `package` names, and the current file is not a `_test.gala` file.
-Test files may diverge by one character (like Go's `pkg_test` convention);
-regular sources cannot.
+different `package` names, and neither file is a `_test.gala` file. Test
+files may diverge (like Go's `pkg_test` convention); regular sources cannot.
 
 **Minimal repro.**
 
 ```
-lib/a.gala  // package mylib
-lib/b.gala  // package other   <-- triggers the error
+lib/a.gala   // package mylib
+lib/b.gala   // package other
 ```
 
-**Error output.**
+`lib/a.gala`:
 
+```gala
+package mylib
+
+func Hello() string = "hello"
 ```
-[SemanticError GALA-E0010] b.gala:1:0 directory lib has files with different package names: "mylib" and "other" (hint: use the same package name across all sibling .gala files, or move the file to a different directory)
+
+`lib/b.gala`:
+
+```gala
+package other
+
+func Bye() string = "bye"
 ```
+
+**Error output.** Two details are easy to misread:
+
+* the message names the **sibling** file and the sibling's package (`b.gala`
+  / `"other"`), while `but sibling files declare "mylib"` reports the package
+  of the file currently being compiled; and
+* the caret is on the `package` keyword of the **file being compiled**
+  (`a.gala`), not on the sibling the message names.
+
+```text
+error[GALA-E0010]: package file lib/b.gala declares package "other" but sibling files declare "mylib"
+  --> lib/a.gala:1:1
+  |
+1 | package mylib
+  | ^^^^^^^ use the same package name across all sibling .gala files, or…
+  |
+  = hint: use the same package name across all sibling .gala files, or move the file to a different directory
+```
+
+The paths are shown here workspace-relative; the CLI prints them absolute.
+Which file appears where depends on which one the compiler reached first, so
+the two names may be swapped in your output.
+
+**Second wording.** The analyzer raises this code from two places. Sibling
+*discovery* produces the message above; the later sibling-*filtering* pass
+produces a differently-worded one that names the directory instead:
+
+```text
+error[GALA-E0010]: directory lib has files with different package names: "other" and "mylib"
+```
+
+(First name = the file being compiled, second = the sibling; the directory is
+printed absolute.) Both wordings carry the same code and the same hint.
+`gala build` normally surfaces the first.
 
 **Fix.** Either rename one of the packages so both files agree, or move the
 outlier file into its own directory.

--- a/docs/errors/GALA-E0015.md
+++ b/docs/errors/GALA-E0015.md
@@ -5,7 +5,7 @@ assigned to a variable, returned from a function as an expression, or passed
 as an argument) and one of its branches ends with a bare `return` — a
 `return` statement with no value.
 
-**Minimal repro.**
+**Minimal repro.** (`main.gala`)
 
 ```gala
 package main
@@ -13,22 +13,37 @@ package main
 import "os"
 
 func run(path string) {
-    val data = Try(os.ReadFile(path)) match {
+    val data = Try(() => os.ReadFile(path)) match {
         case Success(b)   => string(b)
         case Failure(err) => {
             Println(s"error: ${err.Error()}")
-            return                     // <- bare return in a value-match branch
+            return
         }
     }
     Println(data)
 }
+
+func main() {
+    run("missing.txt")
+}
 ```
 
-**Error output.**
+**Error output.** The caret sits on the head of the match subject (`Try`),
+not on the offending `return`: the diagnosis is about the match expression as
+a whole, and the hint names the type the wrapping function must return.
 
+```text
+error[GALA-E0015]: bare `return` inside a match branch whose result is used as a value
+  --> main.gala:6:16
+  |
+6 |     val data = Try(() => os.ReadFile(path)) match {
+  |                ^^^ the match is wrapped in a function that must return string
+  |
+  = hint: the match is wrapped in a function that must return string; restructure to early-exit before the match, or use combinators like .Recover / .GetOrElse. See docs/errors/GALA-E0015.md
 ```
-[SemanticError GALA-E0015] main.gala:10:31 bare `return` inside a match branch whose result is used as a value
-```
+
+The `-->` line echoes the source path as the compiler resolved it; the CLI
+prints it absolute.
 
 **Why it is an error.** GALA transpiles a match-as-value into a Go
 immediately-invoked function expression (IIFE):
@@ -53,7 +68,7 @@ compiler rejects it with *"not enough return values"*.
 
     ```gala
     func run(path string) {
-        val result = Try(os.ReadFile(path))
+        val result = Try(() => os.ReadFile(path))
         if (result.IsFailure()) {
             Println(s"error: ${result.GetError().Error()}")
             return
@@ -67,7 +82,7 @@ compiler rejects it with *"not enough return values"*.
 
     ```gala
     func run(path string) {
-        val data = Try(os.ReadFile(path))
+        val data = Try(() => os.ReadFile(path))
             .Map((b) => string(b))
             .GetOrElse("")
         if (data == "") { return }
@@ -78,7 +93,7 @@ compiler rejects it with *"not enough return values"*.
 3.  **Return from a `match` used as the function body** — if the match
     itself is the function's last expression, each branch can legitimately
     `return` a value (including `return` on its own when the function is
-    `Unit`/void).
+    void).
 
 **Rationale.** GALA's match-as-value form has expression semantics: every
 branch must contribute a value of the match's result type. A bare `return`

--- a/docs/errors/GALA-E0015.md
+++ b/docs/errors/GALA-E0015.md
@@ -13,7 +13,7 @@ package main
 import "os"
 
 func run(path string) {
-    val data = Try(() => os.ReadFile(path)) match {
+    val data = Try(os.ReadFile(path)) match {
         case Success(b)   => string(b)
         case Failure(err) => {
             Println(s"error: ${err.Error()}")
@@ -36,7 +36,7 @@ a whole, and the hint names the type the wrapping function must return.
 error[GALA-E0015]: bare `return` inside a match branch whose result is used as a value
   --> main.gala:6:16
   |
-6 |     val data = Try(() => os.ReadFile(path)) match {
+6 |     val data = Try(os.ReadFile(path)) match {
   |                ^^^ the match is wrapped in a function that must return string
   |
   = hint: the match is wrapped in a function that must return string; restructure to early-exit before the match, or use combinators like .Recover / .GetOrElse. See docs/errors/GALA-E0015.md
@@ -68,7 +68,7 @@ compiler rejects it with *"not enough return values"*.
 
     ```gala
     func run(path string) {
-        val result = Try(() => os.ReadFile(path))
+        val result = Try(os.ReadFile(path))
         if (result.IsFailure()) {
             Println(s"error: ${result.GetError().Error()}")
             return
@@ -82,7 +82,7 @@ compiler rejects it with *"not enough return values"*.
 
     ```gala
     func run(path string) {
-        val data = Try(() => os.ReadFile(path))
+        val data = Try(os.ReadFile(path))
             .Map((b) => string(b))
             .GetOrElse("")
         if (data == "") { return }

--- a/docs/errors/GALA-E0018.md
+++ b/docs/errors/GALA-E0018.md
@@ -13,31 +13,56 @@ emit a literal `Variant{}` whose type parameter Go cannot deduce —
 producing an obscure `cannot infer T` error far from the GALA source.
 This code surfaces the failure at the GALA call site instead.
 
-**Minimal repro.**
+**Minimal repro.** (`main.gala`)
 
 ```gala
 package main
 
-sealed type Box[T] = case Empty()
+sealed type Box[T any] {
+    case Empty()
+    case Filled(value T)
+}
 
-func main(): Unit = {
-    val x = Empty()  // No annotation, no enclosing type — parameter T is unbound
+func main() {
+    val x = Empty()
     Println(x)
 }
 ```
 
-**Error output.**
+**Error output.** Two details often surprise readers:
 
-```
-[SemanticError GALA-E0018] line 5:13 cannot infer type parameter for sealed variant constructor "Empty()" of "Box" (hint: annotate the variable (e.g. `val x: Box[Int] = Empty()`) or pass type args explicitly (`Empty[Int]()`))
+* the message names only the constructor (`"Empty()"`), not the parent sealed
+  type — the parent appears in the hint, not in the header; and
+* the caret is a single `^` on the **closing paren** of `Empty()`, because the
+  diagnostic is anchored at the call suffix rather than at the callee name.
+
+```text
+error[GALA-E0018]: cannot infer type parameter for sealed variant constructor "Empty()"
+  --> main.gala:9:18
+  |
+9 |     val x = Empty()
+  |                  ^ annotate the binding
+  |
+  = hint: annotate the binding (e.g. `val x Box[int] = Empty()`) or pass type args explicitly (`Empty[int]()`)
 ```
 
-**Fix.** Pick the form that documents intent best:
+The `-->` line echoes the source path as the compiler resolved it; the CLI
+prints it absolute. The hint names your actual parent sealed type, so the
+example it prints is copy-pasteable as-is.
+
+**Fix.** Pick the form that documents intent best. Both compile:
 
 ```gala
-val x: Box[Int] = Empty()   // declarative; reads as a binding, not a call
-val x = Empty[Int]()         // explicit instantiation; useful when the type param is the operative information
+val x Box[int] = Empty()   // declarative; reads as a binding, not a call
 ```
+
+```gala
+val x = Empty[int]()       // explicit instantiation; useful when the type param is the operative information
+```
+
+Note the annotation syntax: in GALA the type follows the binding name with
+**no colon** (`val x Box[int] = ...`), and primitive types are spelled
+lowercase (`int`, not `Int`).
 
 Or, when the constructor is an arm of a `match` against a value of the
 parent type, the inference signal is already present and no annotation
@@ -47,9 +72,10 @@ is needed.
 expected-type signal flowing from the enclosing context. When that
 signal is absent, the transpiler has historically fallen through to an
 untyped composite literal and let Go deduce — which fails confusingly.
-Failing fast, with a hint that names the three resolving signals,
-points the user at the cheapest fix.
+Failing fast, with a hint that names the resolving signals, points the user
+at the cheapest fix.
 
 **Scope.** Only zero-arg sealed-variant constructors of *generic*
-sealed types. Variants of non-generic sealed types and constructors
-that take arguments contributing to inference are unaffected.
+sealed types written without explicit type args. Variants of non-generic
+sealed types, explicit `Variant[T]()` shapes, and constructors that take
+arguments contributing to inference are unaffected.

--- a/docs/errors/GALA-E0018.md
+++ b/docs/errors/GALA-E0018.md
@@ -50,6 +50,37 @@ The `-->` line echoes the source path as the compiler resolved it; the CLI
 prints it absolute. The hint names your actual parent sealed type, so the
 example it prints is copy-pasteable as-is.
 
+**When the constructor comes from another package.** If you reached the
+variant through an ordinary import, the hint qualifies both names the same way
+your call site does — otherwise the example it printed would not be in scope
+where you need to paste it:
+
+```gala
+package main
+
+import "t/cmdpkg"
+
+func main() {
+    val x = cmdpkg.NoCmd()
+    Println(x)
+}
+```
+
+```text
+error[GALA-E0018]: cannot infer type parameter for sealed variant constructor "NoCmd()"
+  --> main.gala:6:25
+  |
+6 |     val x = cmdpkg.NoCmd()
+  |                         ^ annotate the binding
+  |
+  = hint: annotate the binding (e.g. `val x cmdpkg.Cmd[int] = cmdpkg.NoCmd()`) or pass type args explicitly (`cmdpkg.NoCmd[int]()`)
+```
+
+Note the message still names the constructor bare (`"NoCmd()"`) while the hint
+qualifies it. A dot-imported package, or a variant reached through the std
+prelude, brings its names into scope unqualified, so the hint prints them bare
+in those cases.
+
 **Fix.** Pick the form that documents intent best. Both compile:
 
 ```gala

--- a/docs/errors/GALA-E0025.md
+++ b/docs/errors/GALA-E0025.md
@@ -2,18 +2,52 @@
 
 **When it fires.** A type or function name was used without a package
 qualifier (e.g. bare `Array`, `ArrayTabulate`, `MyType`) and resolves
-to a symbol in a GALA package that this file does not import. GALA
+to a symbol in a GALA package that *this file* does not import. GALA
 mirrors Go's rule: cross-package symbols require an explicit `import`
 declaration in the file that uses them. Sibling files' imports do not
-propagate.
+propagate — which is exactly how this usually sneaks in, so the repro
+below needs two files.
 
-**Error output.**
+**Minimal repro.**
 
+`effects/seed.gala` — imports the package:
+
+```gala
+package effects
+
+import . "martianoff/gala/collection_immutable"
+
+func Seed() Array[string] = ArrayOf("a", "b")
 ```
-[SemanticError GALA-E0025] line 6:9 undefined: ArrayTabulate (used in effects.BuildLabels) — 'collection_immutable' is not imported in this file (hint: add an explicit import to this file. For unqualified usage: `import . "<path-ending-in-collection_immutable>"`. For qualified usage: `import "<path>"` and call it as `collection_immutable.ArrayTabulate`. Sibling files' imports do not propagate.)
+
+`effects/labels.gala` — same package, *no* import of its own:
+
+```gala
+package effects
+
+func BuildLabels(n int) Array[string] = ArrayTabulate(n, (i) => s"row=$i")
 ```
 
-**Fix.** Add the explicit import. Two equivalent forms:
+**Error output.** The check walks a declaration's types, so the first
+offender reported is the **return type** `Array` — not `ArrayTabulate` in the
+body. The caret is on the declared function name, and the context in
+parentheses is package-qualified (`effects.BuildLabels`).
+
+```text
+error[GALA-E0025]: undefined: Array (used in effects.BuildLabels) — 'collection_immutable' is not imported in this file
+  --> effects/labels.gala:3:6
+  |
+3 | func BuildLabels(n int) Array[string] = ArrayTabulate(n, (i) => s"row=$i")
+  |      ^^^^^^^^^^^ add an explicit import to this file
+  |
+  = hint: add an explicit import to this file. For unqualified usage: `import . "<path-ending-in-collection_immutable>"`. For qualified usage: `import "<path>"` and call it as `collection_immutable.Array`. Sibling files' imports do not propagate.
+```
+
+The `-->` line echoes the source path as the compiler resolved it; the CLI
+prints it absolute. Note the hint's qualified-usage example names the symbol
+actually being reported (`collection_immutable.Array`).
+
+**Fix.** Add the explicit import to the offending file. Two equivalent forms:
 
 ```gala
 package effects
@@ -33,8 +67,8 @@ func BuildLabels(n int) collection_immutable.Array[string] =
     collection_immutable.ArrayTabulate(n, (i) => s"row=$i")
 ```
 
-**Rationale.** Up to GALA 0.39 the analyzer fell back to "current
-package qualification" when a bare name didn't resolve. That silently
+**Rationale.** The analyzer used to fall back to "current package
+qualification" when a bare name didn't resolve. That silently
 mis-qualified cross-package types as belonging to the current package
 and broke type-param inference downstream — `func(i int) any` instead
 of `func(i int) string` was the canonical failure. Promoting this to
@@ -42,7 +76,7 @@ a coded error matches Go's compile-time safety: every cross-package
 reference is enforced at the import declaration, not at call-site
 type inference.
 
-**Scope.** Analyzer post-pass (validateExplicitImports). The
+**Scope.** Analyzer post-pass (`validateExplicitImports`). The
 transformer no longer relies on the fallback because every name
 reaching it is either qualified or guaranteed to have a matching
 import.

--- a/docs/errors/GALA-E0025.md
+++ b/docs/errors/GALA-E0025.md
@@ -47,6 +47,19 @@ The `-->` line echoes the source path as the compiler resolved it; the CLI
 prints it absolute. Note the hint's qualified-usage example names the symbol
 actually being reported (`collection_immutable.Array`).
 
+**The `used in ...` context is not always qualified.** It is the analyzer's
+metadata key for the offending declaration, and that key carries a package
+prefix for every package *except* `main` and `test`. Move the same two files
+into `package main` and the identical failure reads:
+
+```text
+error[GALA-E0025]: undefined: Array (used in BuildLabels) — 'collection_immutable' is not imported in this file
+```
+
+Everything else — the caret, the locus, the hint — is unchanged; only the
+parenthesized context loses its prefix. Search for the symbol name rather than
+the whole parenthesized phrase.
+
 **Fix.** Add the explicit import to the offending file. Two equivalent forms:
 
 ```gala

--- a/internal/parser/BUILD.bazel
+++ b/internal/parser/BUILD.bazel
@@ -15,10 +15,14 @@ go_library(
 go_test(
     name = "parser_test",
     srcs = [
+        "empty_line_unicode_test.go",
         "grammar_test.go",
         "parser_concurrent_test.go",
         "parser_test.go",
     ],
     embed = [":parser"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/internal/parser/empty_line_unicode_test.go
+++ b/internal/parser/empty_line_unicode_test.go
@@ -1,0 +1,161 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmptyLineChecksAreRuneIndexed guards the blank-line layout checks
+// against a rune/byte offset mismatch.
+//
+// ANTLR reports token offsets as code-point indices, but checkEmptyLines used
+// to slice the raw source string with them. A Go string slices by BYTES, so a
+// single non-ASCII rune anywhere before the package/import boundary shifted
+// the inspected window by the extra bytes of that rune — and the checker then
+// examined text that was not the gap it meant to examine. The visible symptom
+// was a well-formed file rejected with "importDeclaration should follow by an
+// empty line" (or the packageClause variant) purely because a comment
+// contained an em dash, a curly quote, or any accented letter.
+//
+// Each case below is correctly formatted and must parse cleanly. The ASCII
+// twin of every Unicode case is included so a failure points at the encoding
+// rather than at the layout.
+func TestEmptyLineChecksAreRuneIndexed(t *testing.T) {
+	p := NewAntlrGalaParser()
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "ascii comment between package and import",
+			input: `package main
+
+// dot import - the symbols come into scope unqualified
+import "os"
+
+func main() {
+    Println(os.Getpid())
+}`,
+		},
+		{
+			name: "em dash in comment between package and import",
+			input: `package main
+
+// dot import — the symbols come into scope unqualified
+import "os"
+
+func main() {
+    Println(os.Getpid())
+}`,
+		},
+		{
+			name: "non-ascii in the package-level doc comment",
+			input: `package main
+
+// Café metrics — counts drinks served.
+// Prices are in €.
+import "os"
+
+func main() {
+    Println(os.Getpid())
+}`,
+		},
+		{
+			name: "non-ascii inside a string before the first declaration",
+			input: `package main
+
+import "os"
+
+val greeting = "naïve café — ☕"
+
+func main() {
+    Println(greeting)
+    Println(os.Getpid())
+}`,
+		},
+		{
+			name: "no imports, non-ascii comment before first declaration",
+			input: `package main
+
+// Ünïcödé comment — no imports in this file.
+func main() {
+    Println("ok")
+}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree, err := p.Parse(tc.input)
+			require.NoError(t, err, "well-formed source must parse")
+			assert.NotNil(t, tree)
+		})
+	}
+}
+
+// TestEmptyLineChecksStillRejectMissingBlankLines is the negative half: the
+// rune-indexing fix must not weaken the layout rules it was fixing. Both
+// violations are still errors, with and without non-ASCII text present.
+func TestEmptyLineChecksStillRejectMissingBlankLines(t *testing.T) {
+	p := NewAntlrGalaParser()
+
+	cases := []struct {
+		name    string
+		input   string
+		wantMsg string
+	}{
+		{
+			name: "no blank line after package clause",
+			input: `package main
+import "os"
+
+func main() {
+    Println(os.Getpid())
+}`,
+			wantMsg: "packageClause should follow by an empty line",
+		},
+		{
+			name: "no blank line after package clause, with non-ascii",
+			input: `package main
+// café
+import "os"
+
+func main() {
+    Println(os.Getpid())
+}`,
+			wantMsg: "packageClause should follow by an empty line",
+		},
+		{
+			name: "no blank line after import declaration",
+			input: `package main
+
+import "os"
+func main() {
+    Println(os.Getpid())
+}`,
+			wantMsg: "importDeclaration should follow by an empty line",
+		},
+		{
+			name: "no blank line after import declaration, with non-ascii",
+			input: `package main
+
+// café — metrics
+import "os"
+func main() {
+    Println(os.Getpid())
+}`,
+			wantMsg: "importDeclaration should follow by an empty line",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := p.Parse(tc.input)
+			require.Error(t, err, "layout violation must still be rejected")
+			assert.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -62,7 +62,7 @@ func (p *AntlrGalaParser) ParseLenient(input string) (antlr.Tree, []error) {
 
 	var errs []error
 	errs = append(errs, errorListener.Errors...)
-	if err := p.checkEmptyLines(input, tree); err != nil {
+	if err := p.checkEmptyLines(is, tree); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -135,7 +135,17 @@ func isolateParserCaches(p *antlr.BaseParser) {
 
 var emptyLineRegex = regexp.MustCompile(`\r?\n\s*\r?\n`)
 
-func (p *AntlrGalaParser) checkEmptyLines(input string, tree antlr.Tree) error {
+// checkEmptyLines enforces the blank line required after the package clause and
+// after the import block. It reads the gaps out of `is` rather than out of the
+// raw source string: ANTLR token offsets index the input as a stream of CODE
+// POINTS, and a Go string slices by BYTES, so slicing the raw string with them
+// silently reads the wrong window as soon as the file contains any non-ASCII
+// rune (an em dash in a comment is enough) — which rejected perfectly
+// well-formed files with a bogus "should follow by an empty line" syntax error.
+// The InputStream owns the rune buffer those offsets index into and exposes it
+// through GetText, so asking it keeps the offsets and the text in the same
+// coordinate space by construction, with no second conversion of the source.
+func (p *AntlrGalaParser) checkEmptyLines(is *antlr.InputStream, tree antlr.Tree) error {
 	sourceFile, ok := tree.(grammar.ISourceFileContext)
 	if !ok {
 		return nil
@@ -145,14 +155,6 @@ func (p *AntlrGalaParser) checkEmptyLines(input string, tree antlr.Tree) error {
 	if pkg == nil || pkg.GetStop() == nil {
 		return nil
 	}
-
-	// ANTLR token offsets index the input as a stream of CODE POINTS, not
-	// bytes. Slicing the raw string with them silently reads the wrong window
-	// as soon as the file contains any non-ASCII rune (an em dash in a comment
-	// is enough), which used to reject perfectly well-formed files with a
-	// bogus "should follow by an empty line" syntax error. Work in runes so
-	// the offsets and the slicing agree.
-	runes := []rune(input)
 
 	pkgEnd := pkg.GetStop().GetStop()
 
@@ -167,7 +169,7 @@ func (p *AntlrGalaParser) checkEmptyLines(input string, tree antlr.Tree) error {
 	}
 
 	if nextToken != nil {
-		if between, ok := runeSpan(runes, pkgEnd+1, nextToken.GetStart()); ok {
+		if between, ok := runeSpan(is, pkgEnd+1, nextToken.GetStart()); ok {
 			if !emptyLineRegex.MatchString(between) {
 				return galaerr.NewSyntaxError(nextToken.GetLine(), 0, "packageClause should follow by an empty line")
 			}
@@ -180,7 +182,7 @@ func (p *AntlrGalaParser) checkEmptyLines(input string, tree antlr.Tree) error {
 			importEnd := lastImport.GetStop().GetStop()
 			nextTop := tops[0].GetStart()
 
-			if between, ok := runeSpan(runes, importEnd+1, nextTop.GetStart()); ok {
+			if between, ok := runeSpan(is, importEnd+1, nextTop.GetStart()); ok {
 				if !emptyLineRegex.MatchString(between) {
 					return galaerr.NewSyntaxError(nextTop.GetLine(), 0, "importDeclaration should follow by an empty line")
 				}
@@ -191,14 +193,24 @@ func (p *AntlrGalaParser) checkEmptyLines(input string, tree antlr.Tree) error {
 	return nil
 }
 
-// runeSpan returns runes[start:end] as a string, reporting ok=false when the
-// span is not a usable window into the source (out of range or empty). It
-// keeps the bounds checks in one place so both call sites above agree.
-func runeSpan(runes []rune, start, end int) (string, bool) {
-	if start < 0 || end > len(runes) || start >= end {
+// runeSpan returns the source text between the code-point offsets [start, end)
+// as a string, reporting ok=false when the span is not a usable window into the
+// source. It keeps the bounds checks in one place so both call sites above
+// agree, and converts the caller's exclusive end to the inclusive stop
+// InputStream.GetText expects.
+//
+// A degenerate span (start >= end) reports ok=false, so the caller skips the
+// check rather than testing an empty string — which the blank-line regex can
+// never match and which would therefore report a missing blank line at a
+// position where there is no gap to inspect at all. GALA's grammar has no way
+// to produce a zero-width gap here (the package name and the next keyword are
+// always separated by at least one space), so this only pins down the
+// degenerate case rather than changing any reachable behaviour.
+func runeSpan(is *antlr.InputStream, start, end int) (string, bool) {
+	if start < 0 || start >= end || end > is.Size() {
 		return "", false
 	}
-	return string(runes[start:end]), true
+	return is.GetText(start, end-1), true
 }
 
 type GalaErrorListener struct {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -146,6 +146,14 @@ func (p *AntlrGalaParser) checkEmptyLines(input string, tree antlr.Tree) error {
 		return nil
 	}
 
+	// ANTLR token offsets index the input as a stream of CODE POINTS, not
+	// bytes. Slicing the raw string with them silently reads the wrong window
+	// as soon as the file contains any non-ASCII rune (an em dash in a comment
+	// is enough), which used to reject perfectly well-formed files with a
+	// bogus "should follow by an empty line" syntax error. Work in runes so
+	// the offsets and the slicing agree.
+	runes := []rune(input)
+
 	pkgEnd := pkg.GetStop().GetStop()
 
 	imports := sourceFile.AllImportDeclaration()
@@ -159,8 +167,7 @@ func (p *AntlrGalaParser) checkEmptyLines(input string, tree antlr.Tree) error {
 	}
 
 	if nextToken != nil {
-		if pkgEnd+1 < len(input) && nextToken.GetStart() <= len(input) {
-			between := input[pkgEnd+1 : nextToken.GetStart()]
+		if between, ok := runeSpan(runes, pkgEnd+1, nextToken.GetStart()); ok {
 			if !emptyLineRegex.MatchString(between) {
 				return galaerr.NewSyntaxError(nextToken.GetLine(), 0, "packageClause should follow by an empty line")
 			}
@@ -173,8 +180,7 @@ func (p *AntlrGalaParser) checkEmptyLines(input string, tree antlr.Tree) error {
 			importEnd := lastImport.GetStop().GetStop()
 			nextTop := tops[0].GetStart()
 
-			if importEnd+1 < len(input) && nextTop.GetStart() <= len(input) {
-				between := input[importEnd+1 : nextTop.GetStart()]
+			if between, ok := runeSpan(runes, importEnd+1, nextTop.GetStart()); ok {
 				if !emptyLineRegex.MatchString(between) {
 					return galaerr.NewSyntaxError(nextTop.GetLine(), 0, "importDeclaration should follow by an empty line")
 				}
@@ -183,6 +189,16 @@ func (p *AntlrGalaParser) checkEmptyLines(input string, tree antlr.Tree) error {
 	}
 
 	return nil
+}
+
+// runeSpan returns runes[start:end] as a string, reporting ok=false when the
+// span is not a usable window into the source (out of range or empty). It
+// keeps the bounds checks in one place so both call sites above agree.
+func runeSpan(runes []rune, start, end int) (string, bool) {
+	if start < 0 || end > len(runes) || start >= end {
+		return "", false
+	}
+	return string(runes[start:end]), true
 }
 
 type GalaErrorListener struct {

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "dot_import_test.go",
         "equal_test.go",
         "error_codes_test.go",
+        "error_docs_guard_test.go",
         "expected_arg_stack_test.go",
         "expected_type_sealed_variant_overlap_test.go",
         "forbidden_builtins_test.go",
@@ -143,6 +144,10 @@ go_test(
     # collection_immutable), add its gala_sources here or the type will
     # widen to "any" on CI while passing locally on Windows (no sandbox).
     data = [
+        # Error-code reference pages read by the doc-verification guard
+        # (error_docs_guard_test.go), which asserts each page quotes the
+        # compiler's real output verbatim.
+        "//docs/errors:error_docs",
         "//collection_immutable:gala_sources",
         "//collection_mutable:gala_sources",
         "//examples:single_file_gala_sources",

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -226,7 +226,7 @@ func (t *galaASTTransformer) applyCallSuffix(base ast.Expr, suffix *grammar.Post
 										galaerr.CodeSealedVariantUninferred,
 										line, col,
 										fmt.Sprintf("cannot infer type parameter for sealed variant constructor %q", bareName+"()"),
-										uninferredVariantHint(parent, bareName),
+										t.uninferredVariantHint(parent, pkgQualifier, bareName),
 									)
 								}
 							}
@@ -2432,31 +2432,76 @@ func (t *galaASTTransformer) findSealedVariantFields(variantName, pkgQualifier s
 	}
 }
 
-// uninferredVariantHint builds the GALA-E0018 remediation hint. Both example
-// forms it prints must be valid, copy-pasteable GALA:
+// uninferredVariantHint builds the GALA-E0018 remediation hint. Every example
+// form it prints must be valid, copy-pasteable GALA at the offending call
+// site. Three things decide that:
 //
 //   - a type annotation follows the binding name with NO colon
-//     (`val x Box[int] = Empty()`), and
-//   - GALA's primitive spellings are lowercase (`int`, not `Int`).
+//     (`val x Box[int] = Empty()`);
+//   - GALA's primitive spellings are lowercase (`int`, not `Int`); and
+//   - both the parent type and the constructor must be spelled the way they
+//     are actually reachable in this file.
 //
 // The parent sealed type comes from the metadata the caller already resolved to
 // decide this diagnostic applies, so the annotation names a type that actually
-// exists at the call site rather than a `ParentType` placeholder the user would
-// have to translate. Both names are printed bare, matching the constructor name
-// in the message and the way the call site is written: this diagnostic only
-// fires on an unqualified zero-arg constructor, so the parent is reachable
-// unqualified there too (adding the metadata's package qualifier would produce
-// `std.Option[int]` for a prelude type that the file never imports under that
-// name). An unnamed parent degrades the hint to the explicit-type-args form
-// only, which needs no parent name — never to an example that would not
-// compile.
-func uninferredVariantHint(parent *transpiler.TypeMetadata, bareName string) string {
-	explicit := fmt.Sprintf("pass type args explicitly (`%s[int]()`)", bareName)
+// exists rather than a `ParentType` placeholder the user would have to
+// translate.
+//
+// The qualifier is the subtle part. The call site's `typeName` reaches the
+// caller already resolved, so its package selector may be one the user never
+// typed: a bare `None()` lowers to `std.None` via the prelude. Printing that
+// qualifier unconditionally yields `val x std.Option[int] = std.None()`, which
+// does not compile in a file that never imports std under that name. Dropping
+// it unconditionally is just as wrong the other way: for `cmdpkg.NoCmd()`
+// behind a plain `import "…/cmdpkg"`, the bare `val x Cmd[int] = NoCmd()`
+// fails with `undefined: NoCmd`.
+//
+// So the qualifier is printed exactly when it names a package this file can
+// actually qualify with — an ordinary (non-dot) import, under whatever alias
+// the file bound it to. Dot-imported packages and the std prelude bring their
+// symbols into scope unqualified and are printed bare. An unnamed parent
+// degrades the hint to the explicit-type-args form, which still carries the
+// constructor exactly as the call site spells it — never to an example that
+// would not compile.
+func (t *galaASTTransformer) uninferredVariantHint(parent *transpiler.TypeMetadata, pkgQualifier, bareName string) string {
+	prefix := t.callSiteQualifier(pkgQualifier)
+
+	explicit := fmt.Sprintf("pass type args explicitly (`%s%s[int]()`)", prefix, bareName)
+
 	if parent == nil || parent.Name == "" {
 		return explicit
 	}
-	return fmt.Sprintf("annotate the binding (e.g. `val x %s[int] = %s()`) or %s",
-		parent.Name, bareName, explicit)
+	return fmt.Sprintf("annotate the binding (e.g. `val x %s%s[int] = %s%s()`) or %s",
+		prefix, parent.Name, prefix, bareName, explicit)
+}
+
+// callSiteQualifier returns the `pkg.` prefix that a diagnostic should print
+// in front of a symbol from pkgQualifier, or "" when the symbol is reachable
+// unqualified in the file being transformed.
+//
+// It returns a prefix only for packages brought in by an ordinary import,
+// using the alias the file actually bound (so `import c "…/cmdpkg"` yields
+// `c.`). Dot imports and packages that are not imported here at all — most
+// notably the std prelude, whose selector the resolver attaches to names the
+// user wrote bare — yield "" because qualifying those would name something
+// that is not in scope.
+func (t *galaASTTransformer) callSiteQualifier(pkgQualifier string) string {
+	if pkgQualifier == "" || t.importManager == nil {
+		return ""
+	}
+	if !t.importManager.IsPackage(pkgQualifier) {
+		// Not an ordinary import in this file: std prelude, same package, or
+		// a dot import the resolver qualified behind the user's back.
+		return ""
+	}
+	pkgName := pkgQualifier
+	if resolved, ok := t.importManager.ResolveAlias(pkgQualifier); ok {
+		pkgName = resolved
+	}
+	if t.importManager.IsDotImported(pkgName) {
+		return ""
+	}
+	return pkgQualifier + "."
 }
 
 // findSealedParentForVariant returns the parent sealed type's metadata for a

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -207,14 +207,26 @@ func (t *galaASTTransformer) applyCallSuffix(base ast.Expr, suffix *grammar.Post
 							// and non-sealed generic types still fall through to Go's
 							// deduction.
 							if receiverType == base && baseExpr == base && len(typeMeta.TypeParams) > 0 {
-								if t.isSealedVariantTypeName(typeName) {
+								// The zero-arg call path derives typeName from
+								// getBaseTypeName, which keeps the package selector for
+								// dot-imported / std variants, but metadata is keyed by
+								// the bare case name — so the qualifier is split off and
+								// passed as the lookup scope (findSealedParentForVariant
+								// also resolves import aliases against it). Comparing the
+								// qualified `std.None` directly never matched, so this
+								// guard used to miss `std.None()` and the transpiler
+								// emitted an uninstantiated `std.None{}.Apply()` (invalid
+								// Go) instead. The resolved parent is both the guard and
+								// the hint's source for the annotation example, so it is
+								// looked up once here rather than twice.
+								pkgQualifier, bareName := splitPackageQualifier(typeName)
+								if parent := t.findSealedParentForVariant(bareName, pkgQualifier); parent != nil {
 									line, col := suffix.GetStart().GetLine(), suffix.GetStart().GetColumn()
-									bareName := stripPackagePrefix(typeName)
 									return nil, galaerr.NewCodedSemanticError(
 										galaerr.CodeSealedVariantUninferred,
 										line, col,
 										fmt.Sprintf("cannot infer type parameter for sealed variant constructor %q", bareName+"()"),
-										t.uninferredVariantHint(typeName, bareName),
+										uninferredVariantHint(parent, bareName),
 									)
 								}
 							}
@@ -2420,22 +2432,6 @@ func (t *galaASTTransformer) findSealedVariantFields(variantName, pkgQualifier s
 	}
 }
 
-// isSealedVariantTypeName reports whether `typeName` (qualified `std.None` or
-// bare `None`) is a registered sealed variant, gating the GALA-E0018
-// diagnostic; other generic types fall through to Go's deduction.
-//
-// The zero-arg call path derives the name from `getBaseTypeName`, which keeps
-// the package selector for dot-imported / std variants, but metadata is keyed
-// by the bare case name — so the qualifier is split off and passed as the
-// lookup scope (see findSealedParentForVariant, which also resolves import
-// aliases against it). Comparing the qualified `std.None` directly never
-// matched, so the guard previously missed `std.None()` and the transpiler
-// emitted an uninstantiated `std.None{}.Apply()` (invalid Go) instead.
-func (t *galaASTTransformer) isSealedVariantTypeName(typeName string) bool {
-	pkgQualifier, bareName := splitPackageQualifier(typeName)
-	return t.findSealedParentForVariant(bareName, pkgQualifier) != nil
-}
-
 // uninferredVariantHint builds the GALA-E0018 remediation hint. Both example
 // forms it prints must be valid, copy-pasteable GALA:
 //
@@ -2443,21 +2439,19 @@ func (t *galaASTTransformer) isSealedVariantTypeName(typeName string) bool {
 //     (`val x Box[int] = Empty()`), and
 //   - GALA's primitive spellings are lowercase (`int`, not `Int`).
 //
-// The parent sealed type is resolved from metadata so the annotation names a
-// type that actually exists at the call site rather than a `ParentType`
-// placeholder the user would have to translate. Both names are printed bare,
-// matching the constructor name in the message and the way the call site is
-// written: this diagnostic only fires on an unqualified zero-arg constructor,
-// so the parent is reachable unqualified there too (adding the metadata's
-// package qualifier would produce `std.Option[int]` for a prelude type that
-// the file never imports under that name). When the parent cannot be resolved
-// the hint degrades to the explicit-type-args form only, which needs no parent
-// name — never to an example that would not compile.
-func (t *galaASTTransformer) uninferredVariantHint(typeName, bareName string) string {
+// The parent sealed type comes from the metadata the caller already resolved to
+// decide this diagnostic applies, so the annotation names a type that actually
+// exists at the call site rather than a `ParentType` placeholder the user would
+// have to translate. Both names are printed bare, matching the constructor name
+// in the message and the way the call site is written: this diagnostic only
+// fires on an unqualified zero-arg constructor, so the parent is reachable
+// unqualified there too (adding the metadata's package qualifier would produce
+// `std.Option[int]` for a prelude type that the file never imports under that
+// name). An unnamed parent degrades the hint to the explicit-type-args form
+// only, which needs no parent name — never to an example that would not
+// compile.
+func uninferredVariantHint(parent *transpiler.TypeMetadata, bareName string) string {
 	explicit := fmt.Sprintf("pass type args explicitly (`%s[int]()`)", bareName)
-
-	pkgQualifier, variantName := splitPackageQualifier(typeName)
-	parent := t.findSealedParentForVariant(variantName, pkgQualifier)
 	if parent == nil || parent.Name == "" {
 		return explicit
 	}

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -214,7 +214,7 @@ func (t *galaASTTransformer) applyCallSuffix(base ast.Expr, suffix *grammar.Post
 										galaerr.CodeSealedVariantUninferred,
 										line, col,
 										fmt.Sprintf("cannot infer type parameter for sealed variant constructor %q", bareName+"()"),
-										fmt.Sprintf("annotate the binding (e.g. `val x: ParentType[Int] = %s()`) or pass type args explicitly (`%s[Int]()`)", bareName, bareName),
+										t.uninferredVariantHint(typeName, bareName),
 									)
 								}
 							}
@@ -2434,6 +2434,35 @@ func (t *galaASTTransformer) findSealedVariantFields(variantName, pkgQualifier s
 func (t *galaASTTransformer) isSealedVariantTypeName(typeName string) bool {
 	pkgQualifier, bareName := splitPackageQualifier(typeName)
 	return t.findSealedParentForVariant(bareName, pkgQualifier) != nil
+}
+
+// uninferredVariantHint builds the GALA-E0018 remediation hint. Both example
+// forms it prints must be valid, copy-pasteable GALA:
+//
+//   - a type annotation follows the binding name with NO colon
+//     (`val x Box[int] = Empty()`), and
+//   - GALA's primitive spellings are lowercase (`int`, not `Int`).
+//
+// The parent sealed type is resolved from metadata so the annotation names a
+// type that actually exists at the call site rather than a `ParentType`
+// placeholder the user would have to translate. Both names are printed bare,
+// matching the constructor name in the message and the way the call site is
+// written: this diagnostic only fires on an unqualified zero-arg constructor,
+// so the parent is reachable unqualified there too (adding the metadata's
+// package qualifier would produce `std.Option[int]` for a prelude type that
+// the file never imports under that name). When the parent cannot be resolved
+// the hint degrades to the explicit-type-args form only, which needs no parent
+// name — never to an example that would not compile.
+func (t *galaASTTransformer) uninferredVariantHint(typeName, bareName string) string {
+	explicit := fmt.Sprintf("pass type args explicitly (`%s[int]()`)", bareName)
+
+	pkgQualifier, variantName := splitPackageQualifier(typeName)
+	parent := t.findSealedParentForVariant(variantName, pkgQualifier)
+	if parent == nil || parent.Name == "" {
+		return explicit
+	}
+	return fmt.Sprintf("annotate the binding (e.g. `val x %s[int] = %s()`) or %s",
+		parent.Name, bareName, explicit)
 }
 
 // findSealedParentForVariant returns the parent sealed type's metadata for a

--- a/internal/transpiler/transformer/error_docs_guard_test.go
+++ b/internal/transpiler/transformer/error_docs_guard_test.go
@@ -1,0 +1,273 @@
+package transformer_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"martianoff/gala/galaerr"
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/stretchr/testify/require"
+)
+
+// TestErrorDocsQuoteRealOutput closes the loop between the compiler's
+// diagnostics and the pages under docs/errors/.
+//
+// Those pages exist so a user can paste a message they just saw into a search
+// engine and land on the explanation. That only works if the quoted text is
+// byte-identical to what the compiler emits — and nothing previously enforced
+// that, so the pages drifted: hints were dropped, caret rows were invented,
+// and one page quoted a message no emit site produces.
+//
+// For each covered code this test compiles a minimal repro, renders the
+// resulting diagnostic through the same CLI renderer a user sees
+// (galaerr.RenderRich with color off), and asserts the doc page contains that
+// exact block. A wording change in the transpiler therefore fails here until
+// the page is updated with the new text.
+//
+// Scope note: the table covers the codes whose real output was captured while
+// writing these pages — E0002, E0003, E0006, E0015, E0018 from the in-memory
+// transpiler and E0025 from a temp directory (it needs a sibling file on disk,
+// because the whole point of that code is that a sibling's imports do not
+// propagate). Every other code is deliberately absent rather than stubbed; a
+// stub would advertise coverage that does not exist. See the GALA-E0010 note
+// in the table for a code that cannot be guarded from here at all.
+func TestErrorDocsQuoteRealOutput(t *testing.T) {
+	cases := []struct {
+		code galaerr.ErrorCode
+		// render produces the exact diagnostic block the doc must quote.
+		render func(t *testing.T) string
+	}{
+		{
+			code: galaerr.CodeNonExhaustiveMatch, // GALA-E0002
+			render: func(t *testing.T) string {
+				return renderRepro(t, "main.gala", `package main
+
+sealed type Color {
+    case Red()
+    case Green()
+    case Blue()
+}
+
+func name(c Color) string = c match {
+    case Red()   => "red"
+    case Green() => "green"
+}
+
+func main() {
+    Println(name(Red()))
+}
+`)
+			},
+		},
+		{
+			code: galaerr.CodeMissingDefault, // GALA-E0003
+			render: func(t *testing.T) string {
+				return renderRepro(t, "main.gala", `package main
+
+func name(n int) string = n match {
+    case 1 => "one"
+    case 2 => "two"
+}
+
+func main() {
+    Println(name(1))
+}
+`)
+			},
+		},
+		{
+			code: galaerr.CodeMultipleDefaults, // GALA-E0006
+			render: func(t *testing.T) string {
+				return renderRepro(t, "main.gala", `package main
+
+func name(n int) string = n match {
+    case 1 => "one"
+    case _ => "other"
+    case _ => "also-other"
+}
+
+func main() {
+    Println(name(1))
+}
+`)
+			},
+		},
+		// GALA-E0010 is deliberately absent. It has two emit sites in the
+		// analyzer that produce different text ("package file X declares
+		// package ..." during sibling discovery, "directory D has files with
+		// different package names" during sibling filtering), and only the
+		// first is on the path the CLI takes. The site reachable from this
+		// in-memory entry point is the second one, and its message embeds an
+		// absolute directory path, so there is no stable text for a page to
+		// quote. Guarding it here would lock in a message users never see.
+		{
+			code: galaerr.CodeBareReturnInValueMatch, // GALA-E0015
+			render: func(t *testing.T) string {
+				return renderRepro(t, "main.gala", `package main
+
+import "os"
+
+func run(path string) {
+    val data = Try(() => os.ReadFile(path)) match {
+        case Success(b)   => string(b)
+        case Failure(err) => {
+            Println(s"error: ${err.Error()}")
+            return
+        }
+    }
+    Println(data)
+}
+
+func main() {
+    run("missing.txt")
+}
+`)
+			},
+		},
+		{
+			code: galaerr.CodeSealedVariantUninferred, // GALA-E0018
+			render: func(t *testing.T) string {
+				return renderRepro(t, "main.gala", `package main
+
+sealed type Box[T any] {
+    case Empty()
+    case Filled(value T)
+}
+
+func main() {
+    val x = Empty()
+    Println(x)
+}
+`)
+			},
+		},
+		{
+			code:   galaerr.CodeUnresolvedCrossPackageSymbol, // GALA-E0025
+			render: renderUnresolvedSymbolRepro,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.code), func(t *testing.T) {
+			want := tc.render(t)
+			require.NotEmpty(t, want, "renderer produced no diagnostic")
+			require.Contains(t, want, string(tc.code),
+				"repro did not fail with the code this page documents")
+
+			doc := readErrorDoc(t, tc.code)
+			require.Contains(t, doc, want,
+				"docs/errors/%s.md does not quote the compiler's real output.\n"+
+					"Replace the page's `Error output` block with exactly:\n\n%s\n",
+				tc.code, want)
+		})
+	}
+}
+
+// renderRepro transpiles src and renders the resulting error the way the CLI
+// does: no color, with src supplied as the fallback source so the framed
+// snippet is built from the in-memory repro rather than a file on disk.
+func renderRepro(t *testing.T, path, src string) string {
+	t.Helper()
+	_, err := newDocGuardTranspiler().Transpile(src, path)
+	require.Error(t, err, "repro was expected to fail to compile")
+	return galaerr.RenderRich(err, galaerr.Options{
+		FallbackPath:   path,
+		FallbackSource: src,
+		Color:          false,
+	})
+}
+
+// renderUnresolvedSymbolRepro drives GALA-E0025. The offending file has to sit
+// next to a sibling that *does* import the package, because the point of the
+// code is that a sibling's imports do not propagate — so the repro needs real
+// files on disk for the analyzer's sibling discovery to find.
+func renderUnresolvedSymbolRepro(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "effects")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	seedSrc := `package effects
+
+import . "martianoff/gala/collection_immutable"
+
+func Seed() Array[string] = ArrayOf("a", "b")
+`
+	labelsSrc := `package effects
+
+func BuildLabels(n int) Array[string] = ArrayTabulate(n, (i) => s"row=$i")
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "seed.gala"), []byte(seedSrc), 0o600))
+	labelsPath := filepath.Join(dir, "labels.gala")
+	require.NoError(t, os.WriteFile(labelsPath, []byte(labelsSrc), 0o600))
+
+	_, err := newDocGuardTranspiler().Transpile(labelsSrc, labelsPath)
+	require.Error(t, err, "repro was expected to fail to compile")
+
+	rendered := galaerr.RenderRich(err, galaerr.Options{
+		FallbackPath:   labelsPath,
+		FallbackSource: labelsSrc,
+		Color:          false,
+	})
+	// The temp directory is per-run, so the absolute path in the locus is not
+	// stable text a doc page could quote. Normalize it to the workspace-
+	// relative name the page shows.
+	rendered = strings.ReplaceAll(rendered, labelsPath, "effects/labels.gala")
+	rendered = strings.ReplaceAll(rendered, filepath.ToSlash(labelsPath), "effects/labels.gala")
+	return rendered
+}
+
+func newDocGuardTranspiler() transpiler.Transpiler {
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	return transpiler.NewGalaToGoTranspiler(p, a, tr, g)
+}
+
+// readErrorDoc returns the text of docs/errors/<code>.md, resolved through
+// Bazel runfiles when the test runs under Bazel and by walking up to go.mod
+// otherwise (the same strategy getStdSearchPath uses for the std sources).
+func readErrorDoc(t *testing.T, code galaerr.ErrorCode) string {
+	t.Helper()
+	// Runfiles are addressed with forward slashes on every platform; the
+	// go.mod fallback below uses the OS separator.
+	rel := "docs/errors/" + string(code) + ".md"
+
+	if p, err := bazel.Runfile(rel); err == nil {
+		data, err := os.ReadFile(p)
+		require.NoError(t, err)
+		return normalizeNewlines(string(data))
+	}
+
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			data, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
+			require.NoError(t, err, "error doc page not found")
+			return normalizeNewlines(string(data))
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not locate the repository root to read %s", rel)
+	return ""
+}
+
+// normalizeNewlines makes the comparison independent of how git checked the
+// page out. The renderer always emits "\n"; a CRLF working copy on Windows
+// would otherwise fail every case for a reason that has nothing to do with
+// message drift.
+func normalizeNewlines(s string) string {
+	return strings.ReplaceAll(s, "\r\n", "\n")
+}

--- a/internal/transpiler/transformer/error_docs_guard_test.go
+++ b/internal/transpiler/transformer/error_docs_guard_test.go
@@ -39,11 +39,17 @@ import (
 // in the table for a code that cannot be guarded from here at all.
 func TestErrorDocsQuoteRealOutput(t *testing.T) {
 	cases := []struct {
+		// name distinguishes several rows for the same code. A page often
+		// documents more than one shape of the same diagnostic, and those
+		// extra shapes are the ones most likely to drift, so each gets its
+		// own row rather than the table being keyed by code alone.
+		name string
 		code galaerr.ErrorCode
 		// render produces the exact diagnostic block the doc must quote.
 		render func(t *testing.T) string
 	}{
 		{
+			name: "sealed match missing a variant",
 			code: galaerr.CodeNonExhaustiveMatch, // GALA-E0002
 			render: func(t *testing.T) string {
 				return renderRepro(t, "main.gala", `package main
@@ -66,6 +72,7 @@ func main() {
 			},
 		},
 		{
+			name: "non-sealed match with no default",
 			code: galaerr.CodeMissingDefault, // GALA-E0003
 			render: func(t *testing.T) string {
 				return renderRepro(t, "main.gala", `package main
@@ -82,6 +89,7 @@ func main() {
 			},
 		},
 		{
+			name: "two default arms",
 			code: galaerr.CodeMultipleDefaults, // GALA-E0006
 			render: func(t *testing.T) string {
 				return renderRepro(t, "main.gala", `package main
@@ -107,6 +115,7 @@ func main() {
 		// absolute directory path, so there is no stable text for a page to
 		// quote. Guarding it here would lock in a message users never see.
 		{
+			name: "bare return in a value-producing match",
 			code: galaerr.CodeBareReturnInValueMatch, // GALA-E0015
 			render: func(t *testing.T) string {
 				return renderRepro(t, "main.gala", `package main
@@ -131,6 +140,9 @@ func main() {
 			},
 		},
 		{
+			// Local sealed type: nothing to qualify, so the hint prints both
+			// names bare.
+			name: "unqualified constructor, same package",
 			code: galaerr.CodeSealedVariantUninferred, // GALA-E0018
 			render: func(t *testing.T) string {
 				return renderRepro(t, "main.gala", `package main
@@ -148,13 +160,33 @@ func main() {
 			},
 		},
 		{
+			// The subtle half: the constructor comes from an ordinary import,
+			// so a hint that printed bare names would suggest two identifiers
+			// that are not in scope at the call site. This row pins that the
+			// hint carries the qualifier the user actually wrote.
+			name:   "qualified constructor behind a plain import",
+			code:   galaerr.CodeSealedVariantUninferred, // GALA-E0018
+			render: renderQualifiedVariantRepro,
+		},
+		{
+			// Named package: the "used in ..." context is package-qualified.
+			name:   "offender in a named package",
 			code:   galaerr.CodeUnresolvedCrossPackageSymbol, // GALA-E0025
 			render: renderUnresolvedSymbolRepro,
 		},
+		// The package-main shape of GALA-E0025 is documented on the page but
+		// not pinned here. Its message differs by more than a package name —
+		// the "used in ..." context is printed bare (`used in BuildLabels`)
+		// rather than qualified — and it was captured from `gala build`. The
+		// same source laid out for this in-process entry point compiles
+		// without error, so the check is not reached from here and there is
+		// nothing for a row to assert. Table rows are keyed by code + name
+		// precisely so this row can be added once that gap is understood;
+		// leaving a row that silently passes would be worse than its absence.
 	}
 
 	for _, tc := range cases {
-		t.Run(string(tc.code), func(t *testing.T) {
+		t.Run(string(tc.code)+"/"+tc.name, func(t *testing.T) {
 			want := tc.render(t)
 			require.NotEmpty(t, want, "renderer produced no diagnostic")
 			require.Contains(t, want, string(tc.code),
@@ -162,9 +194,9 @@ func main() {
 
 			doc := readErrorDoc(t, tc.code)
 			require.Contains(t, doc, want,
-				"docs/errors/%s.md does not quote the compiler's real output.\n"+
-					"Replace the page's `Error output` block with exactly:\n\n%s\n",
-				tc.code, want)
+				"docs/errors/%s.md does not quote the compiler's real output for %q.\n"+
+					"Replace (or add) the page's `Error output` block with exactly:\n\n%s\n",
+				tc.code, tc.name, want)
 		})
 	}
 }
@@ -181,6 +213,61 @@ func renderRepro(t *testing.T, path, src string) string {
 		FallbackSource: src,
 		Color:          false,
 	})
+}
+
+// renderQualifiedVariantRepro drives GALA-E0018 at a call site that names the
+// constructor through an ordinary import (`cmdpkg.NoCmd()`). The sealed type
+// has to live in a real sibling package for the qualifier to exist at all, so
+// this repro needs files on disk.
+//
+// This is the shape that catches a hint regressing to bare names: neither
+// `Cmd` nor `NoCmd` is in scope in main.gala, so a bare suggestion here fails
+// to compile with `undefined: NoCmd`.
+func renderQualifiedVariantRepro(t *testing.T) string {
+	t.Helper()
+	// Import paths are resolved by stripping the module prefix and looking the
+	// remainder up under a search root, so the sibling package is written as
+	// <searchRoot>/cmdpkg and imported under the module's own prefix. The
+	// directory name has to match the package name for the analyzer to
+	// register it.
+	searchRoot := t.TempDir()
+	pkgDir := filepath.Join(searchRoot, "cmdpkg")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+
+	cmdSrc := `package cmdpkg
+
+sealed type Cmd[T any] {
+    case NoCmd()
+    case RunCmd(arg T)
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "cmd.gala"), []byte(cmdSrc), 0o600))
+
+	mainDir := filepath.Join(searchRoot, "main")
+	require.NoError(t, os.MkdirAll(mainDir, 0o755))
+	mainSrc := `package main
+
+import "martianoff/gala/cmdpkg"
+
+func main() {
+    val x = cmdpkg.NoCmd()
+    Println(x)
+}
+`
+	mainPath := filepath.Join(mainDir, "main.gala")
+	require.NoError(t, os.WriteFile(mainPath, []byte(mainSrc), 0o600))
+
+	_, err := newDocGuardTranspilerWithPaths(searchRoot).Transpile(mainSrc, mainPath)
+	require.Error(t, err, "repro was expected to fail to compile")
+
+	rendered := galaerr.RenderRich(err, galaerr.Options{
+		FallbackPath:   mainPath,
+		FallbackSource: mainSrc,
+		Color:          false,
+	})
+	rendered = strings.ReplaceAll(rendered, mainPath, "main.gala")
+	rendered = strings.ReplaceAll(rendered, filepath.ToSlash(mainPath), "main.gala")
+	return rendered
 }
 
 // renderUnresolvedSymbolRepro drives GALA-E0025. The offending file has to sit
@@ -223,8 +310,15 @@ func BuildLabels(n int) Array[string] = ArrayTabulate(n, (i) => s"row=$i")
 }
 
 func newDocGuardTranspiler() transpiler.Transpiler {
+	return newDocGuardTranspilerWithPaths()
+}
+
+// newDocGuardTranspilerWithPaths builds a transpiler whose analyzer searches
+// the std sources plus any extra roots, so a repro can import a package it
+// wrote into a temp directory.
+func newDocGuardTranspilerWithPaths(extraRoots ...string) transpiler.Transpiler {
 	p := transpiler.NewAntlrGalaParser()
-	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	a := analyzer.NewGalaAnalyzer(p, append(getStdSearchPath(), extraRoots...))
 	tr := transformer.NewGalaASTTransformer()
 	g := generator.NewGoCodeGenerator()
 	return transpiler.NewGalaToGoTranspiler(p, a, tr, g)
@@ -245,7 +339,17 @@ func readErrorDoc(t *testing.T, code galaerr.ErrorCode) string {
 	roots := getStdSearchPath()
 	require.NotEmpty(t, roots, "could not locate the workspace root")
 
-	data, err := os.ReadFile(filepath.Join(roots[0], "docs", "errors", string(code)+".md"))
-	require.NoError(t, err, "error doc page not found")
+	rel := filepath.Join("docs", "errors", string(code)+".md")
+	data, err := os.ReadFile(filepath.Join(roots[0], rel))
+	require.NoError(t, err, docPageUnreadableMsg, rel)
 	return strings.ReplaceAll(string(data), "\r\n", "\n")
 }
+
+// docPageUnreadableMsg names the usual cause of an unreadable page. Under
+// Bazel the likeliest reason is not a missing file but a page that exists in
+// the source tree and was never added to the //docs/errors:error_docs
+// filegroup, so it was not staged into the sandbox. A bare "no such file"
+// sends the reader hunting for something that is sitting right there.
+const docPageUnreadableMsg = "could not read %s. If the page exists in the " +
+	"source tree, it is probably missing from the //docs/errors:error_docs " +
+	"filegroup, so it was not staged into the test sandbox."

--- a/internal/transpiler/transformer/error_docs_guard_test.go
+++ b/internal/transpiler/transformer/error_docs_guard_test.go
@@ -12,7 +12,6 @@ import (
 	"martianoff/gala/internal/transpiler/generator"
 	"martianoff/gala/internal/transpiler/transformer"
 
-	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/stretchr/testify/require"
 )
 
@@ -115,7 +114,7 @@ func main() {
 import "os"
 
 func run(path string) {
-    val data = Try(() => os.ReadFile(path)) match {
+    val data = Try(os.ReadFile(path)) match {
         case Success(b)   => string(b)
         case Failure(err) => {
             Println(s"error: ${err.Error()}")
@@ -231,43 +230,22 @@ func newDocGuardTranspiler() transpiler.Transpiler {
 	return transpiler.NewGalaToGoTranspiler(p, a, tr, g)
 }
 
-// readErrorDoc returns the text of docs/errors/<code>.md, resolved through
-// Bazel runfiles when the test runs under Bazel and by walking up to go.mod
-// otherwise (the same strategy getStdSearchPath uses for the std sources).
+// readErrorDoc returns the text of docs/errors/<code>.md. getStdSearchPath
+// already resolves the workspace root for this package's tests — through Bazel
+// runfiles when the test runs under Bazel, by walking up to go.mod otherwise —
+// and the pages sit under that same root in both layouts, so it doubles as the
+// doc root and no second lookup strategy is needed.
+//
+// Newlines are normalized so the comparison does not depend on how git checked
+// the page out: the renderer always emits "\n", and a CRLF working copy on
+// Windows would otherwise fail every case for a reason that has nothing to do
+// with message drift.
 func readErrorDoc(t *testing.T, code galaerr.ErrorCode) string {
 	t.Helper()
-	// Runfiles are addressed with forward slashes on every platform; the
-	// go.mod fallback below uses the OS separator.
-	rel := "docs/errors/" + string(code) + ".md"
+	roots := getStdSearchPath()
+	require.NotEmpty(t, roots, "could not locate the workspace root")
 
-	if p, err := bazel.Runfile(rel); err == nil {
-		data, err := os.ReadFile(p)
-		require.NoError(t, err)
-		return normalizeNewlines(string(data))
-	}
-
-	dir, err := os.Getwd()
-	require.NoError(t, err)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			data, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
-			require.NoError(t, err, "error doc page not found")
-			return normalizeNewlines(string(data))
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
-	}
-	t.Fatalf("could not locate the repository root to read %s", rel)
-	return ""
-}
-
-// normalizeNewlines makes the comparison independent of how git checked the
-// page out. The renderer always emits "\n"; a CRLF working copy on Windows
-// would otherwise fail every case for a reason that has nothing to do with
-// message drift.
-func normalizeNewlines(s string) string {
-	return strings.ReplaceAll(s, "\r\n", "\n")
+	data, err := os.ReadFile(filepath.Join(roots[0], "docs", "errors", string(code)+".md"))
+	require.NoError(t, err, "error doc page not found")
+	return strings.ReplaceAll(string(data), "\r\n", "\n")
 }

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -643,12 +643,15 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 		}
 
 		if !hasDefault {
+			// Both diagnoses below are about the match as a whole, so they
+			// anchor on the first case clause (the match keyword itself sits
+			// after the subject and reads worse in the framed snippet).
+			line, col := ctx.GetStart().GetLine(), ctx.GetStart().GetColumn()
+			if len(caseClauses) > 0 {
+				cc := caseClauses[0].(*grammar.CaseClauseContext)
+				line, col = cc.GetStart().GetLine(), cc.GetStart().GetColumn()
+			}
 			if isSealed && !isExhaustive {
-				line, col := ctx.GetStart().GetLine(), ctx.GetStart().GetColumn()
-				if len(caseClauses) > 0 {
-					cc := caseClauses[0].(*grammar.CaseClauseContext)
-					line, col = cc.GetStart().GetLine(), cc.GetStart().GetColumn()
-				}
 				return nil, galaerr.NewCodedSemanticError(
 					galaerr.CodeNonExhaustiveMatch,
 					line, col,
@@ -663,11 +666,6 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 					}},
 				}
 			} else if !isSealed {
-				line, col := ctx.GetStart().GetLine(), ctx.GetStart().GetColumn()
-				if len(caseClauses) > 0 {
-					cc := caseClauses[0].(*grammar.CaseClauseContext)
-					line, col = cc.GetStart().GetLine(), cc.GetStart().GetColumn()
-				}
 				// Message text is deliberately identical to the sibling
 				// GALA-E0003 site in match.go: the two match lowerings
 				// (expression-position here, statement-position there) are
@@ -685,7 +683,6 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 			}
 		}
 		// When foundDefault && isSealed && isExhaustive: unreachable default is harmless, allow it
-		_ = isSealed
 	}
 
 	// Statement-position match with a user-written `return X` inside an arm

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -668,10 +668,19 @@ func (t *galaASTTransformer) buildMatchExpressionFromClauses(subject ast.Expr, p
 					cc := caseClauses[0].(*grammar.CaseClauseContext)
 					line, col = cc.GetStart().GetLine(), cc.GetStart().GetColumn()
 				}
+				// Message text is deliberately identical to the sibling
+				// GALA-E0003 site in match.go: the two match lowerings
+				// (expression-position here, statement-position there) are
+				// the same diagnosis to a user, and a code whose wording
+				// depends on which lowering happened to run is unsearchable.
+				// The remediation lives in the hint only — repeating
+				// `case _ => ...` in the message duplicated what the
+				// renderer already prints as the caret annotation and the
+				// hint footer.
 				return nil, galaerr.NewCodedSemanticError(
 					galaerr.CodeMissingDefault,
 					line, col,
-					"match expression must have a default case (case _ => ...)",
+					"match expression must have a default case",
 					"add `case _ => ...`")
 			}
 		}


### PR DESCRIPTION
## Summary

GALA-E0018's hint told users to write syntax GALA does not have, and seven `docs/errors/` pages quoted message text the compiler never emits. A hint that does not compile is worse than no hint, and doc text that differs from real output is unsearchable — pasting it into a search engine finds nothing.

## Changes

### The E0018 hint

Before: `` annotate the binding (e.g. `val x: ParentType[Int] = Empty()`) ``
After: `` annotate the binding (e.g. `val x Box[int] = Empty()`) ``

Three defects: the colon (GALA has no colon annotation form), capitalized `Int`, and `ParentType` as an untranslatable placeholder. The hint now resolves the real parent sealed type from metadata, so it is literally copy-pasteable. Both forms were written to `.gala` files and run to exit 0.

An audit of every `NewCodedSemanticError` hint, every `Hint:` assignment and every backticked snippet across `internal/` and `galaerr/` found **exactly one** invalid-syntax hint — this one.

### Message drift

| Code | Corrected |
|---|---|
| E0002 | Terse one-liner with no hint → framed block, hint restored, caret moved to the first case clause |
| E0003 | Invented inline `(hint: ...)` form → real framed block |
| E0006 | Hint restored; caret is on the *second* default, not the first |
| E0010 | Invented wording → real message; documented that it names the **sibling** while the caret is on the compiled file |
| E0015 | Hint restored (it names the required return type) |
| E0018 | The doc's `of "Box"` fragment was invented — confirmed absent |
| E0025 | First offender is the **return type** `Array`, not `ArrayTabulate`. Both qualifier shapes documented: named packages emit `used in effects.BuildLabels`, but `main` and `test` packages emit an unqualified `used in BuildLabels` |

### E0003 dual emit site, unified

`match.go` and `postfix.go` are near-duplicate lowerings. For E0002 and E0006 they emit byte-identical text; only E0003 diverged, with `postfix.go` appending `(case _ => ...)`. That asymmetry was the tell. Unified on the shorter form — the hint already carries the remediation.

### Regression guard

`error_docs_guard_test.go` compiles a repro per code, renders it through the same `galaerr.RenderRich` path the CLI uses, and asserts the page quotes it verbatim, printing the exact required block on failure. Scope is limited to codes verified firsthand (E0002, E0003, E0006, E0015, E0018, E0025); E0010 is excluded with a recorded reason.

### Bonus fix: byte-vs-codepoint offsets

`checkEmptyLines` sliced source using ANTLR **code-point** offsets while Go strings slice by **bytes**, so any non-ASCII rune shifted the inspected window — an em dash in a comment before an `import` made a well-formed file fail to compile. Fixed per CLAUDE.md rule 6 rather than worked around. The fix now reads through ANTLR's own `InputStream`, so offsets and text share one coordinate space by construction rather than via a parallel conversion.

## Verification

`bazel build //...` green; `bazel test //...` 384/385 with only the known Windows symlink red. Every corrected doc snippet compiled with `gala build` against a branch-built CLI and a fresh `GALA_HOME`/`GALA_CACHE`.

## Flagged, not fixed

`internal/lsp/signature_help.go` has the same rune/byte confusion: `contextText` slices a byte-indexed string with rune indices, and `lineCharToOffset` computes a genuine byte offset that is then compared against rune-based token offsets. Non-ASCII anywhere earlier in the file corrupts signature help. Out of scope here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)