### PR TITLE
test(errors): pin GALA-E0038's documented output with guard rows

### DIFF
--- a/internal/transpiler/transformer/error_docs_guard_test.go
+++ b/internal/transpiler/transformer/error_docs_guard_test.go
@@ -32,13 +32,25 @@ import (
 //
 // Scope note: the table covers the codes whose real output was captured while
 // writing these pages — E0002, E0003, E0006, E0015, E0018, E0027 through E0031,
-// E0035 and E0036 from the in-memory transpiler, plus E0025 and E0032 from a
-// temp directory (both need real files on disk: E0025 because the whole point
-// of that code is that a sibling's imports do not propagate, E0032 because a
-// collision needs two packages to collide). Every other code is deliberately
+// E0035, E0036 and E0038 from the in-memory transpiler, plus E0025 and E0032
+// from a temp directory (both need real files on disk: E0025 because the whole
+// point of that code is that a sibling's imports do not propagate, E0032 because
+// a collision needs two packages to collide). Every other code is deliberately
 // absent rather than stubbed; a stub would advertise coverage that does not
 // exist. See the GALA-E0010 and GALA-E0026 notes in the table for codes that
 // cannot be guarded from here at all.
+//
+// Most rows assert the whole rendered block. A row may instead assert a single
+// line when that is all its page quotes — see renderEscapeVariant — but never
+// less than the page claims, since a row that cannot fail is worse than no row.
+//
+// Repros are held to the same standard as the pages. A repro is supposed to
+// fail, so a fictional API inside one has nowhere to surface: an E0036 repro
+// once called `io.OpenFile`, which does not exist (GALA's `io` is the IO monad),
+// and passed anyway because E0036 fires during statement transformation, before
+// symbol resolution. Remediation snippets get compile-verified; repros do not.
+// So when adding a row, read its repro for whether every symbol and import is
+// real, not merely whether it triggers the code.
 func TestErrorDocsQuoteRealOutput(t *testing.T) {
 	cases := []struct {
 		// name distinguishes several rows for the same code. A page often
@@ -342,6 +354,58 @@ func main() {
 `)
 			},
 		},
+		{
+			// The full framed block: locus, source row, caret row and hint.
+			// This is the row that pins the caret annotation, including its
+			// truncation to `\UH…` at terseHint's 60-rune cap — the exact
+			// detail a page author is most likely to "repair" by hand after
+			// assuming their terminal clipped it.
+			//
+			// Import-free, like the E0036 row above and for the same reason:
+			// an escape is rejected while the literal is transformed, so
+			// nothing else is needed to trigger it.
+			name: "unrecognised escape in a regular expression",
+			code: galaerr.CodeInvalidStringEscape, // GALA-E0038
+			render: func(t *testing.T) string {
+				return renderRepro(t, "esc.gala", `package main
+
+func main() {
+    val pattern = "(\d{4})"
+    Println(pattern)
+}
+`)
+			},
+		},
+		// The four malformed-escape variants below. Each is a real diagnostic
+		// driven through the same renderer, but the row asserts only the
+		// message line — see renderEscapeVariant for why that is the whole of
+		// what those blocks claim.
+		{
+			name:   "hex escape with too few digits",
+			code:   galaerr.CodeInvalidStringEscape, // GALA-E0038
+			render: renderEscapeVariant(`val s = "\x4"`),
+		},
+		{
+			name:   "octal escape above the maximum byte value",
+			code:   galaerr.CodeInvalidStringEscape, // GALA-E0038
+			render: renderEscapeVariant(`val s = "\400"`),
+		},
+		{
+			name:   "unicode escape naming a surrogate half",
+			code:   galaerr.CodeInvalidStringEscape, // GALA-E0038
+			render: renderEscapeVariant(`val s = "\uD800"`),
+		},
+		{
+			name:   "single quote escaped inside a string literal",
+			code:   galaerr.CodeInvalidStringEscape, // GALA-E0038
+			render: renderEscapeVariant(`val s = "it\'s"`),
+		},
+		// The GALA-E0038 page also documents the rune-literal shape in prose
+		// (`'\d'`), but quotes no output for it, so there is nothing to pin.
+		// Its numeric forms (`'\x41'`) are not guardable here at all: GALA's
+		// CHAR_LIT admits exactly one character after the backslash, so those
+		// fail as ANTLR syntax errors before this check runs, and a row for
+		// them would assert a message the escape validator never emits.
 	}
 
 	for _, tc := range cases {
@@ -357,6 +421,31 @@ func main() {
 					"Replace (or add) the page's `Error output` block with exactly:\n\n%s\n",
 				tc.code, tc.name, want)
 		})
+	}
+}
+
+// renderEscapeVariant drives GALA-E0038 for one malformed escape and returns
+// only the FIRST LINE of the rendered diagnostic.
+//
+// The GALA-E0038 page quotes these four variants as bare message lines rather
+// than as framed blocks, and that is an editorial choice worth preserving: they
+// exist to contrast the `reason` clause after the colon, and four near-identical
+// frames would bury that contrast under ~28 lines of repeated scaffolding. So
+// the row asserts exactly what those blocks claim — the message text — and
+// nothing they do not show. The caret row, locus and hint are pinned by the full
+// framed row above, which quotes an entire block.
+//
+// This still fails on drift: the reason clause is the most detailed text on the
+// page and any rewording of it breaks these rows. What it deliberately does not
+// do is assert a frame the page never printed.
+func renderEscapeVariant(body string) func(t *testing.T) string {
+	return func(t *testing.T) string {
+		t.Helper()
+		src := "package main\n\nfunc main() {\n    " + body + "\n    Println(s)\n}\n"
+		full := renderRepro(t, "esc.gala", src)
+		line, _, found := strings.Cut(full, "\n")
+		require.True(t, found, "rendered diagnostic was a single line: %q", full)
+		return line
 	}
 }
 


### PR DESCRIPTION
## Summary

`docs/errors/GALA-E0038.md` shipped in #442 with roughly six quoted output blocks — including four malformed-escape variants — and **no coverage in the doc-verification guard**. It was the only page in the tree with quoted output and nothing pinning it, and the most escape-dense page there is.

This adds five rows, bringing the table to **21**.

## Why this is worth doing

The guard has already caught three real defects in pages that were written carefully and read as correct:

- **E0028** — a caret annotation transcribed as `…rename one of the aliases`, when the compiler truncates it to `…rename one of the aliase…` at `terseHint`'s 60-rune cap. The author assumed their terminal had clipped it and silently repaired it.
- **E0027** — rewritten for cross-file detection, left quoting only the batch form, so its framed shape had no coverage.
- **E0036** — a published repro calling `io.OpenFile`, which does not exist. GALA's `io` is the IO monad.

None would have been caught by review. All three were in a batch specifically about documentation accuracy.

## Row design

**One full-block row** for the primary `\d` diagnostic, asserting the entire rendered block — locus, source row, caret row, hint. This is the row that pins the `\UH…` truncation.

**Four message-line rows** for the malformed variants. The page quotes those as bare one-liners rather than framed blocks, deliberately: they exist to contrast the `reason` clause after the colon, and four near-identical frames would bury that contrast under ~28 lines of repeated scaffolding. Those rows assert the message line — exactly what the blocks claim and nothing they don't show. The reason clause is the most detailed text on the page, so any rewording still breaks them.

The page was **not** expanded to full blocks to make the rows uniform. That would trade readable documentation for test symmetry.

## Verified to fail, not merely observed green

Every row was mutated independently, and each reddened **only its own row** — re-confirmed after rebasing onto the 16-row table, so there is no cross-talk:

| Mutation | Result |
|---|---|
| `\UH…` → `\UHHHHHHHH` (the E0028 hand-repair) | only the primary row red |
| hex reason reworded | only the hex row red |
| octal `256` → `257` | only the octal row red |
| surrogate range en-dashed | only the surrogate row red |
| quote-fix advice altered | only the quote row red |

## Repro audit — tested, not eyeballed

E0038 fires during literal transformation, *before* symbol resolution, so a fictional symbol in a repro would be as invisible here as `io.OpenFile` was in E0036's. Inspection can't settle that, so each repro was transpiled with **only the bad escape corrected** — if every other symbol is real, it must compile. All five did, and they need no imports at all, which also makes them immune to the sandbox-staging hazard that broke E0036's row.

## Gaps recorded in the table rather than papered over

- The rune-literal shape (`'\d'`) is documented in prose but quotes no output, so there is nothing to pin.
- Its numeric forms (`'\x41'`) are not guardable at all: `CHAR_LIT` admits exactly one character after the backslash, so they fail as ANTLR syntax errors *before* the escape check runs. A row would assert a message the validator never emits.

## Scope note

Both this branch and #446 edited the guard's scope comment. Both sets of information are preserved — the coverage list and E0026 exclusion from #446, the single-line-row rule from here — plus a new paragraph recording the `io.OpenFile` lesson, since that comment is now the only place explaining what makes a row legitimate rather than one that cannot fail.

## Verification

`bazel build //...` green. `bazel test //...` 386/387, sole failure the known `TestGorootFromGoBinarySymlink` Windows symlink-privilege test. The doc page itself needed no edits — it was already byte-exact, truncation included.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)