### PR TITLE
test(build): assert sibling-parse concurrency directly instead of timing it

### DIFF
--- a/internal/build/BUILD.bazel
+++ b/internal/build/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//internal/transpiler/analyzer",
         "//internal/transpiler/generator",
         "//internal/transpiler/transformer",
+        "@com_github_antlr4_go_antlr_v4//:antlr",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@rules_go//go/tools/bazel",

--- a/internal/build/transpile_perf_test.go
+++ b/internal/build/transpile_perf_test.go
@@ -6,9 +6,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/antlr4-go/antlr/v4"
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/stretchr/testify/require"
 
@@ -149,21 +151,72 @@ func TestTranspile_ParallelSiblingPerf_ColdWarm(t *testing.T) {
 	}
 }
 
-// TestTranspile_ParallelSpeedup proves that parseFilesConcurrent
-// actually parallelizes. It pins GOMAXPROCS to 1 (which collapses the
-// worker pool to a single goroutine — the pre-optimization shape) for
-// a baseline pass, then to NumCPU for a parallel pass, and asserts
-// the parallel pass is at least 1.3× faster.
+// concurrencyProbeParser wraps a GalaParser and records the high-water
+// mark of Parse calls that were inside the parser at the same instant.
 //
-// Catches regressions where parseFilesConcurrent is replaced with a
-// for-each parseFileCached or where the goroutine pool sizing logic
-// reverts to 1.
-func TestTranspile_ParallelSpeedup(t *testing.T) {
+// This is what lets the test below assert on parallelism without timing
+// anything. A serialized implementation peaks at 1 whether the machine
+// is idle or oversubscribed, so the signal survives a loaded shared CI
+// runner — unlike a wall-clock speedup ratio, which shrinks toward 1.0
+// purely because the runner is busy and reports that as a regression.
+//
+// Two atomic adds per parse are immeasurable next to an ANTLR parse.
+type concurrencyProbeParser struct {
+	inner    transpiler.GalaParser
+	inFlight atomic.Int64
+	peak     atomic.Int64
+	calls    atomic.Int64
+}
+
+var _ transpiler.GalaParser = (*concurrencyProbeParser)(nil)
+
+func (p *concurrencyProbeParser) Parse(input string) (antlr.Tree, error) {
+	p.enter()
+	defer p.leave()
+	return p.inner.Parse(input)
+}
+
+func (p *concurrencyProbeParser) ParseLenient(input string) (antlr.Tree, []error) {
+	p.enter()
+	defer p.leave()
+	return p.inner.ParseLenient(input)
+}
+
+func (p *concurrencyProbeParser) enter() {
+	p.calls.Add(1)
+	n := p.inFlight.Add(1)
+	for {
+		peak := p.peak.Load()
+		if n <= peak || p.peak.CompareAndSwap(peak, n) {
+			return
+		}
+	}
+}
+
+func (p *concurrencyProbeParser) leave() { p.inFlight.Add(-1) }
+
+// TestTranspile_SiblingParseIsConcurrent proves that
+// parseFilesConcurrent really parses siblings in parallel, by watching
+// how many parses are in flight simultaneously rather than by timing
+// two passes and dividing.
+//
+// Catches the regressions the previous timing assertion targeted — the
+// pool replaced with a for-each parseFileCached, or its sizing logic
+// reverting to 1 — plus one it could not see: the pool losing its cap
+// and oversubscribing a 4-vCPU runner.
+//
+// The GOMAXPROCS=1 control pass is what makes the parallel assertion
+// mean something. parseFilesConcurrent sizes its pool from GOMAXPROCS
+// and is the only place the transpiler spawns goroutines, so at 1 the
+// observed peak must be exactly 1. A probe that had quietly stopped
+// observing anything would report 1 there too — but so would a pool
+// that had reverted to serial, and the control tells the two apart.
+func TestTranspile_SiblingParseIsConcurrent(t *testing.T) {
 	if testing.Short() {
 		t.Skip("perf test skipped in -short mode")
 	}
 	if runtime.NumCPU() < 2 {
-		t.Skip("speedup test requires NumCPU >= 2")
+		t.Skip("concurrency test requires NumCPU >= 2")
 	}
 
 	projectDir := t.TempDir()
@@ -175,64 +228,60 @@ func TestTranspile_ParallelSpeedup(t *testing.T) {
 	content, err := os.ReadFile(target)
 	require.NoError(t, err)
 
-	timeOnce := func(label string, maxprocs int) time.Duration {
+	// One full transpile at the given GOMAXPROCS, reporting the peak
+	// number of simultaneous parses and how many parses ran at all.
+	// Fresh BatchAnalyzer and wiped on-disk cache per run, so every
+	// sibling is genuinely re-parsed instead of served from a cache.
+	peakAt := func(maxprocs int) (peak, calls int64) {
 		t.Helper()
 		prev := runtime.GOMAXPROCS(maxprocs)
 		defer runtime.GOMAXPROCS(prev)
 
-		// Fresh BatchAnalyzer per measurement so the parsedFileCache
-		// doesn't carry across — both passes pay the full sibling-
-		// parse cost.
 		_ = os.RemoveAll(filepath.Join(projectDir, ".gala"))
-		p := transpiler.NewAntlrGalaParser()
+		p := &concurrencyProbeParser{inner: transpiler.NewAntlrGalaParser()}
 		tr := transformer.NewGalaASTTransformer()
 		g := generator.NewGoCodeGenerator()
 		batch := analyzer.NewBatchAnalyzer(p, []string{projectDir, builderStdDir(t)}, projectDir)
 		batch.SetPackageFiles(siblings)
 		txp := transpiler.NewGalaToGoTranspiler(p, batch, tr, g)
 
-		start := time.Now()
 		_, err := txp.Transpile(string(content), target)
-		require.NoErrorf(t, err, "%s: Transpile", label)
-		return time.Since(start)
+		require.NoError(t, err, "Transpile at GOMAXPROCS=%d", maxprocs)
+		return p.peak.Load(), p.calls.Load()
 	}
 
-	// Run multiple iterations and take the BEST (min) per mode —
-	// short benchmarks on a busy machine produce noisy maxima but
-	// the minimum represents the no-contention floor and is a much
-	// more stable signal of the parallel-vs-serial ratio. Single-shot
-	// measurements flake when a GC or background process steals time
-	// from one mode but not the other.
-	const iters = 5
-	bestOf := func(label string, maxprocs int) time.Duration {
-		t.Helper()
-		var best time.Duration
-		for i := 0; i < iters; i++ {
-			d := timeOnce(label, maxprocs)
-			if best == 0 || d < best {
-				best = d
-			}
+	serialPeak, serialCalls := peakAt(1)
+	t.Logf("GOMAXPROCS=1: peak %d simultaneous parses over %d total", serialPeak, serialCalls)
+	require.Greater(t, serialCalls, int64(1),
+		"expected the transpile to parse the target plus its siblings; with one parse there is nothing to parallelize and the assertions below are vacuous")
+	if serialPeak != 1 {
+		t.Errorf("GOMAXPROCS=1 produced a peak of %d simultaneous parses, want exactly 1 — the worker pool no longer sizes itself from GOMAXPROCS, so the parallel check below proves nothing",
+			serialPeak)
+	}
+
+	// Two goroutines being inside Parse at the same instant is a
+	// scheduling outcome, not a guarantee. It is overwhelmingly likely
+	// for parses this long, but retry before failing: three runs that
+	// never once overlap mean the pool is serial in fact, not unlucky.
+	maxprocs := runtime.GOMAXPROCS(0)
+	const attempts = 3
+	var peak, calls int64
+	for attempt := 1; attempt <= attempts; attempt++ {
+		peak, calls = peakAt(maxprocs)
+		t.Logf("GOMAXPROCS=%d attempt %d/%d: peak %d simultaneous parses over %d total",
+			maxprocs, attempt, attempts, peak, calls)
+		if peak > 1 {
+			break
 		}
-		return best
 	}
-	serial := bestOf("serial", 1)
-	t.Logf("serial transpile (GOMAXPROCS=1, best of %d): %s", iters, serial)
 
-	parallel := bestOf("parallel", runtime.NumCPU())
-	t.Logf("parallel transpile (GOMAXPROCS=%d, best of %d): %s", runtime.NumCPU(), iters, parallel)
-
-	speedup := float64(serial) / float64(parallel)
-	t.Logf("speedup: %.2fx", speedup)
-
-	// 1.3× is a conservative floor: locally the optimization
-	// delivers 3-5×, but CI runners with 4 vCPU and short jobs often
-	// only show 1.5-2×. Below 1.3× the parallel path is effectively
-	// inert and we want a loud failure. Best-of-iters above absorbs
-	// transient noise.
-	const minSpeedup = 1.3
-	if speedup < minSpeedup {
-		t.Errorf("parallel speedup %.2fx is below threshold %.2fx — parseFilesConcurrent may have been silently serialized; check that analyzer.parseFilesConcurrent still spawns a goroutine pool of size GOMAXPROCS, and that Analyze + analyzePackage still route through it",
-			speedup, minSpeedup)
+	if peak < 2 {
+		t.Errorf("sibling parses never overlapped in %d runs at GOMAXPROCS=%d (peak %d) — parseFilesConcurrent may have been silently serialized; check that analyzer.parseFilesConcurrent still spawns a goroutine pool of size GOMAXPROCS, and that Analyze + analyzePackage still route through it",
+			attempts, maxprocs, peak)
+	}
+	if peak > int64(maxprocs) {
+		t.Errorf("peak %d simultaneous parses exceeds GOMAXPROCS=%d — parseFilesConcurrent has stopped capping its worker count and will oversubscribe small CI runners",
+			peak, maxprocs)
 	}
 }
 


### PR DESCRIPTION
## Summary

`TestTranspile_ParallelSpeedup` asserts a wall-clock *ratio* between a serial and a parallel transpile pass. On a shared CI runner that ratio is a measurement of how busy the runner is as much as of whether the code parallelizes, and it has failed once and passed on re-run in the same batch. It belongs to the same family as the other timing-dependent flakes on this repo's CI.

**Category**: FLAKY_TEST · **Priority**: P3

## Root cause

The test pinned `GOMAXPROCS` to 1 for a baseline pass, then to `NumCPU` for a parallel pass, and required the parallel pass to be at least 1.3x faster. When the runner is oversubscribed the parallel pass cannot get its share of cores, the ratio collapses toward 1.0, and the test reports a regression that does not exist.

Best-of-5 iterations per mode narrowed the window but could not close it — the minimum only represents a no-contention floor if the machine is quiet at *some* point during the test. If it is busy throughout, every iteration is slow and the floor moves with it.

## Changes

- `internal/build/transpile_perf_test.go`
  - Adds `concurrencyProbeParser`, a `transpiler.GalaParser` decorator recording the high-water mark of `Parse` calls in flight simultaneously. Two atomic adds per parse, immeasurable next to an ANTLR parse. No production code changes — the parser is already injected into `BatchAnalyzer` and `NewGalaToGoTranspiler`.
  - Replaces `TestTranspile_ParallelSpeedup` with `TestTranspile_SiblingParseIsConcurrent`, which asserts on observed simultaneity rather than elapsed time. Load moves wall time but not simultaneity.
- `internal/build/BUILD.bazel` — adds the `antlr` dep needed by the decorator's signature.

Two passes:

- **`GOMAXPROCS=1` control** — peak must be exactly 1. `parseFilesConcurrent` sizes its pool from `GOMAXPROCS` and is the only `go func` in the transpiler, so this holds by construction. It is what makes the second assertion mean something: a probe that had silently stopped observing would also report 1, and the control is what distinguishes that from a genuinely serial pool.
- **`GOMAXPROCS=NumCPU`** — peak must be >= 2 and <= `GOMAXPROCS`. Retried up to 3 times, since two goroutines being inside `Parse` at the same instant is a scheduling outcome; three runs that never once overlap mean the pool is serial in fact, not unlucky.

## Verification

Observed on a 32-core box:

```
GOMAXPROCS=1:              peak 1 simultaneous parses over 20 total
GOMAXPROCS=32 attempt 1/3: peak 8 simultaneous parses over 20 total
--- PASS: TestTranspile_SiblingParseIsConcurrent (0.96s)
```

Negative controls, by injecting each regression into `analyzer.parseFilesConcurrent` and re-running:

| Injected regression | Old timing test | This test |
|---|---|---|
| `workers = 1` (pool reverts to serial) | caught, when the runner is quiet | **FAIL** — peak 1 on all 3 attempts |
| `workers = len(paths)` (cap removed) | not detectable | **FAIL** — peak 7 on the `GOMAXPROCS=1` control |

The second row is new coverage: the timing assertion could not see an uncapped pool oversubscribing a 4-vCPU runner at all.

- `bazel build //...` passes (1430 targets).
- `bazel test //...` — 387/388 pass. The one failure is `TestGorootFromGoBinarySymlink`, which fails on this Windows box with `A required privilege is not held by the client` when creating a symlink. Pre-existing and environmental; it lives in `internal/transpiler/analyzer`, which this diff does not touch.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)