### PR TITLE
docs: document the concurrent/go_interop dot-import collision (GALA-E0032)

### DIFF
--- a/docs/CONCURRENT.MD
+++ b/docs/CONCURRENT.MD
@@ -8,6 +8,28 @@ The `concurrent` package provides asynchronous programming primitives for GALA, 
 import . "martianoff/gala/concurrent"
 ```
 
+### Using `go_interop` in the same file
+
+`concurrent` re-exports `go_interop`'s execution-context API — `ExecutionContext`, its three concrete implementations and their constructors, `GlobalEC`/`SetGlobalEC`, `Spawn`, and the `CancelToken` helpers — as a convenience facade. The two packages therefore export thirteen identical names, and dot-importing both in one file is rejected with [GALA-E0032](errors/GALA-E0032.md).
+
+Dot-import `concurrent` and qualify `go_interop`. `concurrent`'s names carry the shape of the code (`Future`, `Promise`, `Await`) and appear on nearly every line, while `go_interop` is the Go escape hatch and its call sites are worth marking. That is also the direction the standard library takes: `concurrent`, `subprocess`, `json`, `lazy` and both collection packages all import `go_interop` qualified.
+
+```gala
+package main
+
+import (
+    . "martianoff/gala/concurrent"
+    "martianoff/gala/go_interop"
+)
+
+func main() {
+    val encoded = Future(go_interop.ToBytes("payload"))
+    Println(go_interop.ToString(encoded.Get()))
+}
+```
+
+An alias shortens the prefix where it appears often: `gi "martianoff/gala/go_interop"`.
+
 ---
 
 ## Future Monad

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -2147,6 +2147,8 @@ val goSlice = SliceOf(1, 2, 3, 4, 5)    // Creates Go []int
 val empty = SliceEmpty[int]()            // Creates Go []int{}
 ```
 
+> **Note:** A file cannot dot-import both `go_interop` and `concurrent`. `concurrent` re-exports `go_interop`'s execution-context helpers as a convenience facade, so the two packages export thirteen identical names and the combination is rejected with [GALA-E0032](errors/GALA-E0032.md). Dot-import `concurrent` and qualify `go_interop` — see [Using `go_interop` in the same file](CONCURRENT.MD#using-go_interop-in-the-same-file).
+
 **When to use Go slices vs GALA collections:**
 
 | Use Case | Recommendation |
