### PR TITLE
fix(analyzer): report undefined symbols in value position instead of erasing to any

### DIFF
--- a/docs/errors/GALA-E0023.md
+++ b/docs/errors/GALA-E0023.md
@@ -117,6 +117,17 @@ for a guaranteed absence of false positives:
   enumerable. They normally are (via Go type info), and then the check
   stays fully live; they are not when no Go SDK is on PATH. A **named**
   Go import never disables the check.
+
+  One residue of that rule is worth knowing when debugging why the
+  check did not fire in your file. Go metadata is keyed by package
+  *name*, which the analyzer takes to be the import path's last
+  segment. A package whose declared name differs from its final path
+  element — `gopkg.in/yaml.v3` declaring `package yaml` is the
+  canonical case — therefore reads as "contributed nothing", and
+  dot-importing it stands the check down **for the whole file**. This
+  is the safe direction (it can only miss a detection, never invent
+  one), but it means a single such dot import silently disables every
+  check on this page for that file.
 - **The language server.** The LSP runs the analyzer for best-effort
   metadata, and a hard error there drops the whole file's `RichAST` —
   taking completion, hover and go-to-definition with it, while the

--- a/docs/errors/GALA-E0023.md
+++ b/docs/errors/GALA-E0023.md
@@ -52,6 +52,12 @@ at all. And an outright typo surfaced only as `undefined: x` from the
 Go compiler, pointed at generated code rather than the `.gala` line the
 author wrote.
 
+This check closes both outcomes for a name in **value position**, which
+is where the reported cases came from. It does not close them for the
+two excluded positions below — an interpolation body and a type — where
+the same erasure still reaches the generated Go and the author still
+gets the Go compiler's message rather than a framed one.
+
 **Scope.** Analyzer post-pass, run once per top-level file after all
 metadata for the file, its siblings and its imports has been collected
 (`internal/transpiler/analyzer/undefined_symbol.go`). It is an
@@ -68,23 +74,60 @@ So a bare `ArrayTabulate` in a file whose package never imports
 table); the same call in a file whose *sibling* imports it passes E0023
 and is caught by E0025 on the signature that mentions `Array`.
 
-Not covered, by design:
+Not covered. Most of the following are deliberate trades of a missed
+detection for a guaranteed absence of false positives; lambda parameter
+defaults and the assigning form of `range` are instead consequences of
+how the walk is written, and are listed so they are not mistaken for
+guarantees:
 
 - **Type positions.** `func f(x Foo)`, `val v Foo = ...` and `Foo{}`
-  are skipped; unresolved signature types belong to GALA-E0025.
+  are skipped, because the analyzer's type resolution is lossy enough
+  (Go generics, constraints, `map[K]V`, func types) that flagging here
+  would produce false positives. [GALA-E0025](GALA-E0025.md) covers a
+  signature type whose package reached the compilation but whose
+  import this file omitted; it does **not** cover a type name nothing
+  in the compilation declares, because it works from the resolved
+  metadata such a name never produces. So `func total(xs Array[int])`
+  in a package that imports `collection_immutable` nowhere is caught
+  by neither code: it transpiles, erases the body's lambda to
+  `func(acc any, x any) any`, and fails at `go build` with
+  `undefined: Array`. Closing that needs a check that can distinguish
+  an unresolvable type name from a merely lossy one.
 - **Selectors.** In `x.foo().bar`, only `x` is checked — field and
   method names require the receiver's type.
+- **Lambda parameter defaults.** `(x = missingName) => x` binds the
+  parameter without checking its default expression, unlike a function
+  declaration's parameter defaults, which are checked.
+- **The assigning form of `range`.** In `for i, v = range xs` the loop
+  variables are treated as fresh bindings, as they are for `:=`, so an
+  `i` or `v` that was never declared is not reported.
 - **`match` / `case` patterns.** Every identifier in a pattern is
   treated as a binding for that arm, because separating capture names
   from constructor references needs the scrutinee's type. This can miss
   a typo inside a pattern; it can never invent one.
 - **Interpolated strings.** `s"...$x..."` bodies are a single lexer
-  token and never reach the parse tree the walk sees.
-- **Files with an import the analyzer could not load.** If any import
-  failed to resolve, the check stands down entirely for that file:
-  none of that package's exports are in the symbol table, and blaming
-  the author for names the analyzer never saw would be worse than
-  missing a real one.
+  token and never reach the parse tree the walk sees. This is the one
+  gap through which the `any` erasure described under **Rationale**
+  still escapes: `s"${ArrayTabulate(3, (i) => ...)}"` with no
+  collection import transpiles clean and emits `func(i any) string`.
+  Reaching those bodies means re-parsing each fragment (as the capture
+  analyzer already does) and mapping the fragment's token positions
+  back onto the file, so that a hard error can point at the right
+  column.
+- **Files with an import the analyzer could not load.** If a GALA
+  import failed to resolve, the check stands down entirely for that
+  file: none of that package's exports are in the symbol table, and
+  blaming the author for names the analyzer never saw would be worse
+  than missing a real one.
+
+  The same stand-down also applies to a file that **dot-imports a Go
+  package** (`import . "math"`), even though that import is perfectly
+  healthy — a Go dot import contributes unqualified names that depend
+  on Go type info, which is silently unavailable when no Go SDK is on
+  `PATH`. So one such import switches the check off for the whole
+  file, and everything above becomes reachable again there. Named Go
+  imports are unaffected, because their symbols are only reachable
+  through a qualifier, which the check accepts on sight.
 - **The language server.** The LSP runs the analyzer for best-effort
   metadata, and a hard error there drops the whole file's `RichAST` —
   taking completion, hover and go-to-definition with it, while the

--- a/docs/errors/GALA-E0023.md
+++ b/docs/errors/GALA-E0023.md
@@ -1,29 +1,112 @@
-# GALA-E0023 — Undefined variable
+# GALA-E0023 — Undefined symbol
 
-**When it fires.** The inference engine encountered a name reference
-that has no binding in the current type environment. Common causes:
+**When it fires.** An identifier used in *value position* — a variable
+read, a call target, a bare function reference — resolves to nothing.
+The analyzer walks each file with a scope chain and checks every such
+identifier against the complete symbol table it built for that file:
+enclosing bindings, the current package's declarations (including
+sibling files'), every imported package's exports, the implicitly
+dot-imported `std` prelude, package qualifiers, and the language
+builtins. A name that matches none of them is rejected here rather than
+being deferred to the Go compiler.
+
+Common causes:
 
 - The name is misspelled.
-- The name is defined in another package that is not imported.
-- The name is bound by a pattern that did not actually match (e.g.
-  shadowed by an outer binding or referenced outside its arm).
+- The import that introduces it is missing.
+- The binding is out of scope at the reference site (declared in a
+  narrower block, or in a sibling file's function body rather than at
+  package level).
 
-**Error output.**
+**Error output.** Two shapes, depending on whether the analyzer can
+find a package that would supply the name.
+
+The name is declared by exactly one package on the search paths:
 
 ```
-[SemanticError GALA-E0023] line 0:0 undefined variable: foo (hint: check the spelling, ensure the import that introduces it is in scope, and verify the binding is reachable from the reference site)
+[SemanticError GALA-E0023] line 4:12 undefined: SliceOf (hint: SliceOf is declared in the GALA package "martianoff/gala/go_interop", which this file does not import. Add `import . "martianoff/gala/go_interop"` to use it unqualified, or `import "martianoff/gala/go_interop"` and call it as `go_interop.SliceOf`.)
 ```
 
-**Fix.** Import the symbol, fix the typo, or move the reference
-inside the scope where it is bound. If the name is supposed to come
-from a dot-imported package, confirm the import has not been silently
-dropped (look for warnings about unused dot imports).
+The name is declared by several packages, so the choice is the author's:
 
-**Rationale.** Undefined-variable errors are the single most common
-category of inference failure during early development; promoting
-them to a stable code lets editors and CI tools attach extra context
-(e.g. "did you mean…" suggestions sourced from the type environment).
+```
+[SemanticError GALA-E0023] line 4:11 undefined: ArrayTabulate (hint: ArrayTabulate is declared in these GALA packages, none of which this file imports: "martianoff/gala/collection_immutable", "martianoff/gala/collection_mutable". Add `import . "<the one you want>"` to use it unqualified, or import it plainly and qualify the call.)
+```
 
-**Scope.** Inference engine only. The transformer's own scope-walker
-emits its own diagnostics for undefined identifiers in non-inference
-contexts.
+Nothing on the search paths declares the name:
+
+```
+[SemanticError GALA-E0023] line 4:12 undefined: x (hint: check the spelling, add the import that introduces this name, or declare it — every identifier must resolve to a binding, a declaration in this package, or an imported symbol)
+```
+
+**Fix.** Add the import the hint names, correct the spelling, or
+declare the symbol.
+
+**Rationale.** Before this check existed, an unresolved name produced
+no metadata, so type inference fell back to an unconstrained variable
+and the transformer emitted a bare Go identifier. Two bad outcomes
+followed. A missing collection import silently erased a lambda
+parameter to `any` — `func(i any) string` where `func(i int) string`
+was meant — violating the concrete-types invariant with no diagnostic
+at all. And an outright typo surfaced only as `undefined: x` from the
+Go compiler, pointed at generated code rather than the `.gala` line the
+author wrote.
+
+**Scope.** Analyzer post-pass, run once per top-level file after all
+metadata for the file, its siblings and its imports has been collected
+(`internal/transpiler/analyzer/undefined_symbol.go`). It is an
+*existence* check only: whether the resolved symbol is used at a
+sensible type is not its concern.
+
+The two import-related codes divide as follows. E0023 asks whether the
+compilation knows the name **at all**: a symbol whose package reached
+the compilation — including via a sibling file's import — satisfies it.
+[GALA-E0025](GALA-E0025.md) then asks the stricter question of whether
+**this** file declared the import, for the signature types it covers.
+So a bare `ArrayTabulate` in a file whose package never imports
+`collection_immutable` is E0023 (the name is nowhere in the symbol
+table); the same call in a file whose *sibling* imports it passes E0023
+and is caught by E0025 on the signature that mentions `Array`.
+
+Not covered, by design:
+
+- **Type positions.** `func f(x Foo)`, `val v Foo = ...` and `Foo{}`
+  are skipped; unresolved signature types belong to GALA-E0025.
+- **Selectors.** In `x.foo().bar`, only `x` is checked — field and
+  method names require the receiver's type.
+- **`match` / `case` patterns.** Every identifier in a pattern is
+  treated as a binding for that arm, because separating capture names
+  from constructor references needs the scrutinee's type. This can miss
+  a typo inside a pattern; it can never invent one.
+- **Interpolated strings.** `s"...$x..."` bodies are a single lexer
+  token and never reach the parse tree the walk sees.
+- **Files with an import the analyzer could not load.** If any import
+  failed to resolve, the check stands down entirely for that file:
+  none of that package's exports are in the symbol table, and blaming
+  the author for names the analyzer never saw would be worse than
+  missing a real one.
+- **The language server.** The LSP runs the analyzer for best-effort
+  metadata, and a hard error there drops the whole file's `RichAST` —
+  taking completion, hover and go-to-definition with it, while the
+  author is mid-keystroke and the name legitimately does not exist
+  yet. The check is disabled for the LSP analyzer; surfacing it as a
+  non-fatal editor diagnostic needs `Analyze` to return partial
+  results alongside errors.
+- **Names other codes own.** The Go builtins of
+  `GALA-E0035` and the Go statement keywords of
+  `GALA-E0036` keep their own, more specific
+  diagnostics. So do the Go names GALA has not yet classified but that
+  its own sources use — `break`, `continue`, `println`, `print` — which
+  are accepted here rather than pre-empting that decision.
+- **Generated method forms.** `Array_FoldLeft`, `Some_Apply` and the
+  like exist only after transformation (Go forbids a method from
+  introducing its own type parameters, so generic and synthesized
+  methods are emitted as top-level functions). A name whose prefix
+  before an underscore is a known type is accepted, so a misspelling
+  *after* the underscore is left to the Go compiler.
+
+The inference engine (`internal/transpiler/infer`) also raises this
+code for a name with no binding in its type environment, but its
+diagnostics are advisory — the bridge that feeds it approximates
+selectors, methods and generics, so callers deliberately discard its
+errors. The analyzer pass above is the authoritative source.

--- a/docs/errors/GALA-E0023.md
+++ b/docs/errors/GALA-E0023.md
@@ -52,17 +52,24 @@ at all. And an outright typo surfaced only as `undefined: x` from the
 Go compiler, pointed at generated code rather than the `.gala` line the
 author wrote.
 
-This check closes both outcomes for a name in **value position**, which
-is where the reported cases came from. It does not close them for the
-two excluded positions below — an interpolation body and a type — where
-the same erasure still reaches the generated Go and the author still
-gets the Go compiler's message rather than a framed one.
+This check closes both outcomes for a name in **value position**,
+including inside an interpolated string. It does **not** close them for
+a name in **type position**, where the same erasure still reaches the
+generated Go and the author still gets the Go compiler's message rather
+than a framed one — see the first entry under *Not covered*.
 
 **Scope.** Analyzer post-pass, run once per top-level file after all
 metadata for the file, its siblings and its imports has been collected
-(`internal/transpiler/analyzer/undefined_symbol.go`). It is an
-*existence* check only: whether the resolved symbol is used at a
-sensible type is not its concern.
+(`internal/transpiler/analyzer/undefined_symbol.go`). The traversal
+itself is the shared lexical-scope walker in
+`internal/transpiler/scopewalk`, which also backs the concurrency
+capture analysis; this pass supplies the symbol table and decides what
+an unbound reference means. It is an *existence* check only: whether
+the resolved symbol is used at a sensible type is not its concern.
+
+Identifiers inside interpolated strings (`s"…$x…"`, `f"${x + y}"`) **are**
+checked. Such a literal is a single lexer token, so the walker
+re-parses each embedded expression and walks it in the enclosing scope.
 
 The two import-related codes divide as follows. E0023 asks whether the
 compilation knows the name **at all**: a symbol whose package reached
@@ -74,11 +81,8 @@ So a bare `ArrayTabulate` in a file whose package never imports
 table); the same call in a file whose *sibling* imports it passes E0023
 and is caught by E0025 on the signature that mentions `Array`.
 
-Not covered. Most of the following are deliberate trades of a missed
-detection for a guaranteed absence of false positives; lambda parameter
-defaults and the assigning form of `range` are instead consequences of
-how the walk is written, and are listed so they are not mistaken for
-guarantees:
+Not covered. Each of these is a deliberate trade of a missed detection
+for a guaranteed absence of false positives:
 
 - **Type positions.** `func f(x Foo)`, `val v Foo = ...` and `Foo{}`
   are skipped, because the analyzer's type resolution is lossy enough
@@ -92,42 +96,27 @@ guarantees:
   by neither code: it transpiles, erases the body's lambda to
   `func(acc any, x any) any`, and fails at `go build` with
   `undefined: Array`. Closing that needs a check that can distinguish
-  an unresolvable type name from a merely lossy one.
+  an unresolvable type name from a merely lossy one; widening this one
+  would trade away the zero-false-positive property.
 - **Selectors.** In `x.foo().bar`, only `x` is checked — field and
   method names require the receiver's type.
-- **Lambda parameter defaults.** `(x = missingName) => x` binds the
-  parameter without checking its default expression, unlike a function
-  declaration's parameter defaults, which are checked.
-- **The assigning form of `range`.** In `for i, v = range xs` the loop
-  variables are treated as fresh bindings, as they are for `:=`, so an
-  `i` or `v` that was never declared is not reported.
-- **`match` / `case` patterns.** Every identifier in a pattern is
-  treated as a binding for that arm, because separating capture names
-  from constructor references needs the scrutinee's type. This can miss
-  a typo inside a pattern; it can never invent one.
-- **Interpolated strings.** `s"...$x..."` bodies are a single lexer
-  token and never reach the parse tree the walk sees. This is the one
-  gap through which the `any` erasure described under **Rationale**
-  still escapes: `s"${ArrayTabulate(3, (i) => ...)}"` with no
-  collection import transpiles clean and emits `func(i any) string`.
-  Reaching those bodies means re-parsing each fragment (as the capture
-  analyzer already does) and mapping the fragment's token positions
-  back onto the file, so that a hard error can point at the right
-  column.
+- **Constructor names in `match` / `case` patterns.** A pattern's
+  binding names (`case Some(x)` → `x`) are bound; the constructor or
+  extractor it names is neither bound nor checked, because deciding
+  which is which in general needs the scrutinee's type. A typo in a
+  pattern's constructor position is therefore not caught here. The
+  arm's *body* is checked normally, against exactly the names the
+  pattern introduces.
 - **Files with an import the analyzer could not load.** If a GALA
   import failed to resolve, the check stands down entirely for that
   file: none of that package's exports are in the symbol table, and
   blaming the author for names the analyzer never saw would be worse
-  than missing a real one.
-
-  The same stand-down also applies to a file that **dot-imports a Go
-  package** (`import . "math"`), even though that import is perfectly
-  healthy — a Go dot import contributes unqualified names that depend
-  on Go type info, which is silently unavailable when no Go SDK is on
-  `PATH`. So one such import switches the check off for the whole
-  file, and everything above becomes reachable again there. Named Go
-  imports are unaffected, because their symbols are only reachable
-  through a qualifier, which the check accepts on sight.
+  than missing a real one. The same applies to a *dot* import of a Go
+  package that contributed no symbols at all — dot-importing is what
+  makes a Go package's exports reachable unqualified, so they must be
+  enumerable. They normally are (via Go type info), and then the check
+  stays fully live; they are not when no Go SDK is on PATH. A **named**
+  Go import never disables the check.
 - **The language server.** The LSP runs the analyzer for best-effort
   metadata, and a hard error there drops the whole file's `RichAST` —
   taking completion, hover and go-to-definition with it, while the
@@ -147,6 +136,20 @@ guarantees:
   methods are emitted as top-level functions). A name whose prefix
   before an underscore is a known type is accepted, so a misspelling
   *after* the underscore is left to the Go compiler.
+
+**Previously documented gaps that are now closed.** The traversal was
+originally written specifically for this check and had blind spots that
+an earlier revision of this page listed. Moving it onto the shared
+`scopewalk` walker closed four of them, each now covered by a test:
+
+- interpolated-string bodies (`s"${missing(3)}"`), which the walker
+  re-parses;
+- lambda parameter defaults (`(x = missing) => x`), which are now
+  walked like a function declaration's;
+- the assigning form of `range` (`for i, v = range xs`), whose loop
+  variables are references rather than fresh bindings;
+- the file-wide stand-down on any Go dot import, now narrowed to a Go
+  dot import that contributed no symbols at all.
 
 The inference engine (`internal/transpiler/infer`) also raises this
 code for a name with no binding in its type environment, but its

--- a/docs/errors/GALA-E0023.md
+++ b/docs/errors/GALA-E0023.md
@@ -107,11 +107,16 @@ for a guaranteed absence of false positives:
   pattern's constructor position is therefore not caught here. The
   arm's *body* is checked normally, against exactly the names the
   pattern introduces.
-- **Files with an import the analyzer could not load.** If a GALA
-  import failed to resolve, the check stands down entirely for that
-  file: none of that package's exports are in the symbol table, and
-  blaming the author for names the analyzer never saw would be worse
-  than missing a real one. The same applies to a *dot* import of a Go
+- **Any package that failed to load, anywhere in the graph.** If a GALA
+  package could not be analyzed — missing from a search path, a
+  transpile failure, whatever the reason — the check stands down for
+  every file in the compilation, not just files that import it
+  directly. It has to be that broad: the missing package is usually one
+  a *dependency* imported. `std` dot-imports `go_builtins`, so a file
+  that imports nothing at all still resolves bare `Panic` through
+  std's closure; if `go_builtins` did not load, that name goes missing
+  with nothing in the file to hint why, and reporting it would blame
+  the author for an environmental failure. The same applies to a *dot* import of a Go
   package that contributed no symbols at all — dot-importing is what
   makes a Go package's exports reachable unqualified, so they must be
   enumerable. They normally are (via Go type info), and then the check

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -42,7 +42,7 @@ rather than inventing an example — trust the notice at the top of the page.
 | `GALA-E0020` | Package not found | [GALA-E0020.md](GALA-E0020.md) |
 | `GALA-E0021` | Type mismatch (unification failure) | [GALA-E0021.md](GALA-E0021.md) |
 | `GALA-E0022` | Occurs check failure | [GALA-E0022.md](GALA-E0022.md) |
-| `GALA-E0023` | Undefined variable | [GALA-E0023.md](GALA-E0023.md) |
+| `GALA-E0023` | Undefined symbol | [GALA-E0023.md](GALA-E0023.md) |
 | `GALA-E0024` | Internal inference failure | [GALA-E0024.md](GALA-E0024.md) |
 | `GALA-E0025` | Unresolved cross-package symbol | [GALA-E0025.md](GALA-E0025.md) |
 | `GALA-E0026` | Ambiguous sealed-variant reference | [GALA-E0026.md](GALA-E0026.md) |

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2804,6 +2804,7 @@ gala_library(
         "multifile_lib_regress/logic.gala",
         "multifile_lib_regress/pointer_method_field.gala",
         "multifile_lib_regress/proc_session.gala",
+        "multifile_lib_regress/symbol_scope.gala",
         "multifile_lib_regress/team_lookup.gala",
         "multifile_lib_regress/types.gala",
     ],

--- a/examples/multifile_lib_regress/symbol_scope.gala
+++ b/examples/multifile_lib_regress/symbol_scope.gala
@@ -1,0 +1,77 @@
+package multifile_lib_regress
+
+import (
+    . "martianoff/gala/collection_immutable"
+    "martianoff/gala/examples/multifile_lib_regress/team_pkg"
+)
+
+// Regression coverage for the analyzer's undefined-symbol check
+// (GALA-E0023), which must NOT fire on any of the resolution paths a
+// multi-file package relies on. Every identifier below resolves through a
+// different route, and each route is one the check could plausibly get wrong:
+//
+//   - NewUser / Snapshot: declared in the sibling types.gala, so they reach
+//     this file only through the sibling-metadata pass;
+//   - CountIfPositive: declared in the sibling logic.gala;
+//   - scopePrefix / scopeSuffix: package-level `val`s in this file, read from
+//     other functions (package vals live in their own metadata map, not in
+//     Types or Functions);
+//   - team_pkg.Team: a qualified reference through a named import;
+//   - ArrayOf / Some / None: a dot import and the implicit std prelude;
+//   - scopeLocalHelper / scopeDouble: declared *below* their call sites, so
+//     package-level forward references must resolve;
+//   - scopeLocalHelper is called from inside a lambda, and ScopeLambdaCapture's
+//     lambda parameter shadows an outer `val` of the same name;
+//   - every `match` arm binds names in its pattern that the arm body reads.
+//
+// This case only has teeth in multi-file batch transpilation
+// (`--package-files`), which is why it lives here rather than in a
+// single-file example.
+
+val scopePrefix = "scope"
+
+val scopeSuffix = "ok"
+
+// ScopeReport exercises sibling declarations, package vals, forward
+// references, dot imports and the std prelude from one expression.
+func ScopeReport(n int) string {
+    val user = NewUser("dana", "dana@example.com")
+    val counted = CountIfPositive(n) match {
+        case Some(v) => v
+        case None() => 0
+    }
+    val labels = ArrayOf(1, 2, 3).Map((i) => scopeLocalHelper(i + counted))
+    val joined = labels.MkString(",")
+    return s"$scopePrefix:${user.Name}:$joined:$scopeSuffix"
+}
+
+// ScopeLambdaCapture pins the case a naive scope model gets wrong: a lambda
+// parameter shadowing an outer binding of the same name, calling a
+// package-level function declared further down the file.
+func ScopeLambdaCapture(n int) int {
+    val base = n
+    val f = (base int) => scopeDouble(base)
+    return f(base) + f(0)
+}
+
+// scopeDouble reads a sibling-declared function (logic.gala) through a match.
+func scopeDouble(v int) int = CountIfPositive(v) match {
+    case Some(x) => x * 2
+    case None() => -1
+}
+
+// ScopeQualifiedImport reads a symbol from a named-imported subpackage.
+func ScopeQualifiedImport(name string) string {
+    val t = team_pkg.Team(Key = "k", Name = name)
+    return t.Name
+}
+
+// ScopeSnapshotLabel constructs a sibling-declared struct and reads a
+// package-level val from this file in the same expression.
+func ScopeSnapshotLabel() string {
+    val snap = Snapshot(ProjectName = scopePrefix, SavedAt = int64(7))
+    return s"${snap.ProjectName}-${snap.SavedAt}-$scopeSuffix"
+}
+
+// Declared after every use above on purpose.
+func scopeLocalHelper(v int) string = s"v$v"

--- a/examples/multifile_lib_regress/symbol_scope.gala
+++ b/examples/multifile_lib_regress/symbol_scope.gala
@@ -61,13 +61,16 @@ func scopeDouble(v int) int = CountIfPositive(v) match {
 }
 
 // ScopeQualifiedImport reads a symbol from a named-imported subpackage.
-func ScopeQualifiedImport(name string) string {
-    val t = team_pkg.Team(Key = "k", Name = name)
-    return t.Name
-}
+func ScopeQualifiedImport(name string) string =
+    team_pkg.Team(Key = "k", Name = name).Name
 
 // ScopeSnapshotLabel constructs a sibling-declared struct and reads a
 // package-level val from this file in the same expression.
