### PR TITLE
docs(errors): add the 9 missing error-code pages and correct the internal-only codes

### DIFF
--- a/docs/errors/GALA-E0009.md
+++ b/docs/errors/GALA-E0009.md
@@ -1,28 +1,42 @@
 # GALA-E0009 — Unknown pattern type
 
-**When it fires.** The transformer reached a pattern AST node it does not
-recognize. This is defensive — the ANTLR grammar is supposed to prevent any
-pattern shape that the transformer cannot handle from being parsed in the
-first place.
+> **This code indicates a transpiler defect, not a user error.** No valid GALA
+> source can force it. If you see it, the correct response is to **file a bug
+> report with the source that triggered it** — not to change your GALA code.
 
-**Minimal repro.** None — reaching this error means either
+**When it fires.** The transformer reached a pattern AST node it does not
+recognize. It is the `default:` arm of the type switch over pattern contexts in
+`transformPatternWithType`
+(`internal/transpiler/transformer/patterns.go`) — every pattern shape the
+grammar can produce is supposed to have a case above it.
+
+Reaching it means one of:
 
 1. a new grammar rule for patterns was added but no transformer case was
    written for it, or
-2. the grammar accepts a shape that the transformer has never supported.
+2. the grammar accepts a shape the transformer has never supported.
 
-**Error output.**
+**Minimal repro.** None. This is an internal-consistency check, unreachable
+from valid user source; there is no user-triggerable repro to show.
+
+**Error output.** The shape the code produces, from the emit site (`%T` is the
+Go type of the unhandled context):
 
 ```
 [SemanticError GALA-E0009] main.gala:L:C unrecognized pattern syntax (internal type *grammar.FooPatternContext) (hint: this usually means a new grammar rule is missing transformer support; please report at github.com/martianoff/gala/issues)
 ```
 
