### PR TITLE
fix(transpiler): untyped literal into a sized immutable struct field collapses to Immutable[int]

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2855,6 +2855,17 @@ gala_exec_test(
     deps = ["//collection_immutable"],
 )
 
+# An untyped numeric literal initialising an immutable (`val`) struct field
+# must adopt the field's declared type: the field is stored as `Immutable[T]`
+# and the NewImmutable wrapper used to take its type argument from the
+# literal's default type (`int`), so every int64/uint32/float64/byte field
+# failed to compile in the generated Go.
+gala_exec_test(
+    name = "fix005_sized_field_literal",
+    src = "fix005_sized_field_literal.gala",
+    expected = "fix005_sized_field_literal.out",
+)
+
 # Gap #10 regression: tuple literal passed to Append on Array[Tuple[A,B]]
 # infers A,B from the receiver, not falling back to any.
 gala_exec_test(

--- a/examples/fix005_sized_field_literal.gala
+++ b/examples/fix005_sized_field_literal.gala
@@ -1,0 +1,106 @@
+package main
+
+// Untyped numeric literals must adopt the declared type of the immutable
+// (`val`) struct field they initialise. Immutable fields are stored as
+// `Immutable[T]`, and the generated `NewImmutable(...)` wrapper used to take
+// its type argument from the literal's own default type (`0` → int), so any
+// field wider or narrower than `int` — int64 timestamps, uint32 ports,
+// float64 ratios, byte tags — failed to compile in the generated Go with
+// "cannot use Immutable[int] as Immutable[int64]".
+//
+// Every construction spelling is exercised below: positional, named-argument,
+// and Go-style composite literal.
+
+struct Entry(value string, expireAtMs int64)
+
+struct Sizes(i8 int8, i16 int16, i32 int32, i64 int64)
+
+struct Unsigned(u uint, u8 uint8, u16 uint16, u32 uint32, u64 uint64)
+
+struct Ratios(f32 float32, f64 float64)
+
+struct Tags(b byte, r rune)
+
+// A field genuinely declared `int` keeps the plain inferred wrapper — the
+// negative case that must not regress.
+struct Counter(n int, label string)
+
+// Mutable (`var`) fields are stored unwrapped; the untyped literal converts
+// through ordinary Go assignment.
+struct MutableEntry(value string, var expireAtMs int64)
+
+// A generic field's type is a type parameter, not a concrete numeric type:
+// the wrapper must stay inferred so the type argument is resolved from the
+// construction site.
+struct Box[T any](item T)
+
+func describeEntry(e Entry) string = s"${e.value}@${e.expireAtMs}"
+
+func main() {
+    // Positional construction.
+    val positional = Entry("pos", 0)
+    Println(describeEntry(positional))
+
+    // Named-argument construction.
+    val named = Entry(value = "named", expireAtMs = 1)
+    Println(describeEntry(named))
+
+    // Go-style composite literal.
+    val composite = Entry{value: "composite", expireAtMs: 2}
+    Println(describeEntry(composite))
+
+    // Constant arithmetic stays untyped in Go and must convert too.
+    val computed = Entry("computed", 60 * 1000)
+    Println(describeEntry(computed))
+
+    // Negative literals and parenthesised constants.
+    val negative = Entry("negative", -5)
+    Println(describeEntry(negative))
+
+    // Every signed width.
+    val signed = Sizes(1, 2, 3, 4)
+    Println(s"${signed.i8} ${signed.i16} ${signed.i32} ${signed.i64}")
+
+    val signedNamed = Sizes(i8 = 5, i16 = 6, i32 = 7, i64 = 8)
+    Println(s"${signedNamed.i8} ${signedNamed.i16} ${signedNamed.i32} ${signedNamed.i64}")
+
+    // Every unsigned width.
+    val unsigned = Unsigned(1, 2, 3, 4, 5)
+    Println(s"${unsigned.u} ${unsigned.u8} ${unsigned.u16} ${unsigned.u32} ${unsigned.u64}")
+
+    val unsignedComposite = Unsigned{u: 6, u8: 7, u16: 8, u32: 9, u64: 10}
+    Println(s"${unsignedComposite.u} ${unsignedComposite.u8} ${unsignedComposite.u16} ${unsignedComposite.u32} ${unsignedComposite.u64}")
+
+    // Floats: an integer literal must widen, and a float literal must stay a
+    // float32 where the field says so.
+    val ratios = Ratios(1, 2)
+    Println(s"${ratios.f32} ${ratios.f64}")
+
+    val fractional = Ratios(f32 = 0.5, f64 = 1.25)
+    Println(s"${fractional.f32} ${fractional.f64}")
+
+    // byte / rune aliases.
+    val tags = Tags(65, 66)
+    Println(s"${tags.b} ${tags.r}")
+
+    val charTag = Tags{b: 67, r: 'D'}
+    Println(s"${charTag.b} ${charTag.r}")
+
+    // Negative case: a plain `int` field is unchanged.
+    val counter = Counter(7, "hits")
+    Println(s"${counter.label}=${counter.n}")
+
+    val counterNamed = Counter(n = 8, label = "misses")
+    Println(s"${counterNamed.label}=${counterNamed.n}")
+
+    // `var` field: literal converts without any wrapper.
+    val mutableEntry = MutableEntry("mutable", 9)
+    Println(s"${mutableEntry.value}@${mutableEntry.expireAtMs}")
+
+    // Generic field: the type argument comes from the construction site.
+    val boxed = Box(11)
+    Println(boxed.item)
+
+    val boxedTyped = Box[int64](12)
+    Println(boxedTyped.item)
+}

--- a/examples/fix005_sized_field_literal.out
+++ b/examples/fix005_sized_field_literal.out
@@ -1,0 +1,18 @@
+pos@0
+named@1
+composite@2
+computed@60000
+negative@-5
+1 2 3 4
+5 6 7 8
+1 2 3 4 5
+6 7 8 9 10
+1 2
+0.5 1.25
+65 B
+67 D
+hits=7
+misses=8
+mutable@9
+11
+12

--- a/examples/multifile_lib_regress/types.gala
+++ b/examples/multifile_lib_regress/types.gala
@@ -20,4 +20,24 @@ func NewUser(name string, email string) UserInfo = UserInfo(Name = name, Email =
 // path.
 struct Snapshot(ProjectName string, SavedAt int64)
 
+// Untyped numeric literals initialising immutable (`val`) fields must adopt
+// the field's declared type instead of the literal's own default type (`int`).
+// The immutable field is stored as `Immutable[T]`, so an `Immutable[int]`
+// wrapper is not assignable to an `Immutable[int64]` field and the generated
+// Go fails to compile. Batch transpilation resolves the field types from
+// sibling/imported metadata rather than the current file, so each construction
+// spelling is exercised here and again from the consumer package.
+struct Reading(Label string, TakenAtMs int64, Port uint32, Ratio float64, Tag byte)
+
+func NewReadingPositional(label string) Reading = Reading(label, 0, 8080, 1, 7)
+
+func NewReadingNamed(label string) Reading =
+    Reading(Label = label, TakenAtMs = 60 * 1000, Port = 9090, Ratio = 0.5, Tag = 8)
+
+func NewReadingComposite(label string) Reading =
+    Reading{Label: label, TakenAtMs: -2, Port: 443, Ratio: 2, Tag: 9}
+
+func DescribeReading(r Reading) string =
+    s"${r.Label}/${r.TakenAtMs}/${r.Port}/${r.Ratio}/${r.Tag}"
+
 // time.Parse is a Go function returning (time.Time, error)

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -196,11 +196,33 @@ func main() {
     // function — its (width, height) parameters did not match the struct's
     // (ProjectName, SavedAt) field names and a misleading "unknown
     // parameter" error fired at the call site.
+    // The `SavedAt` literal is written bare on purpose: an untyped numeric
+    // literal must take the declared `int64` field type through the
+    // NewImmutable wrapper the immutable field is stored in.
     val snap = multifile_lib_regress.Snapshot(
         ProjectName = "demo",
-        SavedAt = int64(1234),
+        SavedAt = 1234,
     )
     Println(s"snap: ${snap.ProjectName}=${snap.SavedAt}")
+
+    // --- Regression: untyped numeric literals into immutable struct fields
+    // declared with a non-`int` numeric type (int64/uint32/float64/byte).
+    // Constructed both inside the library (all three spellings) and here,
+    // across the package boundary, where the field types come from the
+    // imported package's metadata.
+    Println(multifile_lib_regress.DescribeReading(multifile_lib_regress.NewReadingPositional("pos")))
+    Println(multifile_lib_regress.DescribeReading(multifile_lib_regress.NewReadingNamed("named")))
+    Println(multifile_lib_regress.DescribeReading(multifile_lib_regress.NewReadingComposite("composite")))
+    val xpkgPositional = multifile_lib_regress.Reading("xpos", 5, 1, 3, 4)
+    Println(multifile_lib_regress.DescribeReading(xpkgPositional))
+    val xpkgNamed = multifile_lib_regress.Reading(
+        Label = "xnamed",
+        TakenAtMs = 6,
+        Port = 2,
+        Ratio = 4,
+        Tag = 5,
+    )
+    Println(multifile_lib_regress.DescribeReading(xpkgNamed))
     // Reference a non-clashing helper from the shadow package so the
     // dot-import is actually exercised at compile time.
     Println(ShadowMarker())

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -51,6 +51,11 @@ err: oops
 alice => Alice<a@x>
 bob => Bob<b@x>
 snap: demo=1234
+pos/0/8080/1/7
+named/60000/9090/0.5/8
+composite/-2/443/2/9
+xpos/5/1/3/4
+xnamed/6/2/4/5
 shadow-marker
 chunk[topic]=first line
 end[topic] ok

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -1235,6 +1235,8 @@ func (t *galaASTTransformer) tryTransformCompanionApplyOrStructCtor(
 // Extracted from transformCallWithArgsCtx as part of A1 cont.
 func (t *galaASTTransformer) buildStructLiteral(typeExpr ast.Expr, resolvedTypeName string, fields []string, args []ast.Expr, truncate bool) ast.Expr {
 	immutFlags := t.structImmutFields[resolvedTypeName]
+	fieldTypes := t.structFieldTypes[resolvedTypeName]
+	typeArgSubst := t.structTypeArgSubst(typeExpr, resolvedTypeName)
 	var elts []ast.Expr
 	for i, fieldName := range fields {
 		if i >= len(args) {
@@ -1245,10 +1247,7 @@ func (t *galaASTTransformer) buildStructLiteral(typeExpr ast.Expr, resolvedTypeN
 		}
 		var valExpr ast.Expr
 		if immutFlags != nil && i < len(immutFlags) && immutFlags[i] {
-			valExpr = &ast.CallExpr{
-				Fun:  t.stdIdent("NewImmutable"),
-				Args: []ast.Expr{args[i]},
-			}
+			valExpr = t.wrapImmutableFieldValue(args[i], fieldTypes[fieldName], typeArgSubst)
 		} else {
 			valExpr = args[i]
 		}
@@ -2083,6 +2082,7 @@ func (t *galaASTTransformer) buildStructLiteralWithNamedArgs(
 	fieldTypes := t.structFieldTypes[resolvedTypeName]
 
 	typeExpr := t.inferTypeArgsFromNamedArgs(fun, typeName, resolvedTypeName, namedArgs, fieldTypes)
+	typeArgSubst := t.structTypeArgSubst(typeExpr, resolvedTypeName)
 
 	var elts []ast.Expr
 	for i, fieldName := range fields {
@@ -2100,10 +2100,7 @@ func (t *galaASTTransformer) buildStructLiteralWithNamedArgs(
 
 		valExpr := val
 		if immutFlags != nil && i < len(immutFlags) && immutFlags[i] {
-			valExpr = &ast.CallExpr{
-				Fun:  t.stdIdent("NewImmutable"),
-				Args: []ast.Expr{val},
-			}
+			valExpr = t.wrapImmutableFieldValue(val, fieldTypes[fieldName], typeArgSubst)
 		}
 		elts = append(elts, &ast.KeyValueExpr{Key: ast.NewIdent(fieldName), Value: valExpr})
 	}

--- a/internal/transpiler/transformer/constructors.go
+++ b/internal/transpiler/transformer/constructors.go
@@ -204,6 +204,174 @@ func (t *galaASTTransformer) transformTupleElementExpressions(
 	return out, nil
 }
 
+// wrapImmutableFieldValue builds the `std.NewImmutable(value)` wrapper that
+// backs an immutable (`val`) struct field, naming the type argument explicitly
+// when the value alone would infer the wrong one.
+//
+// Go infers NewImmutable's type parameter from its argument, and an untyped
+// constant argument collapses to its own default type (`0` → int, `1.5` →
+// float64). A field declared `int64` therefore receives an Immutable[int],
+// which is not assignable to Immutable[int64] — even though the constant is
+// perfectly representable and a plain Go field assignment would have converted
+// it. Spelling the type argument (`std.NewImmutable[int64](0)`) restores that
+// conversion at the argument position.
+//
+// typeArgs maps the struct's type-parameter names to the type arguments of the
+// literal being built, so a field declared with a type parameter resolves to the
+// type it is instantiated with at this construction site.
+func (t *galaASTTransformer) wrapImmutableFieldValue(value ast.Expr, fieldType transpiler.Type, typeArgs map[string]ast.Expr) ast.Expr {
+	if typeArg := immutableFieldTypeArg(value, fieldType, typeArgs); typeArg != nil {
+		return &ast.CallExpr{
+			Fun:  &ast.IndexExpr{X: t.stdIdent(transpiler.FuncNewImmutable), Index: typeArg},
+			Args: []ast.Expr{value},
+		}
+	}
+	return &ast.CallExpr{
+		Fun:  t.stdIdent(transpiler.FuncNewImmutable),
+		Args: []ast.Expr{value},
+	}
+}
+
+// immutableFieldTypeArg returns the explicit NewImmutable type argument for a
+// field whose declared type differs from the default type of an untyped
+// constant value, or nil when plain inference is already correct.
+//
+// The rewrite is deliberately confined to untyped numeric constants going into
+// a field whose type resolves to a predeclared numeric type: that is exactly the
+// set of values whose type Go would have taken from the destination but takes
+// from the argument once the NewImmutable wrapper intervenes. Anything else (a
+// typed expression, a named or generic field type, a type parameter with no
+// concrete instantiation here) keeps the inferred form, so no construction that
+// compiles today changes shape.
+func immutableFieldTypeArg(value ast.Expr, fieldType transpiler.Type, typeArgs map[string]ast.Expr) ast.Expr {
+	if transpiler.IsUnusable(fieldType) {
+		return nil
+	}
+	var fieldName string
+	switch ft := fieldType.(type) {
+	case transpiler.BasicType:
+		fieldName = ft.Name
+	case transpiler.NamedType:
+		if ft.Package != "" {
+			return nil
+		}
+		fieldName = ft.Name
+	default:
+		return nil
+	}
+	// A field declared with one of the struct's type parameters takes the type
+	// it is instantiated with here (`Box[int64](0)` → NewImmutable[int64]).
+	if arg, isTypeParam := typeArgs[fieldName]; isTypeParam {
+		argIdent, ok := arg.(*ast.Ident)
+		if !ok {
+			return nil
+		}
+		fieldName = argIdent.Name
+	}
+	if !isNumericPrimitive(fieldName) {
+		return nil
+	}
+	defaultName, ok := untypedNumericConstDefault(value)
+	if !ok || defaultName == fieldName {
+		return nil
+	}
+	return ast.NewIdent(fieldName)
+}
+
+// structTypeArgSubst pairs a struct's type-parameter names with the type
+// arguments carried by the literal's type expression (`Box[int64]` → T: int64).
+// It returns nil when the literal is not an instantiation or the arity does not
+// line up, in which case fields typed with a type parameter stay uninstantiated.
+func (t *galaASTTransformer) structTypeArgSubst(typeExpr ast.Expr, resolvedTypeName string) map[string]ast.Expr {
+	var indices []ast.Expr
+	switch te := typeExpr.(type) {
+	case *ast.IndexExpr:
+		indices = []ast.Expr{te.Index}
+	case *ast.IndexListExpr:
+		indices = te.Indices
+	default:
+		return nil
+	}
+	typeMeta := t.getTypeMeta(resolvedTypeName)
+	if typeMeta == nil || len(typeMeta.TypeParams) != len(indices) {
+		return nil
+	}
+	subst := make(map[string]ast.Expr, len(indices))
+	for i, tp := range typeMeta.TypeParams {
+		subst[tp] = indices[i]
+	}
+	return subst
+}
+
+// untypedNumericConstDefault reports the Go default type of an untyped numeric
+// constant expression (`0` → int, `1.5` → float64, `'a'` → rune) and false for
+// anything that is not built purely from numeric literals. Constant arithmetic
+// stays untyped in Go, so `60 * 1000` is classified like a bare literal.
+func untypedNumericConstDefault(expr ast.Expr) (string, bool) {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		switch e.Kind {
+		case token.INT:
+			return "int", true
+		case token.FLOAT:
+			return "float64", true
+		case token.CHAR:
+			return "rune", true
+		}
+	case *ast.ParenExpr:
+		return untypedNumericConstDefault(e.X)
+	case *ast.UnaryExpr:
+		switch e.Op {
+		case token.ADD, token.SUB, token.XOR:
+			return untypedNumericConstDefault(e.X)
+		}
+	case *ast.BinaryExpr:
+		switch e.Op {
+		case token.SHL, token.SHR:
+			// The shift count does not influence the result's default type.
+			return untypedNumericConstDefault(e.X)
+		case token.ADD, token.SUB, token.MUL, token.QUO, token.REM,
+			token.AND, token.OR, token.XOR, token.AND_NOT:
+			left, okLeft := untypedNumericConstDefault(e.X)
+			right, okRight := untypedNumericConstDefault(e.Y)
+			if !okLeft || !okRight {
+				return "", false
+			}
+			if numericConstRank(right) > numericConstRank(left) {
+				return right, true
+			}
+			return left, true
+		}
+	}
+	return "", false
+}
+
+// numericConstRank orders the untyped numeric constant kinds by how they
+// combine: mixing two kinds in a constant expression yields the wider one.
+func numericConstRank(name string) int {
+	switch name {
+	case "int":
+		return 0
+	case "rune":
+		return 1
+	case "float64":
+		return 2
+	}
+	return -1
+}
+
+// isNumericPrimitive reports whether name is a predeclared Go numeric type —
+// the destinations an untyped numeric constant can convert to implicitly.
+func isNumericPrimitive(name string) bool {
+	switch name {
+	case "int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
+		"float32", "float64", "byte", "rune":
+		return true
+	}
+	return false
+}
+
 func (t *galaASTTransformer) transformCompositeLiteral(ctx *grammar.CompositeLiteralContext) (ast.Expr, error) {
 	// Transform the type
 	typeExpr, err := t.transformType(ctx.Type_())
@@ -237,6 +405,8 @@ func (t *galaASTTransformer) transformCompositeLiteral(ctx *grammar.CompositeLit
 	resolvedTypeName := t.resolveStructTypeName(typeName)
 	immutFlags := t.structImmutFields[resolvedTypeName]
 	fields := t.structFields[resolvedTypeName]
+	fieldTypes := t.structFieldTypes[resolvedTypeName]
+	typeArgSubst := t.structTypeArgSubst(typeExpr, resolvedTypeName)
 	// Build a map from field name to its index for quick lookup
 	fieldIndex := make(map[string]int, len(fields))
 	for i, f := range fields {
@@ -270,10 +440,7 @@ func (t *galaASTTransformer) transformCompositeLiteral(ctx *grammar.CompositeLit
 									"cannot assign nil to immutable field '%s' — use Option[T] with None() for optional values, or 'var %s' to make it mutable",
 									keyIdent.Name, keyIdent.Name))
 							}
-							value = &ast.CallExpr{
-								Fun:  t.stdIdent("NewImmutable"),
-								Args: []ast.Expr{value},
-							}
+							value = t.wrapImmutableFieldValue(value, fieldTypes[keyIdent.Name], typeArgSubst)
 						}
 					}
 				}


### PR DESCRIPTION
## Summary

Fixes **FIX-005**: an untyped numeric literal assigned to an immutable struct field was wrapped as `std.NewImmutable(0)` and typed `int`, ignoring the field's declared type. This broke every non-`int` numeric field.

**Category**: CODEGEN_BUG
**Priority**: P1
**Found in**: validating GALA code samples for the gala-kv design document (RESP2-compatible KV store written in GALA)

```
cannot use std.NewImmutable(0) (value of type std.Immutable[int]) as std.Immutable[int64]
```

## Root Cause

Immutable (`val`) struct fields are stored as `Immutable[T]`, and all three construction paths emitted an **un-indexed** `std.NewImmutable(value)`. Go infers that wrapper's type parameter from its *argument*, and an untyped constant collapses to its own default type (`int`) — so the field's declared type never participated in inference.

## Changes

- `internal/transpiler/transformer/calls.go` — `buildStructLiteral` (positional) and `buildStructLiteralWithNamedArgs` (named-argument): 3-line and 2-line edits. No other function in this file was touched.
- `internal/transpiler/transformer/constructors.go` — the Go-style composite-literal site, plus shared helpers (`wrapImmutableFieldValue`, `immutableFieldTypeArg`, `structTypeArgSubst`, `untypedNumericConstDefault`, `numericConstRank`, `isNumericPrimitive`).
- `examples/fix005_sized_field_literal.gala` / `.out`, `examples/BUILD.bazel` (new `gala_exec_test`).
- `examples/multifile_lib_regress/types.gala`, `examples/multifile_lib_regress_test.gala`, `examples/multifile_lib_regress_test.out`.

### Correction to the original report

The report claimed two of the three sites already had the declared field type in scope. That did not hold — in the pre-fix tree **none** of the three read field types, but all three could reach them from the same map with a one-line lookup, and `resolvedTypeName` was already available at each. No new plumbing was required.

## Guard — no existing construction changes shape

The explicit type argument is emitted **only** when all three hold:

1. the value is an untyped numeric constant expression (literal, parenthesised, unary, or constant arithmetic such as `60 * 1000`), **and**
2. the field type resolves to a predeclared numeric type, **and**
3. that type differs from the constant's Go default.

Everything else keeps today's inferred form. This is why no existing golden test in the transformer package needed updating.

## One case fixed beyond the report

A field declared with a *struct type parameter* was still broken (`Box[int64](12)` → `NewImmutable(12)`). Leaving it would have created a visibly inconsistent hole next to the fixed cases, so `structTypeArgSubst` maps the literal's own type arguments onto the type-parameter names. If the instantiation is absent or is not a plain identifier, the inferred form is kept.

## Verification

- `examples/fix005_sized_field_literal` covers int8/16/32/64, uint/8/16/32/64, float32/float64, byte/rune, constant arithmetic, and negative literals across **positional, named-argument, and Go-style composite-literal** forms.
- Negative cases covered: a plain `int` field, a `var` (unwrapped) field, and both inferred and explicitly-instantiated generic fields.
- Multi-file coverage: `Reading` in `multifile_lib_regress/types.gala` is constructed across the package boundary, where field types come from imported-package metadata. The pre-existing `Snapshot(SavedAt = int64(1234))` workaround was reduced to a bare `1234`, so the fix is exercised on the originally reported shape.
- End-to-end with a branch-built CLI against the report's exact repro (`gala run` in a scratch module) — output matches Expected.
- `bazel build //...` clean.
- `bazel test //...` — 388/389. The sole failure is the known-benign `//internal/transpiler/analyzer:analyzer_test :: TestGorootFromGoBinarySymlink` (Windows symlink privilege), confirmed from the test log as the only `--- FAIL`.

## Repro (before fix)

```gala
struct Entry(val expireAtMs int64)

func main() {
    val e = Entry(0)
    Println(e.expireAtMs)
}
```
→ `cannot use std.NewImmutable(0) (value of type std.Immutable[int]) as std.Immutable[int64]`

## Dependencies

None — reviewable and mergeable independently.

## Report Reference

Originally reported as **BUG-KV-2** in `docs/private/gala-kv-findings/REPORT.md`; detail in `docs/private/BUG_UNTYPED_LITERAL_INTO_SIZED_STRUCT_FIELD.md`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aZRWH39EXTXVALyxALJut