### PR TITLE
ci(perf): re-baseline cold-build budget to 850s and log cache disposition

### DIFF
--- a/.github/workflows/perf-real-build.yml
+++ b/.github/workflows/perf-real-build.yml
@@ -27,6 +27,28 @@ name: Perf — real-repo build budget
 # variance while still firmly trapping a regression (pre-worker was ~1160 s).
 # The cache-size ceiling below is unchanged, so a per-entry blowup is still
 # caught independently of wall time.
+#
+# Cold budget raised 680 s -> 850 s. Read the "Cold build" step below for
+# what it actually measures: setup-bazel restores a Bazel disk cache keyed
+# on `perf-real-build-<go-version>`, so the step is only cold when that key
+# misses. Measured runs split cleanly along that line rather than along any
+# source change:
+#
+#   disk-cache RESTORED   77 s / 364 s / 416 s / 589 s
+#   disk-cache MISSED    648 s / 670 s / 672 s / 750 s
+#
+# 680 s sat inside the cache-miss cluster, so a genuine cold run was close
+# to a coin flip and the gate reddened PRs that changed nothing relevant —
+# including a docs-only PR and a version bump. 850 s clears the worst
+# observed true-cold run (750 s) by ~13%.
+#
+# Note this is a re-baseline, not permission for the build to get slower:
+# the two clusters are not comparable, and any 400-ish figure quoted from
+# an earlier run was a cache-hit measurement. Judge a regression against
+# runs with the same cache disposition, and keep ratcheting the number
+# down as perf work lands. The right long-term shape is a rolling baseline
+# instead of a fixed constant, which would not need this maintenance and
+# would not silently absorb drift; a fixed constant will land back here.
 
 on:
   workflow_dispatch:
@@ -53,7 +75,7 @@ jobs:
       GALA_TUI_REF: main
       GALA_TEAM_REF: master
       WARM_BUDGET_SECONDS: "500"
-      COLD_BUDGET_SECONDS: "680"
+      COLD_BUDGET_SECONDS: "850"
 
     steps:
       - name: Checkout gala (this branch)
@@ -96,6 +118,23 @@ jobs:
         working-directory: gala_team
         run: |
           set -euo pipefail
+          # Report whether setup-bazel restored a disk cache. Without this
+          # the wall time below is uninterpretable: a restored cache and a
+          # missed one differ by ~10x, which reads as a regression when it
+          # is only cache disposition. Pure logging — never fails the step.
+          # setup-bazel writes `common --disk_cache=<dir>` into ~/.bazelrc
+          # whether or not the cache key hit, so presence of the flag proves
+          # nothing — count entries instead.
+          disk_cache=$(grep -hoE -- '--disk_cache=[^[:space:]]+' "$HOME/.bazelrc" 2>/dev/null | head -1 | cut -d= -f2- || true)
+          entries=0
+          if [ -n "${disk_cache:-}" ] && [ -d "$disk_cache" ]; then
+            entries=$(find "$disk_cache" -type f 2>/dev/null | wc -l || echo 0)
+          fi
+          if [ "${entries:-0}" -gt 0 ]; then
+            echo "Disk cache RESTORED: ${entries} entries in ${disk_cache} ($(du -sh "$disk_cache" 2>/dev/null | cut -f1 || echo '?'))"
+          else
+            echo "Disk cache MISSED — this is a true from-scratch cold build"
+          fi
           start=$(date +%s)
           bazel build //cmd:gala_team \
             --override_module=gala=$GITHUB_WORKSPACE/gala_simple \


### PR DESCRIPTION
## Summary

The `Build gala_team against this branch` gate enforced a 680-second cold-build budget that sits *inside* the range a genuine from-scratch build now occupies. The result is that unrelated PRs go red — a docs-only PR and a version bump both failed it — so a real failure is indistinguishable from the baseline one.

**Category**: CI_INFRA · **Priority**: P1

## Root cause

The step labelled "Cold build" is only cold when `setup-bazel`'s disk-cache key (`perf-real-build-<go-version>`) misses. When it hits, Bazel replays most actions and the step finishes in a fraction of the time. Measured runs split cleanly along that line, and not along any source change:

| Run | Branch | Disk cache | Cold wall | Result |
|---|---|---|---|---|
| 30325674151 | docs/highlight… (2nd) | **restored** | **77 s** | pass |
| 30189464952 | master nightly 07-26 | restored | 364 s | pass |
| 30288735817 | fix/…-stale-stdlib | restored | 416 s | pass |
| 30240034052 | master nightly 07-27 | restored | 589 s | pass |
| 30284202026 | fix/…-stale-stdlib | missed | 648 s | pass |
| 30290293605 | fix/…-stdlib-in-source | missed | 670 s | pass |
| 30325486092 | docs/highlight… (1st) | missed | 672 s | pass — 8 s margin |
| 30324017221 | release/bump-0.72.2 | missed | **750 s** | **fail** |

680 s fell between the two clusters, so a true cold run was close to a coin flip. Note the same branch appears in both clusters (416 s and 648 s; 672 s and 77 s) with no build-relevant change between runs — the discriminator is cache state, not code.

## Changes

- `.github/workflows/perf-real-build.yml`
  - `COLD_BUDGET_SECONDS` 680 → 850 — clears the worst observed true-cold run (750 s) by ~13%.
  - Comment block documents the re-baseline and the two clusters, per the file's convention that the budget never moves upward without a written reason.
  - The cold step now logs whether the disk cache was restored, and how many entries it held, before timing the build. Without that the wall time is uninterpretable: the two dispositions differ by ~10x, which reads as a regression when it is not. Pure logging, guarded so it cannot fail the step under `set -euo pipefail`.

## Verification

- Workflow YAML parses; the cold step's shell passes `bash -n`.
- The cache probe was smoke-tested against a populated cache dir (`RESTORED: 2 entries`), an empty one (`MISSED`), and a missing `~/.bazelrc` (`MISSED`).
- `common --disk_cache=/home/runner/.cache/bazel-disk` written to `/home/runner/.bazelrc` confirmed from run 30325674151's `setup-bazel` output, so the grep target is right.

## Notes for review

This is a re-baseline, not a licence for the build to get slower. Two follow-ups worth considering, neither in this PR:

1. Any ~400 s figure quoted from an earlier run was a cache-hit measurement, so it is not a floor this build regressed from. Future comparisons should hold cache disposition constant — which the new log line now makes possible.
2. A fixed constant needs manual maintenance after every compile-time change and will drift back into this state. A rolling baseline would not.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)