@@ -3025,6 +3027,8 @@ func main() {
 ```
 
 > **Note:** If your package mixes `.gala` and `.go` files, dot imports may conflict with type aliases declared in `.go` files. Prefer GALA [type aliases](#type-aliases) over Go type aliases to avoid this. See the [Type Aliases](#type-aliases) section for details.
+
+Two dot-imported packages that export the same name are rejected with [GALA-E0032](errors/GALA-E0032.md); qualify or alias one of them. This is by design for packages that deliberately re-export another's API — `concurrent` is a facade over `go_interop`'s execution-context helpers, so dot-importing both is never meaningful. See [Using `go_interop` in the same file](CONCURRENT.MD#using-go_interop-in-the-same-file).
 
 ### Using Symbols from Other Packages
 

--- a/docs/errors/GALA-E0032.md
+++ b/docs/errors/GALA-E0032.md
@@ -88,6 +88,38 @@ import (
 )
 ```
 
+**The common instance: `concurrent` and `go_interop`.** A file that uses both
+`Future`/`Promise` and `go_interop`'s slice, map or byte helpers runs into this
+pair. `concurrent` re-exports `go_interop`'s execution-context API —
+`ExecutionContext`, its three concrete implementations and their constructors,
+`GlobalEC`/`SetGlobalEC`, `Spawn`, and the `CancelToken` helpers — as a
+convenience facade, so the two packages export thirteen identical names and the
+error lists all thirteen. The facade is the point: dot-importing both is never
+meaningful, because either import already supplies the whole execution-context
+API.
+
+Dot-import `concurrent` and qualify `go_interop`. `concurrent`'s names appear on
+nearly every line of async code, `go_interop` is the Go escape hatch and its
+call sites are worth marking, and the standard library imports `go_interop`
+qualified in every package that also uses `concurrent`:
+
+```gala
+package main
+
+import (
+    . "martianoff/gala/concurrent"
+    "martianoff/gala/go_interop"
+)
+
+func main() {
+    val encoded = Future(go_interop.ToBytes("payload"))
+    Println(go_interop.ToString(encoded.Get()))
+}
+```
+
+See [CONCURRENT.MD](../CONCURRENT.MD) for the same guidance alongside the rest
+of the `concurrent` API.
+
 **Rationale.** Without this check the collision surfaced from `go build`,
 against generated code, naming a file the author never wrote. Detecting it at
 the GALA level names the symbol, names every package that supplies it, and


### PR DESCRIPTION
## Summary

Fixes **FIX-007**: dot-importing both `concurrent` and `go_interop` is rejected with `GALA-E0032`, and the docs showed both as dot-imports with no cross-reference.

**Category**: DOC_GAP
**Priority**: P3
**Found in**: validating GALA code samples for the gala-kv design document (RESP2-compatible KV store written in GALA)

## Root Cause

Not a transpiler defect — the compiler is correct and the diagnostic is good. `concurrent` deliberately re-exports `go_interop`'s execution-context API (`ExecutionContext` + its three implementations and constructors, `GlobalEC`/`SetGlobalEC`, `Spawn`, the `CancelToken` helpers) as a convenience facade, so the two packages export **thirteen identical names**. The reference docs showed each as a dot-import independently, with nothing warning that the combination is rejected or guidance on which to qualify.

## Changes

- `docs/CONCURRENT.MD` — new "Using `go_interop` in the same file" section under `## Import`: names the collision, explains the facade, recommends dot-importing `concurrent` and qualifying `go_interop`, with a verified example and an alias variant.
- `docs/GALA.MD` §9 (Slices / Go Interop) — note at the `import . "martianoff/gala/go_interop"` site, cross-linked to the above.
- `docs/GALA.MD` §Aliases and Dot Imports — the general rule (two dot-imports exporting the same name are rejected; qualify or alias one), noting that for a deliberate facade the combination is never meaningful.
- `docs/errors/GALA-E0032.md` — new "The common instance: `concurrent` and `go_interop`" section. The byte-quoted diagnostic block was **not** touched, so the doc-guard test still holds.

Docs only. Nothing under `internal/` was modified.

## Recommendation rationale

Qualify `go_interop`, dot-import `concurrent`. `concurrent`'s names (`Future`, `Promise`, `Await`, the `Succeeded`/`Failed` extractors) appear on nearly every line of async code, while `go_interop` call sites are isolated escape-hatch touchpoints worth marking explicitly.

This follows existing convention rather than inventing one: no `.gala` file in the repo currently dot-imports both, but every stdlib package importing `go_interop` alongside `concurrent` imports it qualified — `concurrent/future.gala`, `concurrent/event_bus.gala`, `subprocess/async.gala`, plus `json`, `lazy`, `crypto`, and both collection packages.

## Verification

- Example compiled **and run** with `gala` 0.72.2 in a scratch module (prints `payload`); alias variant compiled and run separately.
- The `GALA-E0032` failure was reproduced to confirm the collision and the thirteen colliding names.
- `bazel build //...` green.
- `bazel test //...` — 387/388. The single failure is `//internal/transpiler/analyzer:analyzer_test :: TestGorootFromGoBinarySymlink`, the known Windows "a required privilege is not held by the client" symlink test, unrelated to this change.
- Doc-guard target `//internal/transpiler/transformer:transformer_test` (asserts error pages quote real compiler output byte-for-byte) passed.

## Repro (before this change)

```gala
import (
    . "martianoff/gala/concurrent"
    . "martianoff/gala/go_interop"
)
```
→ `GALA-E0032`, with the docs offering no guidance on which to qualify.

## Dependencies

None — this PR can be reviewed and merged independently.

## Report Reference

Originally reported as **BUG-KV-5** in `docs/private/gala-kv-findings/REPORT.md`; detail in `docs/private/BUG_CONCURRENT_GO_INTEROP_DOT_IMPORT_COLLISION.md`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aZRWH39EXTXVALyxALJut