### PR TITLE
fix(website): footer site map inherited the header nav's dark chrome

### DIFF
--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -228,7 +228,7 @@
       line-height: 1.7;
       background: var(--bg);
     }
-    nav {
+    body > nav {
       background: var(--nav-bg);
       padding: 1rem 2rem;
       display: flex;
@@ -236,14 +236,14 @@
       gap: 2rem;
       flex-wrap: wrap;
     }
-    nav a {
+    body > nav a {
       color: var(--nav-text);
       text-decoration: none;
       font-size: 0.95rem;
       opacity: 0.85;
       transition: opacity 0.2s;
     }
-    nav a:hover { opacity: 1; }
+    body > nav a:hover { opacity: 1; }
     .nav-dropdown {
       position: relative;
     }
@@ -290,7 +290,7 @@
       color: var(--accent);
       opacity: 1;
     }
-    nav .logo {
+    body > nav .logo {
       font-weight: 700;
       font-size: 1.3rem;
       opacity: 1;
@@ -412,10 +412,10 @@
     @media (max-width: 640px) {
       .comparison { grid-template-columns: 1fr; }
       /* Nav becomes a swipeable strip so items never get clipped on small screens */
-      nav { padding: 0.6rem 0.9rem; gap: 0.9rem; flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch; }
-      nav::-webkit-scrollbar { display: none; }
-      nav a { font-size: 0.85rem; white-space: nowrap; }
-      nav .logo { margin-right: 0.9rem; }
+      body > nav { padding: 0.6rem 0.9rem; gap: 0.9rem; flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+      body > nav::-webkit-scrollbar { display: none; }
+      body > nav a { font-size: 0.85rem; white-space: nowrap; }
+      body > nav .logo { margin-right: 0.9rem; }
       pre[class*="language-"], code[class*="language-"] { font-size: 0.78rem; }
       .hero h1 { font-size: 2rem; }
       .hero .tagline { font-size: 1.05rem; }
@@ -437,6 +437,10 @@
     /* Site map in the footer: gives every section page a crawlable, site-wide
        link, and keeps the dropdown-only pages reachable on touch devices where
        the nav menus never open. */
+    /* This is a <nav>, so it must not pick up the header nav's dark chrome.
+       The header rules are scoped to `body > nav`; these resets are belt-and-
+       braces so a future generic `nav` rule cannot silently darken the footer
+       out from under this light-on-white text again. */
     .footer-nav {
       max-width: 860px;
       margin: 0 auto 1.5rem;
@@ -444,6 +448,9 @@
       grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
       gap: 1.25rem;
       text-align: left;
+      background: none;
+      padding: 0;
+      overflow: visible;
     }
     .footer-nav h2 {
       font-size: 0.75rem;


### PR DESCRIPTION
The footer site map is a `<nav>`, so the generic `nav` CSS rules applied to it. It picked up `background: var(--nav-bg)` (dark navy) while keeping the `#444`/`#555` text colours that were authored for the white footer — producing grey-on-navy, below AA contrast.

The colours were never wrong; the background was never meant to be there.

## Also fixed: a mobile bug that came from the same leak

The responsive rules leaked identically:

```css
nav { flex-wrap: nowrap; overflow-x: auto; }
```

On phones that turned the footer site map into a horizontal scroll strip — the exact opposite of its purpose, which is to keep dropdown-only pages reachable on touch devices where hover menus never open.

## Change

Scoped all eight header-nav rules to `body > nav` (the header nav is a direct child of `<body>`; the footer one is inside `<footer>`), and added explicit `background`/`padding`/`overflow` resets on `.footer-nav` so a future generic `nav` rule cannot silently re-break it.

No colour values changed. On the restored white background the existing palette measures roughly **9.7:1** for headings and **7.4:1** for links — both AAA, where grey-on-navy was failing AA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)