### PR TITLE
fix: re-extract the stdlib cache when the embedded snapshot changes

### DIFF
--- a/cmd/gala/commands/lsp.go
+++ b/cmd/gala/commands/lsp.go
@@ -52,10 +52,14 @@ func runLsp(cmd *cobra.Command, args []string) {
 }
 
 func autoResolveLSPSearchPaths() []string {
-	stdlibDir := build.DefaultConfig().EnsureStdlib(Version)
-	fmt.Fprintf(os.Stderr, "[gala-lsp] version=%s stdlib=%s\n", Version, stdlibDir)
-	if stdlibDir != "" {
-		return []string{stdlibDir}
+	stdlibDir, err := build.DefaultConfig().EnsureStdlib(Version)
+	if err != nil {
+		// Without the stdlib the server still starts, but every standard
+		// symbol becomes an unresolved reference — say why, in the log the
+		// editor shows, rather than leaving it to be guessed.
+		fmt.Fprintf(os.Stderr, "[gala-lsp] version=%s stdlib unavailable: %v\n", Version, err)
+		return nil
 	}
-	return nil
+	fmt.Fprintf(os.Stderr, "[gala-lsp] version=%s stdlib=%s\n", Version, stdlibDir)
+	return []string{stdlibDir}
 }

--- a/cmd/gala/commands/transpile.go
+++ b/cmd/gala/commands/transpile.go
@@ -59,7 +59,9 @@ func autoResolveSearchPaths(inputPath string, basePaths []string) []string {
 	config := build.DefaultConfig()
 
 	// Add stdlib path using current CLI version
-	if stdlibDir := config.EnsureStdlib(Version); stdlibDir != "" {
+	if stdlibDir, err := config.EnsureStdlib(Version); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: stdlib cache unavailable: %v\n", err)
+	} else {
 		basePaths = appendIfNew(basePaths, stdlibDir)
 	}
 

--- a/internal/build/BUILD.bazel
+++ b/internal/build/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "config.go",
         "deptranspiler.go",
         "gomod.go",
+        "stdlibver.go",
         "testgen.go",
         "workspace.go",
     ],
@@ -28,6 +29,7 @@ go_test(
     srcs = [
         "apex_perf_test.go",
         "builder_test.go",
+        "config_test.go",
         "contention_perf_test.go",
         "deptranspiler_test.go",
         "go_toolchain_test.go",

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -12,7 +12,6 @@ import (
 
 	"martianoff/gala/internal/depman/fetch"
 	"martianoff/gala/internal/depman/mod"
-	"martianoff/gala/internal/stdlib"
 	"martianoff/gala/internal/transpiler"
 	"martianoff/gala/internal/transpiler/analyzer"
 	"martianoff/gala/internal/transpiler/generator"
@@ -365,33 +364,23 @@ func dirHasGoFiles(dir string) bool {
 	return false
 }
 
-// ensureStdlib extracts the stdlib to the versioned cache if not present.
+// ensureStdlib makes the versioned stdlib cache match the embedded snapshot,
+// re-extracting it when the cached copy was produced by a different snapshot.
+// The work is shared with Config.EnsureStdlib (used by `gala transpile` and the
+// LSP) so both entry points target the same directory and apply the same
+// freshness check.
 func (b *Builder) ensureStdlib() error {
-	stdlibDir := b.config.StdlibVersionDir(b.stdlibVersion)
-
-	// Check if already extracted
-	markerPath := filepath.Join(stdlibDir, ".stdlib-extracted")
-	if _, err := os.Stat(markerPath); err == nil {
-		if b.verbose {
+	stdlibDir, extracted, err := b.config.ensureStdlibExtracted(b.stdlibVersion)
+	if err != nil {
+		return err
+	}
+	if b.verbose {
+		if extracted {
+			fmt.Printf("Extracted stdlib to: %s\n", stdlibDir)
+		} else {
 			fmt.Printf("Stdlib already extracted at: %s\n", stdlibDir)
 		}
-		return nil
 	}
-
-	if b.verbose {
-		fmt.Printf("Extracting stdlib to: %s\n", stdlibDir)
-	}
-
-	// Extract stdlib (includes go.mod files for each package)
-	if err := stdlib.ExtractTo(stdlibDir); err != nil {
-		return fmt.Errorf("extracting stdlib: %w", err)
-	}
-
-	// Write marker file
-	if err := os.WriteFile(markerPath, []byte(b.stdlibVersion), 0644); err != nil {
-		return fmt.Errorf("writing marker: %w", err)
-	}
-
 	return nil
 }
 

--- a/internal/build/config.go
+++ b/internal/build/config.go
@@ -4,8 +4,6 @@ package build
 import (
 	"os"
 	"path/filepath"
-
-	"martianoff/gala/internal/stdlib"
 )
 
 // Config holds configuration for the build system.
@@ -80,37 +78,23 @@ func (c *Config) EnsureDirs() error {
 
 // StdlibVersionDir returns the path for a specific stdlib version.
 // Format: StdlibDir/v{version}/
+// The version string may contain a git describe suffix (e.g.,
+// "0.29.4-1-ga528ffd"); it is normalized to the base version ("0.29.4") here so
+// that every consumer of the cache — build, transpile and the LSP — agrees on
+// one directory.
 func (c *Config) StdlibVersionDir(version string) string {
-	return filepath.Join(c.StdlibDir, "v"+version)
+	return filepath.Join(c.StdlibDir, "v"+normalizeStdlibVersion(version))
 }
 
 // EnsureStdlib extracts the embedded stdlib for the given version and returns
-// the stdlib directory path. This is the canonical stdlib resolution used by
-// both the CLI transpiler and the LSP server.
-// The version string may contain git suffixes (e.g., "0.29.4-1-ga528ffd")
-// which are stripped to find the base version ("0.29.4").
+// the stdlib directory path, or "" if extraction failed. This is the canonical
+// stdlib resolution used by both the CLI transpiler and the LSP server; it
+// shares its implementation with the builder so the two cannot drift apart.
 func (c *Config) EnsureStdlib(version string) string {
-	// Strip git describe suffix: "0.29.4-1-ga528ffd" → "0.29.4"
-	ver := version
-	for i := 0; i < len(ver); i++ {
-		if ver[i] == '-' {
-			// Check if this looks like a git suffix (digit after last dot before dash)
-			ver = ver[:i]
-			break
-		}
+	stdlibDir, _, err := c.ensureStdlibExtracted(version)
+	if err != nil {
+		return ""
 	}
-	stdlibDir := c.StdlibVersionDir(ver)
-
-	markerPath := filepath.Join(stdlibDir, ".stdlib-extracted")
-	if _, err := os.Stat(markerPath); err == nil {
-		return stdlibDir // already extracted
-	}
-
-	os.MkdirAll(stdlibDir, 0755)
-	if err := stdlib.ExtractTo(stdlibDir); err != nil {
-		return "" // extraction failed
-	}
-	os.WriteFile(markerPath, []byte(ver), 0644)
 	return stdlibDir
 }
 

--- a/internal/build/config.go
+++ b/internal/build/config.go
@@ -77,25 +77,25 @@ func (c *Config) EnsureDirs() error {
 }
 
 // StdlibVersionDir returns the path for a specific stdlib version.
-// Format: StdlibDir/v{version}/
-// The version string may contain a git describe suffix (e.g.,
-// "0.29.4-1-ga528ffd"); it is normalized to the base version ("0.29.4") here so
-// that every consumer of the cache — build, transpile and the LSP — agrees on
-// one directory.
+// Format: StdlibDir/v{version}/, with the version put through
+// normalizeStdlibVersion so that every consumer of the cache resolves the same
+// directory for a given binary.
 func (c *Config) StdlibVersionDir(version string) string {
 	return filepath.Join(c.StdlibDir, "v"+normalizeStdlibVersion(version))
 }
 
 // EnsureStdlib extracts the embedded stdlib for the given version and returns
-// the stdlib directory path, or "" if extraction failed. This is the canonical
-// stdlib resolution used by both the CLI transpiler and the LSP server; it
-// shares its implementation with the builder so the two cannot drift apart.
-func (c *Config) EnsureStdlib(version string) string {
+// the stdlib directory path. This is the canonical stdlib resolution used by
+// both the CLI transpiler and the LSP server; it shares its implementation with
+// the builder so the two cannot drift apart.
+//
+// The failure is reported rather than collapsed into an empty path: refusing to
+// repair the cache is exactly the situation this code exists to notice, and a
+// caller that only sees "" degrades it into the far less informative "no stdlib
+// on the search path".
+func (c *Config) EnsureStdlib(version string) (string, error) {
 	stdlibDir, _, err := c.ensureStdlibExtracted(version)
-	if err != nil {
-		return ""
-	}
-	return stdlibDir
+	return stdlibDir, err
 }
 
 // GalaModulePath returns the path where a GALA module version is cached.

--- a/internal/build/config_test.go
+++ b/internal/build/config_test.go
@@ -1,0 +1,252 @@
+package build
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"martianoff/gala/internal/stdlib"
+)
+
+// isolatedConfig returns a Config rooted at a throwaway GALA_HOME so tests
+// never read or write the developer's real stdlib cache.
+func isolatedConfig(t *testing.T) *Config {
+	t.Helper()
+	t.Setenv("GALA_HOME", t.TempDir())
+	config := DefaultConfig()
+	require.NoError(t, config.EnsureDirs())
+	return config
+}
+
+// anyEmbeddedFile returns a deterministic (package, filename) pair from the
+// embedded snapshot so tests can tamper with an extracted file without naming
+// any particular stdlib package.
+func anyEmbeddedFile(t *testing.T) (pkg, file string) {
+	t.Helper()
+	pkgNames := make([]string, 0, len(stdlib.EmbeddedPackages))
+	for name, files := range stdlib.EmbeddedPackages {
+		if len(files) > 0 {
+			pkgNames = append(pkgNames, name)
+		}
+	}
+	require.NotEmpty(t, pkgNames, "embedded stdlib snapshot is empty")
+	sort.Strings(pkgNames)
+	pkg = pkgNames[0]
+
+	fileNames := make([]string, 0, len(stdlib.EmbeddedPackages[pkg]))
+	for name := range stdlib.EmbeddedPackages[pkg] {
+		fileNames = append(fileNames, name)
+	}
+	sort.Strings(fileNames)
+	return pkg, fileNames[0]
+}
+
+// TestNormalizeStdlibVersion verifies the git describe suffix is stripped so
+// that every stdlib cache consumer derives the same directory name.
+func TestNormalizeStdlibVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "plain release", version: "0.29.4", want: "0.29.4"},
+		{name: "git describe suffix", version: "0.29.4-1-ga528ffd", want: "0.29.4"},
+		{name: "prerelease suffix", version: "1.0.0-rc1", want: "1.0.0"},
+		{name: "unstamped dev build", version: "dev", want: "dev"},
+		{name: "empty", version: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, normalizeStdlibVersion(tt.version))
+		})
+	}
+}
+
+// TestStdlibVersionDir_NormalizesForAllCallers verifies `gala build` (which
+// reaches the cache through StdlibVersionDir) and `gala transpile`/`gala lsp`
+// (which reach it through EnsureStdlib) resolve one and the same directory for
+// a version carrying a git describe suffix. Before normalization was shared,
+// the two produced sibling directories with independent freshness markers.
+func TestStdlibVersionDir_NormalizesForAllCallers(t *testing.T) {
+	config := isolatedConfig(t)
+
+	suffixed := config.StdlibVersionDir("0.29.4-1-ga528ffd")
+	plain := config.StdlibVersionDir("0.29.4")
+	require.Equal(t, plain, suffixed)
+
+	ensured := config.EnsureStdlib("0.29.4-1-ga528ffd")
+	require.Equal(t, plain, ensured)
+
+	// The freshness marker must match for both spellings too, otherwise the
+	// shared directory would be wiped and re-extracted on every alternation.
+	require.Equal(t, snapshotFingerprint("0.29.4"), snapshotFingerprint("0.29.4-1-ga528ffd"))
+	require.NotEqual(t, snapshotFingerprint("0.29.4"), snapshotFingerprint("0.30.0"))
+}
+
+// TestEnsureStdlibExtracted_WritesFingerprintMarker verifies a first extraction
+// populates the version directory and records the snapshot fingerprint.
+func TestEnsureStdlibExtracted_WritesFingerprintMarker(t *testing.T) {
+	config := isolatedConfig(t)
+
+	dir, extracted, err := config.ensureStdlibExtracted("dev")
+	require.NoError(t, err)
+	require.True(t, extracted)
+	require.Equal(t, filepath.Join(config.StdlibDir, "vdev"), dir)
+
+	pkg, file := anyEmbeddedFile(t)
+	require.FileExists(t, filepath.Join(dir, pkg, file))
+	require.FileExists(t, filepath.Join(dir, pkg, "go.mod"))
+
+	marker, err := os.ReadFile(filepath.Join(dir, stdlibMarkerName))
+	require.NoError(t, err)
+	require.Equal(t, snapshotFingerprint("dev"), string(marker))
+}
+
+// TestEnsureStdlibExtracted_FastPathWhenFingerprintMatches verifies a second
+// call with an unchanged snapshot does no work.
+func TestEnsureStdlibExtracted_FastPathWhenFingerprintMatches(t *testing.T) {
+	config := isolatedConfig(t)
+
+	dir, extracted, err := config.ensureStdlibExtracted("dev")
+	require.NoError(t, err)
+	require.True(t, extracted)
+
+	// A sentinel survives only if the directory is left untouched.
+	sentinel := filepath.Join(dir, "sentinel.txt")
+	require.NoError(t, os.WriteFile(sentinel, []byte("keep"), 0644))
+
+	dir2, extracted2, err := config.ensureStdlibExtracted("dev")
+	require.NoError(t, err)
+	require.False(t, extracted2, "matching fingerprint must take the fast path")
+	require.Equal(t, dir, dir2)
+	require.FileExists(t, sentinel)
+}
+
+// TestEnsureStdlibExtracted_StaleSnapshotIsReplaced verifies that a cache
+// written by a different snapshot is detected through the marker contents and
+// fully replaced. Previously the marker's mere existence was accepted, so an
+// outdated stdlib could be used indefinitely — silently changing the type
+// information the transpiler compiles against.
+func TestEnsureStdlibExtracted_StaleSnapshotIsReplaced(t *testing.T) {
+	config := isolatedConfig(t)
+
+	dir, _, err := config.ensureStdlibExtracted("dev")
+	require.NoError(t, err)
+
+	pkg, file := anyEmbeddedFile(t)
+	tampered := filepath.Join(dir, pkg, file)
+	require.NoError(t, os.WriteFile(tampered, []byte("// outdated contents\n"), 0644))
+
+	// A file that no longer exists upstream must not survive re-extraction.
+	orphan := filepath.Join(dir, pkg, "removed_upstream.gala")
+	require.NoError(t, os.WriteFile(orphan, []byte("// dropped upstream\n"), 0644))
+
+	// Simulate a marker left behind by an older binary.
+	markerPath := filepath.Join(dir, stdlibMarkerName)
+	require.NoError(t, os.WriteFile(markerPath, []byte("fingerprint-from-an-older-snapshot"), 0644))
+
+	dir2, extracted, err := config.ensureStdlibExtracted("dev")
+	require.NoError(t, err)
+	require.True(t, extracted, "differing fingerprint must force re-extraction")
+	require.Equal(t, dir, dir2)
+
+	restored, err := os.ReadFile(tampered)
+	require.NoError(t, err)
+	require.Equal(t, stdlib.EmbeddedPackages[pkg][file], string(restored))
+	require.NoFileExists(t, orphan, "files dropped upstream must not linger")
+
+	marker, err := os.ReadFile(markerPath)
+	require.NoError(t, err)
+	require.Equal(t, snapshotFingerprint("dev"), string(marker))
+}
+
+// TestEnsureStdlibExtracted_MissingMarkerReExtracts verifies a version
+// directory with no marker at all is treated as stale.
+func TestEnsureStdlibExtracted_MissingMarkerReExtracts(t *testing.T) {
+	config := isolatedConfig(t)
+
+	dir, _, err := config.ensureStdlibExtracted("dev")
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(filepath.Join(dir, stdlibMarkerName)))
+
+	_, extracted, err := config.ensureStdlibExtracted("dev")
+	require.NoError(t, err)
+	require.True(t, extracted)
+}
+
+// TestCheckStdlibVersionDir_RejectsNonVersionDirs verifies the guard that
+// protects the re-extraction wipe: only a direct child of the stdlib cache root
+// may ever be removed, so no version string can escalate into deleting the
+// cache root or the user's home directory.
+func TestCheckStdlibVersionDir_RejectsNonVersionDirs(t *testing.T) {
+	config := isolatedConfig(t)
+
+	tests := []struct {
+		name    string
+		dir     string
+		wantErr bool
+	}{
+		{name: "version dir", dir: filepath.Join(config.StdlibDir, "v0.29.4"), wantErr: false},
+		{name: "dev version dir", dir: config.StdlibVersionDir("dev"), wantErr: false},
+		{name: "cache root itself", dir: config.StdlibDir, wantErr: true},
+		{name: "gala home", dir: config.GalaHome, wantErr: true},
+		{name: "parent escape", dir: filepath.Join(config.StdlibDir, ".."), wantErr: true},
+		{name: "deep escape", dir: filepath.Join(config.StdlibDir, "..", "..", ".."), wantErr: true},
+		{name: "nested path", dir: filepath.Join(config.StdlibDir, "v0.29.4", "std"), wantErr: true},
+		{name: "unrelated path", dir: t.TempDir(), wantErr: true},
+		{name: "empty", dir: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := config.checkStdlibVersionDir(tt.dir)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var unsafeErr *UnsafeStdlibDirError
+			require.True(t, errors.As(err, &unsafeErr))
+		})
+	}
+}
+
+// TestCheckStdlibVersionDir_RejectsDegenerateRoot verifies a Config whose
+// stdlib root is unset or is a filesystem/volume root can never authorize a
+// delete, however plausible the version string looks.
+func TestCheckStdlibVersionDir_RejectsDegenerateRoot(t *testing.T) {
+	volumeRoot := filepath.VolumeName(t.TempDir()) + string(filepath.Separator)
+
+	for _, root := range []string{"", ".", string(filepath.Separator), volumeRoot} {
+		config := &Config{StdlibDir: root}
+		require.Error(t, config.checkStdlibVersionDir(config.StdlibVersionDir("dev")),
+			"root %q must be rejected", root)
+	}
+}
+
+// TestRemoveStdlibVersionDir_LeavesRejectedPathsIntact verifies the guard is
+// enforced by the removal path itself, not only by its callers.
+func TestRemoveStdlibVersionDir_LeavesRejectedPathsIntact(t *testing.T) {
+	config := isolatedConfig(t)
+
+	victim := filepath.Join(config.GalaHome, "precious.txt")
+	require.NoError(t, os.WriteFile(victim, []byte("do not delete"), 0644))
+
+	err := config.removeStdlibVersionDir(config.GalaHome)
+	require.Error(t, err)
+	var unsafeErr *UnsafeStdlibDirError
+	require.True(t, errors.As(err, &unsafeErr))
+	require.FileExists(t, victim)
+	require.DirExists(t, config.StdlibDir)
+
+	// A real version directory is removed.
+	dir := config.StdlibVersionDir("dev")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, config.removeStdlibVersionDir(dir))
+	require.NoDirExists(t, dir)
+}