-**Fix.** Report the issue with the offending source file and the exact
-context type shown in the error. The transpiler needs a new case in
-`transformPatternWithType` (`internal/transpiler/transformer/patterns.go`).
+**What to do.** File an issue at
+[github.com/martianoff/gala/issues](https://github.com/martianoff/gala/issues)
+with the source file and the exact `internal type` shown in the message — that
+type name identifies the missing case directly. Do not try to work around the
+error by rewriting the pattern; the rewrite would only hide a real gap in the
+transpiler.
+
+**Fix (transpiler).** Add the missing case to `transformPatternWithType`.
 
 **Rationale.** Before this code existed the site used a raw
-`fmt.Errorf("unknown pattern type: %T", patCtx)` which produced an
-untracked error without a source span. Users who hit it had no way to
-distinguish "transpiler bug" from "my syntax is wrong". The coded error
-makes the bug class explicit so issues can be filed with a queryable tag.
+`fmt.Errorf("unknown pattern type: %T", patCtx)`, which produced an untracked
+error with no source span. Users who hit it had no way to tell "transpiler bug"
+from "my syntax is wrong". The coded error makes the bug class explicit so
+reports arrive with a queryable tag.

--- a/docs/errors/GALA-E0017.md
+++ b/docs/errors/GALA-E0017.md
@@ -1,31 +1,47 @@
 # GALA-E0017 — Internal transpiler panic
 
-**When it fires.** A `panic` inside the transformer was caught by the
-top-level recover and surfaced as a coded error. This is a transpiler
-bug — well-formed GALA source should never trigger this code. If you
-see it, please file an issue with the offending source snippet so the
-underlying invariant can be tightened or replaced with a coded error
-that names the actual problem.
+> **This code indicates a transpiler defect, not a user error.** Well-formed
+> GALA source should never produce it. If you see it, the correct response is to
+> **file a bug report with the source that triggered it** — not to change your
+> GALA code.
 
-**Error output.**
+**When it fires.** A `panic` raised anywhere inside the transformer was caught
+by the top-level `recover` in `Transform`
+(`internal/transpiler/transformer/transformer.go`) and converted into a coded
+error. Any panic that is not already a `*galaerr.SemanticError` lands here, with
+the recovered value preserved in the message.
+
+**Minimal repro.** None. A panic is by definition an unintended path, so there
+is no user-triggerable repro to show; a specific input that reaches it is a bug
+to be fixed, not a documented trigger.
+
+**Error output.** The shape the code produces, from the emit site:
 
 ```
-[SemanticError GALA-E0017] line 0:0 internal transpiler panic: <recovered message> (hint: please file an issue at https://github.com/martianoff/gala/issues with the source that triggered this panic)
+[SemanticError GALA-E0017] line L:C internal transpiler panic: <recovered value> (hint: please file an issue at https://github.com/martianoff/gala/issues with the source that triggered this panic)
 ```
 
-**Fix (user).** None directly. As a workaround, simplify the surrounding
-expression and re-run; if the simplified form transpiles cleanly, the
-shape of the original expression is the trigger.
+The position is the last source location the transformer recorded before the
+panic, so it is a hint about where the failure happened, not a precise span.
 
-**Fix (transpiler).** Replace the underlying `panic(...)` site with
-either `galaerr.NewCodedSemanticError(...)` (when the cause is
-user-facing GALA) or a documented invariant comment + a panic that
-identifies the invariant (when the caller really should never reach
-that branch). The audit recorded in `panic_audit_test.go` enumerates
-the production-code panic sites that still need this treatment.
+**What to do.** File an issue at
+[github.com/martianoff/gala/issues](https://github.com/martianoff/gala/issues)
+with the source that triggered the panic and the full message. The recovered
+value in the message is the most useful part of the report.
 
-**Rationale.** Before this code existed, an unguarded panic surfaced as
-a raw Go stack trace from the CLI — surprising and unactionable for the
-user, and easy for transpiler maintainers to overlook because no error
-code referenced it. Wrapping at the recover seam gives both groups a
-single search target.
+Reducing the input to the smallest snippet that still panics is genuinely
+helpful for the report — but treat that as producing a bug report, not as fixing
+your code. Rewriting to avoid the panic leaves the defect in place for the next
+person.
+
+**Fix (transpiler).** Replace the underlying `panic(...)` site with either
+`galaerr.NewCodedSemanticError(...)` — when the cause is something user-facing
+that deserves its own code — or a documented invariant comment plus a panic that
+names the invariant, when the branch really is unreachable. The audit in
+`panic_audit_test.go` enumerates the production panic sites still awaiting this
+treatment.
+
+**Rationale.** Before this code existed, an unguarded panic surfaced as a raw Go
+stack trace from the CLI: unactionable for users and easy for maintainers to
+overlook, because no error code referenced it. Wrapping at the recover seam
+gives both groups a single search target.

--- a/docs/errors/GALA-E0017.md
+++ b/docs/errors/GALA-E0017.md
@@ -29,10 +29,8 @@ panic, so it is a hint about where the failure happened, not a precise span.
 with the source that triggered the panic and the full message. The recovered
 value in the message is the most useful part of the report.
 
-Reducing the input to the smallest snippet that still panics is genuinely
-helpful for the report — but treat that as producing a bug report, not as fixing
-your code. Rewriting to avoid the panic leaves the defect in place for the next
-person.
+Reducing the input to the smallest snippet that still panics helps the report —
+but that is a bug report, not a fix.
 
 **Fix (transpiler).** Replace the underlying `panic(...)` site with either
 `galaerr.NewCodedSemanticError(...)` — when the cause is something user-facing

--- a/docs/errors/GALA-E0020.md
+++ b/docs/errors/GALA-E0020.md
@@ -1,29 +1,92 @@
 # GALA-E0020 — Package not found
 
-**When it fires.** The analyzer was asked to resolve a GALA package by
-its import path or relative path, but no matching directory exists on
-any of the configured search paths. Triggered both by explicit
-`import` statements and by directory-walk passes that follow them.
+**When it fires.** The analyzer was asked to resolve a GALA package by its
+import path, but no matching directory exists on any configured search path.
+Triggered both by explicit `import` statements and by the directory-walk passes
+that follow them.
 
-**Error output.**
+**E0020 has no framed `error[GALA-E0020]:` form of its own.** It is raised
+without a source position (line 0, column 0) deep in the analyzer, formatted
+into a warning string, and collected. Transformation then fails with a separate,
+**uncoded** unresolved-imports error, framed at the file's `package` clause,
+with the E0020 text nested inside it in the terse single-line form. So the code
+you grep for appears in the body of a larger diagnostic rather than in its
+header.
+
+**Minimal repro.**
+
+```gala
+package main
+
+import "example.com/demo/doesnotexist"
+
+func main() {
+    Println("hi")
+}
+```
+
+**Error output.** The full, real shape — two stderr warnings followed by the
+framed wrapper:
 
 ```
-[SemanticError GALA-E0020] line 0:0 package not found: <path> (hint: check that the directory exists on a search path; for cross-module imports verify gala.mod has a `require` (and `replace` if local) for the module)
+Warning: failed to transpile dependency example.com/demo/doesnotexist: package not found: example.com/demo/doesnotexist
+Warning: failed to analyze package example.com/demo/doesnotexist (imported at line 3): [SemanticError GALA-E0020] package not found: example.com/demo/doesnotexist (hint: check that the directory exists on a search path; for cross-module imports verify gala.mod has a `require` (and `replace` if local) for the module)
+error: cannot transpile: 1 imported package(s) could not be resolved:
+  - failed to analyze package example.com/demo/doesnotexist (imported at line 3): [SemanticError GALA-E0020] package not found: example.com/demo/doesnotexist (hint: check that the directory exists on a search path; for cross-module imports verify gala.mod has a `require` (and `replace` if local) for the module)
+Hint: ensure all GALA dependencies are available via --search paths or gala.mod
+  --> main.gala:1:1
+  |
+1 | package main
+  | ^^^^^^^
+  |
 ```
+
+Reading it:
+
+- The `Warning:` lines go to **stderr as the analyzer walks imports**. The first
+  reports that the dependency could not be transpiled; the second is the one
+  carrying the GALA-E0020 code, and it names the **line of the offending
+  `import`** — that is the position you actually want.
+- The `error: cannot transpile:` block is the failure that stops the build. It
+  is **uncoded** — there is no `error[GALA-E0020]:` header — and lists one
+  bullet per unresolved import, each repeating the nested E0020 text.
+- The caret frames the `package` clause at line 1, not the import. The wrapper
+  has no better position: it is raised after the whole file has been analyzed,
+  so it points at the compilation unit as a whole.
+
+Analysis continues past the first missing package, so a file with several bad
+imports reports all of them in one run — the count in the header tells you how
+many.
 
 **Fix.** Three common causes:
 
-1. **Typo in the import path** — `import . "github.com/example/foo"` when the directory is `github.com/example/Foo` (case mismatch). GALA preserves case from the filesystem.
-2. **Missing search path** — when running outside Bazel, the standalone CLI needs `--search` to point at the workspace's module root. Bazel rules pass this automatically.
-3. **Cross-module dependency without `replace`** — `gala.mod` has `require github.com/example/foo v0.1.0` but no matching `replace ...` directive points at the local checkout. Add a replace, or run inside a workspace where `go mod download` has fetched the module.
+1. **Typo in the import path** — `import . "github.com/example/foo"` when the
+   directory is `github.com/example/Foo` (case mismatch). GALA preserves case
+   from the filesystem.
+2. **Missing search path** — outside Bazel, the standalone CLI needs `--search`
+   pointing at the workspace's module root. The Bazel rules pass this
+   automatically.
+3. **Cross-module dependency without `replace`** — `gala.mod` has
+   `require github.com/example/foo v0.1.0` but no matching `replace` directive
+   points at the local checkout. Add a `replace`, or run inside a workspace
+   where the module has been fetched.
 
-**Rationale.** Before this code existed, the failure surfaced as a
-generic `package not found: <path>` from the analyzer, with no stable
-identifier for tools or CI to grep. Promoting it to GALA-E0020 lets
-build tooling distinguish "user import is wrong" from other infrastructure
-failures (file-system errors, parser crashes, etc.).
+Use the **line number in the `Warning:` line**, not the caret, to find the
+import to correct.
 
-**Scope.** Only the analyzer's package-resolution failures, not Go-level
-import errors that surface from `go build` after transpilation. Those
-still appear as Go compiler messages (the GALA layer has already
-finished its work).
+**Rationale.** Before this code existed the failure surfaced as a generic
+`package not found: <path>` with no stable identifier for tools or CI to grep.
+The code lets build tooling distinguish "the user's import is wrong" from other
+infrastructure failures.
+
+The terse nested form is deliberate here rather than a rendering gap. E0020 is
+raised with no usable source position — the analyzer knows the import *path*
+that failed, not a span in the file being compiled — so there is nothing to
+frame. The position that matters (the import's line) is recovered by the caller
+and interpolated into the warning text. Wrapping many per-import failures into
+one framed diagnostic keeps a file with five bad imports to a single error
+instead of five disconnected ones.
+
+**Scope.** Only the analyzer's package-resolution failures, not Go-level import
+errors that surface from `go build` after transpilation. Those still appear as
+Go compiler messages, since the GALA layer has already finished its work.

--- a/docs/errors/GALA-E0020.md
+++ b/docs/errors/GALA-E0020.md
@@ -41,24 +41,8 @@ Hint: ensure all GALA dependencies are available via --search paths or gala.mod
   |
 ```
 
-Reading it:
-
-- The `Warning:` lines go to **stderr as the analyzer walks imports**. The first
-  reports that the dependency could not be transpiled; the second is the one
-  carrying the GALA-E0020 code, and it names the **line of the offending
-  `import`** — that is the position you actually want.
-- The `error: cannot transpile:` block is the failure that stops the build. It
-  is **uncoded** — there is no `error[GALA-E0020]:` header — and lists one
-  bullet per unresolved import, each repeating the nested E0020 text.
-- The caret frames the `package` clause at line 1, not the import. The wrapper
-  has no better position: it is raised after the whole file has been analyzed,
-  so it points at the compilation unit as a whole.
-
-Analysis continues past the first missing package, so a file with several bad
-imports reports all of them in one run — the count in the header tells you how
-many.
-
-**Fix.** Three common causes:
+**Fix.** Find the offending import by the **line number in the `Warning:` line**
+— not by the caret, which points at the `package` clause. Three common causes:
 
 1. **Typo in the import path** — `import . "github.com/example/foo"` when the
    directory is `github.com/example/Foo` (case mismatch). GALA preserves case
@@ -71,21 +55,31 @@ many.
    points at the local checkout. Add a `replace`, or run inside a workspace
    where the module has been fetched.
 
-Use the **line number in the `Warning:` line**, not the caret, to find the
-import to correct.
+**Reading the output.**
+
+- The `Warning:` lines go to **stderr as the analyzer walks imports**. The first
+  reports that the dependency could not be transpiled; the second carries the
+  GALA-E0020 code and names the line of the offending `import`.
+- The `error: cannot transpile:` block is the failure that stops the build. It
+  lists one bullet per unresolved import, each repeating the nested E0020 text.
+- The caret frames the `package` clause at line 1. The wrapper has no better
+  position: it is raised after the whole file has been analyzed, so it points at
+  the compilation unit as a whole.
+
+Analysis continues past the first missing package, so a file with several bad
+imports reports all of them in one run — the count in the header tells you how
+many.
 
 **Rationale.** Before this code existed the failure surfaced as a generic
 `package not found: <path>` with no stable identifier for tools or CI to grep.
 The code lets build tooling distinguish "the user's import is wrong" from other
 infrastructure failures.
 
-The terse nested form is deliberate here rather than a rendering gap. E0020 is
-raised with no usable source position — the analyzer knows the import *path*
-that failed, not a span in the file being compiled — so there is nothing to
-frame. The position that matters (the import's line) is recovered by the caller
-and interpolated into the warning text. Wrapping many per-import failures into
-one framed diagnostic keeps a file with five bad imports to a single error
-instead of five disconnected ones.
+The terse nested form is deliberate rather than a rendering gap: E0020 is raised
+with no usable source position — the analyzer knows the import *path* that
+failed, not a span in the file being compiled — so there is nothing to frame.
+Wrapping many per-import failures into one diagnostic also keeps a file with
+five bad imports to a single error instead of five disconnected ones.
 
 **Scope.** Only the analyzer's package-resolution failures, not Go-level import
 errors that surface from `go build` after transpilation. Those still appear as

--- a/docs/errors/GALA-E0021.md
+++ b/docs/errors/GALA-E0021.md
@@ -1,46 +1,100 @@
 # GALA-E0021 — Type mismatch (unification failure)
 
-**When it fires.** Two types that the inference engine required to
-agree could not be unified. Covers every failure of the
-Hindley-Milner unification step, including (but not limited to):
+> **This code is not currently surfaced as a user-facing type check.** It
+> originates in the Hindley-Milner type-inference engine, which the transpiler
+> uses as a type *deriver*, not as a type *checker*. Every caller discards the
+> error. Searching for `GALA-E0021` because of something in your terminal will
+> not find a match — type errors of this class are reported by the **Go
+> compiler**, against the generated Go. See *Where type errors actually come
+> from* below.
 
-- A function argument's type does not match the parameter type.
-- The two arms of an `if` expression produce different types.
-- The condition of an `if` expression is not `bool`.
-- A constructor's positional argument does not match the declared
-  field type.
+**Where it comes from.** Two types that the inference engine required to agree
+could not be unified. The engine
+(`internal/transpiler/infer/infer.go`) raises it from three sites:
 
-The single code lets users grep for one identifier rather than a
-zoo of per-site identifiers; the message describes the specific
-mismatch.
+- general unification failure — `cannot unify <A> and <B>`
+- a non-boolean `if` condition — `if condition must be bool, got <T>`
+- mismatched `if` arms — `if branches must have same type: <A> and <B>`
 
-**Error output (representative).**
+One code covers all three so tools can pin one identifier rather than a zoo of
+per-site ones.
+
+**Why you never see it.** The engine is reachable only through two bridge
+methods, `inferExprType` and `inferIfType`
+(`internal/transpiler/transformer/bridge.go`). Across the transformer there are
+ten call sites of those two methods, and **not one propagates the error**:
+eight discard it explicitly with `_`, and the remaining two bind it only to
+decide whether to fall back to another inference strategy. A unification failure
+therefore degrades the inferred type — it never becomes a diagnostic.
+
+**Where type errors actually come from.** The Go compiler, after transpilation.
+Both classic mismatches transpile with exit 0 and fail at build time:
+
+```gala
+package main
+
+func add(a int, b int) int = a + b
+
+func main() {
+    Println(add(1, "two"))
+}
+```
 
 ```
-[SemanticError GALA-E0021] line 0:0 cannot unify Int and String (hint: the expression's type does not match what the surrounding context expects — annotate the binding or convert the value explicitly)
-
-[SemanticError GALA-E0021] line 0:0 if condition must be bool, got String (hint: the expression's type does not match what the surrounding context expects — annotate the binding or convert the value explicitly)
-
-[SemanticError GALA-E0021] line 0:0 if branches must have same type: Int and String (hint: the expression's type does not match what the surrounding context expects — annotate the binding or convert the value explicitly)
+# gala-build-workspace/gen
+main.gala:6: cannot use "two" (untyped string constant) as int value in argument to add
+go build: exit status 1
 ```
 
-**Fix.** Usually one of three:
+```gala
+package main
 
-1. **Convert one side** — e.g. `Int.toString(n)` to coerce an `Int`
-   to `String`.
-2. **Annotate the variable** — when the inference engine has too
-   little context, an explicit type forces it to commit and the
-   real mismatch surfaces against a fixed reference type.
-3. **Restructure the expression** — if both branches of an `if`
-   honestly produce different types, you usually want a sealed type
-   (`Either[A, B]`, `Option[A]`) instead of mixing the values.
+func main() {
+    val x = if ("nope") 1 else 2
+    Println(x)
+}
+```
 
-**Rationale.** Promoting these errors out of `fmt.Errorf` lets tools
-and CI surface them with a stable identifier. The shared code matches
-how the Go compiler reports its own mismatches under one bucket
-(`cannot use X as Y`) — users learn the code once and recognize it
-across every unification site.
+```
+# gala-build-workspace/gen
+main.gala:5: non-boolean condition in if statement
+go build: exit status 1
+```
 
-**Scope.** Inference failures from `internal/transpiler/infer/`. Type
-errors emitted by the transformer outside the inferer (e.g. specific
-sealed-variant arity checks) still use their own dedicated codes.
+Generated Go carries `//line` directives, so the message is attributed to your
+`.gala` file and line. The **wording**, however, is Go's — it talks about
+untyped constants and Go types, not GALA ones — and any construct that lowers to
+something structurally different in Go (a `match` IIFE, an `Immutable[T]`
+wrapper) will be described in those terms.
+
+**Error output.** The shape the code would produce, from the emit sites:
+
+```
+[SemanticError GALA-E0021] cannot unify Int and String (hint: the expression's type does not match what the surrounding context expects — annotate the binding or convert the value explicitly)
+[SemanticError GALA-E0021] if condition must be bool, got String (hint: ...)
+[SemanticError GALA-E0021] if branches must have same type: Int and String (hint: ...)
+```
+
+These have not been observed from a compiler run — no caller surfaces them.
+
+**Fix.** When the Go compiler reports the mismatch, the remedy is usually one of:
+
+1. **Convert one side** explicitly — GALA has no implicit numeric widening or
+   narrowing.
+2. **Annotate the binding** — an explicit type forces inference to commit, so
+   the mismatch surfaces against a fixed reference type.
+3. **Restructure** — if two `if` or `match` arms honestly produce different
+   types, model that with a sealed type (`Either[A, B]`, `Option[A]`) rather
+   than mixing values.
+
+**Status.** Using Go as the downstream type checker is the current, deliberate
+design: the inference engine derives types for code generation, and Go verifies
+them. This page documents that arrangement rather than a temporary gap. If the
+inferer is ever promoted to a checking role, this code is the identifier those
+diagnostics will carry.
+
+**Scope.** The inference engine only. Type errors the transformer raises
+directly — sealed-variant arity ([GALA-E0004](GALA-E0004.md)), default-parameter
+mismatches ([GALA-E0014](GALA-E0014.md)), untyped parameters
+([GALA-E0033](GALA-E0033.md) / [GALA-E0034](GALA-E0034.md)) — have their own
+codes and *are* surfaced.

--- a/docs/errors/GALA-E0021.md
+++ b/docs/errors/GALA-E0021.md
@@ -5,8 +5,7 @@
 > uses as a type *deriver*, not as a type *checker*. Every caller discards the
 > error. Searching for `GALA-E0021` because of something in your terminal will
 > not find a match — type errors of this class are reported by the **Go
-> compiler**, against the generated Go. See *Where type errors actually come
-> from* below.
+> compiler**, against the generated Go.
 
 **Where it comes from.** Two types that the inference engine required to agree
 could not be unified. The engine
@@ -21,11 +20,13 @@ per-site ones.
 
 **Why you never see it.** The engine is reachable only through two bridge
 methods, `inferExprType` and `inferIfType`
-(`internal/transpiler/transformer/bridge.go`). Across the transformer there are
-ten call sites of those two methods, and **not one propagates the error**:
-eight discard it explicitly with `_`, and the remaining two bind it only to
-decide whether to fall back to another inference strategy. A unification failure
+(`internal/transpiler/transformer/bridge.go`), and **no call site propagates the
+error**. Most discard it explicitly with `_`; the rest bind it only to decide
+whether to fall back to another inference strategy. A unification failure
 therefore degrades the inferred type — it never becomes a diagnostic.
+
+This is the canonical explanation for the inference-engine codes;
+[GALA-E0022](GALA-E0022.md) and [GALA-E0024](GALA-E0024.md) work the same way.
 
 **Where type errors actually come from.** The Go compiler, after transpilation.
 Both classic mismatches transpile with exit 0 and fail at build time:
@@ -41,7 +42,6 @@ func main() {
 ```
 
 ```
-# gala-build-workspace/gen
 main.gala:6: cannot use "two" (untyped string constant) as int value in argument to add
 go build: exit status 1
 ```
@@ -56,10 +56,13 @@ func main() {
 ```
 
 ```
-# gala-build-workspace/gen
 main.gala:5: non-boolean condition in if statement
 go build: exit status 1
 ```
+
+(Both transcripts are lightly trimmed — the real output is prefixed with the
+build workspace's package path, and the exact wording tracks your Go toolchain
+version.)
 
 Generated Go carries `//line` directives, so the message is attributed to your
 `.gala` file and line. The **wording**, however, is Go's — it talks about
@@ -75,8 +78,6 @@ wrapper) will be described in those terms.
 [SemanticError GALA-E0021] if branches must have same type: Int and String (hint: ...)
 ```
 
-These have not been observed from a compiler run — no caller surfaces them.
-
 **Fix.** When the Go compiler reports the mismatch, the remedy is usually one of:
 
 1. **Convert one side** explicitly — GALA has no implicit numeric widening or
@@ -87,11 +88,9 @@ These have not been observed from a compiler run — no caller surfaces them.
    types, model that with a sealed type (`Either[A, B]`, `Option[A]`) rather
    than mixing values.
 
-**Status.** Using Go as the downstream type checker is the current, deliberate
-design: the inference engine derives types for code generation, and Go verifies
-them. This page documents that arrangement rather than a temporary gap. If the
-inferer is ever promoted to a checking role, this code is the identifier those
-diagnostics will carry.
+**Status.** Using Go as the downstream type checker is deliberate, not a
+temporary gap. If the inferer is ever promoted to a checking role, this code is
+the identifier those diagnostics will carry.
 
 **Scope.** The inference engine only. Type errors the transformer raises
 directly — sealed-variant arity ([GALA-E0004](GALA-E0004.md)), default-parameter

--- a/docs/errors/GALA-E0021.md
+++ b/docs/errors/GALA-E0021.md
@@ -2,8 +2,9 @@
 
 > **This code is not currently surfaced as a user-facing type check.** It
 > originates in the Hindley-Milner type-inference engine, which the transpiler
-> uses as a type *deriver*, not as a type *checker*. Every caller discards the
-> error. Searching for `GALA-E0021` because of something in your terminal will
+> uses as a type *deriver*, not as a type *checker*. No call site propagates
+> the error — most discard it explicitly, the rest bind it only to choose a
+> fallback. Searching for `GALA-E0021` because of something in your terminal will
 > not find a match — type errors of this class are reported by the **Go
 > compiler**, against the generated Go.
 

--- a/docs/errors/GALA-E0022.md
+++ b/docs/errors/GALA-E0022.md
@@ -1,39 +1,52 @@
 # GALA-E0022 — Occurs check failure
 
-**When it fires.** During type unification, the inference engine
-attempted to substitute a type variable `T` with a type that
-*contains* `T`. Allowing such a substitution would produce an
-infinite type (e.g. `T = List[T]` with no way to bottom out), so
-Hindley-Milner rejects the unification.
+> **This code is not currently surfaced as a user-facing type check.** Like
+> [GALA-E0021](GALA-E0021.md), it originates in the Hindley-Milner
+> type-inference engine, which the transpiler uses as a type *deriver*, not a
+> type *checker*. Every caller discards the error, so searching for
+> `GALA-E0022` because of something in your terminal will not find a match.
 
-In practice this surfaces from:
+**Where it comes from.** During unification the engine attempted to substitute a
+type variable `T` with a type that *contains* `T`. Allowing it would produce an
+infinite type (`T = List[T]` with no way to bottom out), so Hindley-Milner
+rejects the substitution. The check lives in `bind`
+(`internal/transpiler/infer/infer.go`).
 
-- A recursive value that has no fixed point (the function calls
-  itself with a value of the wrong shape, and the inferer cannot
-  pin a finite type).
-- A pattern that destructures the *whole* value into one of its
-  fields (e.g. matching a struct field against the entire struct).
+**Why you never see it.** The engine is reachable only through `inferExprType`
+and `inferIfType` (`internal/transpiler/transformer/bridge.go`). All ten call
+sites of those two methods across the transformer discard the error — eight
+with an explicit `_`, two by inspecting it only to choose a fallback inference
+strategy. An occurs-check failure degrades the inferred type; it never becomes a
+diagnostic.
 
-**Error output.**
+Type errors of this class — like every other type error in GALA today — are
+reported by the **Go compiler** against the generated Go. In practice an
+infinite type has no Go equivalent to emit, so what surfaces is whatever the
+degraded inference produced, which is usually a plain Go type error at the
+recursion site.
+
+**Minimal repro.** None. No caller surfaces the error, so there is nothing to
+show from a compiler run.
+
+**Error output.** The shape the code would produce, from the emit site:
 
 ```
-[SemanticError GALA-E0022] line 0:0 occurs check failed: T in List[T] (hint: the inferred type would have to refer to itself; add an explicit type annotation or restructure the recursion)
+[SemanticError GALA-E0022] occurs check failed: T in List[T] (hint: the inferred type would have to refer to itself; add an explicit type annotation or restructure the recursion)
 ```
 
-**Fix.** Add an explicit type annotation at the recursion point so
-inference does not have to discover the fixpoint, or restructure the
-value so the recursion has a base case the inferer can see:
+This has not been observed from a compiler run.
 
-```gala
-// Force the type at the recursion site:
-func length[T](xs List[T]) Int = ...
-```
+**Fix.** When a recursive definition fails to build, add an explicit type
+annotation at the recursion point so inference does not have to discover the
+fixpoint, or restructure the value so the recursion has a base case. Annotating
+the function signature is usually enough — a declared parameter and return type
+give every recursive call a fixed reference type.
 
-**Rationale.** Occurs check failures are extremely rare in
-straight-line GALA code; when they do fire, the inferer's diagnostic
-is opaque without knowing what "occurs check" means. The dedicated
-code lets the docs page link out to a primer instead of cramming
-type-theory into the error message.
+**Status.** Using Go as the downstream type checker is the current, deliberate
+design. This page documents that arrangement rather than a temporary gap. If the
+inferer is ever promoted to a checking role, this code is the identifier such
+diagnostics will carry.
 
 **Scope.** Hindley-Milner unification only. The transformer's own
-recursive-type guards (e.g. `Immutable[Immutable[T]]`) emit `GALA-E0001`.
+recursive-type guard for `Immutable[Immutable[T]]` is
+[GALA-E0001](GALA-E0001.md), and that one *is* surfaced.

--- a/docs/errors/GALA-E0022.md
+++ b/docs/errors/GALA-E0022.md
@@ -3,7 +3,7 @@
 > **This code is not currently surfaced as a user-facing type check.** Like
 > [GALA-E0021](GALA-E0021.md), it originates in the Hindley-Milner
 > type-inference engine, which the transpiler uses as a type *deriver*, not a
-> type *checker*. Every caller discards the error, so searching for
+> type *checker*. No call site propagates the error, so searching for
 > `GALA-E0022` because of something in your terminal will not find a match. If
 > the inferer is ever promoted to a checking role, this code is the identifier
 > such diagnostics will carry.

--- a/docs/errors/GALA-E0022.md
+++ b/docs/errors/GALA-E0022.md
@@ -4,7 +4,9 @@
 > [GALA-E0021](GALA-E0021.md), it originates in the Hindley-Milner
 > type-inference engine, which the transpiler uses as a type *deriver*, not a
 > type *checker*. Every caller discards the error, so searching for
-> `GALA-E0022` because of something in your terminal will not find a match.
+> `GALA-E0022` because of something in your terminal will not find a match. If
+> the inferer is ever promoted to a checking role, this code is the identifier
+> such diagnostics will carry.
 
 **Where it comes from.** During unification the engine attempted to substitute a
 type variable `T` with a type that *contains* `T`. Allowing it would produce an
@@ -12,12 +14,9 @@ infinite type (`T = List[T]` with no way to bottom out), so Hindley-Milner
 rejects the substitution. The check lives in `bind`
 (`internal/transpiler/infer/infer.go`).
 
-**Why you never see it.** The engine is reachable only through `inferExprType`
-and `inferIfType` (`internal/transpiler/transformer/bridge.go`). All ten call
-sites of those two methods across the transformer discard the error — eight
-with an explicit `_`, two by inspecting it only to choose a fallback inference
-strategy. An occurs-check failure degrades the inferred type; it never becomes a
-diagnostic.
+**Why you never see it.** No caller propagates the inference engine's errors —
+see [GALA-E0021](GALA-E0021.md) for the full explanation. An occurs-check
+failure degrades the inferred type; it never becomes a diagnostic.
 
 Type errors of this class — like every other type error in GALA today — are
 reported by the **Go compiler** against the generated Go. In practice an
@@ -25,8 +24,7 @@ infinite type has no Go equivalent to emit, so what surfaces is whatever the
 degraded inference produced, which is usually a plain Go type error at the
 recursion site.
 
-**Minimal repro.** None. No caller surfaces the error, so there is nothing to
-show from a compiler run.
+**Minimal repro.** None — no caller surfaces the error.
 
 **Error output.** The shape the code would produce, from the emit site:
 
@@ -34,18 +32,11 @@ show from a compiler run.
 [SemanticError GALA-E0022] occurs check failed: T in List[T] (hint: the inferred type would have to refer to itself; add an explicit type annotation or restructure the recursion)
 ```
 
-This has not been observed from a compiler run.
-
 **Fix.** When a recursive definition fails to build, add an explicit type
 annotation at the recursion point so inference does not have to discover the
 fixpoint, or restructure the value so the recursion has a base case. Annotating
 the function signature is usually enough — a declared parameter and return type
 give every recursive call a fixed reference type.
-
-**Status.** Using Go as the downstream type checker is the current, deliberate
-design. This page documents that arrangement rather than a temporary gap. If the
-inferer is ever promoted to a checking role, this code is the identifier such
-diagnostics will carry.
 
 **Scope.** Hindley-Milner unification only. The transformer's own
 recursive-type guard for `Immutable[Immutable[T]]` is

--- a/docs/errors/GALA-E0024.md
+++ b/docs/errors/GALA-E0024.md
@@ -2,7 +2,7 @@
 
 > **This code indicates a transpiler defect, not a user error** — and it is
 > **not currently surfaced** either. It originates in the Hindley-Milner
-> type-inference engine, whose errors every caller discards, so it cannot reach
+> type-inference engine, whose errors no call site propagates, so it cannot reach
 > your terminal today. If a future change does surface it, the correct response
 > is to **file a bug report with the source that triggered it**, not to change
 > your GALA code.

--- a/docs/errors/GALA-E0024.md
+++ b/docs/errors/GALA-E0024.md
@@ -13,15 +13,12 @@ inference-layer counterpart of [GALA-E0017](GALA-E0017.md) (internal transformer
 panic). The emit site is the tail of `infer`
 (`internal/transpiler/infer/infer.go`).
 
-**Why you never see it.** The engine is reachable only through `inferExprType`
-and `inferIfType` (`internal/transpiler/transformer/bridge.go`). All ten call
-sites of those two methods across the transformer discard the error — eight with
-an explicit `_`, two by inspecting it only to choose a fallback inference
-strategy. The inferer is used as a type *deriver*, never as a *checker*, so an
-unhandled node degrades the inferred type instead of failing the build. The same
-applies to [GALA-E0021](GALA-E0021.md) and [GALA-E0022](GALA-E0022.md); type
-errors of that class are reported by the **Go compiler** against the generated
-Go.
+**Why you never see it.** No caller propagates the inference engine's errors —
+see [GALA-E0021](GALA-E0021.md) for the full explanation. The inferer is used as
+a type *deriver*, never as a *checker*, so an unhandled node degrades the
+inferred type instead of failing the build. The same applies to
+[GALA-E0021](GALA-E0021.md) and [GALA-E0022](GALA-E0022.md); type errors of that
+class are reported by the **Go compiler** against the generated Go.
 
 **Minimal repro.** None. This is an internal-consistency check, unreachable from
 valid user source and currently unreachable from any source at all.

--- a/docs/errors/GALA-E0024.md
+++ b/docs/errors/GALA-E0024.md
@@ -1,26 +1,48 @@
 # GALA-E0024 — Internal inference failure
 
-**When it fires.** The inference engine was asked to infer the type
-of an expression node it does not know how to handle. This is a
-transpiler bug — well-formed GALA source should always reach a
-recognized branch. If you see this code, please file an issue with
-the offending snippet so the missing case can be added.
+> **This code indicates a transpiler defect, not a user error** — and it is
+> **not currently surfaced** either. It originates in the Hindley-Milner
+> type-inference engine, whose errors every caller discards, so it cannot reach
+> your terminal today. If a future change does surface it, the correct response
+> is to **file a bug report with the source that triggered it**, not to change
+> your GALA code.
 
-**Error output.**
+**Where it comes from.** The inference engine reached the fall-through at the
+end of its main `switch` — an expression node it has no case for. It is the
+inference-layer counterpart of [GALA-E0017](GALA-E0017.md) (internal transformer
+panic). The emit site is the tail of `infer`
+(`internal/transpiler/infer/infer.go`).
+
+**Why you never see it.** The engine is reachable only through `inferExprType`
+and `inferIfType` (`internal/transpiler/transformer/bridge.go`). All ten call
+sites of those two methods across the transformer discard the error — eight with
+an explicit `_`, two by inspecting it only to choose a fallback inference
+strategy. The inferer is used as a type *deriver*, never as a *checker*, so an
+unhandled node degrades the inferred type instead of failing the build. The same
+applies to [GALA-E0021](GALA-E0021.md) and [GALA-E0022](GALA-E0022.md); type
+errors of that class are reported by the **Go compiler** against the generated
+Go.
+
+**Minimal repro.** None. This is an internal-consistency check, unreachable from
+valid user source and currently unreachable from any source at all.
+
+**Error output.** The shape the code produces, from the emit site (`%T` is the
+Go type of the unhandled node):
 
 ```
-[SemanticError GALA-E0024] line 0:0 unknown expression type: *infer.SomeNewNode (hint: please file an issue at https://github.com/martianoff/gala/issues with the source that triggered this failure)
+[SemanticError GALA-E0024] unknown expression type: *infer.SomeNewNode (hint: please file an issue at https://github.com/martianoff/gala/issues with the source that triggered this failure)
 ```
 
-**Fix (user).** None directly. As a workaround, simplify the
-surrounding expression and re-run; if a simpler form transpiles
-cleanly, the shape of the original is the trigger.
+This has not been observed from a compiler run.
 
-**Fix (transpiler).** Add the missing case to the inferer's main
-`switch` and emit a coded diagnostic with a real source span if the
-new shape can fail.
+**What to do.** If you ever see it, file an issue at
+[github.com/martianoff/gala/issues](https://github.com/martianoff/gala/issues)
+with the source and the exact node type from the message — that type name
+identifies the missing case directly. Do not rewrite your GALA to route around
+it; the rewrite would only hide a real gap.
 
-**Rationale.** Mirrors `GALA-E0017` (internal transformer panic) but
-for the inference layer. Wrapping these failures with a code gives
-maintainers a stable search target and end users a single hint
+**Fix (transpiler).** Add the missing case to the inferer's main `switch`.
+
+**Rationale.** Wrapping the fall-through with a code gives maintainers a stable
+search target and, should it ever become user-visible, gives users one hint
 about how to file the bug.

--- a/docs/errors/GALA-E0026.md
+++ b/docs/errors/GALA-E0026.md
@@ -1,5 +1,11 @@
 # GALA-E0026 — Ambiguous sealed-variant reference
 
+> **No valid source reaches this code today.** Its precondition is a strict
+> subset of [GALA-E0032](GALA-E0032.md)'s, and E0032 is checked earlier — so
+> every construction attempted reports E0032 instead. It is retained as a
+> backstop. If you are here from a real error message, you want
+> [GALA-E0032](GALA-E0032.md).
+
 **When it fires.** An *unqualified* sealed-variant constructor name is used with
 **named arguments** (e.g. `Box(W = 1)`), and that case name is declared by a
 sealed type in **two or more dot-imported packages**. The transpiler cannot pick
@@ -18,15 +24,12 @@ The check lives in the variant-resolution helpers
   `shapes.Box(...)`, resolution stops after the scoped pass — the ambiguity
   scan is skipped entirely.
 
-**Minimal repro.** None that reaches this code today.
-
-The precondition for GALA-E0026 — two dot-imported packages that each declare a
-sealed case of the same name — is a strict subset of the precondition for
-[GALA-E0032](GALA-E0032.md) (two dot-imported packages exporting the same
-identifier). Every sealed case registers a companion type under its own name, so
-the dot-import collision check sees the clash first. `ValidateDotImports` runs
-early in `Transform`, well before any expression is transformed, so it always
-reports first:
+**Minimal repro.** None. The precondition for GALA-E0026 — two dot-imported
+packages that each declare a sealed case of the same name — is a strict subset
+of the precondition for [GALA-E0032](GALA-E0032.md) (two dot-imported packages
+exporting the same identifier). Every sealed case registers a companion type
+under its own name, so the dot-import collision check sees the clash first, and
+it runs before any expression is transformed:
 
 ```gala
 package main
@@ -42,38 +45,24 @@ func main() {
 }
 ```
 
-Compiling that program reports GALA-E0032, not GALA-E0026:
-
-```
-error[GALA-E0032]: dot-import symbol collision(s) detected:
-  - symbol "Box" is exported by multiple dot-imported packages: shapes, widgets
-Use a qualified or aliased import for one of the packages to resolve the conflict.
-(Some stdlib packages intentionally re-export names from another package as a convenience facade — e.g. `concurrent` re-exports `go_interop`'s execution-context helpers — so dot-importing both is never meaningful. Pick the facade you want.)
-  --> main.gala:3:1
-  |
-3 | import (
-  | ^^^^^^ qualify or alias one of the dot-imports to disambiguate
-  |
-  = hint: qualify or alias one of the dot-imports to disambiguate
-```
+Compiling that program reports `error[GALA-E0032]` naming `Box` and both
+packages — see [GALA-E0032](GALA-E0032.md) for the exact output.
 
 Narrowing the setup does not help either. With a *single* dot import, the
 ambiguity scan requires at least two dot-imported packages to contribute a
 match, and the package-scoped first pass resolves the name before the scan runs.
 
-So GALA-E0026 is currently a **defensive check that no valid user source can
-reach**. It is retained because the two guards in front of it are independent of
-each other: if the dot-import collision check were ever narrowed (for example to
-allow deliberate re-export facades), this error would become the backstop that
-keeps variant resolution from silently picking by import order.
+The code is retained because the two guards in front of it are independent: if
+the dot-import collision check were ever narrowed (for example to allow
+deliberate re-export facades), this error would become the backstop that keeps
+variant resolution from silently picking by import order.
 
-**Error output.** The message the code would produce, taken from the emit site:
+**Error output.** The message the code would produce, taken from the emit site
+(not observed from a compiler run):
 
 ```
 [SemanticError GALA-E0026] file.gala:L:C ambiguous sealed-variant reference: case "Box" is declared in multiple dot-imported packages (shapes, widgets) (hint: qualify the call site with the package name, e.g. `shapes.Box(...)`)
 ```
-
-This form has not been observed from a compiler run — see *Minimal repro* above.
 
 **Fix.** Whichever of the two codes you actually see, the remedy is the same:
 stop dot-importing both packages, or qualify the reference.

--- a/docs/errors/GALA-E0026.md
+++ b/docs/errors/GALA-E0026.md
@@ -1,0 +1,106 @@
+# GALA-E0026 — Ambiguous sealed-variant reference
+
+**When it fires.** An *unqualified* sealed-variant constructor name is used with
+**named arguments** (e.g. `Box(W = 1)`), and that case name is declared by a
+sealed type in **two or more dot-imported packages**. The transpiler cannot pick
+one without silently shadowing the others, so it refuses and asks for a
+qualifier.
+
+The check lives in the variant-resolution helpers
+(`findSealedVariant` / `findSealedVariantFields` in
+`internal/transpiler/transformer/calls.go`). Two guards run before it:
+
+- **Local declarations win.** The first resolution pass is scoped to the
+  explicitly named package, or to the current package when there is no
+  qualifier. A same-named variant in your own package always shadows every
+  dot-import, and never reaches the ambiguity check.
+- **An explicit qualifier is authoritative.** When the call site writes
+  `shapes.Box(...)`, resolution stops after the scoped pass — the ambiguity
+  scan is skipped entirely.
+
+**Minimal repro.** None that reaches this code today.
+
+The precondition for GALA-E0026 — two dot-imported packages that each declare a
+sealed case of the same name — is a strict subset of the precondition for
+[GALA-E0032](GALA-E0032.md) (two dot-imported packages exporting the same
+identifier). Every sealed case registers a companion type under its own name, so
+the dot-import collision check sees the clash first. `ValidateDotImports` runs
+early in `Transform`, well before any expression is transformed, so it always
+reports first:
+
+```gala
+package main
+
+import (
+    . "example.com/demo/shapes"   // sealed type Shape { case Box(W int) ... }
+    . "example.com/demo/widgets"  // sealed type Widget { case Box(H int) ... }
+)
+
+func main() {
+    val b = Box(W = 1)
+    Println(b)
+}
+```
+
+Compiling that program reports GALA-E0032, not GALA-E0026:
+
+```
+error[GALA-E0032]: dot-import symbol collision(s) detected:
+  - symbol "Box" is exported by multiple dot-imported packages: shapes, widgets
+Use a qualified or aliased import for one of the packages to resolve the conflict.
+(Some stdlib packages intentionally re-export names from another package as a convenience facade — e.g. `concurrent` re-exports `go_interop`'s execution-context helpers — so dot-importing both is never meaningful. Pick the facade you want.)
+  --> main.gala:3:1
+  |
+3 | import (
+  | ^^^^^^ qualify or alias one of the dot-imports to disambiguate
+  |
+  = hint: qualify or alias one of the dot-imports to disambiguate
+```
+
+Narrowing the setup does not help either. With a *single* dot import, the
+ambiguity scan requires at least two dot-imported packages to contribute a
+match, and the package-scoped first pass resolves the name before the scan runs.
+
+So GALA-E0026 is currently a **defensive check that no valid user source can
+reach**. It is retained because the two guards in front of it are independent of
+each other: if the dot-import collision check were ever narrowed (for example to
+allow deliberate re-export facades), this error would become the backstop that
+keeps variant resolution from silently picking by import order.
+
+**Error output.** The message the code would produce, taken from the emit site:
+
+```
+[SemanticError GALA-E0026] file.gala:L:C ambiguous sealed-variant reference: case "Box" is declared in multiple dot-imported packages (shapes, widgets) (hint: qualify the call site with the package name, e.g. `shapes.Box(...)`)
+```
+
+This form has not been observed from a compiler run — see *Minimal repro* above.
+
+**Fix.** Whichever of the two codes you actually see, the remedy is the same:
+stop dot-importing both packages, or qualify the reference.
+
+```gala
+package main
+
+import (
+    . "example.com/demo/shapes"
+    "example.com/demo/widgets"
+)
+
+func main() {
+    val a = Box(W = 1)              // resolves to shapes.Box
+    val b = widgets.Box(H = 2)      // explicitly qualified
+    Println(s"$a $b")
+}
+```
+
+**Rationale.** Before this code existed, variant lookup walked the dot-import
+list and returned the first match it found. Because the walk crossed a Go map
+(`typeMetas`), the "first" match was not stable — the same source could resolve
+to a different variant between builds, producing silently divergent output.
+Collecting every match and rejecting more than one makes the failure
+deterministic and names both candidate packages.
+
+**Scope.** Only unqualified, named-argument constructor calls resolved through
+the dot-import fallback. Positional calls resolve through the companion
+`Apply` path and never enter this helper; qualified calls and local
+declarations short-circuit before it.

--- a/docs/errors/GALA-E0027.md
+++ b/docs/errors/GALA-E0027.md
@@ -62,7 +62,7 @@ a **sealed type** matched inside one function:
 package main
 
 func greet(name string, formal bool = true) string =
-    if (formal) "hello " + name else "hi " + name
+    if (formal) s"hello $name" else s"hi $name"
 
 func main() {
     Println(greet("world"))
@@ -80,8 +80,8 @@ conflict at the declaration site.
 covered by [GALA-E0012](GALA-E0012.md); interface method specs by
 [GALA-E0029](GALA-E0029.md).
 
-Duplicates across **sibling files** of one package still fail the build, but
-from the Go compiler rather than from this code:
+Duplicates across **sibling files** of one package still fail the build, but as
+of this writing they are reported by the Go compiler rather than by this code:
 
 ```
 main.gala:3: greet redeclared in this block
@@ -92,3 +92,5 @@ That message is attributed to the right `.gala` lines via `//line` directives,
 but it is phrased in Go's terms and cites a generated-file location alongside
 each source location. Compare [GALA-E0028](GALA-E0028.md), which *does* report
 cross-file duplicates at the GALA level.
+
+**Related redeclaration codes.** [GALA-E0011](GALA-E0011.md) types · [GALA-E0012](GALA-E0012.md) methods · [GALA-E0027](GALA-E0027.md) functions · [GALA-E0028](GALA-E0028.md) type aliases · [GALA-E0029](GALA-E0029.md) interface method specs · [GALA-E0030](GALA-E0030.md) struct fields · [GALA-E0031](GALA-E0031.md) sealed cases.

--- a/docs/errors/GALA-E0027.md
+++ b/docs/errors/GALA-E0027.md
@@ -1,0 +1,94 @@
+# GALA-E0027 — Function redeclared
+
+**When it fires.** Two top-level functions with the same name are declared in
+the same package. GALA mirrors Go's "redeclared in this block" rule: a package
+has one namespace for its top-level functions, and there is no overloading —
+differing parameter lists do not make two `greet` functions distinct.
+
+In practice this code fires for duplicates **within a single file**.
+Re-analysing the *same* file is not a redeclaration, so incremental builds and
+LSP passes do not trip it. Two `greet` declarations split across **sibling files
+of the same package** are not reported here today — they fall through to the Go
+compiler instead (see *Scope*).
+
+**Minimal repro.**
+
+```gala
+package main
+
+func greet(name string) string = "hello " + name
+func greet(other string) string = "hi " + other
+
+func main() {
+    Println(greet("world"))
+}
+```
+
+**Error output.**
+
+```
+error[GALA-E0027]: function "greet" in package "main" redeclared (first defined in main.gala)
+  --> main.gala:4:1
+  |
+4 | func greet(other string) string = "hi " + other
+  | ^^^^ remove the duplicate declaration or rename one of the functions
+  |
+  = hint: remove the duplicate declaration or rename one of the functions
+```
+
+The message names the file the *first* declaration came from and the caret marks
+the second.
+
+**Fix.** Delete the redundant declaration, or rename one of them so each name
+describes what it does:
+
+```gala
+package main
+
+func greet(name string) string = "hello " + name
+func greetInformally(other string) string = "hi " + other
+
+func main() {
+    Println(greet("world"))
+    Println(greetInformally("world"))
+}
+```
+
+If you reached for a second definition because you wanted to accept different
+argument shapes, GALA's answer is not overloading but **default parameters** or
+a **sealed type** matched inside one function:
+
+```gala
+package main
+
+func greet(name string, formal bool = true) string =
+    if (formal) "hello " + name else "hi " + name
+
+func main() {
+    Println(greet("world"))
+    Println(greet("world", false))
+}
+```
+
+**Rationale.** The analyzer previously overwrote the earlier metadata entry with
+the later one. The second declaration silently won, the first was lost, and call
+sites that expected the first got the second's body — a whole function
+disappearing with no diagnostic. Rejecting the redeclaration surfaces the
+conflict at the declaration site.
+
+**Scope.** Top-level functions declared in the same file. Methods on a type are
+covered by [GALA-E0012](GALA-E0012.md); interface method specs by
+[GALA-E0029](GALA-E0029.md).
+
+Duplicates across **sibling files** of one package still fail the build, but
+from the Go compiler rather than from this code:
+
+```
+main.gala:3: greet redeclared in this block
+	a.gala:3[...gen/a.gen.go:6:6]: other declaration of greet
+```
+
+That message is attributed to the right `.gala` lines via `//line` directives,
+but it is phrased in Go's terms and cites a generated-file location alongside
+each source location. Compare [GALA-E0028](GALA-E0028.md), which *does* report
+cross-file duplicates at the GALA level.

--- a/docs/errors/GALA-E0027.md
+++ b/docs/errors/GALA-E0027.md
@@ -1,22 +1,24 @@
 # GALA-E0027 — Function redeclared
 
-**When it fires.** Two top-level functions with the same name are declared in
-the same package. GALA mirrors Go's "redeclared in this block" rule: a package
-has one namespace for its top-level functions, and there is no overloading —
-differing parameter lists do not make two `greet` functions distinct.
+**When it fires.** A top-level function with the same name is declared more than
+once in the same package (across any combination of files). GALA mirrors Go's
+"redeclared in this block" rule: a package has one namespace for its top-level
+functions, and there is no overloading — differing parameter lists do not make
+two `greet` functions distinct.
 
-In practice this code fires for duplicates **within a single file**.
-Re-analysing the *same* file is not a redeclaration, so incremental builds and
-LSP passes do not trip it. Two `greet` declarations split across **sibling files
-of the same package** are not reported here today — they fall through to the Go
-compiler instead (see *Scope*).
-
-**Minimal repro.**
+**Minimal repro — two files.**
 
 ```gala
+// a.gala
 package main
 
 func greet(name string) string = "hello " + name
+```
+
+```gala
+// b.gala
+package main
+
 func greet(other string) string = "hi " + other
 
 func main() {
@@ -27,17 +29,42 @@ func main() {
 **Error output.**
 
 ```
-error[GALA-E0027]: function "greet" in package "main" redeclared (first defined in main.gala)
-  --> main.gala:4:1
-  |
-4 | func greet(other string) string = "hi " + other
-  | ^^^^ remove the duplicate declaration or rename one of the functions
-  |
-  = hint: remove the duplicate declaration or rename one of the functions
+Error transpiling a.gala: [SemanticError GALA-E0027] a.gala:3:5 function "greet" in package "main" redeclared (also declared at b.gala:3) (hint: remove the duplicate declaration or rename one of the functions)
+Error transpiling b.gala: [SemanticError GALA-E0027] b.gala:3:5 function "greet" in package "main" redeclared (also declared at a.gala:3) (hint: remove the duplicate declaration or rename one of the functions)
 ```
 
-The message names the file the *first* declaration came from and the caret marks
-the second.
+Every file of the package is compiled, so both declarations are reported, each
+naming the *other* one. Batch analysis order is not source order, so the message
+does not claim either declaration came first — it points at the other
+declaration site and leaves the choice of which to delete to you.
+
+**Minimal repro — one file.**
+
+```gala
+// a.gala
+package main
+
+func greet(name string) string = "hello " + name
+
+func greet(other string) string = "hi " + other
+
+func main() {
+    Println(greet("world"))
+}
+```
+
+**Error output.**
+
+```
+Error transpiling a.gala: [SemanticError GALA-E0027] a.gala:5:0 function "greet" in package "main" redeclared (also declared at line 3) (hint: remove the duplicate declaration or rename one of the functions)
+```
+
+When the other declaration is in the file the error is reported against, the
+message gives its line instead of repeating the file name.
+
+`gala build` reports the same diagnostic in the rich framed CLI form, with the
+caret on the offending name, and stops at the first one rather than listing
+both.
 
 **Fix.** Delete the redundant declaration, or rename one of them so each name
 describes what it does:
@@ -70,27 +97,17 @@ func main() {
 }
 ```
 
-**Rationale.** The analyzer previously overwrote the earlier metadata entry with
-the later one. The second declaration silently won, the first was lost, and call
-sites that expected the first got the second's body — a whole function
-disappearing with no diagnostic. Rejecting the redeclaration surfaces the
-conflict at the declaration site.
+**Rationale.** The analyzer keys top-level functions by name in a single
+per-package map; a second declaration silently overwrote the first. The later
+definition won, the earlier was lost, and call sites that expected the first got
+the second's body — a whole function disappearing with no diagnostic. Because
+the map is populated across the whole package, the same silent overwrite applied
+whether the duplicate sat in one file or in two. Rejecting it at the analyzer
+names both sites in GALA source terms instead of leaving it to the Go compiler's
+`greet redeclared in this block` against generated code.
 
-**Scope.** Top-level functions declared in the same file. Methods on a type are
+**Scope.** Top-level functions anywhere in one package. Methods on a type are
 covered by [GALA-E0012](GALA-E0012.md); interface method specs by
 [GALA-E0029](GALA-E0029.md).
-
-Duplicates across **sibling files** of one package still fail the build, but as
-of this writing they are reported by the Go compiler rather than by this code:
-
-```
-main.gala:3: greet redeclared in this block
-	a.gala:3[...gen/a.gen.go:6:6]: other declaration of greet
-```
-
-That message is attributed to the right `.gala` lines via `//line` directives,
-but it is phrased in Go's terms and cites a generated-file location alongside
-each source location. Compare [GALA-E0028](GALA-E0028.md), which *does* report
-cross-file duplicates at the GALA level.
 
 **Related redeclaration codes.** [GALA-E0011](GALA-E0011.md) types · [GALA-E0012](GALA-E0012.md) methods · [GALA-E0027](GALA-E0027.md) functions · [GALA-E0028](GALA-E0028.md) type aliases · [GALA-E0029](GALA-E0029.md) interface method specs · [GALA-E0030](GALA-E0030.md) struct fields · [GALA-E0031](GALA-E0031.md) sealed cases.

--- a/docs/errors/GALA-E0027.md
+++ b/docs/errors/GALA-E0027.md
@@ -62,9 +62,21 @@ Error transpiling a.gala: [SemanticError GALA-E0027] a.gala:5:0 function "greet"
 When the other declaration is in the file the error is reported against, the
 message gives its line instead of repeating the file name.
 
-`gala build` reports the same diagnostic in the rich framed CLI form, with the
-caret on the offending name, and stops at the first one rather than listing
-both.
+`gala build` reports the same diagnostic in the rich framed CLI form, and stops
+at the first one rather than listing both:
+
+```
+error[GALA-E0027]: function "greet" in package "main" redeclared (also declared at line 3)
+  --> a.gala:5:1
+  |
+5 | func greet(other string) string = "hi " + other
+  | ^^^^ remove the duplicate declaration or rename one of the functi…
+  |
+  = hint: remove the duplicate declaration or rename one of the functions
+```
+
+The annotation beside the caret is the hint truncated to fit; the `= hint:`
+footer carries it in full.
 
 **Fix.** Delete the redundant declaration, or rename one of them so each name
 describes what it does:

--- a/docs/errors/GALA-E0028.md
+++ b/docs/errors/GALA-E0028.md
@@ -45,8 +45,8 @@ type StringHandler func(string) string
 type IntHandler func(int) int
 
 func main() {
-    val upper StringHandler = (s string) => s + "!"
-    val double IntHandler = (n int) => n * 2
+    val upper StringHandler = (s) => s + "!"
+    val double IntHandler = (n) => n * 2
     Println(upper("hi"))
     Println(double(21))
 }
@@ -62,3 +62,5 @@ wrong thing. Rejecting at the declaration keeps the failure local.
 **Scope.** Type aliases (`type Foo = Bar` / `type Foo func(...)`). Duplicate
 *type declarations* (structs, sealed types, interfaces) are
 [GALA-E0011](GALA-E0011.md).
+
+**Related redeclaration codes.** [GALA-E0011](GALA-E0011.md) types · [GALA-E0012](GALA-E0012.md) methods · [GALA-E0027](GALA-E0027.md) functions · [GALA-E0028](GALA-E0028.md) type aliases · [GALA-E0029](GALA-E0029.md) interface method specs · [GALA-E0030](GALA-E0030.md) struct fields · [GALA-E0031](GALA-E0031.md) sealed cases.

--- a/docs/errors/GALA-E0028.md
+++ b/docs/errors/GALA-E0028.md
@@ -29,12 +29,14 @@ error[GALA-E0028]: type alias "Handler" already declared in package "main"
   --> main.gala:4:6
   |
 4 | type Handler func(int) int
-  |      ^^^^^^^ remove the duplicate declaration or rename one of the aliases
+  |      ^^^^^^^ remove the duplicate declaration or rename one of the aliase…
   |
   = hint: remove the duplicate declaration or rename one of the aliases
 ```
 
-The caret points at the *second* alias's name — the one to rename or remove.
+The caret points at the *second* alias's name — the one to rename or remove. The
+annotation beside the caret is the hint truncated to fit; the `= hint:` footer
+carries it in full.
 
 **Fix.** Give each alias a distinct name that says what it aliases:
 

--- a/docs/errors/GALA-E0028.md
+++ b/docs/errors/GALA-E0028.md
@@ -5,9 +5,9 @@ same name is declared more than once in the same package. The transformer keeps
 one lookup table of alias name → underlying type; a second alias under the same
 name would replace the first.
 
-Like [GALA-E0027](GALA-E0027.md), the alias table is seeded from sibling files
-when transformation begins, so this catches both within-file duplicates and
-duplicates split across two files of the same package.
+Like [GALA-E0027](GALA-E0027.md), this covers duplicates within one file and
+duplicates split across sibling files of the same package — the alias table is
+seeded from siblings when transformation begins.
 
 **Minimal repro.**
 

--- a/docs/errors/GALA-E0028.md
+++ b/docs/errors/GALA-E0028.md
@@ -1,0 +1,64 @@
+# GALA-E0028 — Type alias redeclared
+
+**When it fires.** A type alias (`type Handler func(string) string`) with the
+same name is declared more than once in the same package. The transformer keeps
+one lookup table of alias name → underlying type; a second alias under the same
+name would replace the first.
+
+Like [GALA-E0027](GALA-E0027.md), the alias table is seeded from sibling files
+when transformation begins, so this catches both within-file duplicates and
+duplicates split across two files of the same package.
+
+**Minimal repro.**
+
+```gala
+package main
+
+type Handler func(string) string
+type Handler func(int) int
+
+func main() {
+    Println("unused")
+}
+```
+
+**Error output.**
+
+```
+error[GALA-E0028]: type alias "Handler" already declared in package "main"
+  --> main.gala:4:6
+  |
+4 | type Handler func(int) int
+  |      ^^^^^^^ remove the duplicate declaration or rename one of the aliases
+  |
+  = hint: remove the duplicate declaration or rename one of the aliases
+```
+
+The caret points at the *second* alias's name — the one to rename or remove.
+
+**Fix.** Give each alias a distinct name that says what it aliases:
+
+```gala
+package main
+
+type StringHandler func(string) string
+type IntHandler func(int) int
+
+func main() {
+    val upper StringHandler = (s string) => s + "!"
+    val double IntHandler = (n int) => n * 2
+    Println(upper("hi"))
+    Println(double(21))
+}
+```
+
+**Rationale.** The silent overwrite was worse than a lost declaration: because
+the alias table is consulted whenever a type name needs resolving, the *second*
+alias's underlying type would be substituted at call sites written against the
+first. The resulting Go failed to compile at some unrelated line, or — when both
+underlying types happened to be structurally compatible — compiled and did the
+wrong thing. Rejecting at the declaration keeps the failure local.
+
+**Scope.** Type aliases (`type Foo = Bar` / `type Foo func(...)`). Duplicate
+*type declarations* (structs, sealed types, interfaces) are
+[GALA-E0011](GALA-E0011.md).

--- a/docs/errors/GALA-E0029.md
+++ b/docs/errors/GALA-E0029.md
@@ -4,10 +4,6 @@
 same name. GALA has no overloading, so the two specs are not distinct methods —
 the second simply replaces the first in the interface's method table.
 
-The check is scoped to one parse of one interface declaration: re-analysing the
-same source (incremental builds, LSP passes) preserves the method map across
-calls and does not re-trigger it.
-
 **Minimal repro.**
 
 ```gala
@@ -92,3 +88,5 @@ in the analyzer names the interface, the method, and the offending line.
 
 **Scope.** Method specs inside a single `interface` declaration. Duplicate
 *implementations* on a concrete type are [GALA-E0012](GALA-E0012.md).
+
+**Related redeclaration codes.** [GALA-E0011](GALA-E0011.md) types · [GALA-E0012](GALA-E0012.md) methods · [GALA-E0027](GALA-E0027.md) functions · [GALA-E0028](GALA-E0028.md) type aliases · [GALA-E0029](GALA-E0029.md) interface method specs · [GALA-E0030](GALA-E0030.md) struct fields · [GALA-E0031](GALA-E0031.md) sealed cases.

--- a/docs/errors/GALA-E0029.md
+++ b/docs/errors/GALA-E0029.md
@@ -1,0 +1,94 @@
+# GALA-E0029 — Interface method redeclared
+
+**When it fires.** An `interface` declaration lists two method specs with the
+same name. GALA has no overloading, so the two specs are not distinct methods —
+the second simply replaces the first in the interface's method table.
+
+The check is scoped to one parse of one interface declaration: re-analysing the
+same source (incremental builds, LSP passes) preserves the method map across
+calls and does not re-trigger it.
+
+**Minimal repro.**
+
+```gala
+package main
+
+type Repo interface {
+    Find(id int) string
+    Find(name string) string
+}
+
+func main() {
+    Println("unused")
+}
+```
+
+**Error output.**
+
+```
+error[GALA-E0029]: method "Find" already declared in interface "Repo"
+  --> main.gala:5:5
+  |
+5 |     Find(name string) string
+  |     ^^^^ rename or remove the duplicate method
+  |
+  = hint: rename or remove the duplicate method
+```
+
+**Fix.** Name each method for what it does. Two lookups that differ by key are
+two methods:
+
+```gala
+package main
+
+type Repo interface {
+    FindByID(id int) string
+    FindByName(name string) string
+}
+
+struct MemoryRepo(label string)
+
+func (r MemoryRepo) FindByID(id int) string = s"${r.label}#$id"
+func (r MemoryRepo) FindByName(name string) string = s"${r.label}:$name"
+
+func main() {
+    val repo = MemoryRepo("users")
+    Println(repo.FindByID(1))
+    Println(repo.FindByName("ada"))
+}
+```
+
+If the two specs really are one operation over different input shapes, model the
+input as a sealed type and take a single parameter:
+
+```gala
+sealed type Key {
+    case ByID(id int)
+    case ByName(name string)
+}
+
+type Repo interface {
+    Find(key Key) string
+}
+```
+
+A type parameter on the method *spec* is not an option: Go requires interface
+methods to have no type parameters, so `Find[K any](key K) string` inside an
+interface produces Go that does not compile
+(`interface method must have no type parameters`). Put the type parameter on
+the interface itself instead:
+
+```gala
+type Repo[K any] interface {
+    Find(key K) string
+}
+```
+
+**Rationale.** The earlier spec's metadata was silently overwritten by the later
+one. That hid a real mistake — the author believed both signatures existed —
+and pushed the failure to the Go compiler, which reports it against generated
+code (`duplicate method Find`) with no pointer back to the GALA line. Rejecting
+in the analyzer names the interface, the method, and the offending line.
+
+**Scope.** Method specs inside a single `interface` declaration. Duplicate
+*implementations* on a concrete type are [GALA-E0012](GALA-E0012.md).

--- a/docs/errors/GALA-E0030.md
+++ b/docs/errors/GALA-E0030.md
@@ -1,0 +1,83 @@
+# GALA-E0030 — Struct field redeclared
+
+**When it fires.** A struct declares two fields with the same name. Both struct
+syntaxes are covered:
+
+- **Shorthand form** — `struct Point(X int, X int)`
+- **Block form** — `type Point struct { val x int; val x int }`
+
+The check is scoped to one parse of one struct declaration, so re-analysis does
+not re-trigger it.
+
+**Minimal repro.**
+
+```gala
+package main
+
+struct Point(X int, X int)
+
+func main() {
+    val p = Point(1, 2)
+    Println(p.X)
+}
+```
+
+**Error output.**
+
+```
+error[GALA-E0030]: field "X" already declared in struct "Point"
+  --> main.gala:3:21
+  |
+3 | struct Point(X int, X int)
+  |                     ^ rename or remove the duplicate field
+  |
+  = hint: rename or remove the duplicate field
+```
+
+The caret points at the second occurrence of the name.
+
+The block form reports identically:
+
+```
+error[GALA-E0030]: field "x" already declared in struct "Point"
+  --> main.gala:5:9
+  |
+5 |     val x int
+  |         ^ rename or remove the duplicate field
+  |
+  = hint: rename or remove the duplicate field
+```
+
+**Fix.** Rename the duplicate, or delete it if it was a copy-paste artefact:
+
+```gala
+package main
+
+struct Point(X int, Y int)
+
+func main() {
+    val p = Point(1, 2)
+    Println(s"${p.X}, ${p.Y}")
+}
+```
+
+If you wanted several values under one conceptual name, hold a collection
+instead of repeating the field:
+
+```gala
+import . "martianoff/gala/collection_immutable"
+
+struct Path(Points Array[int])
+```
+
+**Rationale.** The duplicate was doubly damaging. The field-type map kept only
+the later type, so the earlier field's type was lost; and the ordered
+`FieldNames` list contained the name *twice*, which the generator emitted
+verbatim — producing Go with a duplicated struct field that could not compile.
+Because the resulting failure surfaced in generated code, it pointed at a line
+the author never wrote. Rejecting in the analyzer keeps the error on the
+declaration.
+
+**Scope.** Fields within one struct declaration. A field name that collides with
+a *type* name in the same package is [GALA-E0016](GALA-E0016.md); duplicate
+sealed-variant case names are [GALA-E0031](GALA-E0031.md).

--- a/docs/errors/GALA-E0030.md
+++ b/docs/errors/GALA-E0030.md
@@ -6,9 +6,6 @@ syntaxes are covered:
 - **Shorthand form** — `struct Point(X int, X int)`
 - **Block form** — `type Point struct { val x int; val x int }`
 
-The check is scoped to one parse of one struct declaration, so re-analysis does
-not re-trigger it.
-
 **Minimal repro.**
 
 ```gala
@@ -81,3 +78,5 @@ declaration.
 **Scope.** Fields within one struct declaration. A field name that collides with
 a *type* name in the same package is [GALA-E0016](GALA-E0016.md); duplicate
 sealed-variant case names are [GALA-E0031](GALA-E0031.md).
+
+**Related redeclaration codes.** [GALA-E0011](GALA-E0011.md) types · [GALA-E0012](GALA-E0012.md) methods · [GALA-E0027](GALA-E0027.md) functions · [GALA-E0028](GALA-E0028.md) type aliases · [GALA-E0029](GALA-E0029.md) interface method specs · [GALA-E0030](GALA-E0030.md) struct fields · [GALA-E0031](GALA-E0031.md) sealed cases.

--- a/docs/errors/GALA-E0031.md
+++ b/docs/errors/GALA-E0031.md
@@ -8,9 +8,6 @@ Every sealed case generates a companion type plus `Apply`, `Unapply`, and an
 later case's definitions overwrite the earlier's and only one variant remains
 reachable — code the author wrote silently disappears.
 
-The check is scoped to one parse of one sealed type declaration, so re-analysis
-does not re-trigger it.
-
 **Minimal repro.**
 
 ```gala
@@ -84,5 +81,7 @@ method Box.Unapply already declared at ...
 ```
 
 That still fails the build, but the message is phrased against the generated Go
-and cites two line numbers per conflict, so prefer distinct case names across
-every sealed type in a package.
+and cites two line numbers per conflict (exact wording tracks your Go toolchain
+version), so prefer distinct case names across every sealed type in a package.
+
+**Related redeclaration codes.** [GALA-E0011](GALA-E0011.md) types · [GALA-E0012](GALA-E0012.md) methods · [GALA-E0027](GALA-E0027.md) functions · [GALA-E0028](GALA-E0028.md) type aliases · [GALA-E0029](GALA-E0029.md) interface method specs · [GALA-E0030](GALA-E0030.md) struct fields · [GALA-E0031](GALA-E0031.md) sealed cases.

--- a/docs/errors/GALA-E0031.md
+++ b/docs/errors/GALA-E0031.md
@@ -1,0 +1,88 @@
+# GALA-E0031 — Sealed variant case redeclared
+
+**When it fires.** A `sealed type` declaration lists two `case` variants with
+the same name.
+
+Every sealed case generates a companion type plus `Apply`, `Unapply`, and an
+`isXxx` predicate. Two cases sharing a name generate the same set twice, so the
+later case's definitions overwrite the earlier's and only one variant remains
+reachable — code the author wrote silently disappears.
+
+The check is scoped to one parse of one sealed type declaration, so re-analysis
+does not re-trigger it.
+
+**Minimal repro.**
+
+```gala
+package main
+
+sealed type Shape {
+    case Box(W int)
+    case Box(H int)
+}
+
+func main() {
+    val b = Box(1)
+    Println(b)
+}
+```
+
+**Error output.**
+
+```
+error[GALA-E0031]: sealed case "Box" already declared in sealed type "Shape"
+  --> main.gala:5:10
+  |
+5 |     case Box(H int)
+  |          ^^^ rename or remove the duplicate case
+  |
+  = hint: rename or remove the duplicate case
+```
+
+**Fix.** Give each case a name that describes the shape it carries. Cases that
+differ in their fields are different cases:
+
+```gala
+package main
+
+sealed type Shape {
+    case Rect(W int, H int)
+    case Square(Side int)
+}
+
+func area(s Shape) int = s match {
+    case Rect(w, h) => w * h
+    case Square(side) => side * side
+}
+
+func main() {
+    Println(area(Rect(2, 3)))
+    Println(area(Square(4)))
+}
+```
+
+If both cases genuinely carry the same data and you only wanted one, delete the
+duplicate.
+
+**Rationale.** This is the sealed-type analogue of
+[GALA-E0030](GALA-E0030.md): a silent overwrite that removes reachable code. It
+was especially hard to spot because the resulting program still compiled — a
+`match` over the sealed type would simply never select the lost variant, and
+exhaustiveness checking ([GALA-E0002](GALA-E0002.md)) saw only the surviving
+one, so it did not complain either. Rejecting at the declaration is the only
+place the mistake is visible.
+
+**Scope.** Cases within a single `sealed type` declaration. Two *different*
+sealed types in the same package that each declare a case of the same name are
+**not** covered by this check — they are caught later by the Go compiler,
+because both cases generate a companion type under the same name:
+
+```
+Box redeclared in this block
+method Box.Apply already declared at ...
+method Box.Unapply already declared at ...
+```
+
+That still fails the build, but the message is phrased against the generated Go
+and cites two line numbers per conflict, so prefer distinct case names across
+every sealed type in a package.

--- a/docs/errors/GALA-E0032.md
+++ b/docs/errors/GALA-E0032.md
@@ -88,12 +88,6 @@ import (
 )
 ```
 
-**Facade packages.** Some stdlib packages deliberately re-export another
-package's names as a convenience facade — `concurrent` re-exports
-`go_interop`'s execution-context helpers, for instance. Dot-importing both
-sides of a facade is never useful: pick whichever one you actually want and
-drop the other.
-
 **Rationale.** Without this check the collision surfaced from `go build`,
 against generated code, naming a file the author never wrote. Detecting it at
 the GALA level names the symbol, names every package that supplies it, and

--- a/docs/errors/GALA-E0032.md
+++ b/docs/errors/GALA-E0032.md
@@ -1,0 +1,111 @@
+# GALA-E0032 — Dot-import symbol collision
+
+**When it fires.** Two or more **dot-imported** packages export the same
+identifier. A dot import (`import . "path"`) drops every exported name of the
+package into the current file's namespace; when two of them supply the same
+name, the generated Go contains two declarations of that identifier and Go
+rejects it with "redeclared in this block".
+
+The check needs at least two dot imports to run, and considers every exported
+name the analyzer knows about: GALA types (including sealed-variant companions),
+functions, companion objects, and the exports of dot-imported Go packages.
+It runs early in transformation, before any expression is transformed.
+
+**Minimal repro.**
+
+`pkg_a/a.gala`:
+
+```gala
+package pkg_a
+
+func Greet() string = "hello from a"
+```
+
+`pkg_b/b.gala`:
+
+```gala
+package pkg_b
+
+func Greet() string = "hello from b"
+```
+
+`main.gala`:
+
+```gala
+package main
+
+import (
+    . "example.com/demo/pkg_a"
+    . "example.com/demo/pkg_b"
+)
+
+func main() {
+    Println("hi")
+}
+```
+
+**Error output.**
+
+```
+error[GALA-E0032]: dot-import symbol collision(s) detected:
+  - symbol "Greet" is exported by multiple dot-imported packages: pkg_a, pkg_b
+Use a qualified or aliased import for one of the packages to resolve the conflict.
+(Some stdlib packages intentionally re-export names from another package as a convenience facade — e.g. `concurrent` re-exports `go_interop`'s execution-context helpers — so dot-importing both is never meaningful. Pick the facade you want.)
+  --> main.gala:3:1
+  |
+3 | import (
+  | ^^^^^^ qualify or alias one of the dot-imports to disambiguate
+  |
+  = hint: qualify or alias one of the dot-imports to disambiguate
+```
+
+Every colliding symbol is listed, one bullet per name, with the packages that
+supply it. The caret points at the import block rather than a single import,
+because the collision is a property of the set.
+
+**Fix.** Demote one of the dot imports to a qualified import and prefix its uses:
+
+```gala
+package main
+
+import (
+    . "example.com/demo/pkg_a"
+    "example.com/demo/pkg_b"
+)
+
+func main() {
+    Println(Greet())            // pkg_a, via the dot import
+    Println(pkg_b.Greet())      // pkg_b, explicitly qualified
+}
+```
+
+An alias works too when you want both short:
+
+```gala
+import (
+    . "example.com/demo/pkg_a"
+    b "example.com/demo/pkg_b"
+)
+```
+
+**Facade packages.** Some stdlib packages deliberately re-export another
+package's names as a convenience facade — `concurrent` re-exports
+`go_interop`'s execution-context helpers, for instance. Dot-importing both
+sides of a facade is never useful: pick whichever one you actually want and
+drop the other.
+
+**Rationale.** Without this check the collision surfaced from `go build`,
+against generated code, naming a file the author never wrote. Detecting it at
+the GALA level names the symbol, names every package that supplies it, and
+points at the import block that has to change. It was previously reported as an
+uncoded semantic error; the stable code lets tooling distinguish an import
+conflict from other semantic failures.
+
+**Scope.** Dot imports only. A qualified import can never collide, because its
+names live behind the package selector. A collision between a dot-imported
+name and a *local* declaration is not flagged here — local declarations shadow
+dot imports by design.
+
+**Related.** [GALA-E0026](GALA-E0026.md) covers ambiguity between sealed-variant
+constructors from two dot-imported packages. Because a sealed case registers a
+companion type under its own name, that situation is caught by this check first.

--- a/docs/errors/GALA-E0035.md
+++ b/docs/errors/GALA-E0035.md
@@ -37,10 +37,9 @@ The caret underlines the callee identifier exactly — the diagnostic carries a
 precise span rather than letting the renderer guess the token width. The caret
 row shows a shortened hint; the full text is on the `= hint:` line.
 
-## Replacements
-
-Every forbidden builtin and the replacement the compiler suggests, verbatim from
-the suggestion table in `internal/transpiler/transformer/calls.go`:
+**Replacements.** Every forbidden builtin and the replacement the compiler
+suggests, verbatim from the suggestion table in
+`internal/transpiler/transformer/calls.go`:
 
 | Builtin | Hint the compiler emits |
 |---|---|
@@ -76,24 +75,14 @@ func main() {
 }
 ```
 
-**Pick `.Size()` or `.ByteSize()` deliberately.** This is the substantive part
-of the `len` replacement, not a cosmetic rename. Go's `len(string)` returns
-**bytes**, so any non-ASCII text mis-counts. GALA splits the two meanings:
-
-- `.Size()` — logical size. Characters for a string, elements for a collection.
-  `"héllo".Size() == 5`.
-- `.ByteSize()` — raw bytes. `"héllo".ByteSize() == 6`.
-
-Use `.Size()` when you mean "how many things"; use `.ByteSize()` only when you
-are doing genuine byte-level work (indexing into a byte buffer, computing an
-offset, sizing an I/O read). Using `.Size()` as the bound of a **byte** loop
-truncates multibyte input — the exact bug `len` used to cause silently.
-
-**The check is resolver-aware.** A name you declared yourself is your
-declaration, not the builtin. A user-defined `func delete(...)` or
-`func copy(...)` is left alone, as is a local `val`/`var`/parameter or a
-declared type with one of these names. A *selector* call is never a bare
-builtin either — `x.copy()` is a method call and is not checked.
+**Pick deliberately.** Go's `len(string)` returns **bytes**, so non-ASCII text
+mis-counts. Use `.Size()` when you mean "how many things"; use `.ByteSize()`
+only for genuine byte-level work (indexing a byte buffer, computing an offset,
+sizing an I/O read). Using `.Size()` as the bound of a **byte** loop truncates
+multibyte input — the exact bug `len` used to cause silently. See
+[GALA.MD §11](../GALA.MD) and
+[GALA_BEST_PRACTICES.MD](../GALA_BEST_PRACTICES.MD) for the language-reference
+treatment.
 
 **Rationale.** GALA's rule is that every symbol resolves through an import, a
 GALA declaration, or the std prelude. The Go builtins were the one exception:
@@ -103,5 +92,10 @@ the `len` case, where the leaked builtin silently had the wrong semantics for
 text. Forbidding the bare form removes the special case and routes each
 operation to something with a name that says what it does.
 
-**Related.** Go-only *statement* keywords (`defer`, `go`, `goto`, …) are
-rejected by [GALA-E0036](GALA-E0036.md) under the same reasoning.
+**Scope.** Bare calls only, and the check is **resolver-aware**: a name you
+declared yourself is your declaration, not the builtin. A user-defined
+`func delete(...)` or `func copy(...)` is left alone, as is a local
+`val`/`var`/parameter or a declared type with one of these names. A *selector*
+call is never a bare builtin either — `x.copy()` is a method call and is not
+checked. Go-only *statement* keywords (`defer`, `go`, `goto`, …) are rejected by
+[GALA-E0036](GALA-E0036.md) under the same reasoning.

--- a/docs/errors/GALA-E0035.md
+++ b/docs/errors/GALA-E0035.md
@@ -1,0 +1,107 @@
+# GALA-E0035 — Bare Go builtin is not part of GALA's surface
+
+**When it fires.** A Go builtin (`len`, `append`, `make`, `new`, `cap`, `copy`,
+`delete`, `close`, `complex`, `real`, `imag`, `panic`, `recover`) is called as a
+bare function.
+
+These were the last symbols that resolved with **no import and no GALA
+declaration** — an implicit Go leakage the language removes. Each one has a
+GALA-native form or a sanctioned interop wrapper, so a bare call is a hard
+error rather than a warning.
+
+**Minimal repro.**
+
+```gala
+package main
+
+func main() {
+    val s = "héllo"
+    val n = len(s)
+    Println(n)
+}
+```
+
+**Error output.**
+
+```
+error[GALA-E0035]: bare Go builtin "len(...)" is not part of GALA's surface
+  --> main.gala:5:13
+  |
+5 |     val n = len(s)
+  |             ^^^ use `.Size()`
+  |
+  = hint: use `.Size()` (logical size — characters for strings) or `.ByteSize()` (raw bytes) instead of `len(...)`
+```
+
+The caret underlines the callee identifier exactly — the diagnostic carries a
+precise span rather than letting the renderer guess the token width. The caret
+row shows a shortened hint; the full text is on the `= hint:` line.
+
+## Replacements
+
+Every forbidden builtin and the replacement the compiler suggests, verbatim from
+the suggestion table in `internal/transpiler/transformer/calls.go`:
+
+| Builtin | Hint the compiler emits |
+|---|---|
+| `len` | use `.Size()` (logical size — characters for strings) or `.ByteSize()` (raw bytes) instead of `len(...)` |
+| `append` | use `go_interop.SliceAppend` / `SliceAppendAll`, or build an `Array`/`List` from collection_immutable |
+| `make` | use `go_interop.SliceWithSize` / `SliceWithCapacity` / `MapEmpty`, or an empty `Array`/`HashMap` |
+| `new` | use `go_interop.New[T]()` for a pointer, or a zero value / `Option[T]` |
+| `cap` | use `go_interop.SliceCap(...)` |
+| `copy` | use `go_interop.SliceCopy(...)`, or copy an `Array` |
+| `delete` | use `go_interop.MapDelete(...)`, or `HashMap.Remove(...)` |
+| `close` | use `go_interop.CloseChan(...)` (or `CloseSignal(...)` for a signal channel) |
+| `complex` | use `go_interop.Complex(...)` |
+| `real` | use `go_interop.Real(...)` |
+| `imag` | use `go_interop.Imag(...)` |
+| `panic` | use `go_builtins.Panic(...)` — or prefer `Option` / `Try` / `Either` for recoverable failure |
+| `recover` | `recover` is not available on the GALA surface; `Try` captures panics — use `Try(() => ...)` / `TryApply` |
+
+**Fix.** Use the GALA-native form. For `len`, that is `.Size()` or
+`.ByteSize()`:
+
+```gala
+package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    val s = "héllo"
+    Println(s.Size())      // 5 — characters
+    Println(s.ByteSize())  // 6 — raw bytes
+
+    val nums = ArrayOf(1, 2, 3)
+    Println(nums.Size())   // 3
+}
+```
+
+**Pick `.Size()` or `.ByteSize()` deliberately.** This is the substantive part
+of the `len` replacement, not a cosmetic rename. Go's `len(string)` returns
+**bytes**, so any non-ASCII text mis-counts. GALA splits the two meanings:
+
+- `.Size()` — logical size. Characters for a string, elements for a collection.
+  `"héllo".Size() == 5`.
+- `.ByteSize()` — raw bytes. `"héllo".ByteSize() == 6`.
+
+Use `.Size()` when you mean "how many things"; use `.ByteSize()` only when you
+are doing genuine byte-level work (indexing into a byte buffer, computing an
+offset, sizing an I/O read). Using `.Size()` as the bound of a **byte** loop
+truncates multibyte input — the exact bug `len` used to cause silently.
+
+**The check is resolver-aware.** A name you declared yourself is your
+declaration, not the builtin. A user-defined `func delete(...)` or
+`func copy(...)` is left alone, as is a local `val`/`var`/parameter or a
+declared type with one of these names. A *selector* call is never a bare
+builtin either — `x.copy()` is a method call and is not checked.
+
+**Rationale.** GALA's rule is that every symbol resolves through an import, a
+GALA declaration, or the std prelude. The Go builtins were the one exception:
+they resolved out of nowhere because the generated Go happened to have them in
+scope. That is invisible coupling to the target language, and it hurt most in
+the `len` case, where the leaked builtin silently had the wrong semantics for
+text. Forbidding the bare form removes the special case and routes each
+operation to something with a name that says what it does.
+
+**Related.** Go-only *statement* keywords (`defer`, `go`, `goto`, …) are
+rejected by [GALA-E0036](GALA-E0036.md) under the same reasoning.

--- a/docs/errors/GALA-E0036.md
+++ b/docs/errors/GALA-E0036.md
@@ -38,10 +38,9 @@ error[GALA-E0036]: bare Go statement keyword "defer" is not part of GALA's surfa
   = hint: GALA has no `defer`; use the `resource` combinators — `Using` / `Bracket` / `WithLock` from martianoff/gala/resource (or a `use x = ...` binding) — which guarantee cleanup on every exit path
 ```
 
-## Replacements
-
-Every forbidden keyword and the replacement the compiler suggests, verbatim from
-the suggestion table in `internal/transpiler/transformer/statements.go`:
+**Replacements.** Every forbidden keyword and the replacement the compiler
+suggests, verbatim from the suggestion table in
+`internal/transpiler/transformer/statements.go`:
 
 | Keyword | Hint the compiler emits |
 |---|---|
@@ -54,7 +53,10 @@ the suggestion table in `internal/transpiler/transformer/statements.go`:
 
 **Fix — `defer` becomes `use`.** `use x = acquire` binds `x` for the rest of the
 enclosing block and guarantees `x.Close()` runs when the function returns, on
-every path. The resource must satisfy `Close() error`. No import is needed.
+every path — normal return or panic. The resource must satisfy `Close() error`.
+No import is needed. See
+[GALA.MD §11, "`use` — scoped resource binding"](../GALA.MD) for the full
+treatment.
 
 ```gala
 package main
@@ -93,19 +95,8 @@ is a checked concurrency boundary, so the transpiler verifies the closure only
 captures shareable state (see [GALA-E0037](GALA-E0037.md)). `Spawn` is the
 unchecked escape hatch.
 
-**Fix — `goto` / `fallthrough`.** Neither has a GALA equivalent by design.
-`match` arms never fall through; combine patterns with `|` when several should
-share a body, or restructure into pattern matching, recursion, or a `for` loop.
-
-**Fix — `select` / `chan`.** Channel construction and multiplexing live behind
-the `go_interop` channel helpers rather than as surface syntax.
-
-**The check is resolver-aware.** Like the builtin check
-([GALA-E0035](GALA-E0035.md)), a name the program itself declared is that
-declaration, not a leaked keyword — a user-defined function, a local
-`val`/`var`/parameter, or a declared type named `select` is left alone. Only a
-*bare* identifier statement is flagged; anything with a postfix, operator, or
-argument list (`x.defer()`) is an ordinary expression and is not checked.
+The remaining four keywords have no GALA equivalent by design — the table's
+hints are the whole answer.
 
 **Rationale.** A GALA program should not depend on the shape of the Go the
 transpiler happens to emit. The bare-keyword forms did exactly that: whether
@@ -114,3 +105,10 @@ blank line or reordering two statements could silently change whether cleanup
 ran at all. Rejecting the bare form removes that coupling and points at
 constructs — `use`, the `resource` combinators, `Future` — that make the
 guarantee explicit and are checked.
+
+**Scope.** Bare identifier statements only, and the check is **resolver-aware**:
+like the builtin check ([GALA-E0035](GALA-E0035.md)), a name the program itself
+declared is that declaration, not a leaked keyword — a user-defined function, a
+local `val`/`var`/parameter, or a declared type named `select` is left alone.
+Anything with a postfix, operator, or argument list (`x.defer()`) is an ordinary
+expression and is not checked.

--- a/docs/errors/GALA-E0036.md
+++ b/docs/errors/GALA-E0036.md
@@ -11,17 +11,14 @@ Go statement, so `defer` on one line and `f.Close()` on the next glued together
 into a Go `DeferStmt`. That behaviour is undocumented and fragile — it depends
 entirely on what happens to follow — so a bare use is a hard error.
 
-**Minimal repro.**
+**Minimal repro.** The keyword is rejected on its own — no import or resource is
+needed to trigger it, because the check runs before any symbol is resolved:
 
 ```gala
 package main
 
-import "martianoff/gala/io"
-
 func main() {
-    val f = io.OpenFile("data.txt")
     defer
-    f.Close()
     Println("done")
 }
 ```
@@ -30,13 +27,17 @@ func main() {
 
 ```
 error[GALA-E0036]: bare Go statement keyword "defer" is not part of GALA's surface
-  --> main.gala:7:5
+  --> main.gala:4:5
   |
-7 |     defer
+4 |     defer
   |     ^^^^^ GALA has no `defer`
   |
   = hint: GALA has no `defer`; use the `resource` combinators — `Using` / `Bracket` / `WithLock` from martianoff/gala/resource (or a `use x = ...` binding) — which guarantee cleanup on every exit path
 ```
+
+In real code the offender is usually a Go-style `defer f.Close()`, where the
+keyword and the call sit on consecutive lines; the diagnostic points at the
+keyword either way.
 
 **Replacements.** Every forbidden keyword and the replacement the compiler
 suggests, verbatim from the suggestion table in

--- a/docs/errors/GALA-E0036.md
+++ b/docs/errors/GALA-E0036.md
@@ -1,0 +1,116 @@
+# GALA-E0036 — Bare Go statement keyword is not part of GALA's surface
+
+**When it fires.** One of the Go-only statement keywords — `defer`, `go`,
+`goto`, `fallthrough`, `select`, `chan` — appears as a bare identifier
+statement.
+
+None of these are GALA keywords, so the parser accepts them as an ordinary
+identifier expression-statement. They only ever produced working Go *by
+accident*: the final gofmt pass re-absorbed the following statement into a real
+Go statement, so `defer` on one line and `f.Close()` on the next glued together
+into a Go `DeferStmt`. That behaviour is undocumented and fragile — it depends
+entirely on what happens to follow — so a bare use is a hard error.
+
+**Minimal repro.**
+
+```gala
+package main
+
+import "martianoff/gala/io"
+
+func main() {
+    val f = io.OpenFile("data.txt")
+    defer
+    f.Close()
+    Println("done")
+}
+```
+
+**Error output.**
+
+```
+error[GALA-E0036]: bare Go statement keyword "defer" is not part of GALA's surface
+  --> main.gala:7:5
+  |
+7 |     defer
+  |     ^^^^^ GALA has no `defer`
+  |
+  = hint: GALA has no `defer`; use the `resource` combinators — `Using` / `Bracket` / `WithLock` from martianoff/gala/resource (or a `use x = ...` binding) — which guarantee cleanup on every exit path
+```
+
+## Replacements
+
+Every forbidden keyword and the replacement the compiler suggests, verbatim from
+the suggestion table in `internal/transpiler/transformer/statements.go`:
+
+| Keyword | Hint the compiler emits |
+|---|---|
+| `defer` | GALA has no `defer`; use the `resource` combinators — `Using` / `Bracket` / `WithLock` from martianoff/gala/resource (or a `use x = ...` binding) — which guarantee cleanup on every exit path |
+| `go` | GALA has no bare `go` statement; use `go_interop.Spawn(() => ...)` to start a goroutine |
+| `goto` | GALA has no `goto`; use structured control flow — pattern matching, recursion, or a `for` loop |
+| `fallthrough` | GALA has no `fallthrough`; `match` arms never fall through — combine patterns with `\|` or restructure the match |
+| `select` | GALA has no `select` statement; use the go_interop channel helpers |
+| `chan` | GALA has no bare `chan` statement; use the go_interop channel helpers to build and operate on channels |
+
+**Fix — `defer` becomes `use`.** `use x = acquire` binds `x` for the rest of the
+enclosing block and guarantees `x.Close()` runs when the function returns, on
+every path. The resource must satisfy `Close() error`. No import is needed.
+
+```gala
+package main
+
+struct Handle(name string)
+
+func (h Handle) Close() error {
+    Println(s"close ${h.name}")
+    return nil
+}
+
+func open(name string) Handle = Handle(name)
+
+func work() {
+    use f = open("data.txt")
+    Println(s"reading ${f.name}")
+}
+
+func main() {
+    work()
+    Println("done")
+}
+```
+
+Multiple `use` bindings release **LIFO** — the last acquired closes first — so
+nested resources unwind in the right order. `use` lowers to Go `defer` in the
+generated code, which is the one sanctioned place Go's `defer` still exists.
+
+When you need explicit control over acquire and release, or the resource does
+not implement `Close() error`, reach for the `resource` combinators
+(`Using` / `Bracket` / `WithLock`) instead.
+
+**Fix — `go` becomes `Spawn` (or, better, `Future`).** `go_interop.Spawn(() =>
+...)` starts a goroutine directly. Prefer `concurrent.Future` where you can: it
+is a checked concurrency boundary, so the transpiler verifies the closure only
+captures shareable state (see [GALA-E0037](GALA-E0037.md)). `Spawn` is the
+unchecked escape hatch.
+
+**Fix — `goto` / `fallthrough`.** Neither has a GALA equivalent by design.
+`match` arms never fall through; combine patterns with `|` when several should
+share a body, or restructure into pattern matching, recursion, or a `for` loop.
+
+**Fix — `select` / `chan`.** Channel construction and multiplexing live behind
+the `go_interop` channel helpers rather than as surface syntax.
+
+**The check is resolver-aware.** Like the builtin check
+([GALA-E0035](GALA-E0035.md)), a name the program itself declared is that
+declaration, not a leaked keyword — a user-defined function, a local
+`val`/`var`/parameter, or a declared type named `select` is left alone. Only a
+*bare* identifier statement is flagged; anything with a postfix, operator, or
+argument list (`x.defer()`) is an ordinary expression and is not checked.
+
+**Rationale.** A GALA program should not depend on the shape of the Go the
+transpiler happens to emit. The bare-keyword forms did exactly that: whether
+`defer` "worked" depended on gofmt re-absorbing the next statement, so adding a
+blank line or reordering two statements could silently change whether cleanup
+ran at all. Rejecting the bare form removes that coupling and points at
+constructs — `use`, the `resource` combinators, `Future` — that make the
+guarantee explicit and are checked.

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -11,6 +11,21 @@ Each code has a dedicated documentation page in this directory explaining:
 - how to fix it
 - the underlying design rationale (so you can judge edge cases)
 
+Not every code is something you can trigger, and the pages say so rather than
+inventing an example:
+
+- **Transpiler defects.** [GALA-E0009](GALA-E0009.md),
+  [GALA-E0017](GALA-E0017.md), and [GALA-E0024](GALA-E0024.md) cannot be forced
+  by any valid source. The right response is a bug report, not a source change.
+- **Not currently surfaced.** [GALA-E0021](GALA-E0021.md),
+  [GALA-E0022](GALA-E0022.md), and [GALA-E0024](GALA-E0024.md) originate in the
+  type-inference engine, whose errors every caller discards. Type errors of that
+  class are reported by the Go compiler against the generated Go.
+- **Shadowed by an earlier check.** [GALA-E0026](GALA-E0026.md) is defensive;
+  [GALA-E0032](GALA-E0032.md) reports first in every construction found so far.
+- **Nested inside a wrapper.** [GALA-E0020](GALA-E0020.md) has no framed header
+  of its own — it appears inside an uncoded unresolved-imports error.
+
 ## Index
 
 | Code | Title | Page |
@@ -53,20 +68,6 @@ Each code has a dedicated documentation page in this directory explaining:
 | `GALA-E0036` | Bare Go statement keyword is forbidden | [GALA-E0036.md](GALA-E0036.md) |
 | `GALA-E0037` | Unshareable capture across a concurrency boundary | [GALA-E0037.md](GALA-E0037.md) |
 | `GALA-E0038` | Invalid string escape sequence | [GALA-E0038.md](GALA-E0038.md) |
-
-Every code defined in `galaerr/errors.go` now has a page. Three of them describe
-conditions no valid source can reach — [GALA-E0009](GALA-E0009.md),
-[GALA-E0017](GALA-E0017.md), and [GALA-E0024](GALA-E0024.md) signal a
-**transpiler defect**, and the right response is a bug report, not a source
-change. Three more originate in the type-inference engine and are **not
-currently surfaced** to users at all: [GALA-E0021](GALA-E0021.md),
-[GALA-E0022](GALA-E0022.md), and [GALA-E0024](GALA-E0024.md) — type errors of
-that class are reported by the Go compiler against the generated Go.
-[GALA-E0026](GALA-E0026.md) is a defensive check that
-[GALA-E0032](GALA-E0032.md) reports first in every construction found so far,
-and [GALA-E0020](GALA-E0020.md) surfaces nested inside an unresolved-imports
-wrapper rather than as a standalone framed diagnostic. Each page says so
-explicitly.
 
 ## Adding a new code
 

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -39,10 +39,34 @@ Each code has a dedicated documentation page in this directory explaining:
 | `GALA-E0022` | Occurs check failure | [GALA-E0022.md](GALA-E0022.md) |
 | `GALA-E0023` | Undefined variable | [GALA-E0023.md](GALA-E0023.md) |
 | `GALA-E0024` | Internal inference failure | [GALA-E0024.md](GALA-E0024.md) |
+| `GALA-E0025` | Unresolved cross-package symbol | [GALA-E0025.md](GALA-E0025.md) |
+| `GALA-E0026` | Ambiguous sealed-variant reference | [GALA-E0026.md](GALA-E0026.md) |
+| `GALA-E0027` | Function redeclared | [GALA-E0027.md](GALA-E0027.md) |
+| `GALA-E0028` | Type alias redeclared | [GALA-E0028.md](GALA-E0028.md) |
+| `GALA-E0029` | Interface method redeclared | [GALA-E0029.md](GALA-E0029.md) |
+| `GALA-E0030` | Struct field redeclared | [GALA-E0030.md](GALA-E0030.md) |
+| `GALA-E0031` | Sealed variant case redeclared | [GALA-E0031.md](GALA-E0031.md) |
+| `GALA-E0032` | Dot-import symbol collision | [GALA-E0032.md](GALA-E0032.md) |
 | `GALA-E0033` | Untyped lambda parameter | [GALA-E0033.md](GALA-E0033.md) |
 | `GALA-E0034` | Untyped function/struct parameter | [GALA-E0034.md](GALA-E0034.md) |
+| `GALA-E0035` | Bare Go builtin is forbidden | [GALA-E0035.md](GALA-E0035.md) |
+| `GALA-E0036` | Bare Go statement keyword is forbidden | [GALA-E0036.md](GALA-E0036.md) |
 | `GALA-E0037` | Unshareable capture across a concurrency boundary | [GALA-E0037.md](GALA-E0037.md) |
 | `GALA-E0038` | Invalid string escape sequence | [GALA-E0038.md](GALA-E0038.md) |
+
+Every code defined in `galaerr/errors.go` now has a page. Three of them describe
+conditions no valid source can reach — [GALA-E0009](GALA-E0009.md),
+[GALA-E0017](GALA-E0017.md), and [GALA-E0024](GALA-E0024.md) signal a
+**transpiler defect**, and the right response is a bug report, not a source
+change. Three more originate in the type-inference engine and are **not
+currently surfaced** to users at all: [GALA-E0021](GALA-E0021.md),
+[GALA-E0022](GALA-E0022.md), and [GALA-E0024](GALA-E0024.md) — type errors of
+that class are reported by the Go compiler against the generated Go.
+[GALA-E0026](GALA-E0026.md) is a defensive check that
+[GALA-E0032](GALA-E0032.md) reports first in every construction found so far,
+and [GALA-E0020](GALA-E0020.md) surfaces nested inside an unresolved-imports
+wrapper rather than as a standalone framed diagnostic. Each page says so
+explicitly.
 
 ## Adding a new code
 

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -11,20 +11,10 @@ Each code has a dedicated documentation page in this directory explaining:
 - how to fix it
 - the underlying design rationale (so you can judge edge cases)
 
-Not every code is something you can trigger, and the pages say so rather than
-inventing an example:
-
-- **Transpiler defects.** [GALA-E0009](GALA-E0009.md),
-  [GALA-E0017](GALA-E0017.md), and [GALA-E0024](GALA-E0024.md) cannot be forced
-  by any valid source. The right response is a bug report, not a source change.
-- **Not currently surfaced.** [GALA-E0021](GALA-E0021.md),
-  [GALA-E0022](GALA-E0022.md), and [GALA-E0024](GALA-E0024.md) originate in the
-  type-inference engine, whose errors every caller discards. Type errors of that
-  class are reported by the Go compiler against the generated Go.
-- **Shadowed by an earlier check.** [GALA-E0026](GALA-E0026.md) is defensive;
-  [GALA-E0032](GALA-E0032.md) reports first in every construction found so far.
-- **Nested inside a wrapper.** [GALA-E0020](GALA-E0020.md) has no framed header
-  of its own — it appears inside an uncoded unresolved-imports error.
+Not every code is something you can trigger. Some signal a transpiler defect,
+some originate in the type-inference engine and are never surfaced, and one is
+shadowed by an earlier check. Those pages open with a bold notice saying so
+rather than inventing an example — trust the notice at the top of the page.
 
 ## Index
 
@@ -64,8 +54,8 @@ inventing an example:
 | `GALA-E0032` | Dot-import symbol collision | [GALA-E0032.md](GALA-E0032.md) |
 | `GALA-E0033` | Untyped lambda parameter | [GALA-E0033.md](GALA-E0033.md) |
 | `GALA-E0034` | Untyped function/struct parameter | [GALA-E0034.md](GALA-E0034.md) |
-| `GALA-E0035` | Bare Go builtin is forbidden | [GALA-E0035.md](GALA-E0035.md) |
-| `GALA-E0036` | Bare Go statement keyword is forbidden | [GALA-E0036.md](GALA-E0036.md) |
+| `GALA-E0035` | Bare Go builtin is not part of GALA's surface | [GALA-E0035.md](GALA-E0035.md) |
+| `GALA-E0036` | Bare Go statement keyword is not part of GALA's surface | [GALA-E0036.md](GALA-E0036.md) |
 | `GALA-E0037` | Unshareable capture across a concurrency boundary | [GALA-E0037.md](GALA-E0037.md) |
 | `GALA-E0038` | Invalid string escape sequence | [GALA-E0038.md](GALA-E0038.md) |
 
@@ -81,20 +71,42 @@ inventing an example:
 
 ## Page template
 
-```markdown
+````markdown
 # GALA-Exxxx — Short title
+
+> Optional bold notice, when the code is NOT an ordinary user error — e.g. it
+> signals a transpiler defect, is not currently surfaced, or is shadowed by an
+> earlier check. Put it at the very top so a reader knows immediately that the
+> page will not hand them a fix.
 
 **When it fires.** Plain-English description of the invariant that was violated.
 
 **Minimal repro.**
+
 ```gala
 // paste the smallest code that triggers the error
 ```
 
-**Error output.** `[SemanticError GALA-Exxxx] file.gala:L:C <message> (hint: <hint>)`
+**Error output.** Paste the framed output from a real run, with `NO_COLOR=1`:
 
-**Fix.** One or two paragraphs describing how to correct the code.
+```
+error[GALA-Exxxx]: <message>
+  --> file.gala:L:C
+  |
+L |     <source line>
+  |     ^^^^ <terse hint>
+  |
+  = hint: <full hint>
+```
+
+If the code cannot be triggered from valid source, say so plainly and quote the
+message from the emit site instead — do not invent a repro.
+
+**Fix.** How to correct the code. Every snippet must compile with `gala build`.
 
 **Rationale.** Why the rule exists — usually the class of bug it prevents or
-the semantic it protects. Links to related transpiler work or issues.
-```
+the semantic it protects.
+
+**Scope.** What this code does and does not cover, with links to the neighbouring
+codes a reader may have wanted instead.
+````

--- a/internal/transpiler/transformer/error_docs_guard_test.go
+++ b/internal/transpiler/transformer/error_docs_guard_test.go
@@ -31,12 +31,14 @@ import (
 // the page is updated with the new text.
 //
 // Scope note: the table covers the codes whose real output was captured while
-// writing these pages — E0002, E0003, E0006, E0015, E0018 from the in-memory
-// transpiler and E0025 from a temp directory (it needs a sibling file on disk,
-// because the whole point of that code is that a sibling's imports do not
-// propagate). Every other code is deliberately absent rather than stubbed; a
-// stub would advertise coverage that does not exist. See the GALA-E0010 note
-// in the table for a code that cannot be guarded from here at all.
+// writing these pages — E0002, E0003, E0006, E0015, E0018, E0027 through E0031,
+// E0035 and E0036 from the in-memory transpiler, plus E0025 and E0032 from a
+// temp directory (both need real files on disk: E0025 because the whole point
+// of that code is that a sibling's imports do not propagate, E0032 because a
+// collision needs two packages to collide). Every other code is deliberately
+// absent rather than stubbed; a stub would advertise coverage that does not
+// exist. See the GALA-E0010 and GALA-E0026 notes in the table for codes that
+// cannot be guarded from here at all.
 func TestErrorDocsQuoteRealOutput(t *testing.T) {
 	cases := []struct {
 		// name distinguishes several rows for the same code. A page often
@@ -183,6 +185,162 @@ func main() {
 		// nothing for a row to assert. Table rows are keyed by code + name
 		// precisely so this row can be added once that gap is understood;
 		// leaving a row that silently passes would be worse than its absence.
+
+		// GALA-E0026 is deliberately absent, and cannot be added. Its
+		// precondition — two dot-imported packages each declaring a sealed
+		// case of the same name — is a strict subset of GALA-E0032's, and the
+		// dot-import collision check runs first, so every repro that would
+		// reach it reports E0032 instead. A row here could only ever assert
+		// E0032's output, which is exactly the "row that cannot fail" this
+		// table avoids. The page says the same thing in prose and quotes its
+		// message from the emit site rather than from a run.
+		{
+			// Two declarations in one file. The cross-file shape the page also
+			// documents is not pinned: it needs a sibling on disk, and the
+			// batch entry point that reports both sites renders the terse
+			// single-line form rather than the framed block this test asserts.
+			name: "two functions of the same name in one file",
+			code: galaerr.CodeFunctionRedeclared, // GALA-E0027
+			render: func(t *testing.T) string {
+				return renderRepro(t, "a.gala", `package main
+
+func greet(name string) string = "hello " + name
+
+func greet(other string) string = "hi " + other
+
+func main() {
+    Println(greet("world"))
+}
+`)
+			},
+		},
+		{
+			name: "two aliases of the same name",
+			code: galaerr.CodeTypeAliasRedeclared, // GALA-E0028
+			render: func(t *testing.T) string {
+				return renderRepro(t, "main.gala", `package main
+
+type Handler func(string) string
+type Handler func(int) int
+
+func main() {
+    Println("unused")
+}
+`)
+			},
+		},
+		{
+			name: "two method specs of the same name",
+			code: galaerr.CodeInterfaceMethodRedeclared, // GALA-E0029
+			render: func(t *testing.T) string {
+				return renderRepro(t, "main.gala", `package main
+
+type Repo interface {
+    Find(id int) string
+    Find(name string) string
+}
+
+func main() {
+    Println("unused")
+}
+`)
+			},
+		},
+		{
+			// Shorthand struct syntax.
+			name: "duplicate field, shorthand struct",
+			code: galaerr.CodeStructFieldRedeclared, // GALA-E0030
+			render: func(t *testing.T) string {
+				return renderRepro(t, "main.gala", `package main
+
+struct Point(X int, X int)
+
+func main() {
+    val p = Point(1, 2)
+    Println(p.X)
+}
+`)
+			},
+		},
+		{
+			// Block struct syntax reaches a different emit site in the
+			// analyzer, so it gets its own row.
+			name: "duplicate field, block struct",
+			code: galaerr.CodeStructFieldRedeclared, // GALA-E0030
+			render: func(t *testing.T) string {
+				return renderRepro(t, "main.gala", `package main
+
+type Point struct {
+    val x int
+    val x int
+}
+
+func main() {
+    val p = Point(x = 1)
+    Println(p.x)
+}
+`)
+			},
+		},
+		{
+			name: "two sealed cases of the same name",
+			code: galaerr.CodeSealedVariantCaseRedeclared, // GALA-E0031
+			render: func(t *testing.T) string {
+				return renderRepro(t, "main.gala", `package main
+
+sealed type Shape {
+    case Box(W int)
+    case Box(H int)
+}
+
+func main() {
+    val b = Box(1)
+    Println(b)
+}
+`)
+			},
+		},
+		{
+			// Needs two real dot-imported packages on disk for the collision
+			// to exist at all.
+			name:   "same symbol from two dot-imported packages",
+			code:   galaerr.CodeDotImportCollision, // GALA-E0032
+			render: renderDotImportCollisionRepro,
+		},
+		{
+			// The `len` row also pins the terse caret annotation, which is
+			// derived by truncating the hint at its first " (" — a detail no
+			// other covered code exercises.
+			name: "bare len call",
+			code: galaerr.CodeForbiddenGoBuiltin, // GALA-E0035
+			render: func(t *testing.T) string {
+				return renderRepro(t, "main.gala", `package main
+
+func main() {
+    val s = "héllo"
+    val n = len(s)
+    Println(n)
+}
+`)
+			},
+		},
+		{
+			name: "bare defer statement",
+			code: galaerr.CodeForbiddenStatementKeyword, // GALA-E0036
+			render: func(t *testing.T) string {
+				return renderRepro(t, "main.gala", `package main
+
+import "martianoff/gala/io"
+
+func main() {
+    val f = io.OpenFile("data.txt")
+    defer
+    f.Close()
+    Println("done")
+}
+`)
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -252,6 +410,51 @@ import "martianoff/gala/cmdpkg"
 func main() {
     val x = cmdpkg.NoCmd()
     Println(x)
+}
+`
+	mainPath := filepath.Join(mainDir, "main.gala")
+	require.NoError(t, os.WriteFile(mainPath, []byte(mainSrc), 0o600))
+
+	_, err := newDocGuardTranspilerWithPaths(searchRoot).Transpile(mainSrc, mainPath)
+	require.Error(t, err, "repro was expected to fail to compile")
+
+	rendered := galaerr.RenderRich(err, galaerr.Options{
+		FallbackPath:   mainPath,
+		FallbackSource: mainSrc,
+		Color:          false,
+	})
+	rendered = strings.ReplaceAll(rendered, mainPath, "main.gala")
+	rendered = strings.ReplaceAll(rendered, filepath.ToSlash(mainPath), "main.gala")
+	return rendered
+}
+
+// renderDotImportCollisionRepro drives GALA-E0032. The collision is a property
+// of two packages both exporting a name, so both have to exist on disk for the
+// analyzer to discover their exports — an in-memory single file cannot express
+// it. The reported package names come from the `package` clauses, not the
+// import paths, so the module prefix used here does not leak into the message
+// the page quotes.
+func renderDotImportCollisionRepro(t *testing.T) string {
+	t.Helper()
+	searchRoot := t.TempDir()
+	for _, pkg := range []string{"pkg_a", "pkg_b"} {
+		dir := filepath.Join(searchRoot, pkg)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		src := "package " + pkg + "\n\nfunc Greet() string = \"hello from " + pkg + "\"\n"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, pkg+".gala"), []byte(src), 0o600))
+	}
+
+	mainDir := filepath.Join(searchRoot, "main")
+	require.NoError(t, os.MkdirAll(mainDir, 0o755))
+	mainSrc := `package main
+
+import (
+    . "martianoff/gala/pkg_a"
+    . "martianoff/gala/pkg_b"
+)
+
+func main() {
+    Println("hi")
 }
 `
 	mainPath := filepath.Join(mainDir, "main.gala")

--- a/internal/transpiler/transformer/error_docs_guard_test.go
+++ b/internal/transpiler/transformer/error_docs_guard_test.go
@@ -325,17 +325,18 @@ func main() {
 			},
 		},
 		{
+			// Deliberately import-free. A bare keyword is rejected during
+			// statement transformation, before any symbol is resolved, so the
+			// repro needs nothing else to trigger it — and an import here
+			// would be staged into the Linux sandbox or not, making the row
+			// pass on Windows and fail on CI for reasons unrelated to E0036.
 			name: "bare defer statement",
 			code: galaerr.CodeForbiddenStatementKeyword, // GALA-E0036
 			render: func(t *testing.T) string {
 				return renderRepro(t, "main.gala", `package main
 
-import "martianoff/gala/io"
-
 func main() {
-    val f = io.OpenFile("data.txt")
     defer
-    f.Close()
     Println("done")
 }
 `)


### PR DESCRIPTION
## Summary

`docs/errors/` covered E0001–E0025 plus E0033/E0034. Nine shipped, user-facing codes had **no page at all**, and several existing pages described internal-only checks as though a user could hit and fix them.

## Pages created (9)

E0026, E0027, E0028, E0029, E0030, E0031, E0032, E0035, E0036.

E0037 already existed on master, so it was out of scope. E0035 and E0036 have full suggestion tables in source and got substantial pages rather than stubs — mining those tables is most of the value of those two.

Every page quotes **verbatim framed output captured from a branch-built CLI**, with a fresh `GALA_HOME`/`GALA_CACHE`. All 14 remediation snippets were compiled with `gala build`; three drafts failed verification and were corrected or removed rather than published.

## E0026 is unreachable — documented honestly, not fabricated

Its precondition (two or more dot-imported packages each declaring a sealed case of the same name) is a strict subset of E0032's, and `ValidateDotImports` runs earlier in `Transform`. Every construction attempted — non-generic, generic, single-dot-import — reported E0032 or transpiled cleanly. Both emit sites are additionally reachable only via named-argument calls.

Rather than invent a plausible-looking repro, the page states it is a defensive check with no user-triggerable example.

## Pages corrected

- **E0009, E0017, E0024** — now state plainly that these indicate a **transpiler defect, not a user error**, and that the response is to report it rather than change the GALA code. Each emit site was read to confirm the unreachability claim before asserting it.
- **E0020** — has no `error[GALA-E0020]:` framed form. The real output nests the terse single-line form inside an unresolved-imports wrapper, framed at the `package` clause. The page now shows that actual shape. This is a legitimate surviving use of the terse format, so no compiler behaviour was changed.
- **E0021, E0022** — documented as **inference-internal**. These are raised only by the Hindley-Milner engine, and **no call site propagates the error**: eight discard it explicitly with `_`, and two bind it as a fallback guard without ever returning it. Verified empirically — `add(1, "two")` and `if ("nope") 1 else 2` both transpile with exit 0 and fail later at `go build`. So a user searching for E0021 will not see it in their terminal today, and the pages now say so.

## Verification after FIX-003 merged

FIX-003 changed E0012/E0027 behaviour mid-flight, so every repro was re-run against the rebuilt CLI rather than assumed:

- **E0027 rewritten.** It previously did not catch cross-file duplicate functions; it now does. The Go-compiler fall-through transcript was removed and `Scope` now reads "anywhere in one package". Note E0027 says **"redeclared"**, not "redefined" — only the `(also declared at …)` half of the wording is shared with E0011/E0012.
- All other quoted outputs re-confirmed byte-identical: E0020, E0026, E0028, E0029, E0030, E0031, E0032, E0035, E0036.
- E0027 restructured to E0011/E0012's exact section sequence so the three redefinition pages read as a set.

## Flagged, not fixed

- "GALA has no overloading" is asserted in E0027 and E0029 but appears nowhere in `docs/GALA.MD` — reference-level content living only in error pages.
- Duplicate case names across two *different* sealed types in one package are not caught by E0031; they fail later at `go build`. Documented in E0031's Scope as a candidate for a GALA-level check.
- Generic type aliases (`type Handler[T any] func(T) T`) emit Go requiring go1.23 against a workspace pinned to `-lang=go1.22`. The suggestion was removed from the E0028 page.
- There is no website error-code index; `docs/errors/README.md` is the only one, and no test validates it against `galaerr`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)