### PR TITLE
fix(transpiler): bare variant name in a match pattern silently becomes a catch-all binding

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -563,7 +563,17 @@ val desc = s match {
 }
 ```
 
-Variants with one or more fields always require parentheses (`case Rectangle(w, h)`, not `case Rectangle`).
+Variants with one or more fields always require parentheses (`case Rectangle(w, h)`, not `case Rectangle`). Writing the bare form for a field-bearing variant is rejected with [GALA-E0039](errors/GALA-E0039.md): a bare identifier is otherwise a variable binding, and a binding matches *every* value, so the arm would silently become a catch-all.
+
+The rule is scoped to the type being matched. A bare identifier that does not name a variant of the match subject's type is an ordinary binding, exactly as before:
+
+```gala
+val n = 42
+val d = n match {
+    case Rectangle => s"bound $Rectangle"   // OK — `int` has no `Rectangle` variant
+    case _         => "other"
+}
+```
 
 This generates:
 - Parent struct `Shape` with all variant fields merged + `_variant` discriminator

--- a/docs/errors/GALA-E0039.md
+++ b/docs/errors/GALA-E0039.md
@@ -1,0 +1,101 @@
+# GALA-E0039 — Bare variant name in a match pattern
+
+**When it fires.** A `case` pattern is a bare identifier that names a
+field-bearing `case` variant of the type being matched — `case Circle` against a
+`Shape`, or `case Some` against an `Option[T]`.
+
+A bare identifier in pattern position is a *variable binding*, and a binding
+matches every value. So the arm reads as a test for that variant but behaves as
+a catch-all: it swallows every other variant, and the identifier inside the arm
+body is bound to the whole match subject rather than to the variant's fields.
+
+**Minimal repro.**
+
+```gala
+package main
+
+sealed type Shape {
+    case Circle(R float64)
+    case Square(S float64)
+}
+
+func main() {
+    val s = Square(2.0)
+    val r = s match {
+        case Circle    => "circle"
+        case Square(x) => s"square $x"
+    }
+    Println(r)
+}
+```
+
+**Error output.**
+
+```
+error[GALA-E0039]: `Circle` is a variant of sealed type "Shape", so `case Circle` binds a new variable and matches every value instead of testing for Circle
+  --> main.gala:11:14
+   |
+11 |         case Circle    => "circle"
+   |              ^^^^^^ write `case Circle(_)` to match the variant, or rename the b…
+   |
+   = hint: write `case Circle(_)` to match the variant, or rename the binding if you meant to capture the whole value
+```
+
+**Fix.** Spell the variant with parentheses, using `_` for fields the arm does
+not need:
+
+```gala
+package main
+
+sealed type Shape {
+    case Circle(R float64)
+    case Square(S float64)
+}
+
+func main() {
+    val s = Square(2.0)
+    val r = s match {
+        case Circle(_) => "circle"
+        case Square(x) => s"square $x"
+    }
+    Println(r)
+}
+```
+
+If you genuinely wanted a catch-all binding, rename it so it does not collide
+with a variant of the matched type — `case other => …` — or use `case _ => …`
+when the value is not needed.
+
+**Rationale.** This is a silent wrong-answer bug, which is why it is an error
+rather than a warning. The old behaviour compiled, exited 0, and printed the
+result of the wrong arm; nothing in the generated Go looked suspicious, and a
+reviewer reading `case Circle =>` in a diff had no visual cue that it meant
+something entirely different from `case Circle(_) =>`.
+
+Rejecting it cannot break a program that was not already misleading: a binding
+named after a variant of the matched type was, by construction, acting as a
+catch-all that appeared to be a variant test.
+
+**Scope.** The check is scoped to the *matched* type. A bare identifier that
+does not name a variant of the match subject's type is an ordinary binding and
+is left alone, even if some unrelated type in the program declares a variant of
+that name:
+
+```gala
+val n = 42
+val d = n match {
+    case Circle => s"bound $Circle"   // OK — `int` has no `Circle` variant
+    case _      => "other"
+}
+```
+
+**Zero-field variants are not affected.** For a variant that declares no fields,
+the bare form is the documented shorthand and continues to work — `case Point`
+is exactly `case Point()`, including when the parent sealed type is generic
+(`case None` over an `Option[int]`). See
+[§4 of the language reference](../GALA.MD#sealed-types).
+
+**Related pattern codes.** [GALA-E0002](GALA-E0002.md) non-exhaustive sealed
+match · [GALA-E0004](GALA-E0004.md) sealed variant arity mismatch ·
+[GALA-E0005](GALA-E0005.md) missing `Unapply` on an extractor ·
+[GALA-E0009](GALA-E0009.md) unknown pattern type.

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -58,6 +58,7 @@ rather than inventing an example — trust the notice at the top of the page.
 | `GALA-E0036` | Bare Go statement keyword is not part of GALA's surface | [GALA-E0036.md](GALA-E0036.md) |
 | `GALA-E0037` | Unshareable capture across a concurrency boundary | [GALA-E0037.md](GALA-E0037.md) |
 | `GALA-E0038` | Invalid string escape sequence | [GALA-E0038.md](GALA-E0038.md) |
+| `GALA-E0039` | Bare variant name in a match pattern | [GALA-E0039.md](GALA-E0039.md) |
 | `GALA-E0040` | Go slice or map type in an expression | [GALA-E0040.md](GALA-E0040.md) |
 
 ## Adding a new code

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -477,6 +477,17 @@ gala_exec_test(
     expected = "generic_sealed_exhaustive.out",
 )
 
+# A bare identifier naming a zero-field variant of the matched type is that
+# variant's pattern, not a binding. This test asserts RUNTIME OUTPUT because the
+# failure mode it guards is silent: a binding matches every value, so the arm
+# becomes a catch-all and the program compiles, exits 0, and prints the wrong
+# answer.
+gala_exec_test(
+    name = "bare_variant_pattern",
+    src = "bare_variant_pattern.gala",
+    expected = "bare_variant_pattern.out",
+)
+
 gala_exec_test(
     name = "string_escapes",
     src = "string_escapes.gala",
@@ -2822,9 +2833,24 @@ gala_library(
     visibility = ["//visibility:public"],
 )
 
+# Sibling package whose sealed types are matched from the consumer with the
+# BARE form of a zero-field variant (`case Vacant`, `case Off`). A bare
+# identifier in pattern position is otherwise a variable binding, which matches
+# everything — so a regression here turns each arm into a silent catch-all that
+# still compiles. Covers both a generic parent (Slot[T], where the variant's
+# companion needs its type argument recovered from the matched type) and a
+# non-generic one (Flag), across a package boundary.
+gala_library(
+    name = "multifile_lib_regress_variant_pkg",
+    srcs = ["multifile_lib_regress/variant_pkg/variant.gala"],
+    importpath = "martianoff/gala/examples/multifile_lib_regress/variant_pkg",
+    visibility = ["//visibility:public"],
+)
+
 gala_library(
     name = "multifile_lib_regress",
     srcs = [
+        "multifile_lib_regress/bare_variant.gala",
         "multifile_lib_regress/consult_end.gala",
         "multifile_lib_regress/cross_file_methods.gala",
         "multifile_lib_regress/cross_file_methods_ext.gala",
@@ -2863,6 +2889,7 @@ gala_exec_test(
         ":multifile_lib_regress_directive_pkg",
         ":multifile_lib_regress_proc_pkg",
         ":multifile_lib_regress_shadow_func",
+        ":multifile_lib_regress_variant_pkg",
         "//collection_immutable",
         "//examples/go_struct_bridge",
     ],

--- a/examples/bare_variant_pattern.gala
+++ b/examples/bare_variant_pattern.gala
@@ -1,0 +1,76 @@
+package main
+
+// A bare identifier in pattern position is a variable binding, and a binding
+// matches every value. When the identifier names a zero-field variant of the
+// type being matched, it must therefore be read as that variant's pattern —
+// otherwise the arm silently becomes a catch-all that swallows every other
+// variant. These cases assert the RUNTIME answer, not just that they compile:
+// the failure mode this file guards against exits 0 with the wrong output.
+
+sealed type Signal {
+    case Ping(Seq int)
+    case Pong
+}
+
+sealed type Slot[T any] {
+    case Filled(Value T)
+    case Empty
+}
+
+// std.Option is generic, so `None`'s companion carries a type parameter. The
+// bare form has to resolve it from the matched type exactly as `case None()`
+// already does.
+func describe(o Option[int]) string = o match {
+    case None    => "none"
+    case Some(v) => s"some $v"
+}
+
+// Arm order reversed: the bare arm must not shadow the arms after it.
+func describeNoneFirst(o Option[int]) string = o match {
+    case Some(v) => s"some $v"
+    case None    => "none"
+}
+
+// Non-generic user sealed type.
+func signal(s Signal) string = s match {
+    case Pong    => "pong"
+    case Ping(n) => s"ping $n"
+}
+
+// Generic user sealed type — same shape as Option, declared locally.
+func slot(s Slot[string]) string = s match {
+    case Empty     => "empty"
+    case Filled(v) => s"filled $v"
+}
+
+// Both fixes are needed for this one shape, which is why it lives here rather
+// than in generic_sealed_exhaustive.gala. The subject's type is INFERRED from a
+// variant constructor instead of declared, which is what left a generic sealed
+// type unrecognized; and the zero-field arm is written bare, which is what
+// turned that arm into a catch-all. With either fix absent this is rejected or
+// answers with the wrong arm.
+func slotInferred() string = Filled("y") match {
+    case Empty     => "empty"
+    case Filled(v) => s"filled $v"
+}
+
+// A guard on a bare-variant arm still tests the variant, not a binding.
+func signalGuarded(s Signal) string = s match {
+    case Pong if true => "pong-guarded"
+    case Ping(n)      => s"ping $n"
+    case _            => "other"
+}
+
+func main() {
+    Println(describe(Some(42)))
+    Println(describe(None[int]()))
+    Println(describeNoneFirst(Some(7)))
+    Println(describeNoneFirst(None[int]()))
+    Println(signal(Ping(3)))
+    Println(signal(Pong()))
+    Println(slot(Filled("x")))
+    Println(slot(Empty[string]()))
+    Println(slotInferred())
+    Println(signalGuarded(Pong()))
+    Println(signalGuarded(Ping(9)))
+}

--- a/examples/bare_variant_pattern.out
+++ b/examples/bare_variant_pattern.out
@@ -1,0 +1,11 @@
+some 42
+none
+some 7
+none
+ping 3
+pong
+filled x
+empty
+filled y
+pong-guarded
+ping 9

--- a/examples/multifile_lib_regress/bare_variant.gala
+++ b/examples/multifile_lib_regress/bare_variant.gala
@@ -1,0 +1,49 @@
+package multifile_lib_regress
+
+// Bare-identifier arms over sealed types, exercised through the multi-file
+// BatchAnalyzer path rather than a single-file `gala_test`.
+//
+// A bare identifier in pattern position is a variable binding, and a binding
+// matches every value. When the identifier names a zero-field variant of the
+// type being matched it must be lowered as that variant's pattern instead —
+// otherwise the arm becomes a silent catch-all: the program compiles, exits 0,
+// and answers with the wrong arm. Sealed-variant metadata reaches the
+// transformer differently under batch analysis than in single-file mode, so the
+// shape is worth covering on both paths.
+
+// Cursor is generic, so `AtEnd`'s companion carries a type parameter that has
+// to be resolved from the matched type before the extractor can be called.
+sealed type Cursor[T any] {
+    case AtItem(Item T)
+    case AtEnd
+}
+
+// Marker is the non-generic control.
+sealed type Marker {
+    case Named(Label string)
+    case Anonymous
+}
+
+func DescribeCursor(c Cursor[string]) string = c match {
+    case AtEnd      => "cursor-end"
+    case AtItem(it) => s"cursor-item $it"
+}
+
+func DescribeMarker(m Marker) string = m match {
+    case Anonymous  => "marker-anon"
+    case Named(lbl) => s"marker-named $lbl"
+}
+
+// The bare arm listed FIRST must not swallow the arms after it.
+func DescribeOption(o Option[int]) string = o match {
+    case None    => "opt-none"
+    case Some(n) => s"opt-some $n"
+}
+
+func ItemCursor(v string) Cursor[string] = AtItem(v)
+
+func EndCursor() Cursor[string] = AtEnd[string]()
+
+func NamedMarker(label string) Marker = Named(label)
+
+func AnonymousMarker() Marker = Anonymous()

--- a/examples/multifile_lib_regress/variant_pkg/variant.gala
+++ b/examples/multifile_lib_regress/variant_pkg/variant.gala
@@ -1,0 +1,29 @@
+package variant_pkg
+
+// Sealed types whose zero-field variants are matched with the bare form from
+// ANOTHER package (the consumer dot-imports this one). Variant metadata for an
+// imported sealed type is resolved through the import graph rather than from
+// the file being transformed, so the bare-identifier lowering has to work off
+// the matched type's metadata rather than anything local to the match.
+
+// Generic parent — the zero-field variant's companion carries a type parameter
+// that must be recovered from the matched type.
+sealed type Slot[T any] {
+    case Holds(Value T)
+    case Vacant
+}
+
+// Non-generic control.
+sealed type Flag {
+    case On(Label string)
+    case Off
+}
+
+func MakeSlot(v string) Slot[string] = Holds(v)
+
+func EmptySlot() Slot[string] = Vacant[string]()
+
+func MakeFlag(on bool) Flag = on match {
+    case true  => On("lit")
+    case false => Off()
+}

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -6,6 +6,7 @@ import (
     "martianoff/gala/examples/multifile_lib_regress/proc_pkg"
     . "martianoff/gala/examples/multifile_lib_regress/directive_pkg"
     . "martianoff/gala/examples/multifile_lib_regress/shadow_func"
+    . "martianoff/gala/examples/multifile_lib_regress/variant_pkg"
     "martianoff/gala/examples/go_struct_bridge"
     . "martianoff/gala/collection_immutable"
     "time"
@@ -416,4 +417,37 @@ func main() {
     Println(multifile_lib_regress.DescribeReply(multifile_lib_regress.MakeAnsweredInt(9)))
     Println(multifile_lib_regress.InferredOutcome())
     Println(multifile_lib_regress.DescribeOutcome(multifile_lib_regress.MakeBad("nope")))
+    // --- Regression: a bare identifier naming a zero-field variant of the
+    // matched type is that variant's pattern, not a fresh binding. A binding
+    // matches everything, so the historic behaviour turned each of these arms
+    // into a silent catch-all — compiling, exiting 0, and answering with the
+    // wrong arm. The library-side functions live in
+    // multifile_lib_regress/bare_variant.gala; the calls below pin the runtime
+    // answer, which is the only thing that catches a reintroduction.
+    Println(multifile_lib_regress.DescribeCursor(multifile_lib_regress.ItemCursor("k")))
+    Println(multifile_lib_regress.DescribeCursor(multifile_lib_regress.EndCursor()))
+    Println(multifile_lib_regress.DescribeMarker(multifile_lib_regress.NamedMarker("m")))
+    Println(multifile_lib_regress.DescribeMarker(multifile_lib_regress.AnonymousMarker()))
+    Println(multifile_lib_regress.DescribeOption(Some(5)))
+    Println(multifile_lib_regress.DescribeOption(None[int]()))
+    // Same shape resolved at the consumer, over sealed types dot-imported from
+    // a sibling package: cross-package variant metadata travels a different
+    // route than same-package metadata. Both the generic (`Slot[T]`) and the
+    // non-generic (`Flag`) parents are covered.
+    MakeSlot("q") match {
+        case Vacant     => Println("slot-vacant")
+        case Holds(v)   => Println(s"slot-holds $v")
+    }
+    EmptySlot() match {
+        case Vacant   => Println("slot-vacant")
+        case Holds(v) => Println(s"slot-holds $v")
+    }
+    MakeFlag(true) match {
+        case Off    => Println("flag-off")
+        case On(lb) => Println(s"flag-on $lb")
+    }
+    MakeFlag(false) match {
+        case Off    => Println("flag-off")
+        case On(lb) => Println(s"flag-on $lb")
+    }
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -96,3 +96,13 @@ reply-silent
 reply-int 9
 outcome-ok 3
 outcome-bad nope
+cursor-item k
+cursor-end
+marker-named m
+marker-anon
+opt-some 5
+opt-none
+slot-holds q
+slot-vacant
+flag-on lit
+flag-off

--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -346,6 +346,16 @@ const (
 	// reports the offending escape in the file the user actually wrote.
 	CodeInvalidStringEscape ErrorCode = "GALA-E0038"
 
+	// E0039: a match arm's pattern is a bare identifier that names a
+	// field-bearing `case` variant of the type being matched (e.g. `case Some`
+	// against an `Option[T]`, or `case Circle` against a `Shape`). A bare
+	// identifier in pattern position is a variable binding, and a binding
+	// matches every value — so the arm becomes a catch-all that swallows the
+	// other variants while reading like a test for this one. The program
+	// compiles and produces the wrong answer. Field-bearing variants must be
+	// spelled with parentheses (`case Circle(_)`).
+	CodeBareVariantBinding ErrorCode = "GALA-E0039"
+
 	// E0040: a Go slice (`[]T`) or map (`map[K]V`) type was written inside an
 	// EXPRESSION — most often as an explicit type argument
 	// (`EmptyHashMap[string, []byte]()`), but also as a conversion

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "assignment_test.go",
         "auto_method_override_test.go",
         "bare_funcref_test.go",
+        "bare_variant_pattern_test.go",
         "bind_test.go",
         "chained_flatmap_test.go",
         "codec_boundary_test.go",

--- a/internal/transpiler/transformer/bare_variant_pattern_test.go
+++ b/internal/transpiler/transformer/bare_variant_pattern_test.go
@@ -1,0 +1,229 @@
+package transformer_test
+
+import (
+	"testing"
+
+	"martianoff/gala/galaerr"
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+
+	"github.com/stretchr/testify/require"
+)
+
+// transpileBareVariant compiles src through the full pipeline and returns the
+// generated Go, or the error.
+func transpileBareVariant(t *testing.T, src string) (string, error) {
+	t.Helper()
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	return transpiler.NewGalaToGoTranspiler(p, a, tr, g).Transpile(src, "main.gala")
+}
+
+// TestBareVariantPatternIsNotABinding pins the lowering of a bare identifier in
+// pattern position.
+//
+// A bare identifier is ordinarily a variable binding, and a binding matches
+// EVERY value. When the identifier names a zero-field variant of the type being
+// matched, treating it as a binding turns the arm into a catch-all: the program
+// compiles, exits 0, and answers with the wrong arm. `case None` over an
+// `Option[int]` used to match a `Some`.
+//
+// The runtime consequence is pinned by examples/bare_variant_pattern (single
+// file) and examples/multifile_lib_regress (batch analysis). These cases pin the
+// generated shape, which is where a regression would first appear: the arm must
+// call the variant's `Unapply`, and must NOT assign the subject to a variable
+// named after the variant.
+func TestBareVariantPatternIsNotABinding(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		// wantContains is the extractor call the arm must lower to.
+		wantContains string
+		// wantAbsent is the binding assignment that must not appear.
+		wantAbsent string
+	}{
+		{
+			// The canonical case. std.Option is generic, so `None`'s companion
+			// carries a type parameter — the reason the bare form used to fall
+			// through to a binding while non-generic variants worked.
+			name: "generic std variant",
+			src: `package main
+
+func main() {
+    val o = Some(42)
+    val r = o match {
+        case None    => "miss"
+        case Some(v) => s"hit $v"
+    }
+    Println(r)
+}`,
+			wantContains: "std.None[int]{}.Unapply(obj)",
+			wantAbsent:   "None := obj",
+		},
+		{
+			// Same shape, declared by the user rather than by std. The
+			// bare form must work identically — no std-specific handling.
+			name: "generic user-declared variant",
+			src: `package main
+
+sealed type Maybe[T any] {
+    case Just(V T)
+    case Nothing
+}
+
+func describe(m Maybe[int]) string = m match {
+    case Nothing => "nothing"
+    case Just(v) => s"just $v"
+}
+
+func main() {
+    Println(describe(Just(42)))
+}`,
+			wantContains: "Nothing[int]{}.Unapply(obj)",
+			wantAbsent:   "Nothing := obj",
+		},
+		{
+			name: "non-generic user-declared variant",
+			src: `package main
+
+sealed type Shape {
+    case Circle(R float64)
+    case Empty
+}
+
+func describe(s Shape) string = s match {
+    case Empty     => "empty"
+    case Circle(r) => s"circle $r"
+}
+
+func main() {
+    Println(describe(Circle(1.0)))
+}`,
+			wantContains: "Empty{}.Unapply(obj)",
+			wantAbsent:   "Empty := obj",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := transpileBareVariant(t, tc.src)
+			require.NoError(t, err)
+			require.Contains(t, out, tc.wantContains,
+				"bare variant arm must call the variant's Unapply")
+			require.NotContains(t, out, tc.wantAbsent,
+				"bare variant arm must not bind the subject to a variable named after the variant")
+		})
+	}
+}
+
+// TestBareVariantNameWithFieldsIsRejected covers the other half: a bare
+// identifier naming a FIELD-BEARING variant of the matched type. There is no
+// sensible lowering — the variant needs its fields bound — and leaving it as a
+// binding is exactly the silent catch-all this check exists to stop.
+func TestBareVariantNameWithFieldsIsRejected(t *testing.T) {
+	cases := []struct {
+		name           string
+		src            string
+		expectContains string
+	}{
+		{
+			name: "user sealed type",
+			src: `package main
+
+sealed type Shape {
+    case Circle(R float64)
+    case Square(S float64)
+}
+
+func main() {
+    val s = Square(2.0)
+    val r = s match {
+        case Circle    => "circle"
+        case Square(x) => s"square $x"
+    }
+    Println(r)
+}`,
+			expectContains: "`Circle` is a variant of sealed type \"Shape\"",
+		},
+		{
+			name: "std Option",
+			src: `package main
+
+func main() {
+    val o = None[int]()
+    val r = o match {
+        case Some   => "hit"
+        case None() => "miss"
+    }
+    Println(r)
+}`,
+			expectContains: "`Some` is a variant of sealed type \"Option\"",
+		},
+		{
+			// The arm body does not reference the bound name. This used to be
+			// reported as `unused variable 'None' in match branch — use '_' to
+			// discard this value`, whose own advice (`use '_'`) produces a real
+			// catch-all that compiles and is still wrong. It must reach the
+			// variant-collision error instead.
+			name: "body does not reference the name",
+			src: `package main
+
+sealed type Shape {
+    case Circle(R float64)
+    case Square(S float64)
+}
+
+func main() {
+    val s = Square(2.0)
+    val r = s match {
+        case Square(x) => s"square $x"
+        case Circle    => "circle"
+    }
+    Println(r)
+}`,
+			expectContains: "`Circle` is a variant of sealed type \"Shape\"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := transpileBareVariant(t, tc.src)
+			require.Error(t, err)
+			var se *galaerr.SemanticError
+			require.ErrorAs(t, err, &se)
+			require.Equal(t, galaerr.CodeBareVariantBinding, se.Code)
+			require.Contains(t, se.Msg, tc.expectContains)
+			require.Contains(t, se.Hint, "to match the variant")
+		})
+	}
+}
+
+// TestBareBindingUnrelatedToMatchedTypeStillBinds pins the boundary of the
+// check. The rule is scoped to variants of the type being matched: a bare
+// identifier that collides with a variant of some UNRELATED type is an ordinary
+// binding and must keep working, because such a binding was never misleading.
+func TestBareBindingUnrelatedToMatchedTypeStillBinds(t *testing.T) {
+	out, err := transpileBareVariant(t, `package main
+
+sealed type Shape {
+    case Circle(R float64)
+    case Square(S float64)
+}
+
+func main() {
+    val n = 42
+    val r = n match {
+        case Circle => s"bound $Circle"
+        case _      => "other"
+    }
+    Println(r)
+    Println(Circle(1.0))
+}`)
+	require.NoError(t, err)
+	require.Contains(t, out, "Circle := obj",
+		"a bare name that is not a variant of the matched type must still bind")
+}