--- a/internal/build/config_test.go
+++ b/internal/build/config_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -79,7 +81,8 @@ func TestStdlibVersionDir_NormalizesForAllCallers(t *testing.T) {
 	plain := config.StdlibVersionDir("0.29.4")
 	require.Equal(t, plain, suffixed)
 
-	ensured := config.EnsureStdlib("0.29.4-1-ga528ffd")
+	ensured, err := config.EnsureStdlib("0.29.4-1-ga528ffd")
+	require.NoError(t, err)
 	require.Equal(t, plain, ensured)
 
 	// The freshness marker must match for both spellings too, otherwise the
@@ -146,9 +149,11 @@ func TestEnsureStdlibExtracted_StaleSnapshotIsReplaced(t *testing.T) {
 	orphan := filepath.Join(dir, pkg, "removed_upstream.gala")
 	require.NoError(t, os.WriteFile(orphan, []byte("// dropped upstream\n"), 0644))
 
-	// Simulate a marker left behind by an older binary.
+	// A marker exactly as an older binary left it: the bare version string,
+	// which used to be written and then never read back. This is the shape the
+	// regression takes in the field, so it is the shape the test uses.
 	markerPath := filepath.Join(dir, stdlibMarkerName)
-	require.NoError(t, os.WriteFile(markerPath, []byte("fingerprint-from-an-older-snapshot"), 0644))
+	require.NoError(t, os.WriteFile(markerPath, []byte("dev"), 0644))
 
 	dir2, extracted, err := config.ensureStdlibExtracted("dev")
 	require.NoError(t, err)
@@ -200,6 +205,10 @@ func TestCheckStdlibVersionDir_RejectsNonVersionDirs(t *testing.T) {
 		{name: "nested path", dir: filepath.Join(config.StdlibDir, "v0.29.4", "std"), wantErr: true},
 		{name: "unrelated path", dir: t.TempDir(), wantErr: true},
 		{name: "empty", dir: "", wantErr: true},
+		{name: "cache root with trailing separator", dir: config.StdlibDir + string(filepath.Separator), wantErr: true},
+		{name: "cache root via dot element", dir: filepath.Join(config.StdlibDir, "."), wantErr: true},
+		{name: "relative path", dir: filepath.Join("stdlib", "v0.29.4"), wantErr: true},
+		{name: "version dir reached through a detour", dir: filepath.Join(config.StdlibDir, "v0.29.4", "..", "v0.29.4"), wantErr: false},
 	}
 
 	for _, tt := range tests {
@@ -212,6 +221,54 @@ func TestCheckStdlibVersionDir_RejectsNonVersionDirs(t *testing.T) {
 			require.Error(t, err)
 			var unsafeErr *UnsafeStdlibDirError
 			require.True(t, errors.As(err, &unsafeErr))
+		})
+	}
+}
+
+// TestCheckStdlibVersionDir_RejectsDifferentlyCasedRoot verifies the cache root
+// cannot be smuggled past the guard by re-spelling it: on a case-insensitive
+// filesystem filepath.Rel folds the case and reports ".", and elsewhere the
+// re-spelling is simply a different path outside the root. Either way it is
+// refused.
+func TestCheckStdlibVersionDir_RejectsDifferentlyCasedRoot(t *testing.T) {
+	config := isolatedConfig(t)
+
+	for _, spelling := range []string{strings.ToUpper(config.StdlibDir), strings.ToLower(config.StdlibDir)} {
+		require.Error(t, config.checkStdlibVersionDir(spelling), "spelling %q must be rejected", spelling)
+	}
+}
+
+// TestStdlibVersionDir_HostileVersionCannotEscapeTheCacheRoot feeds version
+// strings that try to climb out of the cache through the naming funnel and
+// checks that whatever comes out is either refused outright or still a direct
+// child of the cache root. The version is compiled into the binary rather than
+// typed by a user, but it is the only input to the path a wipe is performed on,
+// so it must not be able to widen that wipe.
+func TestStdlibVersionDir_HostileVersionCannotEscapeTheCacheRoot(t *testing.T) {
+	config := isolatedConfig(t)
+	root := filepath.Clean(config.StdlibDir)
+
+	versions := []string{
+		"", ".", "..", "...", "/", "\\", string(filepath.Separator),
+		"../..", "/../../etc", `..\..\Windows`, "../" + filepath.Base(root),
+		`C:\Windows`, `\\server\share`, "//server/share",
+		"-rc1", "v0.29.4", "0.1.0+meta", "a\nb",
+	}
+
+	for _, version := range versions {
+		t.Run(strconv.Quote(version), func(t *testing.T) {
+			dir := config.StdlibVersionDir(version)
+			if err := config.checkStdlibVersionDir(dir); err != nil {
+				var unsafeErr *UnsafeStdlibDirError
+				require.True(t, errors.As(err, &unsafeErr))
+				return
+			}
+			// Accepted: the worst this version string can reach is one direct
+			// child of the cache root, never the root and never outside it.
+			cleaned := filepath.Clean(dir)
+			require.NotEqual(t, root, cleaned)
+			require.Equal(t, root, filepath.Dir(cleaned),
+				"accepted dir %q is not a direct child of %q", dir, root)
 		})
 	}
 }