+//
+// SavedAt is declared int64, and the conversion around the literal is
+// required: a named-argument struct construction does not currently widen an
+// untyped integer literal to the field's declared width, so a bare `7` fails
+// to compile here. Keep the explicit `int64(...)` until that widening lands.
 func ScopeSnapshotLabel() string {
     val snap = Snapshot(ProjectName = scopePrefix, SavedAt = int64(7))
     return s"${snap.ProjectName}-${snap.SavedAt}-$scopeSuffix"

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -359,4 +359,16 @@ func main() {
     // type declared elsewhere must not read as a redefinition.
     val ledger = multifile_lib_regress.LedgerFor("nina")
     Println(s"ledger=${ledger.OwnedBy()}/${ledger.Tagged()}")
+    // --- Regression: the analyzer's undefined-symbol check (GALA-E0023)
+    // must not fire on legal cross-file resolution. Each call below is
+    // built from a different resolution route (sibling declarations,
+    // package-level vals, forward references, dot imports, the std
+    // prelude, a named subpackage import, lambda-parameter shadowing).
+    // A regression that over-fires the check turns these into a hard
+    // analyzer error instead of a wrong result, so this case fails loudly.
+    // See multifile_lib_regress/symbol_scope.gala.
+    Println(multifile_lib_regress.ScopeReport(1))
+    Println(multifile_lib_regress.ScopeLambdaCapture(3))
+    Println(multifile_lib_regress.ScopeQualifiedImport("gamma"))
+    Println(multifile_lib_regress.ScopeSnapshotLabel())
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -79,3 +79,7 @@ processed-42
 Cookie(session=session, path=/)
 Cookie(opt=opt, path=/)
 ledger=nina/ledger:nina
+scope:dana:v2,v3,v4:ok
+5
+gamma
+scope-7-ok

--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -208,10 +208,16 @@ const (
 	// these to keep types finite.
 	CodeOccursCheck ErrorCode = "GALA-E0022"
 
-	// E0023: a variable referenced in an expression has no binding in
-	// the type-inference environment. Usually means the name is mis-
-	// spelled, the import is missing, or the variable is shadowed by a
-	// pattern that did not actually fire.
+	// E0023: an identifier used in value position resolves to nothing —
+	// not a binding in an enclosing scope, not a declaration in the
+	// current package (its siblings included), not an export of any
+	// imported package, not a package qualifier, and not a language
+	// builtin. Usually a misspelling, a missing import, or a reference
+	// outside the scope where the name is bound. Raised authoritatively
+	// by the analyzer's scope walk (see the undefined-symbol pass), and
+	// advisorily by the inference engine for a name absent from its type
+	// environment. Distinct from E0025, which polices *which file* the
+	// import was declared in rather than whether the name exists at all.
 	CodeUndefinedVariable ErrorCode = "GALA-E0023"
 
 	// E0024: the inference engine encountered an expression node it does

--- a/internal/transpiler/analyzer/BUILD.bazel
+++ b/internal/transpiler/analyzer/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "cache.go",
         "cache_codec.go",
         "go_types.go",
+        "undefined_symbol.go",
         "validation.go",
     ],
     importpath = "martianoff/gala/internal/transpiler/analyzer",
@@ -45,9 +46,16 @@ go_test(
         "redefinition_cross_file_test.go",
         "test_exports_test.go",
         "test_helper_test.go",
+        "undefined_symbol_test.go",
         "validation_test.go",
     ],
     data = [
+        # The undefined-symbol negative cases must genuinely resolve names
+        # from these packages rather than have the check stand down on an
+        # unloadable import, so their sources have to be in runfiles.
+        "//collection_immutable:gala_sources",
+        "//go_interop:types.go",
+        "//io:gala_sources",
         "//std:gala_sources",
     ],
     embed = [":analyzer"],

--- a/internal/transpiler/analyzer/BUILD.bazel
+++ b/internal/transpiler/analyzer/BUILD.bazel
@@ -58,6 +58,11 @@ go_test(
         "//go_interop:types.go",
         "//io:gala_sources",
         "//std:gala_sources",
+        # std dot-imports go_builtins, so loading std pulls it in. If it is
+        # not staged, that import fails under the Linux sandbox, which now
+        # stands the undefined-symbol check down for every file — silently
+        # turning the positive tests below into no-ops.
+        "//go_builtins:builtins.go",
     ],
     embed = [":analyzer"],
     deps = [

--- a/internal/transpiler/analyzer/BUILD.bazel
+++ b/internal/transpiler/analyzer/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//internal/transpiler/profiler",
         "//internal/transpiler/registry",
         "//internal/transpiler/resolver",
+        "//internal/transpiler/scopewalk",
         "//internal/transpiler/transformer",
         "@com_github_antlr4_go_antlr_v4//:antlr",
     ],

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -148,6 +148,17 @@ type galaAnalyzer struct {
 	// analyzed. See undefinedSymbolLocalGoNames.
 	localGoNames map[string]map[string]bool
 
+	// packageLoadFailures records every package that failed to load during
+	// this compilation, at any depth. It is the precondition the
+	// undefined-symbol check needs but could not get from a file's own import
+	// list: a package that failed to load contributes none of its symbols, and
+	// the failure is usually in something a DEPENDENCY imported rather than
+	// the file being compiled — std dot-imports go_builtins, so a missing
+	// go_builtins makes bare `Panic` unresolvable in a file that imports
+	// nothing at all. Shared with child analyzers, and never cleared: a
+	// package that could not be loaded stays unloadable for the build.
+	packageLoadFailures map[string]bool
+
 	// importedNames caches, per resolved package directory, the names that
 	// package's .gala sources declare at the top level. It backs the
 	// undefined-symbol check's safety net for export kinds the merged
@@ -219,8 +230,9 @@ func NewGalaAnalyzer(p transpiler.GalaParser, searchPaths []string, projectRoot 
 		parsedFileCache:   make(map[string]*parsedFileEntry),
 		parsedFileCacheMu: &sync.Mutex{},
 		pkgResultCache:  make(map[string]*pkgResultCacheEntry),
-		localGoNames:    make(map[string]map[string]bool),
-		importedNames:   make(map[string]map[string]bool),
+		localGoNames:        make(map[string]map[string]bool),
+		importedNames:       make(map[string]map[string]bool),
+		packageLoadFailures: make(map[string]bool),
 		resolver:         module.NewResolver(searchPaths),
 		cache:            newAnalysisCache(resolveCacheRoot(root)),
 	}
@@ -247,8 +259,9 @@ func NewGalaAnalyzerWithPackageFiles(p transpiler.GalaParser, searchPaths []stri
 		parsedFileCache:   make(map[string]*parsedFileEntry),
 		parsedFileCacheMu: &sync.Mutex{},
 		pkgResultCache:  make(map[string]*pkgResultCacheEntry),
-		localGoNames:    make(map[string]map[string]bool),
-		importedNames:   make(map[string]map[string]bool),
+		localGoNames:        make(map[string]map[string]bool),
+		importedNames:       make(map[string]map[string]bool),
+		packageLoadFailures: make(map[string]bool),
 		resolver:         module.NewResolver(searchPaths),
 		cache:            newAnalysisCache(resolveCacheRoot(root)),
 	}
@@ -277,6 +290,7 @@ func NewGalaAnalyzerForLSP(p transpiler.GalaParser, searchPaths []string, projec
 		pkgResultCache:      make(map[string]*pkgResultCacheEntry),
 		localGoNames:        make(map[string]map[string]bool),
 		importedNames:       make(map[string]map[string]bool),
+		packageLoadFailures: make(map[string]bool),
 		resolver:            module.NewResolver(searchPaths),
 		cache:               newAnalysisCache(resolveCacheRoot(root)),
 		skipTranspileToDisk: true,
@@ -311,8 +325,9 @@ func NewBatchAnalyzer(p transpiler.GalaParser, searchPaths []string, projectRoot
 			parsedFileCache:    make(map[string]*parsedFileEntry),
 			parsedFileCacheMu:  &sync.Mutex{},
 			pkgResultCache:     make(map[string]*pkgResultCacheEntry),
-			localGoNames:       make(map[string]map[string]bool),
-			importedNames:      make(map[string]map[string]bool),
+			localGoNames:        make(map[string]map[string]bool),
+			importedNames:       make(map[string]map[string]bool),
+			packageLoadFailures: make(map[string]bool),
 			resolver:           module.NewResolver(searchPaths),
 			cache:              newAnalysisCache(resolveCacheRoot(root)),
 		},
@@ -2530,7 +2545,17 @@ func (a *galaAnalyzer) isStdType(name string) bool {
 	return registry.IsStdType(name)
 }
 
-func (a *galaAnalyzer) analyzePackage(relPath string) (*transpiler.RichAST, error) {
+func (a *galaAnalyzer) analyzePackage(relPath string) (_ *transpiler.RichAST, retErr error) {
+	// Every failure to load a package is recorded, whatever the reason. The
+	// undefined-symbol check consults the record: a package that did not load
+	// contributes none of its symbols, and its callers' callers cannot tell
+	// that from a name the author never defined. See notePackageLoadFailure.
+	defer func() {
+		if retErr != nil {
+			a.notePackageLoadFailure(relPath)
+		}
+	}()
+
 	var pkgStart time.Time
 	if profiler.Enabled {
 		pkgStart = time.Now()
@@ -3325,8 +3350,9 @@ func (a *galaAnalyzer) ensureTranspiled(importPath string) error {
 			// The undefined-symbol check's two directory caches are shared for
 			// the same reason as the rest: a dependency the child transpiles
 			// pulls in the same packages the parent already indexed.
-			localGoNames:  a.localGoNames,
-			importedNames: a.importedNames,
+			localGoNames:        a.localGoNames,
+			importedNames:       a.importedNames,
+			packageLoadFailures: a.packageLoadFailures,
 		}
 
 		richAST, err := tempAnalyzer.Analyze(tree, srcPath)

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -113,6 +113,17 @@ type galaAnalyzer struct {
 	// on Windows.
 	skipTranspileToDisk bool
 
+	// When true, the undefined-symbol check (GALA-E0023) does not run. Set for
+	// the LSP, whose contract is best-effort metadata for editor features
+	// rather than a compile gate: Analyze surfaces a single error and drops
+	// the RichAST, so one unresolved identifier would abort the whole file's
+	// analysis and take completion, hover and go-to-definition down with it —
+	// while the author is mid-keystroke and the name legitimately does not
+	// exist yet. Reporting it as a non-fatal editor diagnostic instead needs
+	// Analyze to return partial results alongside errors, which is a separate
+	// change.
+	skipUndefinedCheck bool
+
 	// goSrcDirs maps a Go import-path prefix (a module path, or an exact
 	// package path) to the on-disk directory holding that package's .go
 	// source. It is the module-aware escape hatch for third-party Go
@@ -126,6 +137,23 @@ type galaAnalyzer struct {
 	// + GOMODCACHE) and by the worker's --go-src flag (from the Bazel rule).
 	// Nil when no Go module sources are wired in (stdlib-only projects).
 	goSrcDirs map[string]string
+
+	// localGoNames caches, per package directory, the names every top-level
+	// declaration in that directory's hand-written .go files introduces —
+	// unexported ones included. GoTypeInfo deliberately keeps only exported
+	// symbols, because that is what crosses a package boundary; but a .gala
+	// file may call an unexported helper declared in a .go file of its OWN
+	// package, so the undefined-symbol check needs the fuller list. Keyed by
+	// canonical directory path; nil until the first mixed GALA+Go package is
+	// analyzed. See undefinedSymbolLocalGoNames.
+	localGoNames map[string]map[string]bool
+
+	// importedNames caches, per resolved package directory, the names that
+	// package's .gala sources declare at the top level. It backs the
+	// undefined-symbol check's safety net for export kinds the merged
+	// metadata does not model (package-level val/var, notably). Keyed by
+	// canonical directory path. See importedTopLevelNames.
+	importedNames map[string]map[string]bool
 }
 
 // siblingCacheEntry is the value stored in galaAnalyzer.siblingTreeCache.
@@ -246,6 +274,7 @@ func NewGalaAnalyzerForLSP(p transpiler.GalaParser, searchPaths []string, projec
 		resolver:            module.NewResolver(searchPaths),
 		cache:               newAnalysisCache(resolveCacheRoot(root)),
 		skipTranspileToDisk: true,
+		skipUndefinedCheck:  true,
 	}
 }
 
@@ -1496,6 +1525,23 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 		}
 		if errs := validateExplicitImports(richAST, canonFile, explicitImportPkgs, knownGalaPkgs, fileImportSets); len(errs) > 0 {
 			return nil, errs[0]
+		}
+
+		// GALA-E0023: every identifier used in value position must resolve to
+		// something. Runs after all metadata for this file, its siblings and
+		// its imports has been collected, so the scope-based walk sees the
+		// complete symbol table. See undefined_symbol.go for the exact
+		// coverage boundaries — notably that it checks existence only, never
+		// type compatibility, and leaves import discipline to E0025 above.
+		//
+		// The check stands down when this file's own imports did not all
+		// contribute their metadata: every symbol such an import exports is
+		// invisible to the symbol table, and reporting those as undefined
+		// would blame the author for a gap on the analyzer's side.
+		if !a.skipUndefinedCheck && a.fileImportsFullyLoaded(sourceFile) {
+			if errs := a.checkUndefinedSymbols(sourceFile, richAST, filePath); len(errs) > 0 {
+				return nil, errs[0]
+			}
 		}
 	}
 

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -219,6 +219,8 @@ func NewGalaAnalyzer(p transpiler.GalaParser, searchPaths []string, projectRoot 
 		parsedFileCache:   make(map[string]*parsedFileEntry),
 		parsedFileCacheMu: &sync.Mutex{},
 		pkgResultCache:  make(map[string]*pkgResultCacheEntry),
+		localGoNames:    make(map[string]map[string]bool),
+		importedNames:   make(map[string]map[string]bool),
 		resolver:         module.NewResolver(searchPaths),
 		cache:            newAnalysisCache(resolveCacheRoot(root)),
 	}
@@ -245,6 +247,8 @@ func NewGalaAnalyzerWithPackageFiles(p transpiler.GalaParser, searchPaths []stri
 		parsedFileCache:   make(map[string]*parsedFileEntry),
 		parsedFileCacheMu: &sync.Mutex{},
 		pkgResultCache:  make(map[string]*pkgResultCacheEntry),
+		localGoNames:    make(map[string]map[string]bool),
+		importedNames:   make(map[string]map[string]bool),
 		resolver:         module.NewResolver(searchPaths),
 		cache:            newAnalysisCache(resolveCacheRoot(root)),
 	}
@@ -270,7 +274,9 @@ func NewGalaAnalyzerForLSP(p transpiler.GalaParser, searchPaths []string, projec
 		siblingTreeCache:    make(map[string]*siblingCacheEntry),
 		parsedFileCache:     make(map[string]*parsedFileEntry),
 		parsedFileCacheMu:   &sync.Mutex{},
-		pkgResultCache:     make(map[string]*pkgResultCacheEntry),
+		pkgResultCache:      make(map[string]*pkgResultCacheEntry),
+		localGoNames:        make(map[string]map[string]bool),
+		importedNames:       make(map[string]map[string]bool),
 		resolver:            module.NewResolver(searchPaths),
 		cache:               newAnalysisCache(resolveCacheRoot(root)),
 		skipTranspileToDisk: true,
@@ -304,7 +310,9 @@ func NewBatchAnalyzer(p transpiler.GalaParser, searchPaths []string, projectRoot
 			siblingTreeCache:   make(map[string]*siblingCacheEntry),
 			parsedFileCache:    make(map[string]*parsedFileEntry),
 			parsedFileCacheMu:  &sync.Mutex{},
-		pkgResultCache:    make(map[string]*pkgResultCacheEntry),
+			pkgResultCache:     make(map[string]*pkgResultCacheEntry),
+			localGoNames:       make(map[string]map[string]bool),
+			importedNames:      make(map[string]map[string]bool),
 			resolver:           module.NewResolver(searchPaths),
 			cache:              newAnalysisCache(resolveCacheRoot(root)),
 		},
@@ -1538,7 +1546,7 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 		// contribute their metadata: every symbol such an import exports is
 		// invisible to the symbol table, and reporting those as undefined
 		// would blame the author for a gap on the analyzer's side.
-		if !a.skipUndefinedCheck && a.fileImportsFullyLoaded(sourceFile) {
+		if !a.skipUndefinedCheck && a.fileImportsFullyLoaded(scanFileImports(sourceFile), richAST) {
 			if errs := a.checkUndefinedSymbols(sourceFile, richAST, filePath); len(errs) > 0 {
 				return nil, errs[0]
 			}
@@ -3314,6 +3322,11 @@ func (a *galaAnalyzer) ensureTranspiled(importPath string) error {
 			pkgResultCache:     a.pkgResultCache,
 			resolver:           a.resolver,
 			cache:              a.cache,
+			// The undefined-symbol check's two directory caches are shared for
+			// the same reason as the rest: a dependency the child transpiles
+			// pulls in the same packages the parent already indexed.
+			localGoNames:  a.localGoNames,
+			importedNames: a.importedNames,
 		}
 
 		richAST, err := tempAnalyzer.Analyze(tree, srcPath)

--- a/internal/transpiler/analyzer/undefined_symbol.go
+++ b/internal/transpiler/analyzer/undefined_symbol.go
@@ -86,9 +86,30 @@ import (
 //     `map[K]V`, func types) that flagging here would produce false
 //     positives. Type positions are skipped wholesale: only identifiers that
 //     reach a `primary` in expression position are checked.
+//
+//     Note that GALA-E0025 does NOT pick up the whole remainder. It works
+//     from resolved metadata, so it catches a signature type whose package
+//     reached the compilation but whose import this file omitted — not a type
+//     name nothing in the compilation declares. `func total(xs Array[int])`
+//     in a package that imports collection_immutable nowhere therefore passes
+//     both checks, erases its lambda to `func(acc any, x any) any`, and fails
+//     at `go build`. Closing that needs a check that can tell an unresolvable
+//     type name from a merely lossy one; widening this one would trade the
+//     zero-false-positive property for it.
 //   - Identifiers inside interpolated strings (`s"...$x..."`). The
 //     interpolation body is a single lexer token, so those expressions never
 //     reach the parse tree this walk sees.
+//
+//     This is the one exclusion through which the `any`-erasure described
+//     above still escapes: `s"${ArrayTabulate(3, (i) => ...)}"` with no
+//     collection import transpiles clean and emits `func(i any) string`, the
+//     same as an unguarded call did before this pass. Reaching those bodies is
+//     possible — the capture analyzer in internal/transpiler/concurrency
+//     re-parses them with interpolation.Split + ParseExpression and walks the
+//     result in the current scope — but a re-parsed fragment's tokens carry
+//     positions relative to the fragment, not the file, so adopting that here
+//     needs an offset mapping before a hard error could point at the right
+//     `.gala` column. Until that exists the gap is knowingly open.
 //   - `match` / `case` *patterns*. A pattern both binds names and references
 //     constructors, and telling them apart needs the scrutinee's type. Every
 //     identifier in a pattern is therefore treated as a binding scoped to
@@ -97,10 +118,23 @@ import (
 //   - Composite-literal keys (`Point{X: 1}`), named-argument labels
 //     (`f(name = 1)`) and postfix selectors, which are member names rather
 //     than free identifiers.
+//   - Lambda parameter defaults. bindParameters is called with walkDefaults
+//     false from walkLambda, so `(x = missingName) => x` binds `x` without
+//     checking the default — unlike a function declaration's defaults, which
+//     are checked.
+//   - The assigning form of `range`. walkForStatement binds the loop
+//     variables of `for i, v = range xs` exactly as it does for `:=`, so an
+//     `i` or `v` that was never declared is not reported.
 //   - Files whose imports did not all load (see fileImportsFullyLoaded) and
 //     the LSP analyzer (see galaAnalyzer.skipUndefinedCheck). In both cases
 //     the symbol table is knowingly incomplete or the caller's contract is
 //     best-effort, so a hard error would be worse than a missed detection.
+//
+//     Note how wide the first door is: fileImportsFullyLoaded also stands the
+//     check down for a *healthy* dot import of a Go package, so a single
+//     `import . "math"` disables every check above for that whole file. That
+//     is the intended trade — see the reasoning on fileImportsFullyLoaded —
+//     but it is a file-level switch, not a narrow exclusion.
 //
 // ---------------------------------------------------------------------------
 
@@ -134,18 +168,29 @@ var galaBuiltinValueNames = map[string]bool{
 	"print":   true,
 }
 
-// goPredeclaredTypeNames are Go's predeclared type names. They reach
-// expression position as conversions (`int(x)`) and as explicit type
-// arguments (`Unfold[int, string](...)`), both of which route through
-// `primary: identifier`.
-var goPredeclaredTypeNames = map[string]bool{
-	"bool": true, "string": true, "error": true, "any": true,
-	"int": true, "int8": true, "int16": true, "int32": true, "int64": true,
-	"uint": true, "uint8": true, "uint16": true, "uint32": true, "uint64": true,
-	"uintptr": true, "byte": true, "rune": true,
-	"float32": true, "float64": true,
-	"complex64": true, "complex128": true,
-	"comparable": true,
+// otherCheckOwnedNames are the names other coded checks own: the Go builtins of
+// GALA-E0035 and the Go statement keywords of GALA-E0036. Both must keep
+// producing their own, more specific diagnostics rather than being downgraded
+// to a generic "undefined". The union is materialized once because each
+// accessor builds a fresh map per call and the lookup sits on the
+// per-identifier path.
+var otherCheckOwnedNames = func() map[string]bool {
+	out := transformer.ForbiddenGoBuiltins()
+	for name := range transformer.ForbiddenStatementKeywords() {
+		out[name] = true
+	}
+	return out
+}()
+
+// isGoPredeclaredTypeName reports whether name is one of Go's predeclared type
+// names. They reach expression position as conversions (`int(x)`) and as
+// explicit type arguments (`Unfold[int, string](...)`), both of which route
+// through `primary: identifier`. The primitive set is shared with the rest of
+// the transpiler so the two cannot drift; `comparable` is named separately
+// because it is a constraint rather than a type, and so is absent there, but it
+// does appear in type-argument position.
+func isGoPredeclaredTypeName(name string) bool {
+	return transpiler.IsPrimitiveType(name) || name == "comparable"
 }
 
 // inRepoGalaImportPrefix is the import-path prefix of packages that live in
@@ -190,9 +235,12 @@ type undefChecker struct {
 	// file's Go import paths.
 	qualifiers map[string]bool
 
-	// hintRoots are searched (only when an error is already being emitted)
-	// for a GALA package that declares the unresolved name.
-	hintRoots []hintRoot
+	// hintRoots yields the roots to search (only when an error is already being
+	// emitted) for a GALA package that declares the unresolved name. It is
+	// deferred rather than materialized up front because computing the roots
+	// reads each candidate's gala.mod/go.mod, and a successful compile must not
+	// pay for hint machinery it never uses.
+	hintRoots func() []hintRoot
 
 	// importResolves reports whether an import path maps to a directory, so
 	// the hint can suggest a spelling the compiler will accept.
@@ -219,11 +267,11 @@ func (a *galaAnalyzer) checkUndefinedSymbols(
 		declared[name] = true
 	}
 	c := &undefChecker{
-		rich:          richAST,
-		declared:      declared,
-		declaredTypes: indexDeclaredTypeNames(richAST),
+		rich:           richAST,
+		declared:       declared,
+		declaredTypes:  indexDeclaredTypeNames(richAST),
 		qualifiers:     collectQualifiers(sourceFile, richAST),
-		hintRoots:      a.hintRoots(),
+		hintRoots:      a.hintRoots,
 		importResolves: a.importPathResolvesTo,
 		reported:       make(map[string]bool),
 	}
@@ -582,7 +630,7 @@ func modulePrefixOf(dir string) string {
 			continue
 		}
 		for _, line := range strings.Split(string(data), "\n") {
-			if rest, ok := cutPrefix(strings.TrimSpace(line), "module "); ok {
+			if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "module "); ok {
 				return strings.TrimSpace(rest)
 			}
 		}
@@ -599,9 +647,7 @@ func indexDeclaredSymbols(rich *transpiler.RichAST) map[string]bool {
 			return
 		}
 		out[key] = true
-		if idx := strings.LastIndex(key, "."); idx > 0 && idx+1 < len(key) {
-			out[key[idx+1:]] = true
-		}
+		out[simpleNameOf(key)] = true
 	}
 	for k := range rich.Functions {
 		add(k)
@@ -783,13 +829,12 @@ func (c *undefChecker) resolves(name string) bool {
 	if c.inScope(name) {
 		return true
 	}
-	if galaBuiltinValueNames[name] || goPredeclaredTypeNames[name] {
+	if galaBuiltinValueNames[name] || isGoPredeclaredTypeName(name) {
 		return true
 	}
 	// Names owned by other coded checks keep their own, more specific
-	// diagnostics: the Go builtins of GALA-E0035 and the Go statement
-	// keywords of GALA-E0036 must not be downgraded to "undefined".
-	if transformer.ForbiddenGoBuiltins()[name] || transformer.ForbiddenStatementKeywords()[name] {
+	// diagnostics — see otherCheckOwnedNames.
+	if otherCheckOwnedNames[name] {
 		return true
 	}
 	// A bare package name in value position is not a value, but rejecting it
@@ -849,7 +894,7 @@ func (c *undefChecker) report(name string, tok antlr.Token) {
 // declared by GALA packages the search paths can see, it names the import(s)
 // that would bring it into scope; otherwise it falls back to generic guidance.
 func (c *undefChecker) hintFor(name string) string {
-	candidates := galaPackagesDeclaring(name, c.hintRoots, c.importResolves)
+	candidates := galaPackagesDeclaring(name, c.hintRoots(), c.importResolves)
 	switch len(candidates) {
 	case 0:
 		return "check the spelling, add the import that introduces this name, or declare it — " +
@@ -1478,7 +1523,7 @@ func declaresTopLevel(src, name string, keywords []string) bool {
 		}
 		trimmed := strings.TrimRight(line, " \t\r")
 		for _, kw := range keywords {
-			rest, ok := cutPrefix(trimmed, kw)
+			rest, ok := strings.CutPrefix(trimmed, kw)
 			if !ok {
 				continue
 			}
@@ -1488,13 +1533,6 @@ func declaresTopLevel(src, name string, keywords []string) bool {
 		}
 	}
 	return false
-}
-
-func cutPrefix(s, prefix string) (string, bool) {
-	if strings.HasPrefix(s, prefix) {
-		return s[len(prefix):], true
-	}
-	return "", false
 }
 
 // declaredNameIs reports whether the declaration text `rest` names `name`
@@ -1512,7 +1550,7 @@ func declaredNameIs(rest, name string) bool {
 
 func packageClauseOf(src string) string {
 	for _, line := range strings.Split(src, "\n") {
-		if rest, ok := cutPrefix(strings.TrimSpace(line), "package "); ok {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "package "); ok {
 			return strings.TrimSpace(rest)
 		}
 	}

--- a/internal/transpiler/analyzer/undefined_symbol.go
+++ b/internal/transpiler/analyzer/undefined_symbol.go
@@ -340,9 +340,11 @@ func (a *galaAnalyzer) checkUndefinedSymbols(
 // table without any of that package's exports, and a name the analyzer never
 // saw must not be reported as one the author never defined.
 //
-// Exactly two shapes make a file ineligible, both of them "the analyzer did
-// not learn this package's contents", never merely "this package is Go":
+// Three shapes make a file ineligible, all of them "the analyzer did not learn
+// this package's contents", never merely "this package is Go":
 //
+//   - ANY package that failed to load during this compilation, at any depth —
+//     see the packageLoadFailures check below,
 //   - a GALA import with no successfully-analyzed entry in analyzedPkgs, and
 //   - a *dot* import of a Go package that contributed no symbols at all.
 //     Dot-importing is what makes a Go package's exports reachable unqualified,
@@ -356,7 +358,27 @@ func (a *galaAnalyzer) checkUndefinedSymbols(
 // through a qualifier, which the check accepts on sight. An earlier revision
 // stood down for any Go dot-import whatsoever, which silently disabled the
 // check for whole files over a healthy `import . "math"`.
+// notePackageLoadFailure records that a package could not be loaded. Called
+// from analyzePackage's single deferred error path, so it catches a failure at
+// any depth of the import graph.
+func (a *galaAnalyzer) notePackageLoadFailure(relPath string) {
+	if a.packageLoadFailures != nil {
+		a.packageLoadFailures[relPath] = true
+	}
+}
+
 func (a *galaAnalyzer) fileImportsFullyLoaded(imports []fileImport, richAST *transpiler.RichAST) bool {
+	// Any package that failed to load, at any depth, disqualifies every file
+	// in this compilation. The file's own import list is not enough to decide
+	// this: the missing package is usually one a DEPENDENCY imported. std
+	// dot-imports go_builtins, for instance, so a file that imports nothing
+	// still resolves bare `Panic` through std's closure — and if go_builtins
+	// did not load, that name goes missing without anything in the file
+	// hinting why. Reporting it as undefined would blame the author for an
+	// environmental failure.
+	if len(a.packageLoadFailures) > 0 {
+		return false
+	}
 	// The implicitly dot-imported prelude is subject to the same rule: it
 	// never appears in the import list, so check it explicitly. (This is not
 	// a special case for std — it is the one import the language adds on the

--- a/internal/transpiler/analyzer/undefined_symbol.go
+++ b/internal/transpiler/analyzer/undefined_symbol.go
@@ -916,12 +916,18 @@ func (c *undefChecker) report(name string, tok antlr.Token) {
 		return
 	}
 	c.reported[name] = true
+	// The span covers the reported token, which is normally the identifier
+	// itself. For a name found inside an interpolated string the token is the
+	// whole literal (a re-parsed fragment has no file position of its own), so
+	// deriving the span from the token's text underlines the literal rather
+	// than a name-length slice of it.
+	span := tok.GetColumn() + len([]rune(tok.GetText()))
 	err := galaerr.NewCodedSemanticError(
 		galaerr.CodeUndefinedVariable,
 		tok.GetLine(), tok.GetColumn(),
 		fmt.Sprintf("undefined: %s", name),
 		c.hintFor(name),
-	).WithSpan(tok.GetColumn() + len([]rune(name)))
+	).WithSpan(span)
 	c.errs = append(c.errs, err)
 }
 

--- a/internal/transpiler/analyzer/undefined_symbol.go
+++ b/internal/transpiler/analyzer/undefined_symbol.go
@@ -16,6 +16,7 @@ import (
 	"martianoff/gala/internal/parser/grammar"
 	"martianoff/gala/internal/transpiler"
 	"martianoff/gala/internal/transpiler/registry"
+	"martianoff/gala/internal/transpiler/scopewalk"
 	"martianoff/gala/internal/transpiler/transformer"
 )
 
@@ -31,11 +32,20 @@ import (
 // unresolved symbol's signature. This pass turns both into a framed GALA
 // diagnostic at the identifier's own source position.
 //
+// The traversal is the shared lexical-scope walker in
+// internal/transpiler/scopewalk, which also backs the concurrency capture
+// analysis. Both passes need the same notion of "a value-position identifier
+// that no enclosing binder introduced"; this file supplies the symbol table and
+// decides what an unbound reference means. See undefWalkOptions for the few
+// places the two passes' policies differ, and why each is set the way it is.
+//
 // WHAT THIS COVERS
 //
 // Every *bare identifier used in value position* — a variable read, a call
 // target, a bare function reference — must resolve to something the analyzer
-// knows about:
+// knows about. Identifiers inside interpolated strings (`s"…$x…"`) are included:
+// such a literal is a single lexer token, so the walker re-parses each embedded
+// expression and walks it in the enclosing scope. A name must resolve to:
 //
 //   - a binding introduced by an enclosing scope: function/method/lambda
 //     parameters and type parameters, method receivers, `val`/`var`, `:=`,
@@ -80,61 +90,38 @@ import (
 //     here and rejected there — one concern, one code.
 //   - Selectors. In `x.foo().bar`, only `x` is checked. Field and method
 //     names need the receiver's type, which is inference territory.
-//   - Type references (`func f(x Foo)`, `val v Foo = ...`, `Foo{}`). An
-//     unresolved type in a signature already has a dedicated owner, and the
+//   - Type references (`func f(x Foo)`, `val v Foo = ...`, `Foo{}`). The
 //     analyzer's type resolution is lossy enough (Go generics, constraints,
 //     `map[K]V`, func types) that flagging here would produce false
 //     positives. Type positions are skipped wholesale: only identifiers that
 //     reach a `primary` in expression position are checked.
 //
-//     Note that GALA-E0025 does NOT pick up the whole remainder. It works
-//     from resolved metadata, so it catches a signature type whose package
-//     reached the compilation but whose import this file omitted — not a type
-//     name nothing in the compilation declares. `func total(xs Array[int])`
-//     in a package that imports collection_immutable nowhere therefore passes
-//     both checks, erases its lambda to `func(acc any, x any) any`, and fails
-//     at `go build`. Closing that needs a check that can tell an unresolvable
-//     type name from a merely lossy one; widening this one would trade the
-//     zero-false-positive property for it.
-//   - Identifiers inside interpolated strings (`s"...$x..."`). The
-//     interpolation body is a single lexer token, so those expressions never
-//     reach the parse tree this walk sees.
-//
-//     This is the one exclusion through which the `any`-erasure described
-//     above still escapes: `s"${ArrayTabulate(3, (i) => ...)}"` with no
-//     collection import transpiles clean and emits `func(i any) string`, the
-//     same as an unguarded call did before this pass. Reaching those bodies is
-//     possible — the capture analyzer in internal/transpiler/concurrency
-//     re-parses them with interpolation.Split + ParseExpression and walks the
-//     result in the current scope — but a re-parsed fragment's tokens carry
-//     positions relative to the fragment, not the file, so adopting that here
-//     needs an offset mapping before a hard error could point at the right
-//     `.gala` column. Until that exists the gap is knowingly open.
-//   - `match` / `case` *patterns*. A pattern both binds names and references
-//     constructors, and telling them apart needs the scrutinee's type. Every
-//     identifier in a pattern is therefore treated as a binding scoped to
-//     that arm — a deliberate under-approximation that trades missed
-//     detections for zero false positives.
+//     GALA-E0025 does NOT pick up the remainder. It works from resolved
+//     metadata, so it catches a signature type whose package reached the
+//     compilation but whose import this file omitted — not a type name
+//     nothing in the compilation declares. `func total(xs Array[int])` in a
+//     package that imports collection_immutable nowhere therefore passes both
+//     checks, erases its lambda to `func(acc any, x any) any`, and fails at
+//     `go build`. Closing that needs a check that can tell an unresolvable
+//     type name from a merely lossy one; widening this one would trade away
+//     the zero-false-positive property.
+//   - Constructor names in `match` / `case` *patterns*. The shared walker
+//     binds the names a pattern introduces and ignores the constructor or
+//     extractor it names, because telling them apart in general needs the
+//     scrutinee's type. A typo in a pattern's constructor position is not
+//     caught; the arm's body is checked normally.
 //   - Composite-literal keys (`Point{X: 1}`), named-argument labels
 //     (`f(name = 1)`) and postfix selectors, which are member names rather
 //     than free identifiers.
-//   - Lambda parameter defaults. bindParameters is called with walkDefaults
-//     false from walkLambda, so `(x = missingName) => x` binds `x` without
-//     checking the default — unlike a function declaration's defaults, which
-//     are checked.
-//   - The assigning form of `range`. walkForStatement binds the loop
-//     variables of `for i, v = range xs` exactly as it does for `:=`, so an
-//     `i` or `v` that was never declared is not reported.
 //   - Files whose imports did not all load (see fileImportsFullyLoaded) and
 //     the LSP analyzer (see galaAnalyzer.skipUndefinedCheck). In both cases
 //     the symbol table is knowingly incomplete or the caller's contract is
 //     best-effort, so a hard error would be worse than a missed detection.
 //
-//     Note how wide the first door is: fileImportsFullyLoaded also stands the
-//     check down for a *healthy* dot import of a Go package, so a single
-//     `import . "math"` disables every check above for that whole file. That
-//     is the intended trade — see the reasoning on fileImportsFullyLoaded —
-//     but it is a file-level switch, not a narrow exclusion.
+// Four gaps an earlier revision documented are now closed by the move onto the
+// shared walker, each covered by a test: interpolated-string bodies, lambda
+// parameter defaults, the assigning form of `range`, and the file-wide
+// stand-down that any Go dot import used to trigger.
 //
 // ---------------------------------------------------------------------------
 
@@ -205,18 +192,76 @@ type hintRoot struct {
 	prefix string
 }
 
-// undefScope is one lexical scope in the checker's scope chain.
-type undefScope struct {
-	names  map[string]bool
-	parent *undefScope
+// fileImport is one `import` spec of the file under analysis, decoded once so
+// the three consumers below — the eligibility precondition, the qualifier set,
+// and the imported-declaration index — share a single walk of the import list.
+type fileImport struct {
+	// Path is the quoted import path with its quotes stripped.
+	Path string
+	// Alias is the explicit name given to the import (`import ci "…"`), empty
+	// when none was written.
+	Alias string
+	// IsDot marks the `import . "…"` form, which brings the package's exports
+	// into scope unqualified.
+	IsDot bool
 }
 
-// undefChecker walks a parsed GALA file and reports identifiers in value
-// position that resolve to nothing. See the file header for the exact scope.
+// LocalName is how the package is referred to in source: its alias when one was
+// given, otherwise the trailing segment of its path.
+func (fi fileImport) LocalName() string {
+	if fi.Alias != "" {
+		return fi.Alias
+	}
+	name := fi.Path
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return name
+}
+
+// scanFileImports decodes every import spec the file declares.
+func scanFileImports(sf *grammar.SourceFileContext) []fileImport {
+	var out []fileImport
+	for _, impDecl := range sf.AllImportDeclaration() {
+		ctx, ok := impDecl.(*grammar.ImportDeclarationContext)
+		if !ok {
+			continue
+		}
+		for _, spec := range ctx.AllImportSpec() {
+			s, ok := spec.(*grammar.ImportSpecContext)
+			if !ok || s.STRING() == nil {
+				continue
+			}
+			fi := fileImport{Path: strings.Trim(s.STRING().GetText(), "\"")}
+			if alias := s.Identifier(); alias != nil {
+				fi.Alias = alias.GetText()
+			} else {
+				// No identifier but an extra child is the `.` form (the same
+				// test the dot-import scan in Analyze makes).
+				fi.IsDot = s.GetChildCount() > 1
+			}
+			out = append(out, fi)
+		}
+	}
+	return out
+}
+
+// isGalaImport reports whether an import path names a GALA package, using the
+// same in-repo/external split as the import scan in Analyze.
+func (a *galaAnalyzer) isGalaImport(path string) bool {
+	return strings.HasPrefix(path, inRepoGalaImportPrefix) ||
+		(a.resolver != nil && a.resolver.IsGalaPackage(path))
+}
+
+// undefChecker consumes the shared scope walker's stream of unbound
+// value-position references and reports the ones that resolve to nothing. See
+// the file header for the exact scope.
 type undefChecker struct {
 	rich *transpiler.RichAST
 
-	scope *undefScope
+	// walker owns the scope stack and the traversal; this type only decides
+	// what an unbound reference means.
+	walker *scopewalk.Walker
 
 	// declared indexes every symbol the merged metadata knows about, under
 	// both its qualified key ("collection_immutable.Array") and its simple
@@ -259,26 +304,25 @@ func (a *galaAnalyzer) checkUndefinedSymbols(
 	richAST *transpiler.RichAST,
 	filePath string,
 ) []*galaerr.SemanticError {
+	imports := scanFileImports(sourceFile)
 	declared := indexDeclaredSymbols(richAST)
 	for name := range a.undefinedSymbolLocalGoNames(filePath) {
 		declared[name] = true
 	}
-	for name := range a.importedTopLevelNames(sourceFile) {
+	for name := range a.importedTopLevelNames(imports) {
 		declared[name] = true
 	}
 	c := &undefChecker{
 		rich:           richAST,
 		declared:       declared,
 		declaredTypes:  indexDeclaredTypeNames(richAST),
-		qualifiers:     collectQualifiers(sourceFile, richAST),
+		qualifiers:     collectQualifiers(imports, richAST),
 		hintRoots:      a.hintRoots,
 		importResolves: a.importPathResolvesTo,
 		reported:       make(map[string]bool),
 	}
-	c.push()
-	c.bindFileLevelNames(sourceFile)
-	c.walkTopLevel(sourceFile)
-	c.pop()
+	c.walker = scopewalk.New(c, undefWalkOptions())
+	c.walkSourceFile(sourceFile)
 
 	sort.SliceStable(c.errs, func(i, j int) bool {
 		if c.errs[i].Line != c.errs[j].Line {
@@ -296,14 +340,23 @@ func (a *galaAnalyzer) checkUndefinedSymbols(
 // table without any of that package's exports, and a name the analyzer never
 // saw must not be reported as one the author never defined.
 //
-// Two shapes make a file ineligible:
+// Exactly two shapes make a file ineligible, both of them "the analyzer did
+// not learn this package's contents", never merely "this package is Go":
 //
 //   - a GALA import with no successfully-analyzed entry in analyzedPkgs, and
-//   - a *dot* import of a Go package, whose unqualified exports depend on Go
-//     type info that is silently unavailable when no Go SDK is on PATH.
-//     Named Go imports stay eligible because their symbols are only ever
-//     reachable through a qualifier, which the check accepts on sight.
-func (a *galaAnalyzer) fileImportsFullyLoaded(sf *grammar.SourceFileContext) bool {
+//   - a *dot* import of a Go package that contributed no symbols at all.
+//     Dot-importing is what makes a Go package's exports reachable unqualified,
+//     so they have to be enumerable; they normally are, via GoTypeInfo, and
+//     then the check stays fully live. They are not when the Go SDK is absent
+//     (type inference is silently disabled — see the note in CLAUDE.md) or when
+//     the package's name differs from its path's last segment, and only then
+//     does the file stand down.
+//
+// A NAMED Go import never disqualifies a file: its symbols are reachable only
+// through a qualifier, which the check accepts on sight. An earlier revision
+// stood down for any Go dot-import whatsoever, which silently disabled the
+// check for whole files over a healthy `import . "math"`.
+func (a *galaAnalyzer) fileImportsFullyLoaded(imports []fileImport, richAST *transpiler.RichAST) bool {
 	// The implicitly dot-imported prelude is subject to the same rule: it
 	// never appears in the import list, so check it explicitly. (This is not
 	// a special case for std — it is the one import the language adds on the
@@ -311,35 +364,70 @@ func (a *galaAnalyzer) fileImportsFullyLoaded(sf *grammar.SourceFileContext) boo
 	if entry, present := a.analyzedPkgs[registry.StdImportPath]; !present || entry == nil {
 		return false
 	}
-	for _, impDecl := range sf.AllImportDeclaration() {
-		ctx, ok := impDecl.(*grammar.ImportDeclarationContext)
-		if !ok {
-			continue
-		}
-		for _, spec := range ctx.AllImportSpec() {
-			s, ok := spec.(*grammar.ImportSpecContext)
-			if !ok || s.STRING() == nil {
-				continue
-			}
-			path := strings.Trim(s.STRING().GetText(), "\"")
-			// Same in-repo/external split the import scan in Analyze uses.
-			isGala := strings.HasPrefix(path, inRepoGalaImportPrefix) ||
-				(a.resolver != nil && a.resolver.IsGalaPackage(path))
-			if isGala {
-				if entry, present := a.analyzedPkgs[path]; !present || entry == nil {
-					return false
-				}
-				continue
-			}
-			// Dot import of a Go package: `s.Identifier() == nil` with an
-			// extra child is the '.' form (see the dot-import scan in
-			// Analyze).
-			if s.Identifier() == nil && s.GetChildCount() > 1 {
+	for _, imp := range imports {
+		if a.isGalaImport(imp.Path) {
+			if entry, present := a.analyzedPkgs[imp.Path]; !present || entry == nil {
 				return false
 			}
+			continue
+		}
+		if imp.IsDot && !goPackageContributed(richAST, imp.Path) {
+			return false
 		}
 	}
 	return true
+}
+
+// goPackageContributed reports whether the analyzer learned any symbol of the
+// Go package at `importPath`. Go metadata is keyed by package name, which is
+// the path's last segment for the overwhelming majority of packages; a package
+// that renames itself simply reads as "contributed nothing", which is the safe
+// answer for the caller.
+func goPackageContributed(rich *transpiler.RichAST, importPath string) bool {
+	if rich == nil {
+		return false
+	}
+	name := importPath
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	if name == "" {
+		return false
+	}
+	if len(rich.GoExports[name]) > 0 {
+		return true
+	}
+	gi := rich.GoTypeInfo
+	if gi == nil {
+		return false
+	}
+	prefix := name + "."
+	for k := range gi.Functions {
+		if strings.HasPrefix(k, prefix) {
+			return true
+		}
+	}
+	for k := range gi.Types {
+		if strings.HasPrefix(k, prefix) {
+			return true
+		}
+	}
+	for k := range gi.Variables {
+		if strings.HasPrefix(k, prefix) {
+			return true
+		}
+	}
+	for k := range gi.Constants {
+		if strings.HasPrefix(k, prefix) {
+			return true
+		}
+	}
+	for k := range gi.TypeAliases {
+		if strings.HasPrefix(k, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // importedTopLevelNames returns every name declared at the top level of the
@@ -360,29 +448,14 @@ func (a *galaAnalyzer) fileImportsFullyLoaded(sf *grammar.SourceFileContext) boo
 // type resolution or code generation. Results are cached per package directory:
 // analyzePackage has already parsed these files, so parseFileCached usually
 // hits, and a package's sources do not change during a build.
-func (a *galaAnalyzer) importedTopLevelNames(sf *grammar.SourceFileContext) map[string]bool {
+func (a *galaAnalyzer) importedTopLevelNames(imports []fileImport) map[string]bool {
 	out := make(map[string]bool)
-	for _, impDecl := range sf.AllImportDeclaration() {
-		ctx, ok := impDecl.(*grammar.ImportDeclarationContext)
-		if !ok {
-			continue
+	for _, imp := range imports {
+		if !a.isGalaImport(imp.Path) {
+			continue // Go package — its symbols come from GoTypeInfo
 		}
-		for _, spec := range ctx.AllImportSpec() {
-			s, ok := spec.(*grammar.ImportSpecContext)
-			if !ok || s.STRING() == nil {
-				continue
-			}
-			path := strings.Trim(s.STRING().GetText(), "\"")
-			relPath := path
-			isInRepo := strings.HasPrefix(path, inRepoGalaImportPrefix)
-			if isInRepo {
-				relPath = strings.TrimPrefix(path, inRepoGalaImportPrefix)
-			} else if a.resolver == nil || !a.resolver.IsGalaPackage(path) {
-				continue // Go package — its symbols come from GoTypeInfo
-			}
-			for name := range a.packageTopLevelNames(relPath) {
-				out[name] = true
-			}
+		for name := range a.packageTopLevelNames(strings.TrimPrefix(imp.Path, inRepoGalaImportPrefix)) {
+			out[name] = true
 		}
 	}
 	// The implicit prelude is subject to the same treatment as any written
@@ -409,10 +482,9 @@ func (a *galaAnalyzer) packageTopLevelNames(relPath string) map[string]bool {
 	}
 	entries, rerr := os.ReadDir(dirPath)
 	if rerr != nil {
-		if a.importedNames == nil {
-			a.importedNames = make(map[string]map[string]bool)
+		if a.importedNames != nil {
+			a.importedNames[key] = nil
 		}
-		a.importedNames[key] = nil
 		return nil
 	}
 	names := make(map[string]bool)
@@ -427,10 +499,9 @@ func (a *galaAnalyzer) packageTopLevelNames(relPath string) map[string]bool {
 		}
 		collectTopLevelDeclaredNames(tree, names)
 	}
-	if a.importedNames == nil {
-		a.importedNames = make(map[string]map[string]bool)
+	if a.importedNames != nil {
+		a.importedNames[key] = names
 	}
-	a.importedNames[key] = names
 	return names
 }
 
@@ -512,10 +583,9 @@ func (a *galaAnalyzer) undefinedSymbolLocalGoNames(filePath string) map[string]b
 		return cached
 	}
 	names := parseLocalGoDeclNames(filepath.Dir(filePath))
-	if a.localGoNames == nil {
-		a.localGoNames = make(map[string]map[string]bool)
+	if a.localGoNames != nil {
+		a.localGoNames[dir] = names
 	}
-	a.localGoNames[dir] = names
 	return names
 }
 
@@ -691,7 +761,7 @@ func indexDeclaredSymbols(rich *transpiler.RichAST) map[string]bool {
 
 // collectQualifiers builds the set of identifiers that may legally appear on
 // the left of a `pkg.Symbol` selector.
-func collectQualifiers(sf *grammar.SourceFileContext, rich *transpiler.RichAST) map[string]bool {
+func collectQualifiers(imports []fileImport, rich *transpiler.RichAST) map[string]bool {
 	q := make(map[string]bool)
 	q[registry.StdPackageName] = true
 	if rich.PackageName != "" {
@@ -725,29 +795,11 @@ func collectQualifiers(sf *grammar.SourceFileContext, rich *transpiler.RichAST) 
 			addQualifierOf(q, k)
 		}
 	}
-	// This file's own import declarations: the alias when one is given,
-	// otherwise the trailing path segment — how a Go import is referenced.
-	for _, impDecl := range sf.AllImportDeclaration() {
-		ctx, ok := impDecl.(*grammar.ImportDeclarationContext)
-		if !ok {
-			continue
-		}
-		for _, spec := range ctx.AllImportSpec() {
-			s, ok := spec.(*grammar.ImportSpecContext)
-			if !ok || s.STRING() == nil {
-				continue
-			}
-			if alias := s.Identifier(); alias != nil {
-				q[alias.GetText()] = true
-				continue
-			}
-			path := strings.Trim(s.STRING().GetText(), "\"")
-			if idx := strings.LastIndex(path, "/"); idx >= 0 {
-				path = path[idx+1:]
-			}
-			if path != "" {
-				q[path] = true
-			}
+	// This file's own imports: the alias when one is given, otherwise the
+	// trailing path segment — how a Go import is referenced.
+	for _, imp := range imports {
+		if name := imp.LocalName(); name != "" {
+			q[name] = true
 		}
 	}
 	return q
@@ -790,43 +842,26 @@ func addQualifierOf(q map[string]bool, qualified string) {
 	}
 }
 
-// --- scope handling ---------------------------------------------------------
-
-func (c *undefChecker) push() {
-	c.scope = &undefScope{names: make(map[string]bool), parent: c.scope}
-}
-
-func (c *undefChecker) pop() {
-	if c.scope != nil {
-		c.scope = c.scope.parent
-	}
-}
-
-func (c *undefChecker) bind(name string) {
-	if name == "" || c.scope == nil {
-		return
-	}
-	c.scope.names[name] = true
-}
-
-func (c *undefChecker) inScope(name string) bool {
-	for s := c.scope; s != nil; s = s.parent {
-		if s.names[name] {
-			return true
-		}
-	}
-	return false
-}
-
 // --- resolution -------------------------------------------------------------
 
-// resolves reports whether `name` denotes anything at all at this point in the
-// walk.
+// Reference implements scopewalk.Visitor. The shared walker calls it for every
+// value-position identifier no enclosing scope binds; anything that does not
+// then resolve through the compilation's symbol table is the error this pass
+// exists to raise. `use` describes how the name was used, which this pass does
+// not need — existence is existence however the name is spelled at the call
+// site.
+func (c *undefChecker) Reference(name string, tok antlr.Token, use scopewalk.Use) {
+	if c.resolves(name) {
+		return
+	}
+	c.report(name, tok)
+}
+
+// resolves reports whether `name` denotes anything at all. Scope is already
+// handled by the shared walker — it only reports names no scope binds — so this
+// consults the compilation's symbol table alone.
 func (c *undefChecker) resolves(name string) bool {
 	if name == "" {
-		return true
-	}
-	if c.inScope(name) {
 		return true
 	}
 	if galaBuiltinValueNames[name] || isGoPredeclaredTypeName(name) {
@@ -920,12 +955,114 @@ func (c *undefChecker) hintFor(name string) string {
 
 // --- walking ----------------------------------------------------------------
 
+// undefWalkOptions configures the shared scope walker for this pass. Every
+// choice is the one that cannot invent a reference, because a false positive
+// here is a hard compile error on code that works:
+//
+//   - ParseInterpolations descends into `s"…$x"` bodies, so a name used only
+//     inside an interpolation is checked like any other.
+//   - RequireCleanInterpolationParse drops a fragment whose re-parse reported
+//     errors, so ANTLR's error recovery can never become a diagnostic. Narrow
+//     by nature: the expression parser stops at the longest valid prefix
+//     without complaining, so `${x +}` still yields `x`.
+//   - SkipCompositeLiteralKeys omits `T{Field: v}`'s key, which names a struct
+//     field rather than a value.
+//   - SkipTypedPatternArgument omits the identifier of an `x: T` pattern in
+//     argument position, which is not clearly a value reference.
+//   - BindWholePattern stays FALSE, so a `case` binds only the names it
+//     actually introduces instead of every identifier it mentions. Constructor
+//     and extractor names in a pattern are still neither bound nor checked —
+//     the walker ignores them — but they no longer leak into the arm's scope,
+//     so the arm's BODY is checked against the names the pattern really
+//     introduces rather than a set inflated by its constructors. Strictly
+//     tighter, and it cannot add a reference the blunt form did not have.
+//   - EnterFunctionScope binds the two binders the walker does not model: a
+//     declaration's type parameters and a method's receiver.
+func undefWalkOptions() scopewalk.Options {
+	return scopewalk.Options{
+		ParseInterpolations:            true,
+		RequireCleanInterpolationParse: true,
+		SkipCompositeLiteralKeys:       true,
+		SkipTypedPatternArgument:       true,
+		EnterFunctionScope:             bindFunctionDeclarationScope,
+	}
+}
+
+// bindFunctionDeclarationScope binds a function or method declaration's own
+// type parameters, and, for a method, its receiver name together with any type
+// parameters the receiver type introduces (`func (l *List[T]) …` brings both
+// `l` and `T` into scope).
+func bindFunctionDeclarationScope(w *scopewalk.Walker, fn grammar.IFunctionDeclarationContext) {
+	fc, ok := fn.(*grammar.FunctionDeclarationContext)
+	if !ok {
+		return
+	}
+	bindTypeParameters(w, fc.TypeParameters())
+	recv := fc.Receiver()
+	if recv == nil {
+		return
+	}
+	rc, ok := recv.(*grammar.ReceiverContext)
+	if !ok {
+		return
+	}
+	w.BindID(rc.Identifier())
+	// The receiver's type arguments are the method's view of the type's
+	// parameters; they can sit behind a pointer or nest (`*List[T]`,
+	// `Pair[K, V]`), so every identifier in the receiver type is bound. Binding
+	// the type's own name alongside them is harmless — it is a declaration in
+	// this package either way.
+	w.BindIdentifiersIn(rc.Type_())
+}
+
+func bindTypeParameters(w *scopewalk.Walker, tp grammar.ITypeParametersContext) {
+	if tp == nil {
+		return
+	}
+	list := tp.(*grammar.TypeParametersContext).TypeParameterList()
+	if list == nil {
+		return
+	}
+	for _, p := range list.(*grammar.TypeParameterListContext).AllTypeParameter() {
+		w.BindID(p.(*grammar.TypeParameterContext).Identifier(0))
+	}
+}
+
+// walkSourceFile drives the shared walker over a whole file. Only declarations
+// that hold value-position expressions are entered: a `type` / `sealed type` /
+// `embed` declaration contains types and string literals, never a value this
+// check inspects.
+func (c *undefChecker) walkSourceFile(sf *grammar.SourceFileContext) {
+	w := c.walker
+	w.PushScope()
+	defer w.PopScope()
+	c.bindFileLevelNames(sf)
+
+	for _, topDecl := range sf.AllTopLevelDeclaration() {
+		switch {
+		case topDecl.FunctionDeclaration() != nil:
+			w.WalkFunctionDeclaration(topDecl.FunctionDeclaration())
+		case topDecl.ValDeclaration() != nil:
+			w.Walk(topDecl.ValDeclaration().(*grammar.ValDeclarationContext).ExpressionList())
+		case topDecl.VarDeclaration() != nil:
+			w.Walk(topDecl.VarDeclaration().(*grammar.VarDeclarationContext).ExpressionList())
+		case topDecl.StructShorthandDeclaration() != nil:
+			ctx := topDecl.StructShorthandDeclaration().(*grammar.StructShorthandDeclarationContext)
+			w.PushScope()
+			bindTypeParameters(w, ctx.TypeParameters())
+			w.BindParameters(ctx.Parameters())
+			w.WalkParameterDefaults(ctx.Parameters())
+			w.PopScope()
+		}
+	}
+}
+
 // bindFileLevelNames registers declarations whose names are not reachable
 // through richAST metadata: tuple-pattern package vals (`val (a, b) = ...`,
 // which extractPackageVals deliberately skips) and `embed val` directives.
 func (c *undefChecker) bindFileLevelNames(sf *grammar.SourceFileContext) {
 	for _, d := range c.rich.EmbedDirectives {
-		c.bind(d.VarName)
+		c.walker.Bind(d.VarName)
 	}
 	for _, topDecl := range sf.AllTopLevelDeclaration() {
 		var tp grammar.ITuplePatternContext
@@ -935,464 +1072,12 @@ func (c *undefChecker) bindFileLevelNames(sf *grammar.SourceFileContext) {
 		case topDecl.VarDeclaration() != nil:
 			tp = topDecl.VarDeclaration().(*grammar.VarDeclarationContext).TuplePattern()
 		case topDecl.EmbedDeclaration() != nil:
-			ctx := topDecl.EmbedDeclaration().(*grammar.EmbedDeclarationContext)
-			if ctx.Identifier() != nil {
-				c.bind(ctx.Identifier().GetText())
-			}
+			c.walker.BindID(topDecl.EmbedDeclaration().(*grammar.EmbedDeclarationContext).Identifier())
 		}
 		if tp != nil {
-			c.bindIdentifierList(tp.(*grammar.TuplePatternContext).IdentifierList())
+			c.walker.BindIdentifierList(tp.(*grammar.TuplePatternContext).IdentifierList())
 		}
 	}
-}
-
-func (c *undefChecker) walkTopLevel(sf *grammar.SourceFileContext) {
-	for _, topDecl := range sf.AllTopLevelDeclaration() {
-		switch {
-		case topDecl.FunctionDeclaration() != nil:
-			c.walkFunctionDeclaration(topDecl.FunctionDeclaration().(*grammar.FunctionDeclarationContext))
-		case topDecl.ValDeclaration() != nil:
-			c.walkExpr(topDecl.ValDeclaration().(*grammar.ValDeclarationContext).ExpressionList())
-		case topDecl.VarDeclaration() != nil:
-			c.walkExpr(topDecl.VarDeclaration().(*grammar.VarDeclarationContext).ExpressionList())
-		case topDecl.StructShorthandDeclaration() != nil:
-			ctx := topDecl.StructShorthandDeclaration().(*grammar.StructShorthandDeclarationContext)
-			c.walkParameterDefaults(ctx.Parameters(), ctx.TypeParameters())
-		}
-		// typeDeclaration / sealedTypeDeclaration / embedDeclaration hold no
-		// value-position expressions this check inspects.
-	}
-}
-
-// walkParameterDefaults checks the default-value expressions of a parameter
-// list in a scope holding the declaration's type parameters and the parameter
-// names seen so far (a default may reference an earlier parameter).
-func (c *undefChecker) walkParameterDefaults(params grammar.IParametersContext, typeParams grammar.ITypeParametersContext) {
-	if params == nil {
-		return
-	}
-	c.push()
-	defer c.pop()
-	c.bindTypeParameters(typeParams)
-	c.bindParameters(params, true)
-}
-
-func (c *undefChecker) walkFunctionDeclaration(ctx *grammar.FunctionDeclarationContext) {
-	c.push()
-	defer c.pop()
-
-	c.bindTypeParameters(ctx.TypeParameters())
-	if recv := ctx.Receiver(); recv != nil {
-		rc := recv.(*grammar.ReceiverContext)
-		if rc.Identifier() != nil {
-			c.bind(rc.Identifier().GetText())
-		}
-		// A method's receiver type may introduce type parameters
-		// (`func (s Stack[T]) Push(v T)`); bind their names so `T` resolves
-		// in the signature and body.
-		c.bindReceiverTypeParams(rc.Type_())
-	} else if ctx.Identifier() != nil {
-		// A local function may recurse; top-level ones are already
-		// package-level, but nested ones are not.
-		c.bind(ctx.Identifier().GetText())
-	}
-	if sig := ctx.Signature(); sig != nil {
-		c.bindParameters(sig.(*grammar.SignatureContext).Parameters(), true)
-	}
-	if b := ctx.Block(); b != nil {
-		c.walkBlock(b.(*grammar.BlockContext))
-	} else {
-		c.walkExpr(ctx.Expression())
-	}
-}
-
-// bindReceiverTypeParams binds the type-parameter names a method receiver
-// introduces (`Stack[T]` → `T`). Every identifier in the receiver type is
-// bound, at any nesting depth, because the type parameters can sit behind a
-// pointer or a nested type argument (`*List[T]`, `Pair[K, V]`) and because
-// binding the type's own name alongside them is harmless — it is a
-// declaration in the same package either way.
-func (c *undefChecker) bindReceiverTypeParams(t grammar.ITypeContext) {
-	if t == nil {
-		return
-	}
-	for _, id := range collectIdentifiers(t) {
-		c.bind(id)
-	}
-}
-
-func (c *undefChecker) bindTypeParameters(tp grammar.ITypeParametersContext) {
-	if tp == nil {
-		return
-	}
-	list := tp.(*grammar.TypeParametersContext).TypeParameterList()
-	if list == nil {
-		return
-	}
-	for _, p := range list.(*grammar.TypeParameterListContext).AllTypeParameter() {
-		if id := p.(*grammar.TypeParameterContext).Identifier(0); id != nil {
-			c.bind(id.GetText())
-		}
-	}
-}
-
-// bindParameters binds each named parameter. With walkDefaults set, default
-// expressions are checked as they are reached, so a default may reference an
-// earlier parameter but not a later one.
-func (c *undefChecker) bindParameters(params grammar.IParametersContext, walkDefaults bool) {
-	if params == nil {
-		return
-	}
-	pl := params.(*grammar.ParametersContext).ParameterList()
-	if pl == nil {
-		return
-	}
-	for _, p := range pl.(*grammar.ParameterListContext).AllParameter() {
-		pc := p.(*grammar.ParameterContext)
-		if walkDefaults {
-			if pd := pc.ParamDefault(); pd != nil {
-				c.walkExpr(pd.(*grammar.ParamDefaultContext).Expression())
-			}
-		}
-		if pc.Identifier() != nil {
-			c.bind(pc.Identifier().GetText())
-		}
-	}
-}
-
-func (c *undefChecker) bindIdentifierList(il grammar.IIdentifierListContext) {
-	if il == nil {
-		return
-	}
-	for _, id := range il.(*grammar.IdentifierListContext).AllIdentifier() {
-		c.bind(id.GetText())
-	}
-}
-
-func (c *undefChecker) walkBlock(b *grammar.BlockContext) {
-	if b == nil {
-		return
-	}
-	c.push()
-	defer c.pop()
-	// Hoist local function and type declarations so mutually recursive local
-	// helpers resolve regardless of declaration order.
-	for _, st := range b.AllStatement() {
-		sc, ok := st.(*grammar.StatementContext)
-		if !ok || sc.Declaration() == nil {
-			continue
-		}
-		d := sc.Declaration().(*grammar.DeclarationContext)
-		if fd := d.FunctionDeclaration(); fd != nil {
-			fc := fd.(*grammar.FunctionDeclarationContext)
-			if fc.Identifier() != nil && fc.Receiver() == nil {
-				c.bind(fc.Identifier().GetText())
-			}
-		}
-		if td := d.TypeDeclaration(); td != nil {
-			tc := td.(*grammar.TypeDeclarationContext)
-			if tc.Identifier() != nil {
-				c.bind(tc.Identifier().GetText())
-			}
-		}
-	}
-	for _, st := range b.AllStatement() {
-		c.walkStatement(st.(*grammar.StatementContext))
-	}
-}
-
-func (c *undefChecker) walkStatement(st *grammar.StatementContext) {
-	if st == nil {
-		return
-	}
-	if d := st.Declaration(); d != nil {
-		c.walkDeclaration(d.(*grammar.DeclarationContext))
-		return
-	}
-	if r := st.ReturnStatement(); r != nil {
-		c.walkExpr(r.(*grammar.ReturnStatementContext).Expression())
-	}
-}
-
-func (c *undefChecker) walkDeclaration(d *grammar.DeclarationContext) {
-	switch {
-	case d.ValDeclaration() != nil:
-		vc := d.ValDeclaration().(*grammar.ValDeclarationContext)
-		c.walkExpr(vc.ExpressionList())
-		c.bindIdentifierList(vc.IdentifierList())
-		if tp := vc.TuplePattern(); tp != nil {
-			c.bindIdentifierList(tp.(*grammar.TuplePatternContext).IdentifierList())
-		}
-	case d.VarDeclaration() != nil:
-		vc := d.VarDeclaration().(*grammar.VarDeclarationContext)
-		c.walkExpr(vc.ExpressionList())
-		c.bindIdentifierList(vc.IdentifierList())
-		if tp := vc.TuplePattern(); tp != nil {
-			c.bindIdentifierList(tp.(*grammar.TuplePatternContext).IdentifierList())
-		}
-	case d.BindDeclaration() != nil:
-		bc := d.BindDeclaration().(*grammar.BindDeclarationContext)
-		c.walkExpr(bc.Expression())
-		if bc.Identifier() != nil {
-			c.bind(bc.Identifier().GetText())
-		}
-	case d.AlsoDeclaration() != nil:
-		ac := d.AlsoDeclaration().(*grammar.AlsoDeclarationContext)
-		c.walkExpr(ac.Expression())
-		if ac.Identifier() != nil {
-			c.bind(ac.Identifier().GetText())
-		}
-	case d.UseDeclaration() != nil:
-		uc := d.UseDeclaration().(*grammar.UseDeclarationContext)
-		c.walkExpr(uc.Expression())
-		if uc.Identifier() != nil {
-			c.bind(uc.Identifier().GetText())
-		}
-	case d.FunctionDeclaration() != nil:
-		c.walkFunctionDeclaration(d.FunctionDeclaration().(*grammar.FunctionDeclarationContext))
-	case d.IfStatement() != nil:
-		c.walkIfStatement(d.IfStatement().(*grammar.IfStatementContext))
-	case d.ForStatement() != nil:
-		c.walkForStatement(d.ForStatement().(*grammar.ForStatementContext))
-	case d.SimpleStatement() != nil:
-		c.walkSimpleStatement(d.SimpleStatement().(*grammar.SimpleStatementContext))
-	}
-	// typeDeclaration / importDeclaration hold no value-position expressions.
-}
-
-func (c *undefChecker) walkIfStatement(ctx *grammar.IfStatementContext) {
-	c.push()
-	defer c.pop()
-	if init := ctx.SimpleStatement(); init != nil {
-		c.walkSimpleStatement(init.(*grammar.SimpleStatementContext))
-	}
-	c.walkExpr(ctx.Expression())
-	for _, b := range ctx.AllBlock() {
-		c.walkBlock(b.(*grammar.BlockContext))
-	}
-	if elseIf := ctx.IfStatement(); elseIf != nil {
-		c.walkIfStatement(elseIf.(*grammar.IfStatementContext))
-	}
-}
-
-func (c *undefChecker) walkForStatement(ctx *grammar.ForStatementContext) {
-	c.push()
-	defer c.pop()
-	if fc := ctx.ForClause(); fc != nil {
-		f := fc.(*grammar.ForClauseContext)
-		for _, ss := range f.AllSimpleStatement() {
-			c.walkSimpleStatement(ss.(*grammar.SimpleStatementContext))
-		}
-		c.walkExpr(f.Expression())
-	}
-	if rc := ctx.RangeClause(); rc != nil {
-		r := rc.(*grammar.RangeClauseContext)
-		c.walkExpr(r.Expression())
-		c.bindIdentifierList(r.IdentifierList())
-	}
-	if cond := ctx.ForCondition(); cond != nil {
-		c.walkExpr(cond.(*grammar.ForConditionContext).Expression())
-	}
-	if b := ctx.Block(); b != nil {
-		c.walkBlock(b.(*grammar.BlockContext))
-	}
-}
-
-func (c *undefChecker) walkSimpleStatement(ctx *grammar.SimpleStatementContext) {
-	if ctx == nil {
-		return
-	}
-	switch {
-	case ctx.IncDecStmt() != nil:
-		c.walkExpr(ctx.IncDecStmt().(*grammar.IncDecStmtContext).Expression())
-	case ctx.Assignment() != nil:
-		for _, el := range ctx.Assignment().(*grammar.AssignmentContext).AllExpressionList() {
-			c.walkExpr(el)
-		}
-	case ctx.ShortVarDecl() != nil:
-		s := ctx.ShortVarDecl().(*grammar.ShortVarDeclContext)
-		c.walkExpr(s.ExpressionList())
-		c.bindIdentifierList(s.IdentifierList())
-	case ctx.Expression() != nil:
-		c.walkExpr(ctx.Expression())
-	}
-}
-
-// walkExpr is the generic expression walker. It descends the precedence chain
-// generically and only takes over at nodes whose identifiers need special
-// treatment.
-func (c *undefChecker) walkExpr(node antlr.Tree) {
-	if node == nil {
-		return
-	}
-	switch n := node.(type) {
-	case *grammar.PostfixExprContext:
-		c.walkPostfixExpr(n)
-	case *grammar.LambdaExpressionContext:
-		c.walkLambda(n)
-	case *grammar.PartialFunctionLiteralContext:
-		for _, cc := range n.AllCaseClause() {
-			c.walkCaseClause(cc.(*grammar.CaseClauseContext))
-		}
-	case *grammar.BlockContext:
-		c.walkBlock(n)
-	case *grammar.ArgumentContext:
-		// `argument: (identifier '=')? (lambdaExpression | pattern)` — the
-		// optional leading identifier is a named-argument label, not a
-		// reference.
-		if lam := n.LambdaExpression(); lam != nil {
-			c.walkLambda(lam.(*grammar.LambdaExpressionContext))
-			return
-		}
-		c.walkArgumentPattern(n.Pattern())
-	case *grammar.KeyedElementContext:
-		// `keyedElement: (expression ':')? expression` — a leading key is a
-		// struct field name in the common case, so only the value is checked.
-		if exprs := n.AllExpression(); len(exprs) > 0 {
-			c.walkExpr(exprs[len(exprs)-1])
-		}
-	case *grammar.TypeContext:
-		// Type positions are out of scope for this check (see file header).
-	case *grammar.IfExpressionContext:
-		c.walkExpr(n.Expression())
-		for _, br := range n.AllIfExprBranch() {
-			b := br.(*grammar.IfExprBranchContext)
-			if blk := b.Block(); blk != nil {
-				c.walkBlock(blk.(*grammar.BlockContext))
-			} else {
-				c.walkExpr(b.Expression())
-			}
-		}
-	case *grammar.DeclarationContext:
-		c.walkDeclaration(n)
-	case *grammar.StatementContext:
-		c.walkStatement(n)
-	case *grammar.SimpleStatementContext:
-		c.walkSimpleStatement(n)
-	default:
-		for i := 0; i < node.GetChildCount(); i++ {
-			c.walkExpr(node.GetChild(i))
-		}
-	}
-}
-
-// walkArgumentPattern treats a `pattern` node appearing in *argument* position
-// as an ordinary expression. The same grammar rule serves `case` patterns,
-// where identifiers bind instead — see walkCaseClause.
-func (c *undefChecker) walkArgumentPattern(p grammar.IPatternContext) {
-	switch pn := p.(type) {
-	case nil:
-		return
-	case *grammar.ExpressionPatternContext:
-		c.walkExpr(pn.Expression())
-	case *grammar.RestPatternContext:
-		c.walkExpr(pn.Expression())
-	case *grammar.TypedPatternContext:
-		// `x: T` in argument position is not an expression reference.
-	default:
-		c.walkExpr(p)
-	}
-}
-
-func (c *undefChecker) walkLambda(n *grammar.LambdaExpressionContext) {
-	c.push()
-	defer c.pop()
-	c.bindParameters(n.Parameters(), false)
-	if b := n.Block(); b != nil {
-		c.walkBlock(b.(*grammar.BlockContext))
-		return
-	}
-	c.walkExpr(n.Expression())
-}
-
-// walkCaseClause binds every identifier the pattern mentions, then checks the
-// guard and body against that scope. Binding constructors as well as capture
-// names is deliberate: telling them apart needs the scrutinee's type, and
-// over-binding can only miss detections, never invent them.
-func (c *undefChecker) walkCaseClause(cc *grammar.CaseClauseContext) {
-	c.push()
-	defer c.pop()
-	if p := cc.Pattern(); p != nil {
-		for _, id := range collectIdentifiers(p) {
-			c.bind(id)
-		}
-	}
-	c.walkExpr(cc.GetGuard())
-	if b := cc.GetBodyBlock(); b != nil {
-		c.walkBlock(b.(*grammar.BlockContext))
-	}
-	if s := cc.GetBodyStmt(); s != nil {
-		c.walkSimpleStatement(s.(*grammar.SimpleStatementContext))
-	}
-}
-
-func (c *undefChecker) walkPostfixExpr(n *grammar.PostfixExprContext) {
-	suffixes := n.AllPostfixSuffix()
-	if prim := n.PrimaryExpr(); prim != nil {
-		pe := prim.(*grammar.PrimaryExprContext)
-		if p := pe.Primary(); p != nil {
-			pc := p.(*grammar.PrimaryContext)
-			if id := pc.Identifier(); id != nil {
-				name := id.GetText()
-				// `pkg.Symbol` — the head is a package qualifier, not a value.
-				isQualifier := len(suffixes) > 0 &&
-					isSelectorSuffix(suffixes[0]) &&
-					!c.inScope(name) &&
-					c.qualifiers[name]
-				if !isQualifier && !c.resolves(name) {
-					c.report(name, id.GetStart())
-				}
-			} else {
-				c.walkExpr(pc)
-			}
-		} else {
-			c.walkExpr(pe)
-		}
-	}
-	for _, sfx := range suffixes {
-		sc := sfx.(*grammar.PostfixSuffixContext)
-		if sc.Identifier() != nil {
-			continue // member selector — not a free identifier
-		}
-		if al := sc.ArgumentList(); al != nil {
-			for _, arg := range al.(*grammar.ArgumentListContext).AllArgument() {
-				c.walkExpr(arg)
-			}
-			continue
-		}
-		// Either an index (`xs[i]`) or an explicit type-argument list
-		// (`Unfold[int, string](...)`). Both route through primary
-		// identifiers, and type names resolve through the declared index.
-		c.walkExpr(sc.ExpressionList())
-	}
-	for _, cc := range n.AllCaseClause() {
-		c.walkCaseClause(cc.(*grammar.CaseClauseContext))
-	}
-}
-
-func isSelectorSuffix(s grammar.IPostfixSuffixContext) bool {
-	sc, ok := s.(*grammar.PostfixSuffixContext)
-	return ok && sc.Identifier() != nil
-}
-
-// collectIdentifiers returns every `identifier` leaf under `node`.
-func collectIdentifiers(node antlr.Tree) []string {
-	var out []string
-	var walk func(antlr.Tree)
-	walk = func(t antlr.Tree) {
-		if t == nil {
-			return
-		}
-		if id, ok := t.(*grammar.IdentifierContext); ok {
-			out = append(out, id.GetText())
-			return
-		}
-		for i := 0; i < t.GetChildCount(); i++ {
-			walk(t.GetChild(i))
-		}
-	}
-	walk(node)
-	return out
 }
 
 // --- import hint discovery --------------------------------------------------

--- a/internal/transpiler/analyzer/undefined_symbol.go
+++ b/internal/transpiler/analyzer/undefined_symbol.go
@@ -1,0 +1,1520 @@
+package analyzer
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/antlr4-go/antlr/v4"
+
+	"martianoff/gala/galaerr"
+	"martianoff/gala/internal/parser/grammar"
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/registry"
+	"martianoff/gala/internal/transpiler/transformer"
+)
+
+// ---------------------------------------------------------------------------
+// Undefined-symbol check (GALA-E0023)
+//
+// Before this pass existed, a name that resolved to *nothing* was simply
+// carried through: the analyzer produced no metadata for it, the inference
+// engine fell back to an unconstrained type variable, and the transformer
+// emitted a bare Go identifier. The user's first signal was either `undefined:
+// x` from the Go compiler pointed at generated code, or — worse — a silently
+// erased `any` in a lambda parameter whose type could only have come from the
+// unresolved symbol's signature. This pass turns both into a framed GALA
+// diagnostic at the identifier's own source position.
+//
+// WHAT THIS COVERS
+//
+// Every *bare identifier used in value position* — a variable read, a call
+// target, a bare function reference — must resolve to something the analyzer
+// knows about:
+//
+//   - a binding introduced by an enclosing scope: function/method/lambda
+//     parameters and type parameters, method receivers, `val`/`var`, `:=`,
+//     `for`/`range` variables, `use`/`bind`/`also` bindings, and every
+//     identifier bound by a `match` or partial-function case pattern;
+//   - a package-level declaration of the current package, including ones
+//     contributed by sibling files: functions, types, sealed variants and
+//     their companions, struct shorthands, type aliases, package vals/vars
+//     and `embed val`s;
+//   - a symbol of any package whose metadata reached this compilation —
+//     GALA (`Types` / `Functions` / `CompanionObjects` / `TypeAliases`) or Go
+//     (`GoTypeInfo` / `GoExports`). The `std` prelude goes through exactly
+//     this lookup like any other package; there is no std special case;
+//   - a package qualifier (`os` in `os.Getenv(...)`, or an import alias);
+//   - the `<Type>_<Method>` function form the transformer emits for generic
+//     and synthesized methods (`Array_FoldLeft`, `Some_Apply`), anchored on a
+//     type the compilation knows — see isGeneratedMethodForm;
+//   - a language builtin: `Println` / `Print`, the predeclared Go type names
+//     used for conversions and type arguments, the loop-control and
+//     predeclared-print names GALA has not classified (`break`, `continue`,
+//     `println`, `print` — see galaBuiltinValueNames), and the names other
+//     coded checks own — the Go builtins of GALA-E0035 and the Go statement
+//     keywords of GALA-E0036 — which must keep producing their own, more
+//     specific diagnostics.
+//
+// A name that matches none of the above is reported as GALA-E0023 at its
+// `.gala` position. When the name IS declared by a GALA package on the
+// module's search paths, the hint names the import to add; that association
+// is discovered by reading the candidate packages' own top-level
+// declarations, never from a hardcoded name list and never from a path
+// substring.
+//
+// WHAT THIS DELIBERATELY DOES NOT COVER
+//
+//   - Type compatibility. This is an *existence* check only; whether
+//     `add(1, "two")` type-checks is not its business.
+//   - Import discipline. Resolution is deliberately permissive about *which*
+//     package a name came from: any symbol present in the merged metadata
+//     counts. Requiring the current file's own import is GALA-E0025's job
+//     (validateExplicitImports), which is unchanged by this pass. So a name
+//     visible only because a sibling file imported its package is accepted
+//     here and rejected there — one concern, one code.
+//   - Selectors. In `x.foo().bar`, only `x` is checked. Field and method
+//     names need the receiver's type, which is inference territory.
+//   - Type references (`func f(x Foo)`, `val v Foo = ...`, `Foo{}`). An
+//     unresolved type in a signature already has a dedicated owner, and the
+//     analyzer's type resolution is lossy enough (Go generics, constraints,
+//     `map[K]V`, func types) that flagging here would produce false
+//     positives. Type positions are skipped wholesale: only identifiers that
+//     reach a `primary` in expression position are checked.
+//   - Identifiers inside interpolated strings (`s"...$x..."`). The
+//     interpolation body is a single lexer token, so those expressions never
+//     reach the parse tree this walk sees.
+//   - `match` / `case` *patterns*. A pattern both binds names and references
+//     constructors, and telling them apart needs the scrutinee's type. Every
+//     identifier in a pattern is therefore treated as a binding scoped to
+//     that arm — a deliberate under-approximation that trades missed
+//     detections for zero false positives.
+//   - Composite-literal keys (`Point{X: 1}`), named-argument labels
+//     (`f(name = 1)`) and postfix selectors, which are member names rather
+//     than free identifiers.
+//   - Files whose imports did not all load (see fileImportsFullyLoaded) and
+//     the LSP analyzer (see galaAnalyzer.skipUndefinedCheck). In both cases
+//     the symbol table is knowingly incomplete or the caller's contract is
+//     best-effort, so a hard error would be worse than a missed detection.
+//
+// ---------------------------------------------------------------------------
+
+// galaBuiltinValueNames are names always in scope in expression position that
+// no GALA or Go package declares. Keep this to genuine language surface —
+// anything a package declares must resolve through metadata instead.
+var galaBuiltinValueNames = map[string]bool{
+	// Auto-imported print helpers, rewritten to fmt.Println / fmt.Print by
+	// the transformer (see rewriteBuiltinPrintFuncs).
+	"Println": true,
+	"Print":   true,
+	// The blank identifier is a binding sink, never a reference.
+	"_": true,
+	// Loop control. The grammar has no `break` / `continue` statement, so both
+	// parse as a bare identifier expression-statement and survive to the
+	// generated Go — the same mechanism GALA-E0036 rejects for `defer` / `go`
+	// / `goto`. Unlike those, these two are in active use (examples/for_loops,
+	// json/codec, test/bench) and have no GALA-native replacement while `for`
+	// loops exist, so they are accepted here. Whether they should be grammar
+	// keywords, or join E0036's forbidden set, is a language decision this
+	// existence check must not pre-empt.
+	"break":    true,
+	"continue": true,
+	// Go's predeclared `println` / `print`. Like `break` above, these are not
+	// GALA surface — they reach the generated Go as bare identifiers and Go
+	// resolves them — but they are in use (examples/hello, examples/complex,
+	// examples/with_main) and GALA-E0035 has not claimed them the way it
+	// claimed `len` / `append` / `make`. Whether they should join that set is
+	// that check's decision, not this one's.
+	"println": true,
+	"print":   true,
+}
+
+// goPredeclaredTypeNames are Go's predeclared type names. They reach
+// expression position as conversions (`int(x)`) and as explicit type
+// arguments (`Unfold[int, string](...)`), both of which route through
+// `primary: identifier`.
+var goPredeclaredTypeNames = map[string]bool{
+	"bool": true, "string": true, "error": true, "any": true,
+	"int": true, "int8": true, "int16": true, "int32": true, "int64": true,
+	"uint": true, "uint8": true, "uint16": true, "uint32": true, "uint64": true,
+	"uintptr": true, "byte": true, "rune": true,
+	"float32": true, "float64": true,
+	"complex64": true, "complex128": true,
+	"comparable": true,
+}
+
+// inRepoGalaImportPrefix is the import-path prefix of packages that live in
+// this module's own tree, as opposed to external GALA modules resolved
+// through gala.mod. It mirrors the split the import scan in Analyze makes.
+const inRepoGalaImportPrefix = "martianoff/gala/"
+
+// hintRoot is one directory the import hint may search, together with the
+// module import prefix its packages live under.
+type hintRoot struct {
+	dir    string
+	prefix string
+}
+
+// undefScope is one lexical scope in the checker's scope chain.
+type undefScope struct {
+	names  map[string]bool
+	parent *undefScope
+}
+
+// undefChecker walks a parsed GALA file and reports identifiers in value
+// position that resolve to nothing. See the file header for the exact scope.
+type undefChecker struct {
+	rich *transpiler.RichAST
+
+	scope *undefScope
+
+	// declared indexes every symbol the merged metadata knows about, under
+	// both its qualified key ("collection_immutable.Array") and its simple
+	// name ("Array"). Indexing the simple name is what makes the check
+	// permissive about *which* package a symbol came from — see the header's
+	// note on GALA-E0025 owning import discipline.
+	declared map[string]bool
+
+	// declaredTypes holds just the simple names of known types. It backs the
+	// `<Type>_<Method>` function form the transformer emits for generic and
+	// synthesized methods — see isGeneratedMethodForm.
+	declaredTypes map[string]bool
+
+	// qualifiers holds names usable as a package qualifier (`pkg.Symbol`):
+	// GALA package names, import aliases, and the trailing segment of this
+	// file's Go import paths.
+	qualifiers map[string]bool
+
+	// hintRoots are searched (only when an error is already being emitted)
+	// for a GALA package that declares the unresolved name.
+	hintRoots []hintRoot
+
+	// importResolves reports whether an import path maps to a directory, so
+	// the hint can suggest a spelling the compiler will accept.
+	importResolves func(importPath, dir string) bool
+
+	errs []*galaerr.SemanticError
+	// reported dedupes by name, so one misspelling used in twenty places
+	// produces one actionable error rather than twenty.
+	reported map[string]bool
+}
+
+// checkUndefinedSymbols runs the existence check over `sourceFile` and returns
+// the collected errors in source order.
+func (a *galaAnalyzer) checkUndefinedSymbols(
+	sourceFile *grammar.SourceFileContext,
+	richAST *transpiler.RichAST,
+	filePath string,
+) []*galaerr.SemanticError {
+	declared := indexDeclaredSymbols(richAST)
+	for name := range a.undefinedSymbolLocalGoNames(filePath) {
+		declared[name] = true
+	}
+	for name := range a.importedTopLevelNames(sourceFile) {
+		declared[name] = true
+	}
+	c := &undefChecker{
+		rich:          richAST,
+		declared:      declared,
+		declaredTypes: indexDeclaredTypeNames(richAST),
+		qualifiers:     collectQualifiers(sourceFile, richAST),
+		hintRoots:      a.hintRoots(),
+		importResolves: a.importPathResolvesTo,
+		reported:       make(map[string]bool),
+	}
+	c.push()
+	c.bindFileLevelNames(sourceFile)
+	c.walkTopLevel(sourceFile)
+	c.pop()
+
+	sort.SliceStable(c.errs, func(i, j int) bool {
+		if c.errs[i].Line != c.errs[j].Line {
+			return c.errs[i].Line < c.errs[j].Line
+		}
+		return c.errs[i].Column < c.errs[j].Column
+	})
+	return c.errs
+}
+
+// fileImportsFullyLoaded reports whether every import declared by this file
+// actually contributed its metadata. It is the precondition for running the
+// undefined-symbol check: an import whose package failed to analyze (missing
+// from a search path, mid-cycle, or a transpile failure) leaves the symbol
+// table without any of that package's exports, and a name the analyzer never
+// saw must not be reported as one the author never defined.
+//
+// Two shapes make a file ineligible:
+//
+//   - a GALA import with no successfully-analyzed entry in analyzedPkgs, and
+//   - a *dot* import of a Go package, whose unqualified exports depend on Go
+//     type info that is silently unavailable when no Go SDK is on PATH.
+//     Named Go imports stay eligible because their symbols are only ever
+//     reachable through a qualifier, which the check accepts on sight.
+func (a *galaAnalyzer) fileImportsFullyLoaded(sf *grammar.SourceFileContext) bool {
+	// The implicitly dot-imported prelude is subject to the same rule: it
+	// never appears in the import list, so check it explicitly. (This is not
+	// a special case for std — it is the one import the language adds on the
+	// author's behalf, and it must be as loaded as any they wrote.)
+	if entry, present := a.analyzedPkgs[registry.StdImportPath]; !present || entry == nil {
+		return false
+	}
+	for _, impDecl := range sf.AllImportDeclaration() {
+		ctx, ok := impDecl.(*grammar.ImportDeclarationContext)
+		if !ok {
+			continue
+		}
+		for _, spec := range ctx.AllImportSpec() {
+			s, ok := spec.(*grammar.ImportSpecContext)
+			if !ok || s.STRING() == nil {
+				continue
+			}
+			path := strings.Trim(s.STRING().GetText(), "\"")
+			// Same in-repo/external split the import scan in Analyze uses.
+			isGala := strings.HasPrefix(path, inRepoGalaImportPrefix) ||
+				(a.resolver != nil && a.resolver.IsGalaPackage(path))
+			if isGala {
+				if entry, present := a.analyzedPkgs[path]; !present || entry == nil {
+					return false
+				}
+				continue
+			}
+			// Dot import of a Go package: `s.Identifier() == nil` with an
+			// extra child is the '.' form (see the dot-import scan in
+			// Analyze).
+			if s.Identifier() == nil && s.GetChildCount() > 1 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// importedTopLevelNames returns every name declared at the top level of the
+// GALA packages this file imports, read straight from those packages' sources.
+//
+// It is a deliberate safety net rather than the primary resolution path. The
+// merged metadata is the primary path, but it is not a complete record of what
+// a package exports: package-level `val`/`var` declarations, for instance,
+// live in RichAST.PackageVals, which Merge does not carry across a package
+// boundary (it exists for the current package's Immutable-unwrap decisions, and
+// widening it would change how the transformer pre-registers names). Rather
+// than reshape that map — and risk changing generated code for a check that
+// only needs to know whether a name exists — the declarations are read
+// directly. Any future export kind the metadata does not model is covered by
+// the same net.
+//
+// Names are collected only for the *existence* test; nothing here influences
+// type resolution or code generation. Results are cached per package directory:
+// analyzePackage has already parsed these files, so parseFileCached usually
+// hits, and a package's sources do not change during a build.
+func (a *galaAnalyzer) importedTopLevelNames(sf *grammar.SourceFileContext) map[string]bool {
+	out := make(map[string]bool)
+	for _, impDecl := range sf.AllImportDeclaration() {
+		ctx, ok := impDecl.(*grammar.ImportDeclarationContext)
+		if !ok {
+			continue
+		}
+		for _, spec := range ctx.AllImportSpec() {
+			s, ok := spec.(*grammar.ImportSpecContext)
+			if !ok || s.STRING() == nil {
+				continue
+			}
+			path := strings.Trim(s.STRING().GetText(), "\"")
+			relPath := path
+			isInRepo := strings.HasPrefix(path, inRepoGalaImportPrefix)
+			if isInRepo {
+				relPath = strings.TrimPrefix(path, inRepoGalaImportPrefix)
+			} else if a.resolver == nil || !a.resolver.IsGalaPackage(path) {
+				continue // Go package — its symbols come from GoTypeInfo
+			}
+			for name := range a.packageTopLevelNames(relPath) {
+				out[name] = true
+			}
+		}
+	}
+	// The implicit prelude is subject to the same treatment as any written
+	// import — it resolves through the ordinary package path, not a bypass.
+	for name := range a.packageTopLevelNames(registry.StdPackageName) {
+		out[name] = true
+	}
+	return out
+}
+
+// packageTopLevelNames parses the .gala sources of the package at `relPath`
+// and returns the names their top-level declarations introduce.
+func (a *galaAnalyzer) packageTopLevelNames(relPath string) map[string]bool {
+	if a.resolver == nil {
+		return nil
+	}
+	dirPath, err := a.resolver.ResolvePackagePath(relPath)
+	if err != nil || dirPath == "" {
+		return nil
+	}
+	key := canonicalPath(dirPath)
+	if cached, ok := a.importedNames[key]; ok {
+		return cached
+	}
+	entries, rerr := os.ReadDir(dirPath)
+	if rerr != nil {
+		if a.importedNames == nil {
+			a.importedNames = make(map[string]map[string]bool)
+		}
+		a.importedNames[key] = nil
+		return nil
+	}
+	names := make(map[string]bool)
+	for _, e := range entries {
+		n := e.Name()
+		if e.IsDir() || filepath.Ext(n) != ".gala" || strings.HasSuffix(n, "_test.gala") {
+			continue
+		}
+		tree, _, perr := a.parseFileCached(filepath.Join(dirPath, n))
+		if perr != nil || tree == nil {
+			continue
+		}
+		collectTopLevelDeclaredNames(tree, names)
+	}
+	if a.importedNames == nil {
+		a.importedNames = make(map[string]map[string]bool)
+	}
+	a.importedNames[key] = names
+	return names
+}
+
+// collectTopLevelDeclaredNames records into `out` every name the file's
+// top-level declarations introduce: free functions, types, struct shorthands,
+// sealed types and their case variants, package vals/vars (including
+// tuple-pattern destructuring), and embed bindings.
+func collectTopLevelDeclaredNames(sf *grammar.SourceFileContext, out map[string]bool) {
+	record := func(id grammar.IIdentifierContext) {
+		if id != nil {
+			out[id.GetText()] = true
+		}
+	}
+	recordList := func(il grammar.IIdentifierListContext) {
+		if il == nil {
+			return
+		}
+		for _, id := range il.(*grammar.IdentifierListContext).AllIdentifier() {
+			record(id)
+		}
+	}
+	for _, topDecl := range sf.AllTopLevelDeclaration() {
+		switch {
+		case topDecl.FunctionDeclaration() != nil:
+			fc := topDecl.FunctionDeclaration().(*grammar.FunctionDeclarationContext)
+			if fc.Receiver() == nil {
+				record(fc.Identifier())
+			}
+		case topDecl.TypeDeclaration() != nil:
+			record(topDecl.TypeDeclaration().(*grammar.TypeDeclarationContext).Identifier())
+		case topDecl.StructShorthandDeclaration() != nil:
+			record(topDecl.StructShorthandDeclaration().(*grammar.StructShorthandDeclarationContext).Identifier())
+		case topDecl.SealedTypeDeclaration() != nil:
+			sc := topDecl.SealedTypeDeclaration().(*grammar.SealedTypeDeclarationContext)
+			record(sc.Identifier())
+			for _, cc := range sc.AllSealedCase() {
+				record(cc.(*grammar.SealedCaseContext).Identifier())
+			}
+		case topDecl.ValDeclaration() != nil:
+			vc := topDecl.ValDeclaration().(*grammar.ValDeclarationContext)
+			recordList(vc.IdentifierList())
+			if tp := vc.TuplePattern(); tp != nil {
+				recordList(tp.(*grammar.TuplePatternContext).IdentifierList())
+			}
+		case topDecl.VarDeclaration() != nil:
+			vc := topDecl.VarDeclaration().(*grammar.VarDeclarationContext)
+			recordList(vc.IdentifierList())
+			if tp := vc.TuplePattern(); tp != nil {
+				recordList(tp.(*grammar.TuplePatternContext).IdentifierList())
+			}
+		case topDecl.EmbedDeclaration() != nil:
+			record(topDecl.EmbedDeclaration().(*grammar.EmbedDeclarationContext).Identifier())
+		}
+	}
+}
+
+// undefinedSymbolLocalGoNames returns every name declared at the top level of
+// the hand-written .go files sitting alongside `filePath` — unexported ones
+// included.
+//
+// This closes a real gap in the analyzer's symbol table rather than papering
+// over one. A mixed GALA+Go package may have a .gala file call an unexported
+// helper declared in a .go file of the same package (json/codec.gala's
+// `toBytes` comes from json/byte_utils.go). That call is legal Go once
+// generated, but GoTypeInfo intentionally records only *exported* symbols,
+// since those are the ones that cross a package boundary. Widening
+// GoTypeInfo would leak unexported names into cross-package resolution, so
+// the fuller list is collected here instead and used for existence only.
+//
+// Results are cached per directory: a package's .go files do not change
+// during a build, and a 37-file GALA package would otherwise re-parse them
+// once per file.
+func (a *galaAnalyzer) undefinedSymbolLocalGoNames(filePath string) map[string]bool {
+	if filePath == "" {
+		return nil
+	}
+	dir := canonicalPath(filepath.Dir(filePath))
+	if cached, ok := a.localGoNames[dir]; ok {
+		return cached
+	}
+	names := parseLocalGoDeclNames(filepath.Dir(filePath))
+	if a.localGoNames == nil {
+		a.localGoNames = make(map[string]map[string]bool)
+	}
+	a.localGoNames[dir] = names
+	return names
+}
+
+// parseLocalGoDeclNames parses `dir`'s hand-written .go files and returns the
+// names their top-level declarations introduce. Generated (.gen.go) and test
+// files are excluded: the former restate what the .gala sources already
+// contribute, the latter are not part of the package's surface.
+func parseLocalGoDeclNames(dir string) map[string]bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var names map[string]bool
+	record := func(name string) {
+		if name == "" || name == "_" {
+			return
+		}
+		if names == nil {
+			names = make(map[string]bool)
+		}
+		names[name] = true
+	}
+	fset := token.NewFileSet()
+	for _, e := range entries {
+		n := e.Name()
+		if e.IsDir() || !strings.HasSuffix(n, ".go") ||
+			strings.HasSuffix(n, "_test.go") || strings.HasSuffix(n, ".gen.go") {
+			continue
+		}
+		f, perr := parser.ParseFile(fset, filepath.Join(dir, n), nil, parser.SkipObjectResolution)
+		if perr != nil || f == nil {
+			continue
+		}
+		for _, decl := range f.Decls {
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				if d.Recv == nil && d.Name != nil {
+					record(d.Name.Name)
+				}
+			case *ast.GenDecl:
+				for _, spec := range d.Specs {
+					switch s := spec.(type) {
+					case *ast.TypeSpec:
+						if s.Name != nil {
+							record(s.Name.Name)
+						}
+					case *ast.ValueSpec:
+						for _, id := range s.Names {
+							record(id.Name)
+						}
+					}
+				}
+			}
+		}
+	}
+	return names
+}
+
+// importPathResolvesTo reports whether `importPath` is one the analyzer would
+// resolve to `dir`. The hint uses it to pick, among the plausible spellings of
+// a candidate package's import path, one that will actually work when pasted
+// into the file — a directory can be reachable under the module's own prefix,
+// under the GALA distribution prefix, or bare, depending on which search path
+// it came from, and only the resolver knows which.
+func (a *galaAnalyzer) importPathResolvesTo(importPath, dir string) bool {
+	if a.resolver == nil || importPath == "" {
+		return false
+	}
+	// Mirrors the in-repo/external split the import scan in Analyze makes.
+	relPath := strings.TrimPrefix(importPath, inRepoGalaImportPrefix)
+	resolved, err := a.resolver.ResolvePackagePath(relPath)
+	if err != nil || resolved == "" {
+		return false
+	}
+	return canonicalPath(resolved) == canonicalPath(dir)
+}
+
+// hintRoots returns the roots the import hint may scan, each paired with the
+// module import prefix its subdirectories live under.
+func (a *galaAnalyzer) hintRoots() []hintRoot {
+	seen := make(map[string]bool)
+	var roots []hintRoot
+	add := func(dir string) {
+		if dir == "" {
+			return
+		}
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			abs = dir
+		}
+		if seen[abs] {
+			return
+		}
+		seen[abs] = true
+		roots = append(roots, hintRoot{dir: abs, prefix: modulePrefixOf(abs)})
+	}
+	if a.resolver != nil {
+		add(a.resolver.ModuleRoot())
+	}
+	for _, sp := range a.searchPaths {
+		add(sp)
+	}
+	return roots
+}
+
+// modulePrefixOf reads the module name declared by `dir`'s gala.mod (falling
+// back to go.mod), which is the prefix its packages are imported under.
+func modulePrefixOf(dir string) string {
+	for _, name := range []string{"gala.mod", "go.mod"} {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if rest, ok := cutPrefix(strings.TrimSpace(line), "module "); ok {
+				return strings.TrimSpace(rest)
+			}
+		}
+	}
+	return ""
+}
+
+// indexDeclaredSymbols flattens every symbol in the merged metadata into a
+// lookup set keyed by both qualified name and simple name.
+func indexDeclaredSymbols(rich *transpiler.RichAST) map[string]bool {
+	out := make(map[string]bool)
+	add := func(key string) {
+		if key == "" {
+			return
+		}
+		out[key] = true
+		if idx := strings.LastIndex(key, "."); idx > 0 && idx+1 < len(key) {
+			out[key[idx+1:]] = true
+		}
+	}
+	for k := range rich.Functions {
+		add(k)
+	}
+	for k := range rich.Types {
+		add(k)
+	}
+	for k := range rich.CompanionObjects {
+		add(k)
+	}
+	for k := range rich.TypeAliases {
+		add(k)
+	}
+	for k := range rich.PackageVals {
+		add(k)
+	}
+	if gi := rich.GoTypeInfo; gi != nil {
+		for k := range gi.Functions {
+			add(k)
+		}
+		for k := range gi.Types {
+			add(k)
+		}
+		for k := range gi.Variables {
+			add(k)
+		}
+		for k := range gi.Constants {
+			add(k)
+		}
+		for k := range gi.TypeAliases {
+			add(k)
+		}
+	}
+	for pkg, symbols := range rich.GoExports {
+		for _, s := range symbols {
+			add(pkg + "." + s)
+		}
+	}
+	return out
+}
+
+// collectQualifiers builds the set of identifiers that may legally appear on
+// the left of a `pkg.Symbol` selector.
+func collectQualifiers(sf *grammar.SourceFileContext, rich *transpiler.RichAST) map[string]bool {
+	q := make(map[string]bool)
+	q[registry.StdPackageName] = true
+	if rich.PackageName != "" {
+		q[rich.PackageName] = true
+	}
+	for _, name := range rich.Packages {
+		if name != "" {
+			q[name] = true
+		}
+	}
+	for alias := range rich.ImportAliases {
+		q[alias] = true
+	}
+	for pkg := range rich.GoExports {
+		q[pkg] = true
+	}
+	if gi := rich.GoTypeInfo; gi != nil {
+		for k := range gi.Functions {
+			addQualifierOf(q, k)
+		}
+		for k := range gi.Types {
+			addQualifierOf(q, k)
+		}
+		for k := range gi.Variables {
+			addQualifierOf(q, k)
+		}
+		for k := range gi.Constants {
+			addQualifierOf(q, k)
+		}
+		for k := range gi.TypeAliases {
+			addQualifierOf(q, k)
+		}
+	}
+	// This file's own import declarations: the alias when one is given,
+	// otherwise the trailing path segment — how a Go import is referenced.
+	for _, impDecl := range sf.AllImportDeclaration() {
+		ctx, ok := impDecl.(*grammar.ImportDeclarationContext)
+		if !ok {
+			continue
+		}
+		for _, spec := range ctx.AllImportSpec() {
+			s, ok := spec.(*grammar.ImportSpecContext)
+			if !ok || s.STRING() == nil {
+				continue
+			}
+			if alias := s.Identifier(); alias != nil {
+				q[alias.GetText()] = true
+				continue
+			}
+			path := strings.Trim(s.STRING().GetText(), "\"")
+			if idx := strings.LastIndex(path, "/"); idx >= 0 {
+				path = path[idx+1:]
+			}
+			if path != "" {
+				q[path] = true
+			}
+		}
+	}
+	return q
+}
+
+// indexDeclaredTypeNames returns the simple names of every type and companion
+// object the merged metadata knows about. It anchors the `<Type>_<Method>`
+// function form the transformer emits — see isGeneratedMethodForm.
+func indexDeclaredTypeNames(rich *transpiler.RichAST) map[string]bool {
+	out := make(map[string]bool)
+	for k, tm := range rich.Types {
+		if tm != nil && tm.Name != "" {
+			out[tm.Name] = true
+			continue
+		}
+		out[simpleNameOf(k)] = true
+	}
+	for k := range rich.CompanionObjects {
+		out[simpleNameOf(k)] = true
+	}
+	if gi := rich.GoTypeInfo; gi != nil {
+		for k := range gi.Types {
+			out[simpleNameOf(k)] = true
+		}
+	}
+	return out
+}
+
+// simpleNameOf strips a "pkg." qualifier from a metadata key.
+func simpleNameOf(qualified string) string {
+	if idx := strings.LastIndex(qualified, "."); idx > 0 && idx+1 < len(qualified) {
+		return qualified[idx+1:]
+	}
+	return qualified
+}
+
+func addQualifierOf(q map[string]bool, qualified string) {
+	if idx := strings.LastIndex(qualified, "."); idx > 0 {
+		q[qualified[:idx]] = true
+	}
+}
+
+// --- scope handling ---------------------------------------------------------
+
+func (c *undefChecker) push() {
+	c.scope = &undefScope{names: make(map[string]bool), parent: c.scope}
+}
+
+func (c *undefChecker) pop() {
+	if c.scope != nil {
+		c.scope = c.scope.parent
+	}
+}
+
+func (c *undefChecker) bind(name string) {
+	if name == "" || c.scope == nil {
+		return
+	}
+	c.scope.names[name] = true
+}
+
+func (c *undefChecker) inScope(name string) bool {
+	for s := c.scope; s != nil; s = s.parent {
+		if s.names[name] {
+			return true
+		}
+	}
+	return false
+}
+
+// --- resolution -------------------------------------------------------------
+
+// resolves reports whether `name` denotes anything at all at this point in the
+// walk.
+func (c *undefChecker) resolves(name string) bool {
+	if name == "" {
+		return true
+	}
+	if c.inScope(name) {
+		return true
+	}
+	if galaBuiltinValueNames[name] || goPredeclaredTypeNames[name] {
+		return true
+	}
+	// Names owned by other coded checks keep their own, more specific
+	// diagnostics: the Go builtins of GALA-E0035 and the Go statement
+	// keywords of GALA-E0036 must not be downgraded to "undefined".
+	if transformer.ForbiddenGoBuiltins()[name] || transformer.ForbiddenStatementKeywords()[name] {
+		return true
+	}
+	// A bare package name in value position is not a value, but rejecting it
+	// is a separate concern from this existence check.
+	if c.qualifiers[name] {
+		return true
+	}
+	if c.declared[name] {
+		return true
+	}
+	return c.isGeneratedMethodForm(name)
+}
+
+// isGeneratedMethodForm reports whether `name` is the function form of a
+// method on a known type — `Array_FoldLeft`, `Some_Apply`, `Option_Map`.
+//
+// Go forbids a method from introducing its own type parameters, so the
+// transformer emits such methods (and the synthesized Apply / Unapply / Copy /
+// Equal on structs and sealed variants) as top-level `<Type>_<Method>`
+// functions, and GALA source may call that form directly. Those names exist
+// only after transformation, so the analyzer's metadata has no entry for them.
+//
+// The test is anchored on real metadata: the part before an underscore has to
+// be a type this compilation actually knows. It is deliberately not anchored
+// on the suffix, because the suffix may name a method the transformer
+// synthesizes rather than one the author declared — which is exactly the set
+// the analyzer cannot enumerate. The cost is that a misspelling after the
+// underscore (`Array_Fldleft`) is not caught here; the Go compiler still
+// rejects it.
+func (c *undefChecker) isGeneratedMethodForm(name string) bool {
+	for i, r := range name {
+		if r != '_' || i == 0 {
+			continue
+		}
+		if c.declaredTypes[name[:i]] {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *undefChecker) report(name string, tok antlr.Token) {
+	if tok == nil || c.reported[name] {
+		return
+	}
+	c.reported[name] = true
+	err := galaerr.NewCodedSemanticError(
+		galaerr.CodeUndefinedVariable,
+		tok.GetLine(), tok.GetColumn(),
+		fmt.Sprintf("undefined: %s", name),
+		c.hintFor(name),
+	).WithSpan(tok.GetColumn() + len([]rune(name)))
+	c.errs = append(c.errs, err)
+}
+
+// hintFor produces the actionable half of the diagnostic. When the name is
+// declared by GALA packages the search paths can see, it names the import(s)
+// that would bring it into scope; otherwise it falls back to generic guidance.
+func (c *undefChecker) hintFor(name string) string {
+	candidates := galaPackagesDeclaring(name, c.hintRoots, c.importResolves)
+	switch len(candidates) {
+	case 0:
+		return "check the spelling, add the import that introduces this name, or declare it — " +
+			"every identifier must resolve to a binding, a declaration in this package, or an imported symbol"
+	case 1:
+		p := candidates[0]
+		return fmt.Sprintf(
+			"%s is declared in the GALA package %q, which this file does not import. "+
+				"Add `import . %q` to use it unqualified, or `import %q` and call it as `%s.%s`.",
+			name, p.importPath, p.importPath, p.importPath, p.pkgName, name)
+	default:
+		var quoted []string
+		for _, p := range candidates {
+			quoted = append(quoted, fmt.Sprintf("%q", p.importPath))
+		}
+		return fmt.Sprintf(
+			"%s is declared in these GALA packages, none of which this file imports: %s. "+
+				"Add `import . \"<the one you want>\"` to use it unqualified, "+
+				"or import it plainly and qualify the call.",
+			name, strings.Join(quoted, ", "))
+	}
+}
+
+// --- walking ----------------------------------------------------------------
+
+// bindFileLevelNames registers declarations whose names are not reachable
+// through richAST metadata: tuple-pattern package vals (`val (a, b) = ...`,
+// which extractPackageVals deliberately skips) and `embed val` directives.
+func (c *undefChecker) bindFileLevelNames(sf *grammar.SourceFileContext) {
+	for _, d := range c.rich.EmbedDirectives {
+		c.bind(d.VarName)
+	}
+	for _, topDecl := range sf.AllTopLevelDeclaration() {
+		var tp grammar.ITuplePatternContext
+		switch {
+		case topDecl.ValDeclaration() != nil:
+			tp = topDecl.ValDeclaration().(*grammar.ValDeclarationContext).TuplePattern()
+		case topDecl.VarDeclaration() != nil:
+			tp = topDecl.VarDeclaration().(*grammar.VarDeclarationContext).TuplePattern()
+		case topDecl.EmbedDeclaration() != nil:
+			ctx := topDecl.EmbedDeclaration().(*grammar.EmbedDeclarationContext)
+			if ctx.Identifier() != nil {
+				c.bind(ctx.Identifier().GetText())
+			}
+		}
+		if tp != nil {
+			c.bindIdentifierList(tp.(*grammar.TuplePatternContext).IdentifierList())
+		}
+	}
+}
+
+func (c *undefChecker) walkTopLevel(sf *grammar.SourceFileContext) {
+	for _, topDecl := range sf.AllTopLevelDeclaration() {
+		switch {
+		case topDecl.FunctionDeclaration() != nil:
+			c.walkFunctionDeclaration(topDecl.FunctionDeclaration().(*grammar.FunctionDeclarationContext))
+		case topDecl.ValDeclaration() != nil:
+			c.walkExpr(topDecl.ValDeclaration().(*grammar.ValDeclarationContext).ExpressionList())
+		case topDecl.VarDeclaration() != nil:
+			c.walkExpr(topDecl.VarDeclaration().(*grammar.VarDeclarationContext).ExpressionList())
+		case topDecl.StructShorthandDeclaration() != nil:
+			ctx := topDecl.StructShorthandDeclaration().(*grammar.StructShorthandDeclarationContext)
+			c.walkParameterDefaults(ctx.Parameters(), ctx.TypeParameters())
+		}
+		// typeDeclaration / sealedTypeDeclaration / embedDeclaration hold no
+		// value-position expressions this check inspects.
+	}
+}
+
+// walkParameterDefaults checks the default-value expressions of a parameter
+// list in a scope holding the declaration's type parameters and the parameter
+// names seen so far (a default may reference an earlier parameter).
+func (c *undefChecker) walkParameterDefaults(params grammar.IParametersContext, typeParams grammar.ITypeParametersContext) {
+	if params == nil {
+		return
+	}
+	c.push()
+	defer c.pop()
+	c.bindTypeParameters(typeParams)
+	c.bindParameters(params, true)
+}
+
+func (c *undefChecker) walkFunctionDeclaration(ctx *grammar.FunctionDeclarationContext) {
+	c.push()
+	defer c.pop()
+
+	c.bindTypeParameters(ctx.TypeParameters())
+	if recv := ctx.Receiver(); recv != nil {
+		rc := recv.(*grammar.ReceiverContext)
+		if rc.Identifier() != nil {
+			c.bind(rc.Identifier().GetText())
+		}
+		// A method's receiver type may introduce type parameters
+		// (`func (s Stack[T]) Push(v T)`); bind their names so `T` resolves
+		// in the signature and body.
+		c.bindReceiverTypeParams(rc.Type_())
+	} else if ctx.Identifier() != nil {
+		// A local function may recurse; top-level ones are already
+		// package-level, but nested ones are not.
+		c.bind(ctx.Identifier().GetText())
+	}
+	if sig := ctx.Signature(); sig != nil {
+		c.bindParameters(sig.(*grammar.SignatureContext).Parameters(), true)
+	}
+	if b := ctx.Block(); b != nil {
+		c.walkBlock(b.(*grammar.BlockContext))
+	} else {
+		c.walkExpr(ctx.Expression())
+	}
+}
+
+// bindReceiverTypeParams binds the type-parameter names a method receiver
+// introduces (`Stack[T]` → `T`). Every identifier in the receiver type is
+// bound, at any nesting depth, because the type parameters can sit behind a
+// pointer or a nested type argument (`*List[T]`, `Pair[K, V]`) and because
+// binding the type's own name alongside them is harmless — it is a
+// declaration in the same package either way.
+func (c *undefChecker) bindReceiverTypeParams(t grammar.ITypeContext) {
+	if t == nil {
+		return
+	}
+	for _, id := range collectIdentifiers(t) {
+		c.bind(id)
+	}
+}
+
+func (c *undefChecker) bindTypeParameters(tp grammar.ITypeParametersContext) {
+	if tp == nil {
+		return
+	}
+	list := tp.(*grammar.TypeParametersContext).TypeParameterList()
+	if list == nil {
+		return
+	}
+	for _, p := range list.(*grammar.TypeParameterListContext).AllTypeParameter() {
+		if id := p.(*grammar.TypeParameterContext).Identifier(0); id != nil {
+			c.bind(id.GetText())
+		}
+	}
+}
+
+// bindParameters binds each named parameter. With walkDefaults set, default
+// expressions are checked as they are reached, so a default may reference an
+// earlier parameter but not a later one.
+func (c *undefChecker) bindParameters(params grammar.IParametersContext, walkDefaults bool) {
+	if params == nil {
+		return
+	}
+	pl := params.(*grammar.ParametersContext).ParameterList()
+	if pl == nil {
+		return
+	}
+	for _, p := range pl.(*grammar.ParameterListContext).AllParameter() {
+		pc := p.(*grammar.ParameterContext)
+		if walkDefaults {
+			if pd := pc.ParamDefault(); pd != nil {
+				c.walkExpr(pd.(*grammar.ParamDefaultContext).Expression())
+			}
+		}
+		if pc.Identifier() != nil {
+			c.bind(pc.Identifier().GetText())
+		}
+	}
+}
+
+func (c *undefChecker) bindIdentifierList(il grammar.IIdentifierListContext) {
+	if il == nil {
+		return
+	}
+	for _, id := range il.(*grammar.IdentifierListContext).AllIdentifier() {
+		c.bind(id.GetText())
+	}
+}
+
+func (c *undefChecker) walkBlock(b *grammar.BlockContext) {
+	if b == nil {
+		return
+	}
+	c.push()
+	defer c.pop()
+	// Hoist local function and type declarations so mutually recursive local
+	// helpers resolve regardless of declaration order.
+	for _, st := range b.AllStatement() {
+		sc, ok := st.(*grammar.StatementContext)
+		if !ok || sc.Declaration() == nil {
+			continue
+		}
+		d := sc.Declaration().(*grammar.DeclarationContext)
+		if fd := d.FunctionDeclaration(); fd != nil {
+			fc := fd.(*grammar.FunctionDeclarationContext)
+			if fc.Identifier() != nil && fc.Receiver() == nil {
+				c.bind(fc.Identifier().GetText())
+			}
+		}
+		if td := d.TypeDeclaration(); td != nil {
+			tc := td.(*grammar.TypeDeclarationContext)
+			if tc.Identifier() != nil {
+				c.bind(tc.Identifier().GetText())
+			}
+		}
+	}
+	for _, st := range b.AllStatement() {
+		c.walkStatement(st.(*grammar.StatementContext))
+	}
+}
+
+func (c *undefChecker) walkStatement(st *grammar.StatementContext) {
+	if st == nil {
+		return
+	}
+	if d := st.Declaration(); d != nil {
+		c.walkDeclaration(d.(*grammar.DeclarationContext))
+		return
+	}
+	if r := st.ReturnStatement(); r != nil {
+		c.walkExpr(r.(*grammar.ReturnStatementContext).Expression())
+	}
+}
+
+func (c *undefChecker) walkDeclaration(d *grammar.DeclarationContext) {
+	switch {
+	case d.ValDeclaration() != nil:
+		vc := d.ValDeclaration().(*grammar.ValDeclarationContext)
+		c.walkExpr(vc.ExpressionList())
+		c.bindIdentifierList(vc.IdentifierList())
+		if tp := vc.TuplePattern(); tp != nil {
+			c.bindIdentifierList(tp.(*grammar.TuplePatternContext).IdentifierList())
+		}
+	case d.VarDeclaration() != nil:
+		vc := d.VarDeclaration().(*grammar.VarDeclarationContext)
+		c.walkExpr(vc.ExpressionList())
+		c.bindIdentifierList(vc.IdentifierList())
+		if tp := vc.TuplePattern(); tp != nil {
+			c.bindIdentifierList(tp.(*grammar.TuplePatternContext).IdentifierList())
+		}
+	case d.BindDeclaration() != nil:
+		bc := d.BindDeclaration().(*grammar.BindDeclarationContext)
+		c.walkExpr(bc.Expression())
+		if bc.Identifier() != nil {
+			c.bind(bc.Identifier().GetText())
+		}
+	case d.AlsoDeclaration() != nil:
+		ac := d.AlsoDeclaration().(*grammar.AlsoDeclarationContext)
+		c.walkExpr(ac.Expression())
+		if ac.Identifier() != nil {
+			c.bind(ac.Identifier().GetText())
+		}
+	case d.UseDeclaration() != nil:
+		uc := d.UseDeclaration().(*grammar.UseDeclarationContext)
+		c.walkExpr(uc.Expression())
+		if uc.Identifier() != nil {
+			c.bind(uc.Identifier().GetText())
+		}
+	case d.FunctionDeclaration() != nil:
+		c.walkFunctionDeclaration(d.FunctionDeclaration().(*grammar.FunctionDeclarationContext))
+	case d.IfStatement() != nil:
+		c.walkIfStatement(d.IfStatement().(*grammar.IfStatementContext))
+	case d.ForStatement() != nil:
+		c.walkForStatement(d.ForStatement().(*grammar.ForStatementContext))
+	case d.SimpleStatement() != nil:
+		c.walkSimpleStatement(d.SimpleStatement().(*grammar.SimpleStatementContext))
+	}
+	// typeDeclaration / importDeclaration hold no value-position expressions.
+}
+
+func (c *undefChecker) walkIfStatement(ctx *grammar.IfStatementContext) {
+	c.push()
+	defer c.pop()
+	if init := ctx.SimpleStatement(); init != nil {
+		c.walkSimpleStatement(init.(*grammar.SimpleStatementContext))
+	}
+	c.walkExpr(ctx.Expression())
+	for _, b := range ctx.AllBlock() {
+		c.walkBlock(b.(*grammar.BlockContext))
+	}
+	if elseIf := ctx.IfStatement(); elseIf != nil {
+		c.walkIfStatement(elseIf.(*grammar.IfStatementContext))
+	}
+}
+
+func (c *undefChecker) walkForStatement(ctx *grammar.ForStatementContext) {
+	c.push()
+	defer c.pop()
+	if fc := ctx.ForClause(); fc != nil {
+		f := fc.(*grammar.ForClauseContext)
+		for _, ss := range f.AllSimpleStatement() {
+			c.walkSimpleStatement(ss.(*grammar.SimpleStatementContext))
+		}
+		c.walkExpr(f.Expression())
+	}
+	if rc := ctx.RangeClause(); rc != nil {
+		r := rc.(*grammar.RangeClauseContext)
+		c.walkExpr(r.Expression())
+		c.bindIdentifierList(r.IdentifierList())
+	}
+	if cond := ctx.ForCondition(); cond != nil {
+		c.walkExpr(cond.(*grammar.ForConditionContext).Expression())
+	}
+	if b := ctx.Block(); b != nil {
+		c.walkBlock(b.(*grammar.BlockContext))
+	}
+}
+
+func (c *undefChecker) walkSimpleStatement(ctx *grammar.SimpleStatementContext) {
+	if ctx == nil {
+		return
+	}
+	switch {
+	case ctx.IncDecStmt() != nil:
+		c.walkExpr(ctx.IncDecStmt().(*grammar.IncDecStmtContext).Expression())
+	case ctx.Assignment() != nil:
+		for _, el := range ctx.Assignment().(*grammar.AssignmentContext).AllExpressionList() {
+			c.walkExpr(el)
+		}
+	case ctx.ShortVarDecl() != nil:
+		s := ctx.ShortVarDecl().(*grammar.ShortVarDeclContext)
+		c.walkExpr(s.ExpressionList())
+		c.bindIdentifierList(s.IdentifierList())
+	case ctx.Expression() != nil:
+		c.walkExpr(ctx.Expression())
+	}
+}
+
+// walkExpr is the generic expression walker. It descends the precedence chain
+// generically and only takes over at nodes whose identifiers need special
+// treatment.
+func (c *undefChecker) walkExpr(node antlr.Tree) {
+	if node == nil {
+		return
+	}
+	switch n := node.(type) {
+	case *grammar.PostfixExprContext:
+		c.walkPostfixExpr(n)
+	case *grammar.LambdaExpressionContext:
+		c.walkLambda(n)
+	case *grammar.PartialFunctionLiteralContext:
+		for _, cc := range n.AllCaseClause() {
+			c.walkCaseClause(cc.(*grammar.CaseClauseContext))
+		}
+	case *grammar.BlockContext:
+		c.walkBlock(n)
+	case *grammar.ArgumentContext:
+		// `argument: (identifier '=')? (lambdaExpression | pattern)` — the
+		// optional leading identifier is a named-argument label, not a
+		// reference.
+		if lam := n.LambdaExpression(); lam != nil {
+			c.walkLambda(lam.(*grammar.LambdaExpressionContext))
+			return
+		}
+		c.walkArgumentPattern(n.Pattern())
+	case *grammar.KeyedElementContext:
+		// `keyedElement: (expression ':')? expression` — a leading key is a
+		// struct field name in the common case, so only the value is checked.
+		if exprs := n.AllExpression(); len(exprs) > 0 {
+			c.walkExpr(exprs[len(exprs)-1])
+		}
+	case *grammar.TypeContext:
+		// Type positions are out of scope for this check (see file header).
+	case *grammar.IfExpressionContext:
+		c.walkExpr(n.Expression())
+		for _, br := range n.AllIfExprBranch() {
+			b := br.(*grammar.IfExprBranchContext)
+			if blk := b.Block(); blk != nil {
+				c.walkBlock(blk.(*grammar.BlockContext))
+			} else {
+				c.walkExpr(b.Expression())
+			}
+		}
+	case *grammar.DeclarationContext:
+		c.walkDeclaration(n)
+	case *grammar.StatementContext:
+		c.walkStatement(n)
+	case *grammar.SimpleStatementContext:
+		c.walkSimpleStatement(n)
+	default:
+		for i := 0; i < node.GetChildCount(); i++ {
+			c.walkExpr(node.GetChild(i))
+		}
+	}
+}
+
+// walkArgumentPattern treats a `pattern` node appearing in *argument* position
+// as an ordinary expression. The same grammar rule serves `case` patterns,
+// where identifiers bind instead — see walkCaseClause.
+func (c *undefChecker) walkArgumentPattern(p grammar.IPatternContext) {
+	switch pn := p.(type) {
+	case nil:
+		return
+	case *grammar.ExpressionPatternContext:
+		c.walkExpr(pn.Expression())
+	case *grammar.RestPatternContext:
+		c.walkExpr(pn.Expression())
+	case *grammar.TypedPatternContext:
+		// `x: T` in argument position is not an expression reference.
+	default:
+		c.walkExpr(p)
+	}
+}
+
+func (c *undefChecker) walkLambda(n *grammar.LambdaExpressionContext) {
+	c.push()
+	defer c.pop()
+	c.bindParameters(n.Parameters(), false)
+	if b := n.Block(); b != nil {
+		c.walkBlock(b.(*grammar.BlockContext))
+		return
+	}
+	c.walkExpr(n.Expression())
+}
+
+// walkCaseClause binds every identifier the pattern mentions, then checks the
+// guard and body against that scope. Binding constructors as well as capture
+// names is deliberate: telling them apart needs the scrutinee's type, and
+// over-binding can only miss detections, never invent them.
+func (c *undefChecker) walkCaseClause(cc *grammar.CaseClauseContext) {
+	c.push()
+	defer c.pop()
+	if p := cc.Pattern(); p != nil {
+		for _, id := range collectIdentifiers(p) {
+			c.bind(id)
+		}
+	}
+	c.walkExpr(cc.GetGuard())
+	if b := cc.GetBodyBlock(); b != nil {
+		c.walkBlock(b.(*grammar.BlockContext))
+	}
+	if s := cc.GetBodyStmt(); s != nil {
+		c.walkSimpleStatement(s.(*grammar.SimpleStatementContext))
+	}
+}
+
+func (c *undefChecker) walkPostfixExpr(n *grammar.PostfixExprContext) {
+	suffixes := n.AllPostfixSuffix()
+	if prim := n.PrimaryExpr(); prim != nil {
+		pe := prim.(*grammar.PrimaryExprContext)
+		if p := pe.Primary(); p != nil {
+			pc := p.(*grammar.PrimaryContext)
+			if id := pc.Identifier(); id != nil {
+				name := id.GetText()
+				// `pkg.Symbol` — the head is a package qualifier, not a value.
+				isQualifier := len(suffixes) > 0 &&
+					isSelectorSuffix(suffixes[0]) &&
+					!c.inScope(name) &&
+					c.qualifiers[name]
+				if !isQualifier && !c.resolves(name) {
+					c.report(name, id.GetStart())
+				}
+			} else {
+				c.walkExpr(pc)
+			}
+		} else {
+			c.walkExpr(pe)
+		}
+	}
+	for _, sfx := range suffixes {
+		sc := sfx.(*grammar.PostfixSuffixContext)
+		if sc.Identifier() != nil {
+			continue // member selector — not a free identifier
+		}
+		if al := sc.ArgumentList(); al != nil {
+			for _, arg := range al.(*grammar.ArgumentListContext).AllArgument() {
+				c.walkExpr(arg)
+			}
+			continue
+		}
+		// Either an index (`xs[i]`) or an explicit type-argument list
+		// (`Unfold[int, string](...)`). Both route through primary
+		// identifiers, and type names resolve through the declared index.
+		c.walkExpr(sc.ExpressionList())
+	}
+	for _, cc := range n.AllCaseClause() {
+		c.walkCaseClause(cc.(*grammar.CaseClauseContext))
+	}
+}
+
+func isSelectorSuffix(s grammar.IPostfixSuffixContext) bool {
+	sc, ok := s.(*grammar.PostfixSuffixContext)
+	return ok && sc.Identifier() != nil
+}
+
+// collectIdentifiers returns every `identifier` leaf under `node`.
+func collectIdentifiers(node antlr.Tree) []string {
+	var out []string
+	var walk func(antlr.Tree)
+	walk = func(t antlr.Tree) {
+		if t == nil {
+			return
+		}
+		if id, ok := t.(*grammar.IdentifierContext); ok {
+			out = append(out, id.GetText())
+			return
+		}
+		for i := 0; i < t.GetChildCount(); i++ {
+			walk(t.GetChild(i))
+		}
+	}
+	walk(node)
+	return out
+}
+
+// --- import hint discovery --------------------------------------------------
+
+// galaPkgExport names a GALA package that declares a sought-after symbol.
+type galaPkgExport struct {
+	importPath string
+	pkgName    string
+}
+
+// galaDeclarationKeywords are the top-level declaration forms of a .gala
+// source file; goDeclarationKeywords the same for the hand-written .go half of
+// a GALA package (go_interop and friends export their symbols that way).
+var (
+	galaDeclarationKeywords = []string{"func ", "type ", "struct ", "sealed type ", "val ", "var "}
+	goDeclarationKeywords   = []string{"func ", "type ", "var ", "const "}
+)
+
+// galaPackagesDeclaring finds every importable package under one of `roots`
+// that declares a top-level `name`. Declarations are read from the candidate
+// packages' own source — their `func` / `type` / `struct` / `sealed type` /
+// `val` / `var` declarations — so the association comes from real
+// declarations rather than a name list or a path substring. It only runs when
+// an error is already being emitted, so a successful compile never pays for
+// the directory walk.
+func galaPackagesDeclaring(name string, roots []hintRoot, resolves func(importPath, dir string) bool) []galaPkgExport {
+	var found []galaPkgExport
+	for _, root := range roots {
+		if root.dir == "" {
+			continue
+		}
+		seenDir := make(map[string]bool)
+		_ = filepath.Walk(root.dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info == nil {
+				return nil
+			}
+			if info.IsDir() {
+				base := filepath.Base(path)
+				if path != root.dir && (strings.HasPrefix(base, ".") || strings.HasPrefix(base, "bazel-") ||
+					base == "node_modules" || base == "testdata") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			var keywords []string
+			switch {
+			case filepath.Ext(path) == ".gala" && !strings.HasSuffix(path, "_test.gala"):
+				keywords = galaDeclarationKeywords
+			case filepath.Ext(path) == ".go" &&
+				!strings.HasSuffix(path, "_test.go") && !strings.HasSuffix(path, ".gen.go"):
+				keywords = goDeclarationKeywords
+			default:
+				return nil
+			}
+			dir := filepath.Dir(path)
+			if seenDir[dir] {
+				return nil
+			}
+			data, rerr := os.ReadFile(path)
+			if rerr != nil {
+				return nil
+			}
+			src := string(data)
+			if !declaresTopLevel(src, name, keywords) {
+				return nil
+			}
+			pkg := packageClauseOf(src)
+			if pkg == "" || pkg == "main" {
+				return nil
+			}
+			rel, rerr := filepath.Rel(root.dir, dir)
+			if rerr != nil {
+				return nil
+			}
+			rel = filepath.ToSlash(rel)
+			if rel == "." || rel == "" || strings.HasPrefix(rel, "..") {
+				return nil
+			}
+			importPath := pickImportPath(rel, root.prefix, dir, resolves)
+			if importPath == "" {
+				return nil
+			}
+			seenDir[dir] = true
+			found = append(found, galaPkgExport{importPath: importPath, pkgName: pkg})
+			return nil
+		})
+		if len(found) > 0 {
+			break
+		}
+	}
+	// Lexicographic order keeps the hint stable across runs and filesystems.
+	sort.Slice(found, func(i, j int) bool { return found[i].importPath < found[j].importPath })
+	return found
+}
+
+// pickImportPath chooses the spelling of `dir`'s import path that the resolver
+// actually maps back to `dir`, so the hint never suggests a path the compiler
+// would reject. Candidates, in preference order: the containing module's own
+// prefix, the GALA distribution prefix (how the packages shipped with the
+// toolchain are written), and the bare relative path. When the resolver cannot
+// confirm any of them — it is absent, or the package sits somewhere it does not
+// search — the module-prefixed form is returned as the best available guess,
+// since suppressing the hint entirely would be less useful than an approximate
+// one.
+func pickImportPath(rel, modulePrefix, dir string, resolves func(importPath, dir string) bool) string {
+	var candidates []string
+	if modulePrefix != "" {
+		candidates = append(candidates, modulePrefix+"/"+rel)
+	}
+	candidates = append(candidates, inRepoGalaImportPrefix+rel, rel)
+	if resolves != nil {
+		for _, c := range candidates {
+			if resolves(c, dir) {
+				return c
+			}
+		}
+	}
+	return candidates[0]
+}
+
+// declaresTopLevel reports whether `src` declares `name` at the top level.
+// Top-level declarations start in column 0 in both GALA and gofmt'd Go;
+// anything indented belongs to a nested scope and is not an export.
+func declaresTopLevel(src, name string, keywords []string) bool {
+	for _, line := range strings.Split(src, "\n") {
+		if line == "" || line[0] == ' ' || line[0] == '\t' {
+			continue
+		}
+		trimmed := strings.TrimRight(line, " \t\r")
+		for _, kw := range keywords {
+			rest, ok := cutPrefix(trimmed, kw)
+			if !ok {
+				continue
+			}
+			if declaredNameIs(strings.TrimLeft(rest, " \t"), name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func cutPrefix(s, prefix string) (string, bool) {
+	if strings.HasPrefix(s, prefix) {
+		return s[len(prefix):], true
+	}
+	return "", false
+}
+
+// declaredNameIs reports whether the declaration text `rest` names `name`
+// first — i.e. the identifier is followed by a non-identifier character.
+func declaredNameIs(rest, name string) bool {
+	if !strings.HasPrefix(rest, name) {
+		return false
+	}
+	if len(rest) == len(name) {
+		return true
+	}
+	c := rest[len(name)]
+	return !(c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'))
+}
+
+func packageClauseOf(src string) string {
+	for _, line := range strings.Split(src, "\n") {
+		if rest, ok := cutPrefix(strings.TrimSpace(line), "package "); ok {
+			return strings.TrimSpace(rest)
+		}
+	}
+	return ""
+}

--- a/internal/transpiler/analyzer/undefined_symbol_test.go
+++ b/internal/transpiler/analyzer/undefined_symbol_test.go
@@ -832,6 +832,42 @@ func main() {
 	}
 }
 
+// TestUndefinedSymbol_StandsDownOnTransitiveLoadFailure is the guard for the
+// serious half of the stand-down. The file's own imports all resolve, so
+// inspecting them says nothing is wrong — but a package that one of THEM
+// imports failed to load, and its symbols are missing from the table. A name
+// the author never wrote an import for (it would have arrived through the
+// dependency's dot-import) must not be reported as undefined.
+//
+// This is the shape that broke on CI: std dot-imports go_builtins, so a
+// sandbox that staged std but not go_builtins made bare `Panic` vanish in
+// fixtures that import nothing at all.
+func TestUndefinedSymbol_StandsDownOnTransitiveLoadFailure(t *testing.T) {
+	err := analyzeInModule(t, "main.gala", map[string]string{
+		// mid imports a package that does not exist, so analyzing mid
+		// succeeds while a package in its closure fails to load.
+		"mid/mid.gala": `package mid
+
+import . "example.com/hints/missingdep"
+
+func MidHelper() int = 1
+`,
+		"main.gala": `package main
+
+import . "example.com/hints/mid"
+
+func main() {
+    Println(MidHelper())
+    Println(nameOnlyTheMissingDepWouldSupply)
+}
+`,
+	})
+	if err != nil {
+		assert.NotContains(t, err.Error(), "GALA-E0023",
+			"a package that failed to load anywhere in the graph must stand the check down")
+	}
+}
+
 // TestCrossPackageImportCheckStillFires guards the neighbouring contract: the
 // explicit-import check (GALA-E0025) keeps rejecting a signature type that
 // only a sibling file imported. The undefined-symbol check is deliberately

--- a/internal/transpiler/analyzer/undefined_symbol_test.go
+++ b/internal/transpiler/analyzer/undefined_symbol_test.go
@@ -257,6 +257,28 @@ func main() {
 	}
 }
 
+// TestUndefinedSymbol_InterpolationPositionIsTheLiteral pins where the caret
+// lands for a name found inside an interpolated string. The fragment is
+// re-parsed as its own token stream, so its tokens carry fragment-relative
+// positions; reporting one verbatim would put the caret on line 1. The
+// reference is attributed to the enclosing literal instead.
+func TestUndefinedSymbol_InterpolationPositionIsTheLiteral(t *testing.T) {
+	err := analyzeSources(t, `package main
+
+func main() {
+    val ok = 1
+    Println(ok)
+    Println(s"v=$missingInterpName")
+}
+`, nil)
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "undefined: missingInterpName")
+	// The literal is on line 6; line 1 would mean the fragment's own position
+	// leaked through.
+	assert.Contains(t, msg, "line 6:", "caret must point at the literal's line, got: %s", msg)
+}
+
 // TestUndefinedSymbol_NoFalsePositives is the guard rail. Every case here is
 // legal GALA whose identifiers all resolve; a firing means the check's scope
 // model has a hole, not that the program is wrong.

--- a/internal/transpiler/analyzer/undefined_symbol_test.go
+++ b/internal/transpiler/analyzer/undefined_symbol_test.go
@@ -159,6 +159,92 @@ func helper() int {
 			},
 			symbol: "helperLocal",
 		},
+		{
+			// The body of an interpolated string is a single lexer token, so
+			// its embedded expressions are not parse-tree children. The shared
+			// walker re-parses them, which is the only reason this is caught.
+			name: "undefined name inside an interpolated string",
+			src: `package main
+
+func main() {
+    Println(s"total=$missingTotal")
+}
+`,
+			symbol: "missingTotal",
+		},
+		{
+			// The `${...}` form, with a call and a method chain inside it.
+			name: "undefined call target inside an interpolation expression",
+			src: `package main
+
+func main() {
+    Println(s"labels=${missingLabels(3).Size()}")
+}
+`,
+			symbol: "missingLabels",
+		},
+		{
+			// A format string's `%spec` must not confuse the splitter into
+			// hiding the expression before it.
+			name: "undefined name inside a format string",
+			src: `package main
+
+func main() {
+    Println(f"n=${missingCount}%04d")
+}
+`,
+			symbol: "missingCount",
+		},
+		{
+			// A lambda's parameter default is walked, like a function
+			// declaration's. Before the walkers were unified this was a
+			// documented hole.
+			name: "undefined name in a lambda parameter default",
+			src: `package main
+
+func apply(f func(int) int) int = f(1)
+
+func main() {
+    Println(apply((x int = missingDefault) => x))
+}
+`,
+			symbol: "missingDefault",
+		},
+		{
+			// `for i, v = range xs` ASSIGNS to existing variables, so an
+			// undeclared one is a reference, not a binding. The `:=` form
+			// binds and is covered by the negative cases.
+			name: "undeclared variable in an assigning range clause",
+			src: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    val xs = ArrayOf(1, 2, 3)
+    for i, v = range xs.ToGoSlice() {
+        Println(v)
+    }
+    Println(i)
+}
+`,
+			symbol: "i",
+		},
+		{
+			// A healthy Go dot-import must not stand the check down for the
+			// whole file: `math` contributes its exports, so every other name
+			// is still checked.
+			name: "go dot-import does not disable the check",
+			src: `package main
+
+import . "math"
+
+func main() {
+    Println(Sqrt(4.0))
+    Println(missingAfterGoDotImport)
+}
+`,
+			symbol: "missingAfterGoDotImport",
+		},
 	}
 
 	for _, tc := range tests {
@@ -382,6 +468,84 @@ func (h Holder[T]) MapTo[U any](f func(T) U) U = f(h.Value)
 func main() {
     val h = Holder[int](3)
     Println(Holder_MapTo[int, string](h, (v) => s"v=$v"))
+}
+`,
+		},
+		{
+			// Everything an interpolation can legally reference: a parameter,
+			// a local, a lambda parameter, a package-level val, a method chain
+			// and a call. Re-parsing these bodies is what closed the
+			// interpolation escape, so this is where a regression would land.
+			name: "interpolated strings reference bindings of every kind",
+			src: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+val prefix = "p"
+
+func label(n int) string {
+    val local = n * 2
+    val xs = ArrayOf(1, 2, 3)
+    val each = xs.Map((i) => s"i=$i/${i * 2}")
+    return s"$prefix:$n:$local:${each.Size()}:${xs.MkString(",")}"
+}
+
+func main() {
+    Println(label(1))
+    Println(f"padded=${label(2)}%10s")
+}
+`,
+		},
+		{
+			// `$$` is a literal dollar and must not be parsed as a reference;
+			// neither must a bare `$` followed by punctuation.
+			name: "interpolation escapes are not references",
+			src: `package main
+
+func main() {
+    val amount = 5
+    Println(s"cost=$$$amount")
+}
+`,
+		},
+		{
+			// The precise pattern split must still bind capture names, and
+			// must resolve constructors that genuinely exist — including a
+			// nested extractor and a tuple pattern.
+			name: "nested and tuple patterns bind their captures",
+			src: `package main
+
+sealed type Tree {
+    case Leaf(V int)
+    case Node(L Tree, R Tree)
+}
+
+func sum(t Tree) int = t match {
+    case Leaf(v)             => v
+    case Node(Leaf(a), rest) => a + sum(rest)
+    case Node(l, r)          => sum(l) + sum(r)
+}
+
+func pair() int {
+    val (a, b) = Tuple(1, 2)
+    return a + b
+}
+
+func main() {
+    Println(sum(Leaf(1)) + pair())
+}
+`,
+		},
+		{
+			// A Go dot-import whose exports the analyzer can enumerate keeps
+			// the file checked AND resolves its own unqualified names.
+			name: "go dot-import resolves its unqualified exports",
+			src: `package main
+
+import . "math"
+
+func main() {
+    Println(Sqrt(Abs(-4.0)))
 }
 `,
 		},

--- a/internal/transpiler/analyzer/undefined_symbol_test.go
+++ b/internal/transpiler/analyzer/undefined_symbol_test.go
@@ -49,9 +49,9 @@ func analyzeSources(t *testing.T, main string, siblings map[string]string) error
 // declared nowhere.
 func TestUndefinedSymbol_Reported(t *testing.T) {
 	tests := []struct {
-		name    string
-		src     string
-		symbol  string
+		name     string
+		src      string
+		symbol   string
 		siblings map[string]string
 	}{
 		{

--- a/internal/transpiler/analyzer/undefined_symbol_test.go
+++ b/internal/transpiler/analyzer/undefined_symbol_test.go
@@ -1,0 +1,677 @@
+package analyzer_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+)
+
+// analyzeSources writes each named source into a fresh temp module and
+// analyzes `main`, with the other files registered as package siblings. It
+// returns the error the analyzer produced for the main file (nil on success).
+func analyzeSources(t *testing.T, main string, siblings map[string]string) error {
+	t.Helper()
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "gala.mod"),
+		[]byte("module example.com/undef\n\ngala dev\n"), 0644))
+
+	mainFile := filepath.Join(tmp, "main.gala")
+	require.NoError(t, os.WriteFile(mainFile, []byte(main), 0644))
+
+	var sibPaths []string
+	for name, src := range siblings {
+		p := filepath.Join(tmp, name)
+		require.NoError(t, os.WriteFile(p, []byte(src), 0644))
+		sibPaths = append(sibPaths, p)
+	}
+
+	p := transpiler.NewAntlrGalaParser()
+	searchPaths := append([]string{tmp}, getStdSearchPath()...)
+	batch := analyzer.NewBatchAnalyzer(p, searchPaths, tmp)
+	batch.SetPackageFiles(sibPaths)
+
+	tree, err := p.Parse(main)
+	require.NoError(t, err, "test source must parse")
+	_, err = batch.Analyze(tree, mainFile)
+	return err
+}
+
+// TestUndefinedSymbol_Reported covers the names that must now be rejected.
+// Each case is a program whose only defect is a reference that resolves to
+// nothing at all — no import would make it legal, because the name is
+// declared nowhere.
+func TestUndefinedSymbol_Reported(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		symbol  string
+		siblings map[string]string
+	}{
+		{
+			name: "undefined variable in expression",
+			src: `package main
+
+func main() {
+    Println(x + 1)
+}
+`,
+			symbol: "x",
+		},
+		{
+			name: "undefined function call target",
+			src: `package main
+
+func main() {
+    Println(computeTotal(3))
+}
+`,
+			symbol: "computeTotal",
+		},
+		{
+			name: "undefined constructor in value position",
+			src: `package main
+
+func main() {
+    val p = MissingPoint(1, 2)
+    Println(p)
+}
+`,
+			symbol: "MissingPoint",
+		},
+		{
+			name: "undefined name inside a lambda body",
+			src: `package main
+
+func apply(f func(int) int, v int) int = f(v)
+
+func main() {
+    Println(apply((n) => n + missingOffset, 1))
+}
+`,
+			symbol: "missingOffset",
+		},
+		{
+			name: "undefined name in a package-level val initializer",
+			src: `package main
+
+val greeting = missingPrefix
+
+func main() {
+    Println(greeting)
+}
+`,
+			symbol: "missingPrefix",
+		},
+		{
+			name: "undefined name in a match arm body",
+			src: `package main
+
+func classify(v int) string = v match {
+    case 0 => "zero"
+    case _ => missingLabel
+}
+
+func main() {
+    Println(classify(1))
+}
+`,
+			symbol: "missingLabel",
+		},
+		{
+			name: "reference to a binding that is out of scope",
+			src: `package main
+
+func main() {
+    if (true) {
+        val inner = 1
+        Println(inner)
+    } else {
+        Println(0)
+    }
+    Println(inner)
+}
+`,
+			symbol: "inner",
+		},
+		{
+			name: "sibling-file local is not package scope",
+			src: `package main
+
+func main() {
+    Println(helperLocal)
+}
+`,
+			siblings: map[string]string{
+				"other.gala": `package main
+
+func helper() int {
+    val helperLocal = 7
+    return helperLocal
+}
+`,
+			},
+			symbol: "helperLocal",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := analyzeSources(t, tc.src, tc.siblings)
+			require.Error(t, err, "expected the undefined symbol to be rejected")
+			assert.Contains(t, err.Error(), "GALA-E0023")
+			assert.Contains(t, err.Error(), "undefined: "+tc.symbol)
+		})
+	}
+}
+
+// TestUndefinedSymbol_NoFalsePositives is the guard rail. Every case here is
+// legal GALA whose identifiers all resolve; a firing means the check's scope
+// model has a hole, not that the program is wrong.
+func TestUndefinedSymbol_NoFalsePositives(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		siblings map[string]string
+	}{
+		{
+			name: "locals, params and shadowing",
+			src: `package main
+
+func scale(factor int, base int) int {
+    val doubled = base * 2
+    var total = doubled + factor
+    for i := 0; i < 3; i++ {
+        total = total + i
+    }
+    return total
+}
+
+func main() {
+    val factor = 2
+    Println(scale(factor, 3))
+}
+`,
+		},
+		{
+			name: "lambda parameters and nested lambda shadowing",
+			src: `package main
+
+func twice(f func(int) int, v int) int = f(f(v))
+
+func main() {
+    Println(twice((v) => {
+        val inner = (v int) => v * 3
+        return inner(v)
+    }, 2))
+}
+`,
+		},
+		{
+			name: "forward reference within the same file",
+			src: `package main
+
+func main() {
+    Println(later(1))
+}
+
+func later(v int) int = v + 1
+`,
+		},
+		{
+			name: "recursive and mutually recursive functions",
+			src: `package main
+
+func isEven(n int) bool = if (n == 0) true else isOdd(n - 1)
+
+func isOdd(n int) bool = if (n == 0) false else isEven(n - 1)
+
+func main() {
+    Println(isEven(4))
+}
+`,
+		},
+		{
+			name: "sibling-file declarations",
+			src: `package main
+
+func main() {
+    val c = Counter(3)
+    Println(bump(c).Value)
+}
+`,
+			siblings: map[string]string{
+				"counter.gala": `package main
+
+struct Counter(Value int)
+
+func bump(c Counter) Counter = Counter(c.Value + 1)
+`,
+			},
+		},
+		{
+			name: "dot-imported collection package",
+			src: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    val labels = ArrayTabulate(3, (i) => s"item-$i")
+    Println(labels.Size())
+}
+`,
+		},
+		{
+			name: "qualified import and alias",
+			src: `package main
+
+import ci "martianoff/gala/collection_immutable"
+
+func main() {
+    val labels = ci.ArrayTabulate(2, (i) => i * 2)
+    Println(labels.Size())
+}
+`,
+		},
+		{
+			name: "auto-imported std prelude",
+			src: `package main
+
+func head(v int) Option[int] = if (v > 0) Some(v) else None[int]()
+
+func main() {
+    val r = head(1) match {
+        case Some(v) => v
+        case None() => 0
+    }
+    Println(r)
+}
+`,
+		},
+		{
+			name: "go interop symbols",
+			src: `package main
+
+import . "martianoff/gala/go_interop"
+
+func main() {
+    val s = SliceOf(1, 2, 3)
+    Println(SliceCap(s))
+}
+`,
+		},
+		{
+			name: "go stdlib package qualifier",
+			src: `package main
+
+import "os"
+
+func main() {
+    Println(os.Getenv("HOME"))
+}
+`,
+		},
+		{
+			name: "pattern bindings and guards",
+			src: `package main
+
+sealed type Shape {
+    case Circle(R int)
+    case Rect(W int, H int)
+}
+
+func area(s Shape) int = s match {
+    case Circle(r) if r > 0 => r * r * 3
+    case Circle(r) => r
+    case Rect(w, h) => w * h
+}
+
+func main() {
+    Println(area(Circle(2)))
+}
+`,
+		},
+		{
+			name: "method receivers and receiver type parameters",
+			src: `package main
+
+struct Box[T any](Value T)
+
+func (b Box[T]) Get() T = b.Value
+
+func main() {
+    val b = Box[int](5)
+    Println(b.Get())
+}
+`,
+		},
+		{
+			name: "pointer receiver carries the type parameter",
+			src: `package main
+
+type Cell[T any] struct {
+    var value T
+}
+
+func NewCell[T any](v T) *Cell[T] = &Cell[T](value = v)
+
+func (c *Cell[T]) GetOption() Option[T] = Some[T](c.value)
+
+func main() {
+    NewCell(4).GetOption() match {
+        case Some(v) => Println(v)
+        case None()  => Println("none")
+    }
+}
+`,
+		},
+		{
+			name: "generic method called in its generated function form",
+			src: `package main
+
+struct Holder[T any](Value T)
+
+func (h Holder[T]) MapTo[U any](f func(T) U) U = f(h.Value)
+
+func main() {
+    val h = Holder[int](3)
+    Println(Holder_MapTo[int, string](h, (v) => s"v=$v"))
+}
+`,
+		},
+		{
+			name: "use binding",
+			src: `package main
+
+import . "martianoff/gala/io"
+
+func main() {
+    Println("ready")
+}
+`,
+		},
+		{
+			name: "named arguments and default parameters",
+			src: `package main
+
+struct Server(Host string, Port int)
+
+func listen(host string = "localhost", port int = 8080) string = s"$host:$port"
+
+func main() {
+    val srv = Server(Host = "a", Port = 1)
+    Println(listen(port = 9000))
+    Println(srv.Host)
+}
+`,
+		},
+		{
+			name: "type parameters and explicit type arguments",
+			src: `package main
+
+func identity[T any](v T) T = v
+
+func main() {
+    Println(identity[int](3))
+}
+`,
+		},
+		{
+			name: "range loop and tuple destructuring",
+			src: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    val pair = Tuple(1, 2)
+    val (a, b) = pair
+    val xs = ArrayOf(1, 2, 3)
+    var sum = a + b
+    xs.Foreach((v) => Println(v))
+    Println(sum)
+}
+`,
+		},
+		{
+			name: "go builtin keeps its own diagnostic owner",
+			src: `package main
+
+func main() {
+    val xs = "hello"
+    Println(xs.Size())
+}
+`,
+		},
+		{
+			name: "package-level val and embed-style declarations",
+			src: `package main
+
+val defaultName = "gala"
+var counter = 0
+
+func main() {
+    counter = counter + 1
+    Println(s"$defaultName $counter")
+}
+`,
+		},
+		{
+			name: "local function declaration used before its definition",
+			src: `package main
+
+func main() {
+    func helper(v int) int = v * 2
+    Println(helper(2))
+}
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := analyzeSources(t, tc.src, tc.siblings)
+			if err != nil && strings.Contains(err.Error(), "GALA-E0023") {
+				t.Fatalf("undefined-symbol check fired on legal code: %v", err)
+			}
+		})
+	}
+}
+
+// analyzeInModule writes a whole temp module — `files` maps a module-relative
+// path to its contents — and analyzes `mainRel`. It is the hermetic variant of
+// analyzeSources, used where the test needs to control which packages exist on
+// the search path.
+func analyzeInModule(t *testing.T, mainRel string, files map[string]string) error {
+	t.Helper()
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "gala.mod"),
+		[]byte("module example.com/hints\n\ngala dev\n"), 0644))
+	for rel, src := range files {
+		p := filepath.Join(tmp, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0755))
+		require.NoError(t, os.WriteFile(p, []byte(src), 0644))
+	}
+	p := transpiler.NewAntlrGalaParser()
+	batch := analyzer.NewBatchAnalyzer(p, append([]string{tmp}, getStdSearchPath()...), tmp)
+	mainSrc := files[mainRel]
+	tree, err := p.Parse(mainSrc)
+	require.NoError(t, err, "test source must parse")
+	_, err = batch.Analyze(tree, filepath.Join(tmp, filepath.FromSlash(mainRel)))
+	return err
+}
+
+// TestUndefinedSymbol_HintNamesTheMissingImport checks the diagnostic's most
+// valuable half: when exactly one package on the search paths declares the
+// unresolved name, the hint spells out both import forms verbatim.
+func TestUndefinedSymbol_HintNamesTheMissingImport(t *testing.T) {
+	err := analyzeInModule(t, "main.gala", map[string]string{
+		"labels/labels.gala": `package labels
+
+func MakeLabel(n int) string = s"item-$n"
+`,
+		"main.gala": `package main
+
+func main() {
+    Println(MakeLabel(3))
+}
+`,
+	})
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "GALA-E0023")
+	assert.Contains(t, msg, "undefined: MakeLabel")
+	assert.Contains(t, msg, "import . \"example.com/hints/labels\"")
+	assert.Contains(t, msg, "labels.MakeLabel")
+}
+
+// TestUndefinedSymbol_HintListsEveryCandidateImport covers the ambiguous
+// shape: when several packages declare the name, the hint must offer all of
+// them rather than silently picking one. (This is the real-world
+// `ArrayTabulate` situation — both collection_immutable and collection_mutable
+// declare it.)
+func TestUndefinedSymbol_HintListsEveryCandidateImport(t *testing.T) {
+	err := analyzeInModule(t, "main.gala", map[string]string{
+		"immutable/coll.gala": `package immutable
+
+func Tabulate(n int) int = n
+`,
+		"mutable/coll.gala": `package mutable
+
+func Tabulate(n int) int = n + 1
+`,
+		"main.gala": `package main
+
+func main() {
+    Println(Tabulate(3))
+}
+`,
+	})
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "GALA-E0023")
+	assert.Contains(t, msg, "undefined: Tabulate")
+	assert.Contains(t, msg, "\"example.com/hints/immutable\"")
+	assert.Contains(t, msg, "\"example.com/hints/mutable\"")
+}
+
+// TestUndefinedSymbol_HintFindsGoDeclaredPackage pins that the hint's
+// declaration scan also covers a GALA package whose exports are hand-written
+// Go (go_interop's shape) — the import a user forgets just as often.
+func TestUndefinedSymbol_HintFindsGoDeclaredPackage(t *testing.T) {
+	err := analyzeInModule(t, "main.gala", map[string]string{
+		"interop/types.go": `package interop
+
+// SliceLike is a hand-written Go export of a GALA-importable package.
+func SliceLike(n int) []int { return make([]int, n) }
+`,
+		"main.gala": `package main
+
+func main() {
+    Println(SliceLike(3))
+}
+`,
+	})
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "GALA-E0023")
+	assert.Contains(t, msg, "undefined: SliceLike")
+	assert.Contains(t, msg, "\"example.com/hints/interop\"")
+}
+
+// TestUndefinedSymbol_NoHintWhenNothingDeclaresIt covers the fallback text for
+// a name no package on the search paths supplies.
+func TestUndefinedSymbol_NoHintWhenNothingDeclaresIt(t *testing.T) {
+	err := analyzeSources(t, `package main
+
+func main() {
+    Println(x + 1)
+}
+`, nil)
+	require.Error(t, err)
+	msg := err.Error()
+	assert.Contains(t, msg, "GALA-E0023")
+	assert.Contains(t, msg, "undefined: x")
+	assert.Contains(t, msg, "check the spelling")
+}
+
+// TestUndefinedSymbol_ImportedPackageValResolves covers the export kind the
+// merged metadata does not model: a package-level `val` in a dot-imported
+// package. Its name reaches the symbol table only through the check's
+// declaration scan, so a regression there surfaces as a false positive here.
+func TestUndefinedSymbol_ImportedPackageValResolves(t *testing.T) {
+	err := analyzeInModule(t, "main.gala", map[string]string{
+		"conf/conf.gala": `package conf
+
+val DefaultHost = "localhost"
+
+func Describe() string = DefaultHost
+`,
+		"main.gala": `package main
+
+import . "example.com/hints/conf"
+
+func main() {
+    Println(DefaultHost)
+}
+`,
+	})
+	if err != nil && strings.Contains(err.Error(), "GALA-E0023") {
+		t.Fatalf("a dot-imported package-level val must resolve: %v", err)
+	}
+}
+
+// TestUndefinedSymbol_StandsDownOnUnloadableImport pins the safety valve: a
+// file whose import could not be analyzed is not checked at all, because the
+// symbol table is missing that package's exports through no fault of the
+// author's.
+func TestUndefinedSymbol_StandsDownOnUnloadableImport(t *testing.T) {
+	src := `package main
+
+import . "example.com/undef/nowhere"
+
+func main() {
+    Println(SomethingFromNowhere())
+}
+`
+	err := analyzeSources(t, src, nil)
+	if err != nil {
+		assert.NotContains(t, err.Error(), "GALA-E0023",
+			"an unloadable import must suppress the undefined-symbol check")
+	}
+}
+
+// TestCrossPackageImportCheckStillFires guards the neighbouring contract: the
+// explicit-import check (GALA-E0025) keeps rejecting a signature type that
+// only a sibling file imported. The undefined-symbol check is deliberately
+// permissive about which package a name came from so these two codes do not
+// overlap.
+func TestCrossPackageImportCheckStillFires(t *testing.T) {
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "gala.mod"),
+		[]byte("module example.com/undef\n\ngala dev\n"), 0644))
+
+	importer := filepath.Join(tmp, "importer.gala")
+	require.NoError(t, os.WriteFile(importer, []byte(
+		"package lib\n\nimport . \"martianoff/gala/collection_immutable\"\n\nfunc seed() Array[int] = ArrayOf(1)\n"), 0644))
+
+	user := filepath.Join(tmp, "user.gala")
+	userSrc := "package lib\n\nfunc widen(a Array[int]) Array[int] = a\n"
+	require.NoError(t, os.WriteFile(user, []byte(userSrc), 0644))
+
+	p := transpiler.NewAntlrGalaParser()
+	searchPaths := append([]string{tmp}, getStdSearchPath()...)
+	batch := analyzer.NewBatchAnalyzer(p, searchPaths, tmp)
+	batch.SetPackageFiles([]string{importer})
+
+	tree, err := p.Parse(userSrc)
+	require.NoError(t, err)
+	_, err = batch.Analyze(tree, user)
+	require.Error(t, err, "a sibling's import must not satisfy this file's use of Array")
+	assert.Contains(t, err.Error(), "GALA-E0025")
+}

--- a/internal/transpiler/concurrency/capture.go
+++ b/internal/transpiler/concurrency/capture.go
@@ -6,13 +6,16 @@ package concurrency
 // Given a GALA closure (either an explicit lambda or the desugared thunk of a
 // by-name expression such as `Future(counter + 1)`), FreeVariables computes the
 // set of identifiers the closure references from its ENCLOSING scope — the names
-// it "captures". It is a pure, syntactic tree walk over the ANTLR parse tree
-// (exactly like the transformer), with an explicit lexical scope stack. It does
-// not touch the analyzer, the type system, or any transformer state, and it
-// never mutates the AST.
+// it "captures".
 //
-// A capture is a VALUE-POSITION identifier referenced in the body that is not
-// bound within the closure's own scope. Bindings that exclude a name:
+// The traversal itself — the lexical scope stack, every binding-introducing
+// construct, and the value-position reference detection — lives in
+// internal/transpiler/scopewalk, shared with the analyzer's undefined-symbol
+// check. Both passes need the same notion of "a value-position identifier that
+// no enclosing binder introduced"; this file only turns the resulting stream of
+// unbound references into captures, classifying each by HOW it is used.
+//
+// Bindings that exclude a name (all handled by the shared walker):
 //   - the closure's own parameters;
 //   - `val` / `var` declarations inside the body;
 //   - `bind` / `also` do-notation bindings and `use` resource bindings;
@@ -20,36 +23,28 @@ package concurrency
 //   - `match` / partial-function case-pattern bindings (`case Some(x)` binds x);
 //   - a nested lambda's parameters (which shadow only within the nested scope).
 //
-// COMPLETENESS. The walk is complete by construction: the precise handlers below
-// cover every binding-introducing construct and every identifier reference, and
-// ANY parse-tree node without a precise handler falls through to a GENERIC child
-// recursion (walk's default branch) that descends into all children. So no
-// subtree — hence no reference within it — is ever silently skipped, and the
-// analysis stays correct as the grammar grows. This deliberately OVER-approximates
-// (it reports spurious frees, e.g. the callee of a bare `foo(...)` call or a
-// bracketed type argument, rather than miss a genuine capture — the safe
-// direction). PR3 classifies each reported capture (resolving its `val`/`var`
-// kind and type and enforcing shareability); a name that resolves to a top-level
-// function or a type harmlessly falls out as non-local.
+// This deliberately OVER-approximates (it reports spurious frees, e.g. the
+// callee of a bare `foo(...)` call or a bracketed type argument, rather than
+// miss a genuine capture — the safe direction). PR3 classifies each reported
+// capture (resolving its `val`/`var` kind and type and enforcing shareability);
+// a name that resolves to a top-level function or a type harmlessly falls out
+// as non-local. The shared walker's over-approximating options are selected
+// here for exactly that reason.
 //
 // String interpolation (`s"…$counter"`, `f"${x + y}"`) is a SINGLE lexer token,
-// so its embedded expressions are not child nodes. walkLiteral re-parses each
-// embedded expression (via the shared interpolation splitter + the project
-// parser) and walks it through the same machinery, so a variable referenced only
-// inside an interpolation is captured too.
+// so its embedded expressions are not child nodes. The shared walker re-parses
+// each embedded expression and walks it through the same machinery, so a
+// variable referenced only inside an interpolation is captured too.
 //
 // NOTE: like the Shareable predicate (PR1), this pass is wired into no
 // enforcement. It is called only by its tests. PR3 consumes it.
 
 import (
-	"strings"
-
 	"github.com/antlr4-go/antlr/v4"
 
-	"martianoff/gala/internal/interpolation"
-	"martianoff/gala/internal/parser"
 	"martianoff/gala/internal/parser/grammar"
 	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/scopewalk"
 )
 
 // Capture is a single free variable a closure references from its enclosing
@@ -79,13 +74,28 @@ type Capture struct {
 	Whole bool
 }
 
+// captureOptions is the shared walker's configuration for capture analysis.
+// Every choice here is the over-approximating one: a spurious capture is
+// harmless (PR3 discards it as non-local), a missed one is a data race.
+//
+//   - ParseInterpolations: a variable referenced only inside `s"…$x"` is a real
+//     capture and must be seen.
+//   - SkipCompositeLiteralKeys stays false: walking a keyed element's key can
+//     only add a spurious name, never hide one.
+//   - BindWholePattern stays false: the precise split reports a constructor
+//     name as a reference (harmless) while binding the names the pattern
+//     actually introduces (required for correctness).
+//   - SkipTypedPatternArgument stays false: `x: T` in argument position is
+//     unusual, and treating x as a reference is the safe direction.
+var captureOptions = scopewalk.Options{ParseInterpolations: true}
+
 // FreeVariablesInLambda returns the free variables captured by an explicit
 // lambda. The lambda's declared parameters are bound (never captured); its body
 // may be an expression (`(x) => x + n`) or a block (`(x) => { ... }`).
 func FreeVariablesInLambda(lambda grammar.ILambdaExpressionContext) []Capture {
-	a := newCaptureAnalyzer()
-	a.walkLambda(lambda)
-	return a.out
+	c := newCaptureCollector()
+	c.walker.WalkLambda(lambda)
+	return c.out
 }
 
 // FreeVariablesInExpression returns the free variables of a bare expression —
@@ -96,754 +106,50 @@ func FreeVariablesInLambda(lambda grammar.ILambdaExpressionContext) []Capture {
 // paramNames lets a caller seed additional bound names (e.g. an implicit
 // parameter of the thunk); pass nil/empty for the common Future/Spawn thunk.
 func FreeVariablesInExpression(paramNames []string, expr grammar.IExpressionContext) []Capture {
-	a := newCaptureAnalyzer()
-	a.pushScope()
+	c := newCaptureCollector()
+	c.walker.PushScope()
 	for _, p := range paramNames {
-		a.bind(p)
+		c.walker.Bind(p)
 	}
-	a.walk(expr)
-	a.popScope()
-	return a.out
+	c.walker.Walk(expr)
+	c.walker.PopScope()
+	return c.out
 }
 
-// captureAnalyzer holds the walk state: an explicit lexical scope stack
-// (innermost scope last), the accumulated captures in first-seen order, and a
-// name set that de-duplicates them (keeping the first position).
-type captureAnalyzer struct {
-	scopes []map[string]bool
+// captureCollector turns the shared walker's unbound-reference stream into the
+// capture set, de-duplicating by name and keeping the first-seen position.
+type captureCollector struct {
 	out    []Capture
-	index  map[string]int          // capture name -> its position in out (for accumulating usage info)
-	parser *parser.AntlrGalaParser // re-parses interpolation embedded expressions
+	index  map[string]int // capture name -> its position in out
+	walker *scopewalk.Walker
 }
 
-func newCaptureAnalyzer() *captureAnalyzer {
-	return &captureAnalyzer{index: map[string]int{}, parser: parser.NewAntlrGalaParser()}
+var _ scopewalk.Visitor = (*captureCollector)(nil)
+
+func newCaptureCollector() *captureCollector {
+	c := &captureCollector{index: map[string]int{}}
+	c.walker = scopewalk.New(c, captureOptions)
+	return c
 }
 
-func (a *captureAnalyzer) pushScope() {
-	a.scopes = append(a.scopes, map[string]bool{})
-}
-
-func (a *captureAnalyzer) popScope() {
-	a.scopes = a.scopes[:len(a.scopes)-1]
-}
-
-// bind records name as locally bound in the innermost scope. A later reference
-// to name resolves to this local rather than being reported as a capture.
-func (a *captureAnalyzer) bind(name string) {
-	if name == "" || name == "_" {
+// Reference records one unbound value-position use of name. A whole-value use
+// marks the capture Whole (its entire type must be Shareable); a pure field
+// read accumulates the distinct access path instead.
+func (c *captureCollector) Reference(name string, tok antlr.Token, use scopewalk.Use) {
+	idx, ok := c.index[name]
+	if !ok {
+		c.out = append(c.out, Capture{Name: name, Pos: transpiler.PosFromToken(tok)})
+		idx = len(c.out) - 1
+		c.index[name] = idx
+	}
+	if use.Whole {
+		c.out[idx].Whole = true
 		return
 	}
-	if len(a.scopes) == 0 {
-		a.pushScope()
-	}
-	a.scopes[len(a.scopes)-1][name] = true
-}
-
-// bindID binds the text of an identifier context, if present.
-func (a *captureAnalyzer) bindID(id grammar.IIdentifierContext) {
-	if id != nil {
-		a.bind(id.GetText())
-	}
-}
-
-// bound reports whether name is bound in any enclosing scope on the stack.
-func (a *captureAnalyzer) bound(name string) bool {
-	for i := len(a.scopes) - 1; i >= 0; i-- {
-		if a.scopes[i][name] {
-			return true
-		}
-	}
-	return false
-}
-
-// ensureCapture returns the index of the capture named name, creating it (with
-// its diagnostic position fixed to the first-seen token) if absent. Callers must
-// have already confirmed name is unbound and not the blank identifier.
-func (a *captureAnalyzer) ensureCapture(name string, tok antlr.Token) int {
-	if idx, ok := a.index[name]; ok {
-		return idx
-	}
-	a.out = append(a.out, Capture{Name: name, Pos: transpiler.PosFromToken(tok)})
-	idx := len(a.out) - 1
-	a.index[name] = idx
-	return idx
-}
-
-// reference records a WHOLE-VALUE use of name — a bare reference, a call callee,
-// a method receiver, an index/match subject, or a function argument. If name is
-// not bound in any enclosing scope it is a capture; the first such use fixes its
-// diagnostic position, and the capture is marked used-whole (which requires its
-// entire type be Shareable at enforcement time).
-func (a *captureAnalyzer) reference(name string, tok antlr.Token) {
-	if name == "" || name == "_" {
-		return
-	}
-	if a.bound(name) {
-		return
-	}
-	idx := a.ensureCapture(name, tok)
-	a.out[idx].Whole = true
-}
-
-// recordPath records a pure field-read access path (`x.a`, `x.a.b`) on a capture
-// candidate. tok is the position of the BASE identifier (the caret target), and
-// path is the dotted selector chain after it ("a", "a.b"). Distinct paths are
-// de-duplicated. A capture accumulating only paths (never marked Whole) is
-// checked field-sensitively.
-func (a *captureAnalyzer) recordPath(name string, tok antlr.Token, path string) {
-	if name == "" || name == "_" {
-		return
-	}
-	if a.bound(name) {
-		return
-	}
-	idx := a.ensureCapture(name, tok)
-	for _, p := range a.out[idx].Paths {
-		if p == path {
+	for _, p := range c.out[idx].Paths {
+		if p == use.Path {
 			return
 		}
 	}
-	a.out[idx].Paths = append(a.out[idx].Paths, path)
-}
-
-// ---------------------------------------------------------------------------
-// Generic dispatcher
-// ---------------------------------------------------------------------------
-
-// walk is the single entry point for descending an arbitrary parse-tree node.
-// Nodes that affect scoping or contribute references have PRECISE handlers
-// (dispatched here and returning without generic recursion, so nothing is
-// double-walked); every other node falls to the default branch, which recurses
-// into all children so no subtree is ever skipped.
-func (a *captureAnalyzer) walk(node antlr.Tree) {
-	if node == nil {
-		return
-	}
-	switch n := node.(type) {
-	// Scope-introducing constructs.
-	case *grammar.LambdaExpressionContext:
-		a.walkLambda(n)
-		return
-	case *grammar.BlockContext:
-		a.walkBlock(n)
-		return
-	case *grammar.ForStatementContext:
-		a.walkForStatement(n)
-		return
-	case *grammar.IfStatementContext:
-		a.walkIfStatement(n)
-		return
-	case *grammar.FunctionDeclarationContext:
-		a.walkNestedFunction(n)
-		return
-	case *grammar.CaseClauseContext:
-		a.walkCaseClause(n)
-		return
-	case *grammar.PartialFunctionLiteralContext:
-		for _, cc := range n.AllCaseClause() {
-			a.walkCaseClause(cc)
-		}
-		return
-
-	// Order-dependent local bindings: walk the initializer first (in the
-	// pre-binding scope), then bind, so `val x = x + 1` captures the outer x.
-	case *grammar.ValDeclarationContext:
-		a.walkValVarDecl(n.ExpressionList(), n.IdentifierList(), n.TuplePattern())
-		return
-	case *grammar.VarDeclarationContext:
-		a.walkValVarDecl(n.ExpressionList(), n.IdentifierList(), n.TuplePattern())
-		return
-	case *grammar.ShortVarDeclContext:
-		if el := n.ExpressionList(); el != nil {
-			for _, e := range el.AllExpression() {
-				a.walk(e)
-			}
-		}
-		a.bindIdentifierList(n.IdentifierList())
-		return
-	case *grammar.BindDeclarationContext:
-		a.walk(n.Expression())
-		a.bindID(n.Identifier())
-		return
-	case *grammar.AlsoDeclarationContext:
-		a.walk(n.Expression())
-		a.bindID(n.Identifier())
-		return
-	case *grammar.UseDeclarationContext:
-		a.walk(n.Expression())
-		a.bindID(n.Identifier())
-		return
-
-	// Reference-contributing leaves.
-	case *grammar.PostfixExprContext:
-		a.walkPostfixExpr(n)
-		return
-	case *grammar.PrimaryContext:
-		a.walkPrimary(n)
-		return
-	case *grammar.PostfixSuffixContext:
-		a.walkPostfixSuffix(n)
-		return
-	case *grammar.ArgumentContext:
-		a.walkArgument(n)
-		return
-	}
-
-	// Default: no precise handler — recurse into every child so unhandled
-	// forms still surface their references (over-approximating, never missing).
-	for i := 0; i < node.GetChildCount(); i++ {
-		a.walk(node.GetChild(i))
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Scope-introducing handlers
-// ---------------------------------------------------------------------------
-
-// walkLambda pushes a fresh scope, binds the lambda's parameters into it, walks
-// the body, and pops. Used both for the top-level analyzed lambda and for every
-// nested lambda encountered during the walk — so a nested lambda's params shadow
-// only within its own scope, and a name bound by an OUTER (still-on-stack) lambda
-// param is not reported as a capture.
-func (a *captureAnalyzer) walkLambda(lambda grammar.ILambdaExpressionContext) {
-	if lambda == nil {
-		return
-	}
-	a.pushScope()
-	defer a.popScope()
-
-	a.bindParameters(lambda.Parameters())
-	// A parameter default (`(x = counter) => …`) references the enclosing scope;
-	// walk defaults after binding the param names so they see sibling params.
-	a.walkParameterDefaults(lambda.Parameters())
-
-	if expr := lambda.Expression(); expr != nil {
-		a.walk(expr)
-	} else if block := lambda.Block(); block != nil {
-		a.walkBlock(block)
-	}
-	// lambda.Type_() is the optional return-type annotation — a type, not a value.
-}
-
-// bindParameters binds each named parameter of a parameter list. Type-only
-// parameters (function-type positions with no identifier) bind nothing.
-func (a *captureAnalyzer) bindParameters(params grammar.IParametersContext) {
-	if params == nil {
-		return
-	}
-	pl := params.ParameterList()
-	if pl == nil {
-		return
-	}
-	for _, p := range pl.AllParameter() {
-		if pc, ok := p.(*grammar.ParameterContext); ok {
-			a.bindID(pc.Identifier())
-		}
-	}
-}
-
-// walkParameterDefaults walks the `= expr` default of each parameter, so a
-// capture inside a default value is detected.
-func (a *captureAnalyzer) walkParameterDefaults(params grammar.IParametersContext) {
-	if params == nil {
-		return
-	}
-	pl := params.ParameterList()
-	if pl == nil {
-		return
-	}
-	for _, p := range pl.AllParameter() {
-		if pc, ok := p.(*grammar.ParameterContext); ok {
-			if def := pc.ParamDefault(); def != nil {
-				a.walk(def.Expression())
-			}
-		}
-	}
-}
-
-// walkBlock introduces a nested lexical scope and walks the block's statements
-// in order, so a local declared partway through shadows the enclosing name only
-// for references that follow it.
-func (a *captureAnalyzer) walkBlock(block grammar.IBlockContext) {
-	if block == nil {
-		return
-	}
-	a.pushScope()
-	defer a.popScope()
-	for _, s := range block.AllStatement() {
-		a.walk(s)
-	}
-}
-
-// walkValVarDecl walks a `val`/`var` initializer and then binds the declared
-// name(s). The RHS is walked FIRST, in the scope that predates the binding, so
-// `val x = x + 1` captures the outer x while later references resolve to the new
-// local (correct lexical shadowing).
-func (a *captureAnalyzer) walkValVarDecl(exprList grammar.IExpressionListContext, idList grammar.IIdentifierListContext, tuple grammar.ITuplePatternContext) {
-	if exprList != nil {
-		for _, e := range exprList.AllExpression() {
-			a.walk(e)
-		}
-	}
-	a.bindIdentifierList(idList)
-	if tuple != nil {
-		a.bindIdentifierList(tuple.IdentifierList())
-	}
-}
-
-func (a *captureAnalyzer) bindIdentifierList(idList grammar.IIdentifierListContext) {
-	if idList == nil {
-		return
-	}
-	for _, id := range idList.AllIdentifier() {
-		a.bind(id.GetText())
-	}
-}
-
-// walkNestedFunction handles a `func f(...) = body` (or block-bodied) declared
-// inside a block. The function name is bound in the enclosing scope (so it may
-// recurse and later statements may reference it); its parameters live in a fresh
-// nested scope covering only its body.
-func (a *captureAnalyzer) walkNestedFunction(fn grammar.IFunctionDeclarationContext) {
-	a.bindID(fn.Identifier())
-	a.pushScope()
-	defer a.popScope()
-	if sig := fn.Signature(); sig != nil {
-		a.bindParameters(sig.Parameters())
-		a.walkParameterDefaults(sig.Parameters())
-	}
-	if block := fn.Block(); block != nil {
-		a.walkBlock(block)
-	} else if e := fn.Expression(); e != nil {
-		a.walk(e)
-	}
-}
-
-func (a *captureAnalyzer) walkIfStatement(ifs grammar.IIfStatementContext) {
-	// An `if init; cond { … }` init binding is visible in the condition and both
-	// branches but NOT after the statement, so it gets a scope wrapping the whole
-	// statement (letting it fall to generic recursion would leak the binding).
-	a.pushScope()
-	defer a.popScope()
-	if ss := ifs.SimpleStatement(); ss != nil {
-		a.walk(ss)
-	}
-	if cond := ifs.Expression(); cond != nil {
-		a.walk(cond)
-	}
-	for _, b := range ifs.AllBlock() {
-		a.walkBlock(b)
-	}
-	if elseIf := ifs.IfStatement(); elseIf != nil {
-		a.walkIfStatement(elseIf)
-	}
-}
-
-func (a *captureAnalyzer) walkForStatement(fs grammar.IForStatementContext) {
-	// Loop variables live in a scope that wraps the loop body.
-	a.pushScope()
-	defer a.popScope()
-
-	if fc := fs.ForClause(); fc != nil {
-		// forClause: simpleStatement? ';' expression? ';' simpleStatement?
-		for _, ss := range fc.AllSimpleStatement() {
-			a.walk(ss)
-		}
-		if e := fc.Expression(); e != nil {
-			a.walk(e)
-		}
-	} else if rc := fs.RangeClause(); rc != nil {
-		// rangeClause: (identifierList (':=' | '='))? 'range' expression
-		if e := rc.Expression(); e != nil {
-			a.walk(e) // the ranged value resolves before the loop vars bind
-		}
-		if idList := rc.IdentifierList(); idList != nil {
-			if strings.Contains(rc.GetText(), ":=") {
-				// `i, v := range xs` — fresh loop-variable bindings.
-				a.bindIdentifierList(idList)
-			} else {
-				// `i, v = range xs` — assignment to existing (possibly captured) vars.
-				for _, id := range idList.AllIdentifier() {
-					a.reference(id.GetText(), id.GetStart())
-				}
-			}
-		}
-	} else if cond := fs.ForCondition(); cond != nil {
-		a.walk(cond.Expression())
-	}
-
-	a.walkBlock(fs.Block())
-}
-
-// ---------------------------------------------------------------------------
-// Reference-contributing handlers
-// ---------------------------------------------------------------------------
-
-// walkPostfixExpr is the field-access-sensitive handler for a
-// `primaryExpr postfixSuffix* ('match' '{' … '}')?` chain. When the base is a
-// bare value-position identifier (the capture candidate) it classifies HOW the
-// identifier is used — a pure `.field` selector chain is recorded as a read PATH,
-// anything else (a call, an index, a trailing `match`, or a bare reference) as a
-// WHOLE use. Regardless of the base, the contents of every suffix (call
-// arguments, index expressions) and every `match` arm are still walked so nested
-// captures inside them are found.
-func (a *captureAnalyzer) walkPostfixExpr(ctx grammar.IPostfixExprContext) {
-	if ctx == nil {
-		return
-	}
-	pe := ctx.PrimaryExpr()
-	suffixes := ctx.AllPostfixSuffix()
-	caseClauses := ctx.AllCaseClause()
-
-	if id := bareIdentPrimary(pe); id != nil {
-		name := id.GetText()
-		tok := id.GetStart()
-		if path, whole := classifySuffixes(suffixes, len(caseClauses) > 0); whole {
-			a.reference(name, tok)
-		} else {
-			a.recordPath(name, tok, path)
-		}
-	} else {
-		// Base is not a bare identifier (literal, tuple/paren, composite literal,
-		// lambda, if-expression, partial function): recurse into it normally.
-		a.walk(pe)
-	}
-
-	// Walk the contents of each suffix (a call's arguments, an index's
-	// expressions); selector identifiers carry no reference and are ignored.
-	for _, s := range suffixes {
-		a.walkPostfixSuffix(s)
-	}
-	// A trailing `match { … }` — walk each arm for its own captures.
-	for _, cc := range caseClauses {
-		a.walkCaseClause(cc)
-	}
-}
-
-// classifySuffixes decides whether a bare-identifier base followed by the given
-// postfix suffixes (and an optional trailing `match`) is a pure field-read PATH
-// or a WHOLE use. A leading, uninterrupted run of `.field` selectors with no
-// call, index, or match is a field-read path (the dotted chain, e.g. "a.b"); an
-// empty suffix list (a bare reference), a trailing match, or any call/index makes
-// it a whole use. Anything it cannot classify is conservatively a whole use.
-func classifySuffixes(suffixes []grammar.IPostfixSuffixContext, hasMatch bool) (path string, whole bool) {
-	if hasMatch || len(suffixes) == 0 {
-		return "", true
-	}
-	parts := make([]string, 0, len(suffixes))
-	for i, s := range suffixes {
-		sc, ok := s.(*grammar.PostfixSuffixContext)
-		if !ok {
-			return "", true
-		}
-		if id := sc.Identifier(); id != nil {
-			parts = append(parts, id.GetText())
-			continue
-		}
-		// A non-selector suffix: an index `[...]` or a call `(...)`.
-		if sc.ExpressionList() != nil {
-			// Index `[...]` — a value-position use of the whole receiver.
-			return "", true
-		}
-		// A call `(...)`. Tolerate a SINGLE trailing method call on a field-path
-		// receiver: `x.a.b.m(...)` reads the immutable field value `x.a.b` and
-		// calls a method on it. The method runs on that (shareable) value, so it
-		// cannot race — the enforcement pass verifies safety via the receiver
-		// path's leaf type exactly as for a plain field read. The last selector
-		// is the method name, so the receiver path is the rest; at least one
-		// selector must remain (else it is a method on the whole captured value,
-		// which stays a whole use). The call's arguments are walked separately by
-		// the caller, so captures inside them are still found.
-		if i == len(suffixes)-1 && len(parts) >= 2 {
-			return strings.Join(parts[:len(parts)-1], "."), false
-		}
-		return "", true
-	}
-	return strings.Join(parts, "."), false
-}
-
-// bareIdentPrimary returns the identifier context when the primaryExpr is a bare
-// value-position identifier (`x`), or nil for any other primaryExpr shape (a
-// literal/tuple/composite primary, a lambda, an if-expression, or a partial
-// function). Such a bare identifier is the capture candidate a postfix chain
-// applies to.
-func bareIdentPrimary(pe grammar.IPrimaryExprContext) grammar.IIdentifierContext {
-	if pe == nil {
-		return nil
-	}
-	prim := pe.Primary()
-	if prim == nil {
-		return nil
-	}
-	return prim.Identifier()
-}
-
-func (a *captureAnalyzer) walkPrimary(ctx grammar.IPrimaryContext) {
-	if ctx == nil {
-		return
-	}
-	if id := ctx.Identifier(); id != nil {
-		// A bare value-position identifier — the capture candidate.
-		a.reference(id.GetText(), id.GetStart())
-		return
-	}
-	if lit := ctx.Literal(); lit != nil {
-		a.walkLiteral(lit)
-		return
-	}
-	if tup := ctx.TupleExpressionList(); tup != nil {
-		for _, e := range tup.AllExpression() {
-			a.walk(e)
-		}
-		return
-	}
-	if cl := ctx.CompositeLiteral(); cl != nil {
-		a.walkCompositeLiteral(cl)
-	}
-}
-
-// walkLiteral handles literals. All but interpolated/format strings contribute
-// no references. An interpolated (`s"…"`) or format (`f"…"`) string is a single
-// token whose embedded `${…}` / `$name` expressions are NOT parse-tree children,
-// so each embedded expression is re-parsed and walked in the CURRENT scope — a
-// variable referenced only inside an interpolation is captured just like any
-// other reference, and one that resolves to a local is not.
-func (a *captureAnalyzer) walkLiteral(lit grammar.ILiteralContext) {
-	var raw string
-	if tok := lit.INTERPOLATED_STRING(); tok != nil {
-		raw = tok.GetText()
-	} else if tok := lit.FORMAT_STRING(); tok != nil {
-		raw = tok.GetText()
-	} else {
-		return
-	}
-	if len(raw) < 3 {
-		return
-	}
-	// Strip the `s"`/`f"` prefix and the closing `"`, matching the transformer.
-	content := raw[2 : len(raw)-1]
-	for _, part := range interpolation.Split(content) {
-		if part.IsLiteral {
-			continue
-		}
-		expr, _ := a.parser.ParseExpression(part.Text)
-		if expr != nil {
-			a.walk(expr) // best-effort even if the fragment had parse errors
-		}
-	}
-}
-
-// walkCompositeLiteral walks the element values of a composite literal. The
-// literal's `type` (its Type_) is a type, not a value, and is skipped; each
-// keyed element's expressions are value positions.
-func (a *captureAnalyzer) walkCompositeLiteral(ctx grammar.ICompositeLiteralContext) {
-	el := ctx.ElementList()
-	if el == nil {
-		return
-	}
-	for _, ke := range el.AllKeyedElement() {
-		if kec, ok := ke.(*grammar.KeyedElementContext); ok {
-			for _, e := range kec.AllExpression() {
-				a.walk(e)
-			}
-		}
-	}
-}
-
-func (a *captureAnalyzer) walkPostfixSuffix(ctx grammar.IPostfixSuffixContext) {
-	if ctx == nil {
-		return
-	}
-	// `.identifier` is a field/method selector on the preceding value — the
-	// selector name is NOT a capture, so it is intentionally ignored here.
-	if ctx.Identifier() != nil {
-		return
-	}
-	if al := ctx.ArgumentList(); al != nil {
-		for _, arg := range al.AllArgument() {
-			a.walkArgument(arg)
-		}
-		return
-	}
-	// `[ expressionList ]` — index or explicit type args. Indexing exprs are value
-	// references; bracketed type args are over-approximated as references (a type
-	// name harmlessly resolves to non-local in PR3).
-	if el := ctx.ExpressionList(); el != nil {
-		for _, e := range el.AllExpression() {
-			a.walk(e)
-		}
-	}
-}
-
-func (a *captureAnalyzer) walkArgument(arg grammar.IArgumentContext) {
-	if arg == nil {
-		return
-	}
-	// A leading `identifier =` is a named-argument LABEL (present only with `=`),
-	// not a value reference — skip it.
-	if lambda := arg.LambdaExpression(); lambda != nil {
-		a.walkLambda(lambda)
-		return
-	}
-	// In argument position the `pattern` rule is used as a VALUE expression
-	// (references), not as a binding pattern.
-	if pat := arg.Pattern(); pat != nil {
-		a.walkPatternAsValue(pat)
-	}
-}
-
-// walkPatternAsValue walks a `pattern` node that appears in value position (a
-// call argument), treating its identifiers as references rather than bindings.
-func (a *captureAnalyzer) walkPatternAsValue(pat grammar.IPatternContext) {
-	switch p := pat.(type) {
-	case *grammar.ExpressionPatternContext:
-		a.walk(p.Expression())
-	case *grammar.RestPatternContext:
-		a.walk(p.Expression()) // spread: `xs...`
-	case *grammar.TypedPatternContext:
-		// `x: T` in argument position is unusual; treat x as a reference.
-		if id := p.Identifier(); id != nil {
-			a.reference(id.GetText(), id.GetStart())
-		}
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Match / partial-function case clauses
-// ---------------------------------------------------------------------------
-
-func (a *captureAnalyzer) walkCaseClause(cc grammar.ICaseClauseContext) {
-	if cc == nil {
-		return
-	}
-	a.pushScope()
-	defer a.popScope()
-
-	// Pattern bindings (`case Some(x)` binds x) are in scope for the guard & body.
-	a.bindPattern(cc.Pattern())
-
-	if guard := cc.GetGuard(); guard != nil {
-		a.walk(guard)
-	}
-	if block := cc.GetBodyBlock(); block != nil {
-		a.walkBlock(block)
-	} else if stmt := cc.GetBodyStmt(); stmt != nil {
-		a.walk(stmt)
-	}
-}
-
-// bindPattern extracts the binding names of a case-clause pattern (the opposite
-// of walkPatternAsValue): the identifiers a pattern introduces, not the ones it
-// references. Constructor/extractor names and their package qualifiers are NOT
-// bound; their sub-patterns are recursed into.
-func (a *captureAnalyzer) bindPattern(pat grammar.IPatternContext) {
-	switch p := pat.(type) {
-	case *grammar.ExpressionPatternContext:
-		a.bindPatternExpression(p.Expression())
-	case *grammar.RestPatternContext:
-		a.bindPatternExpression(p.Expression()) // `rest...` binds rest
-	case *grammar.TypedPatternContext:
-		a.bindID(p.Identifier()) // `x: T` binds x; T is a type
-	}
-}
-
-// bindPatternExpression binds the names introduced by an expression-shaped
-// pattern: a bare identifier binds itself; a tuple `(a, b)` binds each element's
-// names; an extractor call `Ctor(sub…)` (or `pkg.Ctor(sub…)`, `Ctor[T](sub…)`)
-// binds the sub-patterns' names but not the constructor. Literals bind nothing.
-func (a *captureAnalyzer) bindPatternExpression(expr grammar.IExpressionContext) {
-	pf := singlePostfixExpr(expr)
-	if pf == nil {
-		return
-	}
-	suffixes := pf.AllPostfixSuffix()
-	if len(suffixes) == 0 {
-		// No call/selector suffix: either a bare identifier binding or a
-		// parenthesised (tuple) pattern.
-		prim := primaryOfPrimaryExpr(pf.PrimaryExpr())
-		if prim == nil {
-			return
-		}
-		if id := prim.Identifier(); id != nil {
-			a.bind(id.GetText())
-			return
-		}
-		if tup := prim.TupleExpressionList(); tup != nil {
-			for _, e := range tup.AllExpression() {
-				a.bindPatternExpression(e)
-			}
-		}
-		return
-	}
-	// Extractor/constructor pattern: the primary is the constructor NAME (not a
-	// binding). Each argument-list suffix carries the sub-patterns.
-	for _, s := range suffixes {
-		sc, ok := s.(*grammar.PostfixSuffixContext)
-		if !ok {
-			continue
-		}
-		if al := sc.ArgumentList(); al != nil {
-			for _, arg := range al.AllArgument() {
-				ac, ok := arg.(*grammar.ArgumentContext)
-				if !ok {
-					continue
-				}
-				if sub := ac.Pattern(); sub != nil {
-					a.bindPattern(sub)
-				}
-			}
-		}
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Small parse-tree navigation helpers
-// ---------------------------------------------------------------------------
-
-// singlePostfixExpr descends an expression that is a single, operator-free chain
-// down to its postfixExpr, returning nil if the expression branches (a binary
-// operator, which never occurs in the patterns this is used for).
-func singlePostfixExpr(ctx grammar.IExpressionContext) grammar.IPostfixExprContext {
-	if ctx == nil {
-		return nil
-	}
-	or := ctx.OrExpr()
-	if or == nil {
-		return nil
-	}
-	ands := or.AllAndExpr()
-	if len(ands) != 1 {
-		return nil
-	}
-	eqs := ands[0].AllEqualityExpr()
-	if len(eqs) != 1 {
-		return nil
-	}
-	rels := eqs[0].AllRelationalExpr()
-	if len(rels) != 1 {
-		return nil
-	}
-	adds := rels[0].AllAdditiveExpr()
-	if len(adds) != 1 {
-		return nil
-	}
-	muls := adds[0].AllMultiplicativeExpr()
-	if len(muls) != 1 {
-		return nil
-	}
-	uns := muls[0].AllUnaryExpr()
-	if len(uns) != 1 {
-		return nil
-	}
-	return uns[0].PostfixExpr()
-}
-
-// primaryOfPrimaryExpr returns the PrimaryContext of a primaryExpr, or nil when
-// the primaryExpr is a lambda / if-expression / partial-function alternative.
-func primaryOfPrimaryExpr(pe grammar.IPrimaryExprContext) grammar.IPrimaryContext {
-	if pe == nil {
-		return nil
-	}
-	return pe.Primary()
+	c.out[idx].Paths = append(c.out[idx].Paths, use.Path)
 }

--- a/internal/transpiler/scopewalk/BUILD.bazel
+++ b/internal/transpiler/scopewalk/BUILD.bazel
@@ -1,33 +1,25 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "concurrency",
-    srcs = [
-        "capture.go",
-        "helpers.go",
-        "shareable.go",
-    ],
-    importpath = "martianoff/gala/internal/transpiler/concurrency",
+    name = "scopewalk",
+    srcs = ["scopewalk.go"],
+    importpath = "martianoff/gala/internal/transpiler/scopewalk",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/interpolation",
+        "//internal/parser",
         "//internal/parser/grammar",
-        "//internal/transpiler",
-        "//internal/transpiler/scopewalk",
         "@com_github_antlr4_go_antlr_v4//:antlr",
     ],
 )
 
 go_test(
-    name = "concurrency_test",
-    srcs = [
-        "capture_test.go",
-        "shareable_test.go",
-    ],
-    embed = [":concurrency"],
+    name = "scopewalk_test",
+    srcs = ["scopewalk_test.go"],
     deps = [
+        ":scopewalk",
         "//internal/parser",
         "//internal/parser/grammar",
-        "//internal/transpiler",
         "@com_github_antlr4_go_antlr_v4//:antlr",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/internal/transpiler/scopewalk/scopewalk.go
+++ b/internal/transpiler/scopewalk/scopewalk.go
@@ -1,0 +1,868 @@
+// Package scopewalk is the shared lexical-scope walker over a GALA parse tree.
+//
+// It answers one question — "which value-position identifiers does this code
+// reference that its own scopes do not bind?" — and hands each answer to a
+// Visitor. Two passes are built on it:
+//
+//   - the concurrency capture analysis, which turns the unbound references of a
+//     closure into its free-variable (capture) set, and
+//   - the analyzer's undefined-symbol check, which asks whether each unbound
+//     reference resolves to anything the compilation knows about.
+//
+// Both need exactly the same notion of "a value-position identifier that no
+// enclosing binder introduced", so they share this walk rather than each
+// carrying its own. The differences between them are narrow and explicit — see
+// Options.
+//
+// SCOPE MODEL. An explicit scope stack (innermost last) is pushed by every
+// binding-introducing construct: lambda and function parameters, blocks,
+// `val`/`var`/`:=` declarations, `bind`/`also`/`use` bindings, `for` loop
+// variables, `if init;` statements, nested function declarations, and
+// `match` / partial-function case patterns. Initializers are walked BEFORE the
+// name they bind, so `val x = x + 1` sees the outer `x`.
+//
+// COMPLETENESS. The walk is complete by construction: nodes that affect scoping
+// or contribute references have precise handlers, and every other node falls
+// through to a generic child recursion, so no subtree is ever silently skipped
+// and the analysis stays correct as the grammar grows.
+//
+// VALUE POSITIONS ONLY. References are emitted from exactly two places — a bare
+// identifier `primary`, and the bare-identifier base of a postfix chain. Type
+// positions therefore contribute nothing: a signature's parameter types, a
+// `val`'s type annotation, a composite literal's type and a lambda's return
+// type are never walked as values. TypeContext is additionally short-circuited
+// so a future grammar change cannot leak a type name into the reference stream.
+//
+// STRING INTERPOLATION. `s"…$counter"` and `f"${x + y}"` are SINGLE lexer
+// tokens, so their embedded expressions are not child nodes. With
+// Options.ParseInterpolations set, each embedded expression is re-parsed and
+// walked in the current scope, so a name referenced only inside an
+// interpolation is seen like any other reference.
+package scopewalk
+
+import (
+	"strings"
+
+	"github.com/antlr4-go/antlr/v4"
+
+	"martianoff/gala/internal/interpolation"
+	"martianoff/gala/internal/parser"
+	"martianoff/gala/internal/parser/grammar"
+)
+
+// Use records HOW a reference is used, so a consumer that cares can be
+// field-access-sensitive.
+//
+//   - Whole is true when the name is used AS A VALUE: referenced bare, passed
+//     as an argument, used as a call callee, a method receiver, an index or
+//     `match` subject — anything other than a pure field read.
+//   - Path is the dotted pure field-read chain applied to the name (`x.a.b` →
+//     "a.b"), set only when Whole is false.
+//
+// A consumer that only needs "was this name referenced at all" ignores both.
+type Use struct {
+	Path  string
+	Whole bool
+}
+
+// Visitor receives the walk's output.
+type Visitor interface {
+	// Reference reports a value-position identifier that no scope entered by
+	// the walk binds. The blank identifier is never reported. A name used
+	// several ways is reported once per use, so consumers that aggregate must
+	// de-duplicate.
+	Reference(name string, tok antlr.Token, use Use)
+}
+
+// Options carries the narrow behavioural differences between the passes built
+// on this walker. The zero value is the conservative, over-approximating shape
+// the capture analysis wants: report more rather than miss one.
+type Options struct {
+	// ParseInterpolations re-parses the embedded expressions of interpolated
+	// (`s"…"`) and format (`f"…"`) string literals and walks them in the
+	// current scope. Off by default because it costs a parse per literal.
+	ParseInterpolations bool
+
+	// RequireCleanInterpolationParse drops an embedded expression whose
+	// re-parse reported errors, instead of walking ANTLR's error-recovered
+	// tree — so a pass that reports on unbound names cannot turn parser
+	// recovery into a diagnostic. It is a narrow guard, not a well-formedness
+	// gate: the expression parser is not anchored at end-of-input, so a
+	// fragment with trailing garbage (`${x +}`) parses its longest valid
+	// prefix without error and is walked by either setting.
+	RequireCleanInterpolationParse bool
+
+	// SkipCompositeLiteralKeys omits the key half of a keyed composite-literal
+	// element (`T{Field: v}` walks `v` but not `Field`). A struct literal's key
+	// is a field name rather than a value, so a pass that must not invent
+	// references sets this; a pass that would rather over-report leaves it off.
+	SkipCompositeLiteralKeys bool
+
+	// BindWholePattern makes a `case` pattern bind EVERY identifier it
+	// mentions, constructor names included, instead of binding only the names
+	// the pattern introduces. It is the blunt, zero-false-positive fallback for
+	// a pass that cannot tolerate a spurious reference; leaving it off gives
+	// the precise split, where `case Some(x)` binds `x` and references `Some`.
+	BindWholePattern bool
+
+	// SkipTypedPatternArgument suppresses the reference a `x: T` pattern in
+	// ARGUMENT position would otherwise contribute. The form is vanishingly
+	// rare there and its identifier is not clearly a value.
+	SkipTypedPatternArgument bool
+
+	// EnterFunctionScope, when set, is called after the walker pushes the scope
+	// for a function declaration and before its parameters are bound. It is the
+	// hook for binders this walker does not model itself — type parameters and
+	// a method receiver, which only the analyzer's pass needs.
+	EnterFunctionScope func(w *Walker, fn grammar.IFunctionDeclarationContext)
+}
+
+// Walker holds the scope stack and drives the traversal.
+type Walker struct {
+	visitor Visitor
+	opts    Options
+	scopes  []map[string]bool
+
+	// interpParser re-parses interpolation bodies; created on first use so a
+	// consumer that leaves ParseInterpolations off never pays for it.
+	interpParser *parser.AntlrGalaParser
+}
+
+// New returns a Walker that reports to v.
+func New(v Visitor, opts Options) *Walker {
+	return &Walker{visitor: v, opts: opts}
+}
+
+// ---------------------------------------------------------------------------
+// Scope stack
+// ---------------------------------------------------------------------------
+
+// PushScope opens a nested lexical scope.
+func (w *Walker) PushScope() { w.scopes = append(w.scopes, map[string]bool{}) }
+
+// PopScope closes the innermost scope.
+func (w *Walker) PopScope() {
+	if len(w.scopes) > 0 {
+		w.scopes = w.scopes[:len(w.scopes)-1]
+	}
+}
+
+// Bind records name as locally bound in the innermost scope, so a later
+// reference resolves to it instead of being reported.
+func (w *Walker) Bind(name string) {
+	if name == "" || name == "_" {
+		return
+	}
+	if len(w.scopes) == 0 {
+		w.PushScope()
+	}
+	w.scopes[len(w.scopes)-1][name] = true
+}
+
+// BindID binds the text of an identifier context, if present.
+func (w *Walker) BindID(id grammar.IIdentifierContext) {
+	if id != nil {
+		w.Bind(id.GetText())
+	}
+}
+
+// BindIdentifierList binds every name in an identifier list.
+func (w *Walker) BindIdentifierList(idList grammar.IIdentifierListContext) {
+	if idList == nil {
+		return
+	}
+	for _, id := range idList.AllIdentifier() {
+		w.Bind(id.GetText())
+	}
+}
+
+// BindIdentifiersIn binds every `identifier` leaf under node. It is the blunt
+// instrument for a construct whose binder/reference split the walker does not
+// model — a method receiver's type arguments (`func (s Stack[T]) …` introduces
+// T), or a whole `case` pattern under Options.BindWholePattern. Over-binding
+// can only mask a reference, never invent one.
+func (w *Walker) BindIdentifiersIn(node antlr.Tree) {
+	for _, name := range identifiersUnder(node) {
+		w.Bind(name)
+	}
+}
+
+// Bound reports whether name is bound in any enclosing scope.
+func (w *Walker) Bound(name string) bool {
+	for i := len(w.scopes) - 1; i >= 0; i-- {
+		if w.scopes[i][name] {
+			return true
+		}
+	}
+	return false
+}
+
+// BindParameters binds each named parameter of a parameter list. Type-only
+// parameters (function-type positions with no identifier) bind nothing.
+func (w *Walker) BindParameters(params grammar.IParametersContext) {
+	if params == nil {
+		return
+	}
+	pl := params.ParameterList()
+	if pl == nil {
+		return
+	}
+	for _, p := range pl.AllParameter() {
+		if pc, ok := p.(*grammar.ParameterContext); ok {
+			w.BindID(pc.Identifier())
+		}
+	}
+}
+
+// WalkParameterDefaults walks the `= expr` default of each parameter, so a
+// reference inside a default value is seen.
+func (w *Walker) WalkParameterDefaults(params grammar.IParametersContext) {
+	if params == nil {
+		return
+	}
+	pl := params.ParameterList()
+	if pl == nil {
+		return
+	}
+	for _, p := range pl.AllParameter() {
+		if pc, ok := p.(*grammar.ParameterContext); ok {
+			if def := pc.ParamDefault(); def != nil {
+				w.Walk(def.Expression())
+			}
+		}
+	}
+}
+
+// reference emits an unbound value-position reference.
+func (w *Walker) reference(name string, tok antlr.Token, use Use) {
+	if name == "" || name == "_" || w.Bound(name) {
+		return
+	}
+	w.visitor.Reference(name, tok, use)
+}
+
+// ---------------------------------------------------------------------------
+// Generic dispatcher
+// ---------------------------------------------------------------------------
+
+// Walk descends an arbitrary parse-tree node. Nodes that affect scoping or
+// contribute references have precise handlers (dispatched here, returning
+// without generic recursion so nothing is double-walked); every other node
+// falls to the default branch, which recurses into all children.
+func (w *Walker) Walk(node antlr.Tree) {
+	if node == nil {
+		return
+	}
+	switch n := node.(type) {
+	// A type is never a value: short-circuit so no type name can reach the
+	// reference stream through generic recursion.
+	case *grammar.TypeContext:
+		return
+
+	// Scope-introducing constructs.
+	case *grammar.LambdaExpressionContext:
+		w.WalkLambda(n)
+		return
+	case *grammar.BlockContext:
+		w.WalkBlock(n)
+		return
+	case *grammar.ForStatementContext:
+		w.walkForStatement(n)
+		return
+	case *grammar.IfStatementContext:
+		w.walkIfStatement(n)
+		return
+	case *grammar.FunctionDeclarationContext:
+		w.WalkFunctionDeclaration(n)
+		return
+	case *grammar.CaseClauseContext:
+		w.walkCaseClause(n)
+		return
+	case *grammar.PartialFunctionLiteralContext:
+		for _, cc := range n.AllCaseClause() {
+			w.walkCaseClause(cc)
+		}
+		return
+
+	// Order-dependent local bindings: walk the initializer first (in the
+	// pre-binding scope), then bind, so `val x = x + 1` sees the outer x.
+	case *grammar.ValDeclarationContext:
+		w.walkValVarDecl(n.ExpressionList(), n.IdentifierList(), n.TuplePattern())
+		return
+	case *grammar.VarDeclarationContext:
+		w.walkValVarDecl(n.ExpressionList(), n.IdentifierList(), n.TuplePattern())
+		return
+	case *grammar.ShortVarDeclContext:
+		if el := n.ExpressionList(); el != nil {
+			for _, e := range el.AllExpression() {
+				w.Walk(e)
+			}
+		}
+		w.BindIdentifierList(n.IdentifierList())
+		return
+	case *grammar.BindDeclarationContext:
+		w.Walk(n.Expression())
+		w.BindID(n.Identifier())
+		return
+	case *grammar.AlsoDeclarationContext:
+		w.Walk(n.Expression())
+		w.BindID(n.Identifier())
+		return
+	case *grammar.UseDeclarationContext:
+		w.Walk(n.Expression())
+		w.BindID(n.Identifier())
+		return
+
+	// Reference-contributing leaves.
+	case *grammar.PostfixExprContext:
+		w.walkPostfixExpr(n)
+		return
+	case *grammar.PrimaryContext:
+		w.walkPrimary(n)
+		return
+	case *grammar.PostfixSuffixContext:
+		w.walkPostfixSuffix(n)
+		return
+	case *grammar.ArgumentContext:
+		w.walkArgument(n)
+		return
+	}
+
+	// Default: no precise handler — recurse into every child so unhandled
+	// forms still surface their references.
+	for i := 0; i < node.GetChildCount(); i++ {
+		w.Walk(node.GetChild(i))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scope-introducing handlers
+// ---------------------------------------------------------------------------
+
+// WalkLambda pushes a fresh scope, binds the lambda's parameters into it, walks
+// the body, and pops — so a nested lambda's parameters shadow only within its
+// own scope.
+func (w *Walker) WalkLambda(lambda grammar.ILambdaExpressionContext) {
+	if lambda == nil {
+		return
+	}
+	w.PushScope()
+	defer w.PopScope()
+
+	w.BindParameters(lambda.Parameters())
+	// A parameter default (`(x = n) => …`) may reference a sibling parameter,
+	// so defaults are walked after the names are bound.
+	w.WalkParameterDefaults(lambda.Parameters())
+
+	if expr := lambda.Expression(); expr != nil {
+		w.Walk(expr)
+	} else if block := lambda.Block(); block != nil {
+		w.WalkBlock(block)
+	}
+	// lambda.Type_() is the optional return-type annotation — a type.
+}
+
+// WalkBlock introduces a nested scope and walks the block's statements in
+// order, so a local declared partway through shadows an enclosing name only for
+// references that follow it.
+func (w *Walker) WalkBlock(block grammar.IBlockContext) {
+	if block == nil {
+		return
+	}
+	w.PushScope()
+	defer w.PopScope()
+	for _, s := range block.AllStatement() {
+		w.Walk(s)
+	}
+}
+
+// walkValVarDecl walks a `val`/`var` initializer and then binds the declared
+// name(s) — RHS first, in the scope that predates the binding.
+func (w *Walker) walkValVarDecl(exprList grammar.IExpressionListContext, idList grammar.IIdentifierListContext, tuple grammar.ITuplePatternContext) {
+	if exprList != nil {
+		for _, e := range exprList.AllExpression() {
+			w.Walk(e)
+		}
+	}
+	w.BindIdentifierList(idList)
+	if tuple != nil {
+		w.BindIdentifierList(tuple.IdentifierList())
+	}
+}
+
+// WalkFunctionDeclaration handles a `func f(...) = body` (or block-bodied)
+// declaration. The name is bound in the ENCLOSING scope, so the function may
+// recurse and later statements may call it; its parameters live in a fresh
+// nested scope covering only its body. Options.EnterFunctionScope runs inside
+// that scope, before the parameters bind, for binders this walker does not
+// model (type parameters, a method receiver).
+func (w *Walker) WalkFunctionDeclaration(fn grammar.IFunctionDeclarationContext) {
+	if fn == nil {
+		return
+	}
+	w.BindID(fn.Identifier())
+	w.PushScope()
+	defer w.PopScope()
+	if w.opts.EnterFunctionScope != nil {
+		w.opts.EnterFunctionScope(w, fn)
+	}
+	if sig := fn.Signature(); sig != nil {
+		w.BindParameters(sig.Parameters())
+		w.WalkParameterDefaults(sig.Parameters())
+	}
+	if block := fn.Block(); block != nil {
+		w.WalkBlock(block)
+	} else if e := fn.Expression(); e != nil {
+		w.Walk(e)
+	}
+}
+
+func (w *Walker) walkIfStatement(ifs grammar.IIfStatementContext) {
+	// An `if init; cond { … }` init binding is visible in the condition and
+	// both branches but NOT after the statement, so it gets a scope wrapping
+	// the whole statement.
+	w.PushScope()
+	defer w.PopScope()
+	if ss := ifs.SimpleStatement(); ss != nil {
+		w.Walk(ss)
+	}
+	if cond := ifs.Expression(); cond != nil {
+		w.Walk(cond)
+	}
+	for _, b := range ifs.AllBlock() {
+		w.WalkBlock(b)
+	}
+	if elseIf := ifs.IfStatement(); elseIf != nil {
+		w.walkIfStatement(elseIf)
+	}
+}
+
+func (w *Walker) walkForStatement(fs grammar.IForStatementContext) {
+	// Loop variables live in a scope that wraps the loop body.
+	w.PushScope()
+	defer w.PopScope()
+
+	if fc := fs.ForClause(); fc != nil {
+		// forClause: simpleStatement? ';' expression? ';' simpleStatement?
+		for _, ss := range fc.AllSimpleStatement() {
+			w.Walk(ss)
+		}
+		if e := fc.Expression(); e != nil {
+			w.Walk(e)
+		}
+	} else if rc := fs.RangeClause(); rc != nil {
+		// rangeClause: (identifierList (':=' | '='))? 'range' expression
+		if e := rc.Expression(); e != nil {
+			w.Walk(e) // the ranged value resolves before the loop vars bind
+		}
+		if idList := rc.IdentifierList(); idList != nil {
+			if strings.Contains(rc.GetText(), ":=") {
+				// `i, v := range xs` — fresh loop-variable bindings.
+				w.BindIdentifierList(idList)
+			} else {
+				// `i, v = range xs` — assignment to existing variables.
+				for _, id := range idList.AllIdentifier() {
+					w.reference(id.GetText(), id.GetStart(), Use{Whole: true})
+				}
+			}
+		}
+	} else if cond := fs.ForCondition(); cond != nil {
+		w.Walk(cond.Expression())
+	}
+
+	w.WalkBlock(fs.Block())
+}
+
+// ---------------------------------------------------------------------------
+// Reference-contributing handlers
+// ---------------------------------------------------------------------------
+
+// walkPostfixExpr handles a `primaryExpr postfixSuffix* ('match' … )?` chain.
+// When the base is a bare value-position identifier it classifies HOW the name
+// is used — a pure `.field` selector chain as a read path, anything else as a
+// whole use. Regardless of the base, the contents of every suffix and every
+// `match` arm are walked so nested references are still found.
+func (w *Walker) walkPostfixExpr(ctx grammar.IPostfixExprContext) {
+	if ctx == nil {
+		return
+	}
+	pe := ctx.PrimaryExpr()
+	suffixes := ctx.AllPostfixSuffix()
+	caseClauses := ctx.AllCaseClause()
+
+	if id := bareIdentPrimary(pe); id != nil {
+		path, whole := classifySuffixes(suffixes, len(caseClauses) > 0)
+		w.reference(id.GetText(), id.GetStart(), Use{Path: path, Whole: whole})
+	} else {
+		// Base is not a bare identifier (literal, tuple/paren, composite
+		// literal, lambda, if-expression, partial function): recurse into it.
+		w.Walk(pe)
+	}
+
+	for _, s := range suffixes {
+		w.walkPostfixSuffix(s)
+	}
+	for _, cc := range caseClauses {
+		w.walkCaseClause(cc)
+	}
+}
+
+// classifySuffixes decides whether a bare-identifier base followed by the given
+// suffixes (and an optional trailing `match`) is a pure field-read path or a
+// whole use. A leading, uninterrupted run of `.field` selectors with no call,
+// index, or match is a field-read path; an empty suffix list (a bare
+// reference), a trailing match, or any call/index makes it a whole use.
+func classifySuffixes(suffixes []grammar.IPostfixSuffixContext, hasMatch bool) (path string, whole bool) {
+	if hasMatch || len(suffixes) == 0 {
+		return "", true
+	}
+	parts := make([]string, 0, len(suffixes))
+	for i, s := range suffixes {
+		sc, ok := s.(*grammar.PostfixSuffixContext)
+		if !ok {
+			return "", true
+		}
+		if id := sc.Identifier(); id != nil {
+			parts = append(parts, id.GetText())
+			continue
+		}
+		if sc.ExpressionList() != nil {
+			// Index `[...]` — a value-position use of the whole receiver.
+			return "", true
+		}
+		// A call `(...)`. Tolerate a SINGLE trailing method call on a
+		// field-path receiver: `x.a.b.m(...)` reads the field value `x.a.b` and
+		// calls a method on it. The last selector is the method name, so the
+		// receiver path is the rest; at least one selector must remain (else it
+		// is a method on the whole value, which stays a whole use).
+		if i == len(suffixes)-1 && len(parts) >= 2 {
+			return strings.Join(parts[:len(parts)-1], "."), false
+		}
+		return "", true
+	}
+	return strings.Join(parts, "."), false
+}
+
+// bareIdentPrimary returns the identifier context when the primaryExpr is a
+// bare value-position identifier (`x`), or nil for any other shape.
+func bareIdentPrimary(pe grammar.IPrimaryExprContext) grammar.IIdentifierContext {
+	if pe == nil {
+		return nil
+	}
+	prim := pe.Primary()
+	if prim == nil {
+		return nil
+	}
+	return prim.Identifier()
+}
+
+func (w *Walker) walkPrimary(ctx grammar.IPrimaryContext) {
+	if ctx == nil {
+		return
+	}
+	if id := ctx.Identifier(); id != nil {
+		w.reference(id.GetText(), id.GetStart(), Use{Whole: true})
+		return
+	}
+	if lit := ctx.Literal(); lit != nil {
+		w.walkLiteral(lit)
+		return
+	}
+	if tup := ctx.TupleExpressionList(); tup != nil {
+		for _, e := range tup.AllExpression() {
+			w.Walk(e)
+		}
+		return
+	}
+	if cl := ctx.CompositeLiteral(); cl != nil {
+		w.walkCompositeLiteral(cl)
+	}
+}
+
+// walkLiteral descends into an interpolated (`s"…"`) or format (`f"…"`) string.
+// Such a literal is a single token whose embedded `${…}` / `$name` expressions
+// are NOT parse-tree children, so each is re-parsed and walked in the CURRENT
+// scope. Every other literal contributes no references.
+func (w *Walker) walkLiteral(lit grammar.ILiteralContext) {
+	if !w.opts.ParseInterpolations {
+		return
+	}
+	var raw string
+	if tok := lit.INTERPOLATED_STRING(); tok != nil {
+		raw = tok.GetText()
+	} else if tok := lit.FORMAT_STRING(); tok != nil {
+		raw = tok.GetText()
+	} else {
+		return
+	}
+	if len(raw) < 3 {
+		return
+	}
+	if w.interpParser == nil {
+		w.interpParser = parser.NewAntlrGalaParser()
+	}
+	// Strip the `s"`/`f"` prefix and the closing `"`, matching the transformer.
+	content := raw[2 : len(raw)-1]
+	for _, part := range interpolation.Split(content) {
+		if part.IsLiteral {
+			continue
+		}
+		expr, errs := w.interpParser.ParseExpression(part.Text)
+		if expr == nil {
+			continue
+		}
+		if len(errs) > 0 && w.opts.RequireCleanInterpolationParse {
+			continue
+		}
+		w.Walk(expr)
+	}
+}
+
+// walkCompositeLiteral walks the element values of a composite literal. The
+// literal's type is skipped; each keyed element's value is a value position.
+// The key half is a field name in a struct literal, so
+// Options.SkipCompositeLiteralKeys controls whether it is walked too.
+func (w *Walker) walkCompositeLiteral(ctx grammar.ICompositeLiteralContext) {
+	el := ctx.ElementList()
+	if el == nil {
+		return
+	}
+	for _, ke := range el.AllKeyedElement() {
+		kec, ok := ke.(*grammar.KeyedElementContext)
+		if !ok {
+			continue
+		}
+		exprs := kec.AllExpression()
+		if w.opts.SkipCompositeLiteralKeys && len(exprs) > 1 {
+			exprs = exprs[len(exprs)-1:]
+		}
+		for _, e := range exprs {
+			w.Walk(e)
+		}
+	}
+}
+
+func (w *Walker) walkPostfixSuffix(ctx grammar.IPostfixSuffixContext) {
+	if ctx == nil {
+		return
+	}
+	// `.identifier` is a field/method selector on the preceding value — the
+	// selector name is not a reference.
+	if ctx.Identifier() != nil {
+		return
+	}
+	if al := ctx.ArgumentList(); al != nil {
+		for _, arg := range al.AllArgument() {
+			w.walkArgument(arg)
+		}
+		return
+	}
+	// `[ expressionList ]` — an index or explicit type arguments. Index
+	// expressions are value references; bracketed type arguments route through
+	// the same primaries and resolve harmlessly for both consumers.
+	if el := ctx.ExpressionList(); el != nil {
+		for _, e := range el.AllExpression() {
+			w.Walk(e)
+		}
+	}
+}
+
+func (w *Walker) walkArgument(arg grammar.IArgumentContext) {
+	if arg == nil {
+		return
+	}
+	// A leading `identifier =` is a named-argument LABEL, not a reference.
+	if lambda := arg.LambdaExpression(); lambda != nil {
+		w.WalkLambda(lambda)
+		return
+	}
+	// In argument position the `pattern` rule is used as a VALUE expression.
+	if pat := arg.Pattern(); pat != nil {
+		w.walkPatternAsValue(pat)
+	}
+}
+
+// walkPatternAsValue walks a `pattern` node in value position (a call
+// argument), treating its identifiers as references rather than bindings.
+func (w *Walker) walkPatternAsValue(pat grammar.IPatternContext) {
+	switch p := pat.(type) {
+	case *grammar.ExpressionPatternContext:
+		w.Walk(p.Expression())
+	case *grammar.RestPatternContext:
+		w.Walk(p.Expression()) // spread: `xs...`
+	case *grammar.TypedPatternContext:
+		if w.opts.SkipTypedPatternArgument {
+			return
+		}
+		if id := p.Identifier(); id != nil {
+			w.reference(id.GetText(), id.GetStart(), Use{Whole: true})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Match / partial-function case clauses
+// ---------------------------------------------------------------------------
+
+func (w *Walker) walkCaseClause(cc grammar.ICaseClauseContext) {
+	if cc == nil {
+		return
+	}
+	w.PushScope()
+	defer w.PopScope()
+
+	// Pattern bindings (`case Some(x)` binds x) are in scope for guard & body.
+	w.bindPattern(cc.Pattern())
+
+	if guard := cc.GetGuard(); guard != nil {
+		w.Walk(guard)
+	}
+	if block := cc.GetBodyBlock(); block != nil {
+		w.WalkBlock(block)
+	} else if stmt := cc.GetBodyStmt(); stmt != nil {
+		w.Walk(stmt)
+	}
+}
+
+// bindPattern binds the names a case-clause pattern introduces. Constructor and
+// extractor names are NOT bound — they are references, resolved like any other
+// name — and their sub-patterns are recursed into. Under
+// Options.BindWholePattern every identifier in the pattern is bound instead.
+func (w *Walker) bindPattern(pat grammar.IPatternContext) {
+	if pat == nil {
+		return
+	}
+	if w.opts.BindWholePattern {
+		w.BindIdentifiersIn(pat)
+		return
+	}
+	switch p := pat.(type) {
+	case *grammar.ExpressionPatternContext:
+		w.bindPatternExpression(p.Expression())
+	case *grammar.RestPatternContext:
+		w.bindPatternExpression(p.Expression()) // `rest...` binds rest
+	case *grammar.TypedPatternContext:
+		w.BindID(p.Identifier()) // `x: T` binds x; T is a type
+	}
+}
+
+// bindPatternExpression binds the names introduced by an expression-shaped
+// pattern: a bare identifier binds itself; a tuple `(a, b)` binds each
+// element's names; an extractor call `Ctor(sub…)` (or `pkg.Ctor(sub…)`,
+// `Ctor[T](sub…)`) binds the sub-patterns' names but not the constructor.
+// Literals bind nothing.
+func (w *Walker) bindPatternExpression(expr grammar.IExpressionContext) {
+	pf := singlePostfixExpr(expr)
+	if pf == nil {
+		return
+	}
+	suffixes := pf.AllPostfixSuffix()
+	if len(suffixes) == 0 {
+		// No call/selector suffix: a bare identifier binding, or a
+		// parenthesised (tuple) pattern.
+		prim := primaryOfPrimaryExpr(pf.PrimaryExpr())
+		if prim == nil {
+			return
+		}
+		if id := prim.Identifier(); id != nil {
+			w.Bind(id.GetText())
+			return
+		}
+		if tup := prim.TupleExpressionList(); tup != nil {
+			for _, e := range tup.AllExpression() {
+				w.bindPatternExpression(e)
+			}
+		}
+		return
+	}
+	// Extractor/constructor pattern: the primary is the constructor NAME (not a
+	// binding). Each argument-list suffix carries the sub-patterns.
+	for _, s := range suffixes {
+		sc, ok := s.(*grammar.PostfixSuffixContext)
+		if !ok {
+			continue
+		}
+		if al := sc.ArgumentList(); al != nil {
+			for _, arg := range al.AllArgument() {
+				ac, ok := arg.(*grammar.ArgumentContext)
+				if !ok {
+					continue
+				}
+				if sub := ac.Pattern(); sub != nil {
+					w.bindPattern(sub)
+				}
+			}
+		}
+	}
+}
+
+// identifiersUnder returns every `identifier` leaf under node. It backs
+// Options.BindWholePattern.
+func identifiersUnder(node antlr.Tree) []string {
+	var out []string
+	var rec func(antlr.Tree)
+	rec = func(t antlr.Tree) {
+		if t == nil {
+			return
+		}
+		if id, ok := t.(*grammar.IdentifierContext); ok {
+			out = append(out, id.GetText())
+			return
+		}
+		for i := 0; i < t.GetChildCount(); i++ {
+			rec(t.GetChild(i))
+		}
+	}
+	rec(node)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Parse-tree navigation helpers
+// ---------------------------------------------------------------------------
+
+// singlePostfixExpr descends an expression that is a single, operator-free
+// chain down to its postfixExpr, returning nil if the expression branches.
+func singlePostfixExpr(ctx grammar.IExpressionContext) grammar.IPostfixExprContext {
+	if ctx == nil {
+		return nil
+	}
+	or := ctx.OrExpr()
+	if or == nil {
+		return nil
+	}
+	ands := or.AllAndExpr()
+	if len(ands) != 1 {
+		return nil
+	}
+	eqs := ands[0].AllEqualityExpr()
+	if len(eqs) != 1 {
+		return nil
+	}
+	rels := eqs[0].AllRelationalExpr()
+	if len(rels) != 1 {
+		return nil
+	}
+	adds := rels[0].AllAdditiveExpr()
+	if len(adds) != 1 {
+		return nil
+	}
+	muls := adds[0].AllMultiplicativeExpr()
+	if len(muls) != 1 {
+		return nil
+	}
+	uns := muls[0].AllUnaryExpr()
+	if len(uns) != 1 {
+		return nil
+	}
+	return uns[0].PostfixExpr()
+}
+
+// primaryOfPrimaryExpr returns the PrimaryContext of a primaryExpr, or nil when
+// the primaryExpr is a lambda / if-expression / partial-function alternative.
+func primaryOfPrimaryExpr(pe grammar.IPrimaryExprContext) grammar.IPrimaryContext {
+	if pe == nil {
+		return nil
+	}
+	return pe.Primary()
+}

--- a/internal/transpiler/scopewalk/scopewalk.go
+++ b/internal/transpiler/scopewalk/scopewalk.go
@@ -126,6 +126,15 @@ type Walker struct {
 	// interpParser re-parses interpolation bodies; created on first use so a
 	// consumer that leaves ParseInterpolations off never pays for it.
 	interpParser *parser.AntlrGalaParser
+
+	// posOverride, when set, replaces the token reported for a reference. A
+	// re-parsed interpolation fragment is its own token stream, so its tokens
+	// carry positions relative to the FRAGMENT, not the file — reporting one
+	// verbatim points the caret at line 1, column 1 of the source. While a
+	// fragment is being walked this holds the enclosing string literal's
+	// token, so a reference inside `s"…"` is attributed to the literal that
+	// contains it.
+	posOverride antlr.Token
 }
 
 // New returns a Walker that reports to v.
@@ -233,10 +242,15 @@ func (w *Walker) WalkParameterDefaults(params grammar.IParametersContext) {
 	}
 }
 
-// reference emits an unbound value-position reference.
+// reference emits an unbound value-position reference. Inside a re-parsed
+// interpolation fragment the reported token is the enclosing string literal —
+// see posOverride.
 func (w *Walker) reference(name string, tok antlr.Token, use Use) {
 	if name == "" || name == "_" || w.Bound(name) {
 		return
+	}
+	if w.posOverride != nil {
+		tok = w.posOverride
 	}
 	w.visitor.Reference(name, tok, use)
 }
@@ -583,24 +597,38 @@ func (w *Walker) walkPrimary(ctx grammar.IPrimaryContext) {
 // Such a literal is a single token whose embedded `${…}` / `$name` expressions
 // are NOT parse-tree children, so each is re-parsed and walked in the CURRENT
 // scope. Every other literal contributes no references.
+//
+// A re-parsed fragment is its own token stream: its tokens' line/column are
+// relative to the fragment, so reporting one verbatim would put a caret on line
+// 1 of the file. For the duration of the walk every reference is therefore
+// attributed to the string literal token itself, which is the position a reader
+// needs — the literal that contains the offending name. Resolving to the exact
+// column inside the literal would need Split to preserve each part's span in
+// the original text, which it does not (it unescapes as it goes).
 func (w *Walker) walkLiteral(lit grammar.ILiteralContext) {
 	if !w.opts.ParseInterpolations {
 		return
 	}
-	var raw string
-	if tok := lit.INTERPOLATED_STRING(); tok != nil {
-		raw = tok.GetText()
-	} else if tok := lit.FORMAT_STRING(); tok != nil {
-		raw = tok.GetText()
+	var tok antlr.TerminalNode
+	if t := lit.INTERPOLATED_STRING(); t != nil {
+		tok = t
+	} else if t := lit.FORMAT_STRING(); t != nil {
+		tok = t
 	} else {
 		return
 	}
+	raw := tok.GetText()
 	if len(raw) < 3 {
 		return
 	}
 	if w.interpParser == nil {
 		w.interpParser = parser.NewAntlrGalaParser()
 	}
+
+	prev := w.posOverride
+	w.posOverride = tok.GetSymbol()
+	defer func() { w.posOverride = prev }()
+
 	// Strip the `s"`/`f"` prefix and the closing `"`, matching the transformer.
 	content := raw[2 : len(raw)-1]
 	for _, part := range interpolation.Split(content) {

--- a/internal/transpiler/scopewalk/scopewalk.go
+++ b/internal/transpiler/scopewalk/scopewalk.go
@@ -14,6 +14,23 @@
 // carrying its own. The differences between them are narrow and explicit — see
 // Options.
 //
+// ON ADDING AN OPTION. Options is already at the edge of what a shared walker
+// can carry before it stops being a walker and becomes a configuration object.
+// Every current flag earns its place by marking a spot where the two passes
+// genuinely disagree about what the LANGUAGE means — whether a composite
+// literal's key is a value, whether a pattern's constructor is a reference —
+// and each is set opposite ways by the two callers. Before adding a sixth, ask
+// whether the new behaviour is instead:
+//
+//   - a property of the consumer, not the walk (decide it in Visitor.Reference,
+//     which already sees the name, the token and the use), or
+//   - something both passes would want (then just change the walk), or
+//   - a binder this walker does not model (use EnterFunctionScope, or push a
+//     scope and Bind before calling in).
+//
+// A flag that only one caller ever sets to a non-zero value, or that encodes a
+// preference rather than a disagreement about meaning, belongs in the consumer.
+//
 // SCOPE MODEL. An explicit scope stack (innermost last) is pushed by every
 // binding-introducing construct: lambda and function parameters, blocks,
 // `val`/`var`/`:=` declarations, `bind`/`also`/`use` bindings, `for` loop
@@ -605,6 +622,15 @@ func (w *Walker) walkPrimary(ctx grammar.IPrimaryContext) {
 // needs — the literal that contains the offending name. Resolving to the exact
 // column inside the literal would need Split to preserve each part's span in
 // the original text, which it does not (it unescapes as it goes).
+//
+// FOLLOW-UP: threading a byte offset (and length) for each embedded part
+// through interpolation.Split would let a consumer add it to this token's
+// start and point the caret at the offending name inside the literal rather
+// than at the literal as a whole. The transformer would benefit too — it emits
+// per-part Sprintf arguments and has the same coarse position. The obstacle is
+// only that Split builds its parts by unescaping into a strings.Builder, so
+// the mapping back to source columns is lost; recording spans as it scans is
+// mechanical but touches a shared, well-tested splitter.
 func (w *Walker) walkLiteral(lit grammar.ILiteralContext) {
 	if !w.opts.ParseInterpolations {
 		return

--- a/internal/transpiler/scopewalk/scopewalk_test.go
+++ b/internal/transpiler/scopewalk/scopewalk_test.go
@@ -1,0 +1,248 @@
+package scopewalk_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/antlr4-go/antlr/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"martianoff/gala/internal/parser"
+	"martianoff/gala/internal/parser/grammar"
+	"martianoff/gala/internal/transpiler/scopewalk"
+)
+
+// collector records every unbound reference the walker reports.
+type collector struct {
+	names []string
+	uses  map[string]scopewalk.Use
+}
+
+func newCollector() *collector { return &collector{uses: map[string]scopewalk.Use{}} }
+
+func (c *collector) Reference(name string, tok antlr.Token, use scopewalk.Use) {
+	if _, seen := c.uses[name]; !seen {
+		c.names = append(c.names, name)
+	}
+	// Keep the strongest use: whole beats a field path.
+	prev := c.uses[name]
+	if use.Whole || prev.Whole {
+		c.uses[name] = scopewalk.Use{Whole: true}
+		return
+	}
+	c.uses[name] = use
+}
+
+func (c *collector) sorted() []string {
+	out := append([]string(nil), c.names...)
+	sort.Strings(out)
+	return out
+}
+
+// walkFuncBody parses a whole source file and walks the body of its single
+// top-level function, returning the unbound references.
+func walkFuncBody(t *testing.T, src string, opts scopewalk.Options) *collector {
+	t.Helper()
+	p := parser.NewAntlrGalaParser()
+	tree, errs := p.Parse(src)
+	require.Empty(t, errs, "source must parse")
+	sf, ok := tree.(*grammar.SourceFileContext)
+	require.True(t, ok)
+
+	c := newCollector()
+	w := scopewalk.New(c, opts)
+	w.PushScope()
+	for _, td := range sf.AllTopLevelDeclaration() {
+		if fd := td.FunctionDeclaration(); fd != nil {
+			w.WalkFunctionDeclaration(fd)
+		}
+	}
+	w.PopScope()
+	return c
+}
+
+// TestScopeModel covers the binders every consumer relies on. A name bound by
+// the construct under test must NOT surface as a reference; the sentinel
+// `outer` always must, so a test that binds everything by accident still fails.
+func TestScopeModel(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "parameters and locals are bound",
+			body: "val a = p\nvar b = a\nreturn b + outer",
+			want: []string{"outer"},
+		},
+		{
+			name: "initializer sees the pre-binding scope",
+			body: "val z = z + outer\nreturn z",
+			want: []string{"outer", "z"},
+		},
+		{
+			name: "lambda parameters shadow within their body",
+			body: "val f = (q int) => q + outer\nreturn f(p)",
+			want: []string{"outer"},
+		},
+		{
+			name: "short var decl binds",
+			body: "c := outer\nreturn c",
+			want: []string{"outer"},
+		},
+		{
+			name: "range vars bind, ranged value is a reference",
+			body: "for i, v := range xs { Println(i + v) }\nreturn outer",
+			want: []string{"Println", "outer", "xs"},
+		},
+		{
+			name: "if-init binding does not leak past the statement",
+			body: "if d := p; d > 0 { Println(d) }\nreturn outer",
+			want: []string{"Println", "outer"},
+		},
+		{
+			name: "case pattern binds its captures, not its constructor",
+			body: "return p match {\n    case Some(v) => v + outer\n    case _ => 0\n}",
+			want: []string{"outer"},
+		},
+		{
+			name: "nested function name and params bind",
+			body: "func helper(z int) int = z + outer\nreturn helper(p)",
+			want: []string{"outer"},
+		},
+		{
+			name: "selector and named-arg label are not references",
+			body: "return p.field + g(name = p)",
+			want: []string{"g"},
+		},
+		{
+			name: "type annotations are not references",
+			body: "val t Widget = mk()\nreturn p",
+			want: []string{"mk"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "package main\n\nfunc subject(p int) int {\n    " + tc.body + "\n}\n"
+			got := walkFuncBody(t, src, scopewalk.Options{})
+			assert.Equal(t, tc.want, got.sorted())
+		})
+	}
+}
+
+// TestInterpolationDescent pins the behaviour that closed the interpolation
+// blind spot: an embedded expression is walked in the current scope, so a local
+// stays bound and an unknown name surfaces.
+func TestInterpolationDescent(t *testing.T) {
+	src := "package main\n\nfunc subject(p int) string {\n" +
+		"    val local = p\n" +
+		"    return s\"$local/$outer/${p + other}\"\n" +
+		"}\n"
+
+	off := walkFuncBody(t, src, scopewalk.Options{})
+	assert.Empty(t, off.sorted(), "interpolation bodies are invisible when the option is off")
+
+	on := walkFuncBody(t, src, scopewalk.Options{ParseInterpolations: true})
+	assert.Equal(t, []string{"other", "outer"}, on.sorted())
+}
+
+// TestInterpolationFragmentParsing documents how far a re-parsed fragment is
+// walked. ParseExpression is not anchored at end-of-input, so it consumes the
+// longest valid PREFIX and reports no error for trailing garbage; only a
+// fragment whose prefix is itself malformed produces errors, and that is what
+// RequireCleanInterpolationParse filters.
+func TestInterpolationFragmentParsing(t *testing.T) {
+	strict := scopewalk.Options{
+		ParseInterpolations:            true,
+		RequireCleanInterpolationParse: true,
+	}
+
+	// Trailing garbage: the prefix `x` parses cleanly, so `x` is reported by
+	// both modes. This is the honest limit of the option — it is not a
+	// well-formedness gate on the whole fragment.
+	prefixSrc := "package main\n\nfunc subject(p int) string {\n    return s\"${x +}\"\n}\n"
+	assert.Equal(t, []string{"x"}, walkFuncBody(t, prefixSrc, strict).sorted())
+
+	// A fragment whose prefix is malformed errors out and contributes nothing,
+	// so ANTLR's error-recovered tree can never become a reference.
+	badSrc := "package main\n\nfunc subject(p int) string {\n    return s\"${(}\"\n}\n"
+	assert.Empty(t, walkFuncBody(t, badSrc, strict).sorted())
+}
+
+// TestUseClassification covers the field-path vs whole-value split the capture
+// analysis depends on.
+func TestUseClassification(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantWhole bool
+		wantPath  string
+	}{
+		{name: "bare reference is whole", body: "return cfg", wantWhole: true},
+		{name: "field read is a path", body: "return cfg.a", wantPath: "a"},
+		{name: "nested field read is a dotted path", body: "return cfg.a.b", wantPath: "a.b"},
+		{name: "method on the whole value is whole", body: "return cfg.m()", wantWhole: true},
+		{name: "method on a field path keeps the path", body: "return cfg.a.b.m()", wantPath: "a.b"},
+		{name: "index is whole", body: "return cfg[0]", wantWhole: true},
+		{name: "match subject is whole", body: "return cfg match { case _ => 0 }", wantWhole: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "package main\n\nfunc subject(p int) int {\n    " + tc.body + "\n}\n"
+			got := walkFuncBody(t, src, scopewalk.Options{})
+			use, ok := got.uses["cfg"]
+			require.True(t, ok, "cfg must be reported")
+			assert.Equal(t, tc.wantWhole, use.Whole)
+			if !tc.wantWhole {
+				assert.Equal(t, tc.wantPath, use.Path)
+			}
+		})
+	}
+}
+
+// TestCompositeLiteralKeyOption pins the one place the two consumers disagree
+// about what counts as a value.
+func TestCompositeLiteralKeyOption(t *testing.T) {
+	src := "package main\n\nfunc subject(p int) Thing {\n    return Thing{Field: p, Other: q}\n}\n"
+
+	keys := walkFuncBody(t, src, scopewalk.Options{})
+	assert.Contains(t, keys.sorted(), "Field", "keys are references when the option is off")
+
+	noKeys := walkFuncBody(t, src, scopewalk.Options{SkipCompositeLiteralKeys: true})
+	assert.NotContains(t, noKeys.sorted(), "Field")
+	assert.Contains(t, noKeys.sorted(), "q", "values are still walked")
+}
+
+// TestBindWholePatternOption shows the blunt fallback binding every identifier
+// a pattern mentions, versus the precise split binding only its captures.
+func TestBindWholePatternOption(t *testing.T) {
+	src := "package main\n\nfunc subject(p int) int {\n" +
+		"    return p match {\n        case Ctor(v) => v + Ctor\n    }\n}\n"
+
+	precise := walkFuncBody(t, src, scopewalk.Options{})
+	assert.Contains(t, precise.sorted(), "Ctor",
+		"the precise split leaves a constructor name unbound, so the body use is reported")
+
+	blunt := walkFuncBody(t, src, scopewalk.Options{BindWholePattern: true})
+	assert.NotContains(t, blunt.sorted(), "Ctor",
+		"binding the whole pattern masks the body use")
+}
+
+// TestEnterFunctionScopeHook pins the extension point the analyzer uses to bind
+// type parameters and a method receiver.
+func TestEnterFunctionScopeHook(t *testing.T) {
+	src := "package main\n\nfunc subject(p int) int = p + extra\n"
+
+	without := walkFuncBody(t, src, scopewalk.Options{})
+	assert.Equal(t, []string{"extra"}, without.sorted())
+
+	with := walkFuncBody(t, src, scopewalk.Options{
+		EnterFunctionScope: func(w *scopewalk.Walker, fn grammar.IFunctionDeclarationContext) {
+			w.Bind("extra")
+		},
+	})
+	assert.Empty(t, with.sorted(), "the hook's bindings are in scope for the body")
+}

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -162,6 +162,14 @@ go_test(
         # export scan; same as the embedded-CLI snapshot), so its source must be
         # on the sandbox search path or the import fails to resolve on Linux CI.
         "//go_interop:types.go",
+        # go_builtins is the same shape as go_interop — a pure-Go stdlib
+        # package the analyzer resolves from builtins.go alone. It is not
+        # imported by any fixture directly; std dot-imports it, so it is
+        # pulled in whenever std is loaded, and `Panic` (the sanctioned form —
+        # bare `panic` is GALA-E0035) resolves through that closure. Without
+        # it staged, std's import of go_builtins fails under the Linux sandbox
+        # and every fixture using `Panic` loses the name.
+        "//go_builtins:builtins.go",
     ],
     embed = [":transformer"],
     deps = [

--- a/internal/transpiler/transformer/functions_test.go
+++ b/internal/transpiler/transformer/functions_test.go
@@ -27,6 +27,7 @@ func TestFunctions(t *testing.T) {
 			name: "Lambda with explicit return nil should not duplicate return",
 			input: `package main
 
+import . "martianoff/gala/collection_immutable"
 import . "martianoff/gala/std"
 
 func test() {
@@ -38,6 +39,7 @@ func test() {
 }`,
 			expected: `package main
 
+import . "martianoff/gala/collection_immutable"
 import . "martianoff/gala/std"
 
 func test() {
@@ -87,18 +89,22 @@ var f = std.NewImmutable(func(x int) int {
 `,
 		},
 		{
-			// When HM-based inference cannot resolve the branches' types
-			// (here `c` is undeclared), per-branch fallback inference picks
-			// the common arm type — both arms are int literals, so the IIFE
-			// is typed `func() int` rather than the legacy `func() any`.
+			// The if-expression IIFE takes its type from the arms, not from
+			// the condition: both arms are int literals, so it is typed
+			// `func() int` rather than the legacy `func() any`. The condition
+			// is a plain `var` (it used to be an undeclared name, which the
+			// analyzer now rejects as GALA-E0023).
 			name: "If expression",
 			input: `package main
+
+var c = true
 
 val res = if (c) 1 else 2`,
 			expected: `package main
 
 import "martianoff/gala/std"
 
+var c = true
 var res = std.NewImmutable(func() int {
 	if c {
 		return 1

--- a/internal/transpiler/transformer/some_wrap_sealed_case_test.go
+++ b/internal/transpiler/transformer/some_wrap_sealed_case_test.go
@@ -93,6 +93,7 @@ sealed type T {
 
 	wrapSrc := `package pkg_a
 
+import . "martianoff/gala/collection_immutable"
 import _ "` + modulePath + `/sibling"
 
 func wrap(tag string, x string) Option[T] {

--- a/internal/transpiler/transformer/statements.go
+++ b/internal/transpiler/transformer/statements.go
@@ -59,6 +59,20 @@ var forbiddenStatementKeywordSuggestions = map[string]string{
 	"chan":        "GALA has no bare `chan` statement; use the go_interop channel helpers to build and operate on channels",
 }
 
+// ForbiddenStatementKeywords returns the set of Go-only statement keywords
+// GALA rejects on its surface (GALA-E0036), keyed by name. It is the exported
+// view of forbiddenStatementKeywordSuggestions so other passes — notably the
+// analyzer's undefined-symbol check — can leave these names to the check that
+// owns them instead of reporting the more generic "undefined", without
+// re-declaring a list that could drift out of sync.
+func ForbiddenStatementKeywords() map[string]bool {
+	out := make(map[string]bool, len(forbiddenStatementKeywordSuggestions))
+	for name := range forbiddenStatementKeywordSuggestions {
+		out[name] = true
+	}
+	return out
+}
+
 // checkForbiddenStatementKeyword rejects a bare Go-only statement keyword
 // (`defer`, `go`, `goto`, `fallthrough`, `select`, `chan`) that the parser
 // accepted as a lone identifier expression-statement. Such statements only

--- a/internal/transpiler/transformer/tuple_field_unwrap_repro_test.go
+++ b/internal/transpiler/transformer/tuple_field_unwrap_repro_test.go
@@ -182,27 +182,11 @@ func main() {
 			},
 		},
 		{
-			name: "tuple return type with val and complex type - no import",
-			input: `package main
-
-func parse(url string) Tuple[string, HashMap[string, string]] {
-    val path = "/test"
-    val params = EmptyHashMap[string, string]()
-    return (path, params)
-}
-
-func main() {
-    val result = parse("/test")
-}
-`,
-			check: func(t *testing.T, got string) {
-				fmt.Println("=== tuple return type with val and complex type - no import ===")
-				fmt.Println(got)
-				// Even without import, the return type context should prevent widening to any
-				assert.False(t, strings.Contains(got, "Tuple[string, any]"), "should not widen to Tuple[string, any] when return type is declared, got:\n%s", got)
-			},
-		},
-		{
+			// This case previously had an import-less twin asserting the same
+			// non-widening. Using `EmptyHashMap` without importing
+			// collection_immutable is now a hard GALA-E0023, so the twin was
+			// removed; the analyzer's undefined-symbol tests cover that
+			// rejection, and this case keeps guarding the inference itself.
 			name: "tuple return type with val and complex type - with import",
 			input: `package main
 
@@ -226,21 +210,9 @@ func main() {
 			},
 		},
 		{
-			name: "tuple with HashMap val element - no import",
-			input: `package main
-
-func main() {
-    val params = EmptyHashMap[string, string]()
-    val pair = ("/test", params)
-}
-`,
-			check: func(t *testing.T, got string) {
-				fmt.Println("=== tuple with HashMap val element - no import ===")
-				fmt.Println(got)
-				// Without proper import, HashMap type can't be resolved - this is expected to widen
-			},
-		},
-		{
+			// The import-less twin of this case only documented that an
+			// unresolvable HashMap widened to `any`. That shape is now
+			// rejected outright (GALA-E0023), so it was removed.
 			name: "tuple with HashMap val element - dot import",
 			input: `package main
 

--- a/internal/transpiler/transformer/type_inference_regression_test.go
+++ b/internal/transpiler/transformer/type_inference_regression_test.go
@@ -62,6 +62,7 @@ func MakeTransformer() Transformer = (x) => {
 			name: "void block lambda generates func() not func() any",
 			input: `package main
 
+import . "martianoff/gala/collection_immutable"
 import . "martianoff/gala/std"
 
 func test() {
@@ -134,6 +135,7 @@ func process[T any](items Array[State[T]]) Array[State[T]] {
 			name: "block lambda unifies return types from multiple paths",
 			input: `package main
 
+import . "martianoff/gala/collection_immutable"
 import . "martianoff/gala/std"
 
 func test() {


### PR DESCRIPTION
## Summary

GALA never checked whether a name resolves at all. Two consequences:

```gala
func BuildLabels(n int) Array[string] {
    return ArrayTabulate(n, (i) => s"item-$i")
}
```

with **no import** transpiled clean, exit 0, emitting `func(i any) string` — violating CLAUDE.md rule 3 unconditionally. And `Println(x + 1)` with no `x` in scope transpiled clean, deferring `undefined: x` to the Go compiler against generated Go.

GALA-E0025 exists to catch the first, but it can only report a `NamedType` whose package the file didn't import. A name resolving to **nothing** produces no such metadata, so the single-file case — the easiest one to write — was structurally unguarded.

## Changes

A scope-based **existence check** in the analyzer's finalize phase, walking the ANTLR tree with its own scope chain so diagnostics carry real `.gala` positions. Emits **GALA-E0023**; E0025's contract is untouched (regression test added).

Both repros now exit non-zero with framed, `.gala`-positioned diagnostics. Repro A emits **no `.go` at all**, so no `any` can escape, and its hint names paste-ready import paths resolved from the real resolver.

## Scope — please read before assuming this closes the `any` erasure

It closes it for **value position only**. An adversarial pass constructed three escapes that still reach codegen and emit `any`, all verified against a branch-built CLI:

1. **Interpolated-string body** — `s"${ArrayTabulate(3, (i) => s"item$i")}"` with no import still exits 0 and emits `func(i any) string`. Interpolation bodies are a single lexer token, never in the tree.
2. **Type position** — `func total(xs Array[int]) int = …` with no import still exits 0. Type positions are skipped wholesale because analyzer type resolution is too lossy to flag safely.
3. **A healthy Go dot-import disables the check for the whole file** — `import . "math"` makes the file stand down entirely, so repro A verbatim transpiles clean again.

None of these produces a *successful* build — Go rejects all three — but that was equally true of the original repro. All three are now documented in the source header and in `GALA-E0023.md` rather than left as an implied guarantee.

## Deliberately not covered

Type compatibility (existence only); import discipline (that's E0025's job — one concern, one code); selector tails; `match`/`case` pattern identifiers (separating captures from constructors needs the scrutinee's type); the LSP (a hard error there drops the whole RichAST and kills completion/hover/goto).

## Verification

- `bazel build //...` clean; `bazel test //...` 384/385 with only the known Windows symlink red. `std` and every example green.
- **No false positive could be constructed.** The one candidate — a package-level `val` visible only via a sibling's import — fires, and was proven a *true* positive by rebuilding with the check disabled: the program fails `go build` with `undefined: LibGreeting` in both files. It never worked.
- `examples/multifile_lib_regress/symbol_scope.gala` guards the batch path.
- Blast radius is gated by `analyzeDepth == 1`, so dependency packages are never checked during someone else's build.

## Known follow-ups (filed, not fixed)

- ~300 lines here duplicate `internal/transpiler/concurrency/capture.go`, which performs the same scope-chain walk and is *strictly more capable* in two places this branch lists as out of scope — it re-parses interpolation bodies and distinguishes pattern bindings from constructor references. Unifying is a 1–2 day, medium-high-risk refactor needing ~5 policy flags.
- `parseLocalGoDeclNames` re-parses `.go` files `AnalyzeGoFiles` already caches; three separate `AllImportDeclaration()` re-walks; `isQualifier` in `walkPostfixExpr` is provably dead.
- Cross-package dot-imported package-level vals don't reach generated Go at all — pre-existing, unrelated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)