--- a/internal/transpiler/transformer/error_codes_test.go
+++ b/internal/transpiler/transformer/error_codes_test.go
@@ -361,6 +361,31 @@ func main() {
 			expectContains: `sealed case "Box"`,
 		},
 		{
+			// A bare identifier in pattern position is a variable binding, and
+			// a binding matches every value. When it names a field-bearing
+			// variant of the matched type the arm reads as a test for that
+			// variant but behaves as a catch-all, so the program compiles,
+			// exits 0, and answers with the wrong arm.
+			name: "GALA-E0039 bare variant name binds instead of matching",
+			input: `package main
+
+sealed type Shape {
+    case Circle(R float64)
+    case Square(S float64)
+}
+
+func main() {
+    val s = Square(2.0)
+    val r = s match {
+        case Circle    => "circle"
+        case Square(x) => s"square $x"
+    }
+    Println(r)
+}`,
+			expectCode:     galaerr.CodeBareVariantBinding,
+			expectContains: "`Circle` is a variant of sealed type \"Shape\"",
+		},
+		{
 			// A lambda whose parameter has no annotation and sits in a context
 			// that supplies no expected type (untyped val initializer) cannot be
 			// given a concrete parameter type. Emitting `any` would violate the

--- a/internal/transpiler/transformer/error_docs_guard_test.go
+++ b/internal/transpiler/transformer/error_docs_guard_test.go
@@ -430,6 +430,32 @@ func main() {
 `)
 			},
 		},
+		{
+			// Import-free for the same reason as the E0036/E0038 rows: the
+			// collision is decided from the matched type's own metadata while
+			// the pattern is transformed, so a locally declared sealed type is
+			// the whole repro.
+			name: "bare variant name used as a match pattern",
+			code: galaerr.CodeBareVariantBinding, // GALA-E0039
+			render: func(t *testing.T) string {
+				return renderRepro(t, "main.gala", `package main
+
+sealed type Shape {
+    case Circle(R float64)
+    case Square(S float64)
+}
+
+func main() {
+    val s = Square(2.0)
+    val r = s match {
+        case Circle    => "circle"
+        case Square(x) => s"square $x"
+    }
+    Println(r)
+}
+`)
+			},
+		},
 		// The GALA-E0038 page also documents the rune-literal shape in prose
 		// (`'\d'`), but quotes no output for it, so there is nothing to pin.
 		// Its numeric forms (`'\x41'`) are not guardable here at all: GALA's

--- a/internal/transpiler/transformer/patterns.go
+++ b/internal/transpiler/transformer/patterns.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"strings"
 
 	"martianoff/gala/galaerr"
 	"martianoff/gala/internal/parser/grammar"
@@ -237,6 +238,50 @@ func (t *galaASTTransformer) transformConstructorCallPattern(rawName string, arg
 		msg, hint)
 }
 
+// sealedVariantOfMatchedType reports whether name is declared as a `case`
+// variant of the sealed type currently being matched. It returns the variant
+// declaration together with the parent sealed type's metadata, or (nil, nil)
+// when the matched type is unusable, is not sealed, or declares no such
+// variant. This is deliberately scoped to the matched type: a bare identifier
+// that happens to share a name with some unrelated variant elsewhere in the
+// program is an ordinary binding.
+func (t *galaASTTransformer) sealedVariantOfMatchedType(name string, matchedType transpiler.Type) (*transpiler.SealedVariant, *transpiler.TypeMetadata) {
+	if matchedType == nil || transpiler.IsUnusable(matchedType) {
+		return nil, nil
+	}
+	meta := t.getTypeMeta(matchedType.BaseName())
+	if meta == nil || !meta.IsSealed {
+		return nil, nil
+	}
+	for i := range meta.SealedVariants {
+		if meta.SealedVariants[i].Name == name {
+			return &meta.SealedVariants[i], meta
+		}
+	}
+	return nil, nil
+}
+
+// bareVariantBindingError reports a bare identifier in pattern position that
+// names a field-bearing variant of the type being matched. Such a pattern is
+// parsed as a fresh variable binding, which matches every value — so the arm
+// silently becomes a catch-all and the variant it appears to test is never
+// distinguished. Rejecting it cannot break a program that was not already
+// misleading.
+func bareVariantBindingError(name string, variant *transpiler.SealedVariant, parent *transpiler.TypeMetadata, line, col int) error {
+	placeholders := make([]string, len(variant.FieldNames))
+	for i := range placeholders {
+		placeholders[i] = "_"
+	}
+	return galaerr.NewCodedSemanticError(
+		galaerr.CodeBareVariantBinding,
+		line, col,
+		fmt.Sprintf("`%s` is a variant of sealed type %q, so `case %s` binds a new variable and matches every value instead of testing for %s",
+			name, parent.Name, name, name),
+		fmt.Sprintf("write `case %s(%s)` to match the variant, or rename the binding if you meant to capture the whole value",
+			name, strings.Join(placeholders, ", ")),
+	)
+}
+
 // transformSimpleBindingOrLiteral handles the two remaining pattern shapes once a
 // pattern is known not to be a tuple/extractor/constructor call: a bare identifier
 // binds a variable (with a zero-field sealed-variant shortcut), and anything else
@@ -245,17 +290,38 @@ func (t *galaASTTransformer) transformSimpleBindingOrLiteral(patExprCtx grammar.
 	if p := t.getPrimaryFromExpression(patExprCtx); p != nil && p.Identifier() != nil {
 		name := p.Identifier().GetText()
 
-		// Before treating as a simple binding, check if the identifier refers to a
-		// zero-field extractor (e.g., sealed variant `case Debug`). Writing `case Debug =>`
-		// in a match should be equivalent to `case Debug() =>` when Debug is a sealed
-		// case companion whose Unapply returns bool.
+		// A bare identifier that names a variant of the type being matched is
+		// never a binding — binding it would turn the arm into a catch-all that
+		// silently swallows every other variant.
+		if variant, parent := t.sealedVariantOfMatchedType(name, matchedType); variant != nil {
+			if len(variant.FieldNames) > 0 {
+				return nil, nil, bareVariantBindingError(name, variant, parent,
+					patExprCtx.GetStart().GetLine(), patExprCtx.GetStart().GetColumn())
+			}
+			// Zero-field variant: `case None` means exactly `case None()`. Route
+			// through the constructor-call path so generic parents (Option[T],
+			// Maybe[T], …) get their type arguments inferred from the matched type.
+			// The call-shaped spelling reaches that path with the companion's
+			// canonical name (`std.None`), because it transforms the primary
+			// expression first; resolve the bare name the same way so the emitted
+			// extractor carries its package qualifier.
+			ctorName := name
+			if _, resolved := t.getTypeMetaResolved(name); resolved != "" {
+				ctorName = resolved
+			}
+			return t.transformConstructorCallPattern(ctorName, nil, nil, objExpr, matchedType, patExprCtx)
+		}
+
+		// The identifier may still refer to a zero-field extractor that is not a
+		// variant of the matched type — e.g. a standalone guard extractor, or a
+		// sealed variant matched against a subject whose type could not be
+		// inferred. Writing `case Debug =>` stays equivalent to `case Debug() =>`.
 		if meta := t.getTypeMeta(name); meta != nil {
 			if unapplyMeta, hasUnapply := meta.Methods["Unapply"]; hasUnapply {
 				// Only route through the extractor path for zero-arg extractors — i.e.,
 				// Unapply returns bool (guard extractor) and the type takes no type
 				// parameters. That is precisely the shape generated for zero-field
-				// sealed variants. For 1+-field sealed variants (Option-returning),
-				// a bare identifier legitimately remains a simple binding.
+				// sealed variants.
 				if basic, ok := unapplyMeta.ReturnType.(transpiler.BasicType); ok && basic.Name == "bool" && len(meta.TypeParams) == 0 {
 					return t.generateDirectUnapplyPattern(name, meta, nil, unapplyMeta, objExpr, nil, matchedType)
 				}


### PR DESCRIPTION
## Summary

Fixes **FIX-003**: a bare identifier in a match pattern that names a sealed variant was treated as a fresh variable binding instead of a variant pattern. A binding matches **everything**, so the arm became a catch-all — the program compiled, exited 0, and produced the wrong answer.

**Category**: TRANSPILER_BUG
**Priority**: P1 (silent wrong output, not a compile error)
**Found in**: validating GALA code samples for the gala-kv design document

```gala
val o = Some(42)
val r = o match {
    case None    => s"miss ($None)"
    case Some(v) => s"hit $v"
}
Println(r)      // printed:  miss (Some(42))
```

`None` matched a `Some`. `$None` interpolated to `Some(42)`. Exit code 0. This is the most-written pattern in the language, and the form a reader coming from Scala, Rust, or Swift types by reflex.

## Root Cause

One gate in `transformSimpleBindingOrLiteral` took the zero-field-variant shortcut only when `Unapply` returned `bool` **and** the companion had no type parameters. Each conjunct caused a distinct defect:

- **The type-param conjunct** excluded every zero-field variant of a *generic* parent — `None`'s companion is `None[T]` — so it fell through to the binding path, which matches anything.
- **The bool conjunct** left bare *field-bearing* variant names as bindings, contradicting `docs/GALA.MD` §4, which states variants with one or more fields always require parentheses.

## Changes

- `internal/transpiler/transformer/patterns.go` — the gate.
- `galaerr/errors.go` — new diagnostic **`GALA-E0039`**, "Bare variant name in a match pattern".
- `docs/errors/GALA-E0039.md` (new), `docs/errors/README.md`, `docs/GALA.MD`.
- `examples/BUILD.bazel`, `internal/transpiler/transformer/BUILD.bazel`.

## Semantics change — scoped deliberately

`GALA-E0039` fires only when a bare identifier names a **field-bearing variant of the type being matched**:

```gala
val s = Square(2.0)
s match {
  case Circle    => ...   // GALA-E0039
  case Square(x) => ...
}

val n = 42
n match {
  case Circle => ...      // fine — Circle is not a variant of int
}
```

Zero-field variants keep the bare shorthand, generic parents now included. The error cannot break code that was not already misleading, because such a binding was silently acting as a catch-all.

### Existing examples/tests updated to accommodate the new error: **zero**

The whole `.gala` corpus was grepped for bare-uppercase arms (`case Xxx =>` / `case Xxx if`). Every pre-existing hit (`sealed_bare_variants.gala`, `fix013_named_arg_widen.gala`) is a *zero-field* variant, which keeps working. No pre-existing example or test was modified to accommodate the error — every changed file is the fix itself, an index/BUILD entry, a doc clarification, or added coverage.

## The misleading message is also fixed

Previously, when the arm body didn't reference the bound name, the unused-variable check fired with `unused variable 'None' … use '_' to discard this value`. Following that advice produced a *real* catch-all that compiled and was still wrong.

Both halves now resolve. `case None` over an `Option` lowers to `std.None[int]{}.Unapply(obj)` — a real `None` test with no binding left to be "unused". For the field-bearing analogue, the pattern transform fails with `GALA-E0039` *before* the unused-variable check runs. Pinned by `TestBareVariantNameWithFieldsIsRejected/body_does_not_reference_the_name`.

## Verification

- `internal/transpiler/transformer/bare_variant_pattern_test.go` (new, 7 cases)
- `examples/bare_variant_pattern.{gala,out}` (new) — **asserts runtime output**, not just compilation, since the original repro exited 0 with the wrong answer and a compile-only test would sail past a reintroduction
- `examples/multifile_lib_regress/bare_variant.gala` + `variant_pkg/variant.gala` (new), plus 12 new assertions in `multifile_lib_regress_test`
- +1 row each in `error_codes_test.go` and `error_docs_guard_test.go` (the latter machine-checks that the doc page quotes real compiler output byte-for-byte)
- `bazel build //...` green; `bazel test //...` 388/389, sole failure the known-benign `TestGorootFromGoBinarySymlink` (Windows symlink privilege)
- `bazel run //:gazelle` produced no further changes

## Dependencies

None — branches from `master`. Composes with FIX-004 (see that PR): `case Nothing` bare over a generic user sealed type needs both fixes. That combined shape is deliberately not asserted here; whichever PR lands second should add one assertion for it.

## Report Reference

Originally reported as **BUG-KV-6** in `docs/private/gala-kv-findings/REPORT.md`; detail in `docs/private/BUG_BARE_VARIANT_PATTERN_SILENTLY_BINDS.md`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aZRWH39EXTXVALyxALJut