@@ -249,4 +306,26 @@ func TestRemoveStdlibVersionDir_LeavesRejectedPathsIntact(t *testing.T) {
 	require.NoError(t, os.MkdirAll(dir, 0755))
 	require.NoError(t, config.removeStdlibVersionDir(dir))
 	require.NoDirExists(t, dir)
+}
+
+// TestRemoveStdlibVersionDir_DoesNotFollowASymlinkedVersionDir verifies that a
+// version directory which is really a link is unlinked rather than walked into.
+// The guard is purely lexical, so this property comes from os.RemoveAll itself
+// and is worth pinning: it is what stops a swapped-in link from turning the
+// cache wipe into a delete of whatever it points at.
+func TestRemoveStdlibVersionDir_DoesNotFollowASymlinkedVersionDir(t *testing.T) {
+	config := isolatedConfig(t)
+
+	outside := t.TempDir()
+	bystander := filepath.Join(outside, "bystander.txt")
+	require.NoError(t, os.WriteFile(bystander, []byte("keep"), 0644))
+
+	link := config.StdlibVersionDir("dev")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("host does not permit creating symlinks: %v", err)
+	}
+
+	require.NoError(t, config.removeStdlibVersionDir(link))
+	require.NoDirExists(t, link)
+	require.FileExists(t, bystander, "removing the version directory must not follow the link")
 }

--- a/internal/build/stdlibver.go
+++ b/internal/build/stdlibver.go
@@ -1,12 +1,9 @@
 package build
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"martianoff/gala/internal/stdlib"
@@ -46,17 +43,16 @@ func normalizeStdlibVersion(version string) string {
 }
 
 // snapshotFingerprint returns the marker contents identifying the embedded
-// stdlib snapshot for a given version. It combines the version with the content
-// hash of the embedded packages, so both a version change and a change to the
-// embedded sources invalidate a previously extracted copy.
+// stdlib snapshot for a given version: the normalized version followed by the
+// content hash of the embedded packages, so both a version change and a change
+// to the embedded sources invalidate a previously extracted copy.
+//
+// The marker is only ever compared for equality, so it is stored verbatim
+// rather than digested again — reading it tells whoever is debugging a cache
+// which binary wrote the directory. The two parts cannot run together
+// ambiguously because the fingerprint is a fixed-width hex digest.
 func snapshotFingerprint(version string) string {
-	h := sha256.New()
-	for _, part := range []string{normalizeStdlibVersion(version), stdlib.Fingerprint()} {
-		h.Write([]byte(strconv.Itoa(len(part))))
-		h.Write([]byte{':'})
-		h.Write([]byte(part))
-	}
-	return hex.EncodeToString(h.Sum(nil))
+	return normalizeStdlibVersion(version) + " " + stdlib.Fingerprint()
 }
 
 // checkStdlibVersionDir verifies that dir is a direct child of the stdlib cache
@@ -67,22 +63,19 @@ func (c *Config) checkStdlibVersionDir(dir string) error {
 	target := filepath.Clean(dir)
 	fail := &UnsafeStdlibDirError{Dir: target, Root: root}
 
-	// A degenerate root (unset, relative-current, or a filesystem/volume root
-	// such as "/" or "C:\") can never be a legitimate stdlib cache.
-	if c.StdlibDir == "" || root == "." || filepath.Dir(root) == root {
+	// A degenerate root can never be a legitimate stdlib cache. Each of these
+	// is its own parent: unset (Clean("") == "."), relative-current, and a
+	// filesystem or volume root such as "/" or "C:\".
+	if filepath.Dir(root) == root {
 		return fail
 	}
-	if target == root {
-		return fail
-	}
+
+	// The target must be one named element directly inside the root: not the
+	// root itself (Rel reports "."), not at or above it (".." — and on Windows
+	// Rel matches case-insensitively, so a differently-cased spelling of the
+	// root lands here too), and not nested deeper (any separator).
 	rel, err := filepath.Rel(root, target)
-	if err != nil {
-		return fail
-	}
-	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return fail
-	}
-	if strings.ContainsRune(rel, filepath.Separator) {
+	if err != nil || rel == "." || rel == ".." || strings.ContainsRune(rel, filepath.Separator) {
 		return fail
 	}
 	return nil
@@ -100,6 +93,14 @@ func (c *Config) checkStdlibVersionDir(dir string) error {
 //
 // extracted reports whether files were (re-)written, which callers use for
 // verbose output.
+//
+// There is no cross-process lock. Two binaries that normalize to the same
+// version but carry different snapshots — two unstamped "dev" builds from
+// different trees — will each wipe and rewrite the other's copy, and a third
+// process reading the directory at that moment can see it half-written.
+// Released binaries carry distinct versions and so distinct directories, and a
+// developer's CLI and LSP come from one tree, so this is narrow; it is also
+// noisy and self-correcting, unlike the silent stale cache it replaces.
 func (c *Config) ensureStdlibExtracted(version string) (dir string, extracted bool, err error) {
 	stdlibDir := c.StdlibVersionDir(version)
 	markerPath := filepath.Join(stdlibDir, stdlibMarkerName)

--- a/internal/build/stdlibver.go
+++ b/internal/build/stdlibver.go
@@ -1,0 +1,138 @@
+package build
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"martianoff/gala/internal/stdlib"
+)
+
+// stdlibMarkerName is the file written inside a versioned stdlib directory to
+// record which embedded snapshot produced its contents.
+const stdlibMarkerName = ".stdlib-extracted"
+
+// UnsafeStdlibDirError reports that a computed stdlib version directory does
+// not sit directly under the stdlib cache root and therefore must not be
+// deleted. It guards the re-extraction path: a degenerate or hostile version
+// string must never be able to turn cache invalidation into a recursive delete
+// of the cache root or the user's home directory.
+type UnsafeStdlibDirError struct {
+	Dir  string // the rejected directory
+	Root string // the stdlib cache root it was expected to live under
+}
+
+var _ error = (*UnsafeStdlibDirError)(nil)
+
+func (e *UnsafeStdlibDirError) Error() string {
+	return fmt.Sprintf("refusing to remove stdlib directory %q: not a version directory under %q", e.Dir, e.Root)
+}
+
+// normalizeStdlibVersion reduces a CLI version string to the base version used
+// to name the stdlib cache directory: a `git describe` suffix such as
+// "0.29.4-1-ga528ffd" collapses to "0.29.4". Every consumer of the stdlib cache
+// path must apply the same normalization, otherwise `gala build` and
+// `gala transpile`/`gala lsp` can extract to, and validate, two different
+// directories for the same binary.
+func normalizeStdlibVersion(version string) string {
+	if i := strings.IndexByte(version, '-'); i >= 0 {
+		return version[:i]
+	}
+	return version
+}
+
+// snapshotFingerprint returns the marker contents identifying the embedded
+// stdlib snapshot for a given version. It combines the version with the content
+// hash of the embedded packages, so both a version change and a change to the
+// embedded sources invalidate a previously extracted copy.
+func snapshotFingerprint(version string) string {
+	h := sha256.New()
+	for _, part := range []string{normalizeStdlibVersion(version), stdlib.Fingerprint()} {
+		h.Write([]byte(strconv.Itoa(len(part))))
+		h.Write([]byte{':'})
+		h.Write([]byte(part))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// checkStdlibVersionDir verifies that dir is a direct child of the stdlib cache
+// root, i.e. a plausible version directory. Anything else — the root itself, a
+// path escaping the root, a nested path — is rejected.
+func (c *Config) checkStdlibVersionDir(dir string) error {
+	root := filepath.Clean(c.StdlibDir)
+	target := filepath.Clean(dir)
+	fail := &UnsafeStdlibDirError{Dir: target, Root: root}
+
+	// A degenerate root (unset, relative-current, or a filesystem/volume root
+	// such as "/" or "C:\") can never be a legitimate stdlib cache.
+	if c.StdlibDir == "" || root == "." || filepath.Dir(root) == root {
+		return fail
+	}
+	if target == root {
+		return fail
+	}
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return fail
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fail
+	}
+	if strings.ContainsRune(rel, filepath.Separator) {
+		return fail
+	}
+	return nil
+}
+
+// ensureStdlibExtracted makes the on-disk stdlib cache for `version` match the
+// embedded snapshot and returns its directory.
+//
+// The marker file holds the snapshot fingerprint rather than acting as a bare
+// "something was extracted here" flag, so a cache written by a different binary
+// is detected instead of being trusted forever. When the fingerprints differ,
+// the version directory is removed before re-extracting: ExtractTo overwrites
+// files but never deletes them, so a file dropped upstream would otherwise
+// linger and keep being resolved.
+//
+// extracted reports whether files were (re-)written, which callers use for
+// verbose output.
+func (c *Config) ensureStdlibExtracted(version string) (dir string, extracted bool, err error) {
+	stdlibDir := c.StdlibVersionDir(version)
+	markerPath := filepath.Join(stdlibDir, stdlibMarkerName)
+	want := snapshotFingerprint(version)
+
+	if got, readErr := os.ReadFile(markerPath); readErr == nil && string(got) == want {
+		return stdlibDir, false, nil
+	}
+
+	// Stale or absent: drop whatever is there and write the snapshot afresh.
+	if removeErr := c.removeStdlibVersionDir(stdlibDir); removeErr != nil {
+		return "", false, removeErr
+	}
+	if mkErr := os.MkdirAll(stdlibDir, 0755); mkErr != nil {
+		return "", false, fmt.Errorf("creating stdlib directory: %w", mkErr)
+	}
+	if extractErr := stdlib.ExtractTo(stdlibDir); extractErr != nil {
+		return "", false, fmt.Errorf("extracting stdlib: %w", extractErr)
+	}
+	if writeErr := os.WriteFile(markerPath, []byte(want), 0644); writeErr != nil {
+		return "", false, fmt.Errorf("writing stdlib marker: %w", writeErr)
+	}
+	return stdlibDir, true, nil
+}
+
+// removeStdlibVersionDir deletes a versioned stdlib directory after checking
+// that it really is one.
+func (c *Config) removeStdlibVersionDir(dir string) error {
+	if err := c.checkStdlibVersionDir(dir); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("removing stale stdlib directory: %w", err)
+	}
+	return nil
+}

--- a/internal/stdlib/BUILD.bazel
+++ b/internal/stdlib/BUILD.bazel
@@ -166,6 +166,7 @@ go_library(
     name = "stdlib",
     srcs = [
         "embedded_gen.go",
+        "fingerprint.go",
         "stdlib.go",
     ],
     importpath = "martianoff/gala/internal/stdlib",
@@ -174,6 +175,10 @@ go_library(
 
 go_test(
     name = "stdlib_test",
-    srcs = ["embed_collections_test.go"],
+    srcs = [
+        "embed_collections_test.go",
+        "fingerprint_test.go",
+    ],
     embed = [":stdlib"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/internal/stdlib/fingerprint.go
+++ b/internal/stdlib/fingerprint.go
@@ -1,0 +1,82 @@
+package stdlib
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strconv"
+)
+
+// Fingerprint returns a stable content hash of the embedded standard library
+// snapshot compiled into this binary.
+//
+// Callers cache the extracted stdlib on disk keyed by the CLI version string.
+// That key alone is not sufficient: an unstamped build reports the same version
+// ("dev") for every revision, and even a tagged build can find a cache
+// directory written by an older binary. Because the on-disk copy was previously
+// considered valid whenever a marker file merely existed, an outdated snapshot
+// could survive indefinitely and be used as the authoritative source of stdlib
+// type information — silently changing compiler behaviour (for example, a
+// signature that has since gained a marker type would still be seen in its old,
+// unmarked form, disabling the checks that depend on that marker).
+//
+// Storing this fingerprint in the marker file and comparing contents makes the
+// cache self-invalidating: any change to an embedded file, a file being added
+// or removed, or a change to a generated go.mod produces a different digest and
+// forces a re-extraction.
+//
+// The digest covers exactly what ExtractTo writes to disk: every package's
+// files and the go.mod generated for it. It is computed once, from memory, with
+// no filesystem access.
+func Fingerprint() string {
+	return embeddedFingerprint
+}
+
+// embeddedFingerprint is computed once at package initialisation. The embedded
+// snapshot is immutable for the lifetime of the process, so re-hashing it per
+// call would be pure overhead.
+var embeddedFingerprint = fingerprintPackages(EmbeddedPackages, PackageImportPaths)
+
+// fingerprintPackages hashes a package set in a deterministic order: packages
+// by name, then files by name, then the generated go.mod for the package. Every
+// chunk is length-prefixed so that no rearrangement of names and contents can
+// produce the same digest.
+func fingerprintPackages(packages map[string]map[string]string, importPaths map[string]string) string {
+	h := sha256.New()
+
+	pkgNames := make([]string, 0, len(packages))
+	for pkg := range packages {
+		pkgNames = append(pkgNames, pkg)
+	}
+	sort.Strings(pkgNames)
+
+	writeChunk := func(s string) {
+		h.Write([]byte(strconv.Itoa(len(s))))
+		h.Write([]byte{':'})
+		h.Write([]byte(s))
+	}
+
+	for _, pkg := range pkgNames {
+		writeChunk(pkg)
+
+		files := packages[pkg]
+		fileNames := make([]string, 0, len(files))
+		for name := range files {
+			fileNames = append(fileNames, name)
+		}
+		sort.Strings(fileNames)
+
+		writeChunk(strconv.Itoa(len(fileNames)))
+		for _, name := range fileNames {
+			writeChunk(name)
+			writeChunk(files[name])
+		}
+
+		// ExtractTo also writes a generated go.mod per package, so changes to
+		// it must invalidate the cache just like a source change would.
+		writeChunk("go.mod")
+		writeChunk(generatePackageGoMod(pkg, importPaths[pkg]))
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/stdlib/fingerprint.go
+++ b/internal/stdlib/fingerprint.go
@@ -5,37 +5,38 @@ import (
 	"encoding/hex"
 	"sort"
 	"strconv"
+	"sync"
 )
 
 // Fingerprint returns a stable content hash of the embedded standard library
 // snapshot compiled into this binary.
 //
-// Callers cache the extracted stdlib on disk keyed by the CLI version string.
-// That key alone is not sufficient: an unstamped build reports the same version
-// ("dev") for every revision, and even a tagged build can find a cache
-// directory written by an older binary. Because the on-disk copy was previously
-// considered valid whenever a marker file merely existed, an outdated snapshot
-// could survive indefinitely and be used as the authoritative source of stdlib
-// type information — silently changing compiler behaviour (for example, a
-// signature that has since gained a marker type would still be seen in its old,
-// unmarked form, disabling the checks that depend on that marker).
+// Callers cache the extracted stdlib on disk. The CLI version string is not a
+// sufficient key for that cache: an unstamped build reports the same version
+// ("dev") for every revision, so one cached copy is shared by snapshots that
+// have nothing in common. Since the cached stdlib is the type information the
+// transpiler compiles against, an outdated copy silently changes compiler
+// behaviour — a signature that has gained a marker type is still seen in its
+// old, unmarked form, and the checks driven by that marker stop running.
 //
-// Storing this fingerprint in the marker file and comparing contents makes the
-// cache self-invalidating: any change to an embedded file, a file being added
-// or removed, or a change to a generated go.mod produces a different digest and
-// forces a re-extraction.
+// Comparing this fingerprint instead makes the cache self-invalidating: any
+// change to an embedded file, a file added or removed, or a change to a
+// generated go.mod produces a different digest and forces a re-extraction.
 //
 // The digest covers exactly what ExtractTo writes to disk: every package's
-// files and the go.mod generated for it. It is computed once, from memory, with
-// no filesystem access.
+// files and the go.mod generated for it. It reads no files, and the embedded
+// snapshot is immutable for the lifetime of the process, so it is computed at
+// most once and only if something asks for it.
 func Fingerprint() string {
-	return embeddedFingerprint
+	return embeddedFingerprint()
 }
 
-// embeddedFingerprint is computed once at package initialisation. The embedded
-// snapshot is immutable for the lifetime of the process, so re-hashing it per
-// call would be pure overhead.
-var embeddedFingerprint = fingerprintPackages(EmbeddedPackages, PackageImportPaths)
+// embeddedFingerprint hashes roughly a megabyte of embedded sources, so it is
+// deferred rather than run at package initialisation: most gala subcommands
+// link this package without ever touching the stdlib cache.
+var embeddedFingerprint = sync.OnceValue(func() string {
+	return fingerprintPackages(EmbeddedPackages, PackageImportPaths)
+})
 
 // fingerprintPackages hashes a package set in a deterministic order: packages
 // by name, then files by name, then the generated go.mod for the package. Every

--- a/internal/stdlib/fingerprint_test.go
+++ b/internal/stdlib/fingerprint_test.go
@@ -1,0 +1,107 @@
+package stdlib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFingerprint_StableAcrossCalls verifies the embedded snapshot digest does
+// not change between calls — the cache marker must be comparable over time.
+func TestFingerprint_StableAcrossCalls(t *testing.T) {
+	first := Fingerprint()
+	require.NotEmpty(t, first)
+	require.Equal(t, first, Fingerprint())
+	require.Equal(t, first, fingerprintPackages(EmbeddedPackages, PackageImportPaths))
+}
+
+// TestFingerprintPackages_DetectsContentChanges verifies that every kind of
+// change to the snapshot produces a different digest.
+func TestFingerprintPackages_DetectsContentChanges(t *testing.T) {
+	base := map[string]map[string]string{
+		"alpha": {"a.go": "package alpha\n"},
+		"beta":  {"b.go": "package beta\n"},
+	}
+	imports := map[string]string{
+		"alpha": "example.com/alpha",
+		"beta":  "example.com/beta",
+	}
+	baseline := fingerprintPackages(base, imports)
+	require.NotEmpty(t, baseline)
+
+	tests := []struct {
+		name     string
+		packages map[string]map[string]string
+		imports  map[string]string
+	}{
+		{
+			name: "file content changed",
+			packages: map[string]map[string]string{
+				"alpha": {"a.go": "package alpha // edited\n"},
+				"beta":  {"b.go": "package beta\n"},
+			},
+			imports: imports,
+		},
+		{
+			name: "file added",
+			packages: map[string]map[string]string{
+				"alpha": {"a.go": "package alpha\n", "extra.go": "package alpha\n"},
+				"beta":  {"b.go": "package beta\n"},
+			},
+			imports: imports,
+		},
+		{
+			name: "file removed",
+			packages: map[string]map[string]string{
+				"alpha": {"a.go": "package alpha\n"},
+				"beta":  {},
+			},
+			imports: imports,
+		},
+		{
+			name: "package removed",
+			packages: map[string]map[string]string{
+				"alpha": {"a.go": "package alpha\n"},
+			},
+			imports: imports,
+		},
+		{
+			name:     "import path changed",
+			packages: base,
+			imports: map[string]string{
+				"alpha": "example.com/alpha/v2",
+				"beta":  "example.com/beta",
+			},
+		},
+		{
+			name: "content moved between files",
+			packages: map[string]map[string]string{
+				"alpha": {"a.go": "package beta\n"},
+				"beta":  {"b.go": "package alpha\n"},
+			},
+			imports: imports,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotEqual(t, baseline, fingerprintPackages(tt.packages, tt.imports))
+		})
+	}
+}
+
+// TestFingerprintPackages_IndependentOfMapOrder verifies the digest is derived
+// from sorted names, not Go's randomized map iteration order.
+func TestFingerprintPackages_IndependentOfMapOrder(t *testing.T) {
+	packages := map[string]map[string]string{
+		"alpha": {"a.go": "1", "b.go": "2", "c.go": "3"},
+		"beta":  {"d.go": "4", "e.go": "5"},
+		"gamma": {"f.go": "6"},
+	}
+	imports := map[string]string{"alpha": "x/alpha", "beta": "x/beta", "gamma": "x/gamma"}
+
+	want := fingerprintPackages(packages, imports)
+	for i := 0; i < 20; i++ {
+		require.Equal(t, want, fingerprintPackages(packages, imports))
+	}
+}

--- a/internal/stdlib/stdlib.go
+++ b/internal/stdlib/stdlib.go
@@ -23,6 +23,11 @@ func Packages() []Package {
 }
 
 // ExtractTo extracts all embedded stdlib packages to the given directory.
+//
+// Whatever this writes must also be covered by fingerprintPackages: the on-disk
+// cache is only re-extracted when that digest changes, so an artifact written
+// here but left out of the digest would never be refreshed.
+//
 // The directory structure will be:
 //
 //	destDir/


### PR DESCRIPTION
## Summary

A stale extracted stdlib snapshot silently disabled the `GALA-E0037` data-race check. Racy code compiled with **no error, no warning, exit 0** — a false negative in a safety check, which is the dangerous failure direction: the guarantee disappears with no signal that it is gone.

```gala
func main() {
    var counter = 0
    val f = Future(() => counter + 1)   // reassignable var captured across a
    Println(f.Get())                     // concurrency boundary — must be E0037
}
```

## Root cause

The transpiler discovers concurrency boundaries via the `Sendable[F]` marker on a callee's parameter type. A pre-Sendable cached `concurrent/future.gala` declares `Future`'s body parameter as a bare `func() T`, so no boundary is found and the capture analysis never runs.

Extraction was gated on the mere *existence* of `.stdlib-extracted`. The marker held the version string but was never read back — only `os.Stat`. A source-built CLI reports version `dev`, so `~/.gala/stdlib/vdev/` is written once by the first binary and goes stale permanently; `vdev` is never version-discriminated. Released CLIs key by tag and start clean, but a stale *tagged* directory fails identically.

The checker itself was fine throughout: a boundary declared locally, needing no stdlib, fired correctly even with the stale cache. Only boundary *discovery through the stdlib* was broken.

## Changes

- `internal/stdlib/fingerprint.go` — content digest over the embedded snapshot (sorted packages and files, length-prefixed, including generated per-package `go.mod` content since `ExtractTo` writes those too). No I/O; computed once via `sync.OnceValue`.
- `internal/build/stdlibver.go` — `.stdlib-extracted` now stores the normalized version plus the digest and is compared by content. A mismatch wipes and re-extracts, which also drops files deleted upstream (`ExtractTo` writes unconditionally but never deletes).
- Unified two divergent copies of the extract logic. `EnsureStdlib` stripped the `git describe` suffix while `ensureStdlib` did not, so for `0.29.4-1-gabc` `gala build` used `v0.29.4-1-gabc` — including in the `replace` directives written into go.mod — while `transpile`/`lsp` used `v0.29.4`. Normalization now lives in `Config.StdlibVersionDir`, the single funnel every consumer already goes through.
- `checkStdlibVersionDir` / `removeStdlibVersionDir` confine `RemoveAll` to a direct child of the cache root, enforced inside the remove function rather than by its caller, with a typed `*UnsafeStdlibDirError`.
- `EnsureStdlib` now returns its error instead of collapsing failures into an empty path — which previously turned a deliberate refusal to delete into "no stdlib on the search path", i.e. an LSP that starts fine and resolves nothing.

Fully content-derived: no package names hardcoded, no special-casing of `std`.

## Verification

`internal/build/config_test.go`, `internal/stdlib/fingerprint_test.go` — fingerprint stability and change detection (file added/removed, package removed, import path changed, content swapped between files, map-order independence); marker write/fast-path/stale-replace/missing cycles; and adversarial delete-guard cases: differently-cased cache root, trailing separators and dot elements, relative targets, a nested detour cleaning back to a valid version directory, hostile version strings (`../..`, `/../../etc`, `C:\Windows`, UNC, empty), and a symlinked version directory checked to be unlinked rather than followed.

End-to-end with a branch-built CLI against a temp `GALA_HOME`: pristine stdlib → `E0037`, exit 1; snapshot tampered to drop `Sendable` with the marker left intact → exit 0 (the bug); marker rewritten to what pre-fix binaries wrote → mismatch detected, wiped, re-extracted, `E0037` restored.

`bazel build //...` green; `bazel test //...` 384/385, the sole failure `TestGorootFromGoBinarySymlink` being a pre-existing Windows symlink-privilege test that fails identically on `master`.

**Note:** `bazel test //...` structurally cannot catch this bug. In-repo builds resolve `martianoff/gala/std` to the live `<repo>/std` tree, so `~/.gala/stdlib` is never consulted. The unit tests against a temp `GALA_HOME` are the real coverage.

## Known limitation

The marker validates snapshot *identity*, not on-disk integrity. Hand-editing files inside `~/.gala/stdlib/vX/` while leaving the marker intact still evades detection — cache corruption rather than the upgrade path. There is also no cross-process lock: two unstamped `dev` builds from different trees will each wipe the other's copy. That is noisy and self-correcting, unlike the silent stale cache it replaces.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)