### PR TITLE
fix(analyzer): generic sealed types in main/test packages get no exhaustiveness, E0002 or E0004 checking

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -459,6 +459,17 @@ gala_exec_test(
     expected = "apply_method.out",
 )
 
+# A generic sealed type declared in `main` must be recognized as sealed when the
+# match subject's type is inferred from a variant constructor. Asserts runtime
+# output, not just compilation: the exhaustive-sealed lowering emits a synthetic
+# unreachable default, so a mis-dispatched arm surfaces here rather than in the
+# type checker.
+gala_exec_test(
+    name = "generic_sealed_exhaustive",
+    src = "generic_sealed_exhaustive.gala",
+    expected = "generic_sealed_exhaustive.out",
+)
+
 gala_exec_test(
     name = "string_escapes",
     src = "string_escapes.gala",
@@ -2800,6 +2811,7 @@ gala_library(
         "multifile_lib_regress/cross_file_methods_ext.gala",
         "multifile_lib_regress/directive_chain.gala",
         "multifile_lib_regress/events_pipe.gala",
+        "multifile_lib_regress/generic_sealed.gala",
         "multifile_lib_regress/go_interop.gala",
         "multifile_lib_regress/logic.gala",
         "multifile_lib_regress/pointer_method_field.gala",

--- a/examples/generic_sealed_exhaustive.gala
+++ b/examples/generic_sealed_exhaustive.gala
@@ -1,0 +1,82 @@
+package main
+
+// A generic sealed type declared in `main` must be recognized as sealed when the
+// match subject's type is INFERRED from a variant constructor rather than
+// declared. The variant's `Apply` return type is what carries that type, and it
+// used to be built with a `main.` qualifier — a base name no registry key
+// matches, since types in `main`/`test` are registered unqualified. Every check
+// keyed on the matched type then concluded "not a sealed type", so a match
+// listing every variant was rejected with "match expression must have a default
+// case".
+//
+// The runtime answers are asserted, not just compilation: the exhaustive-sealed
+// path lowers to a synthetic `panic("unreachable")` default, so a match that
+// dispatched to the wrong arm would surface here rather than in the type checker.
+
+sealed type Maybe[T any] {
+    case Just(V T)
+    case Nothing
+}
+
+sealed type Pair[A any, B any] {
+    case Both(L A, R B)
+    case Neither
+}
+
+// Subject type inferred from the constructor — the shape that regressed.
+func describeInferred() string {
+    val m = Just(42)
+    return m match {
+        case Just(v)   => s"just $v"
+        case Nothing() => "nothing"
+    }
+}
+
+func describeInferredNothing() string {
+    val m = Nothing[int]()
+    return m match {
+        case Just(v)   => s"just $v"
+        case Nothing() => "nothing"
+    }
+}
+
+// Inferred subject over the second type parameter position, so the fix is not
+// pinned to a single instantiation.
+func describeInferredString() string {
+    val m = Just("hi")
+    return m match {
+        case Just(v)   => s"just $v"
+        case Nothing() => "nothing"
+    }
+}
+
+// Declared parameter type — this path always worked, kept as the control.
+func describeDeclared(m Maybe[int]) string = m match {
+    case Just(v)   => s"just $v"
+    case Nothing() => "nothing"
+}
+
+// Two type parameters, to prove the fix is not arity-specific.
+func describePair(p Pair[int, string]) string = p match {
+    case Both(l, r) => s"both $l $r"
+    case Neither()  => "neither"
+}
+
+func describePairInferred() string {
+    val p = Both(1, "x")
+    return p match {
+        case Both(l, r) => s"both $l $r"
+        case Neither()  => "neither"
+    }
+}
+
+func main() {
+    Println(describeInferred())
+    Println(describeInferredNothing())
+    Println(describeInferredString())
+    Println(describeDeclared(Just(7)))
+    Println(describeDeclared(Nothing[int]()))
+    Println(describePair(Both(2, "y")))
+    Println(describePair(Neither[int, string]()))
+    Println(describePairInferred())
+}

--- a/examples/generic_sealed_exhaustive.out
+++ b/examples/generic_sealed_exhaustive.out
@@ -1,0 +1,8 @@
+just 42
+nothing
+just hi
+just 7
+nothing
+both 2 y
+neither
+both 1 x

--- a/examples/multifile_lib_regress/generic_sealed.gala
+++ b/examples/multifile_lib_regress/generic_sealed.gala
@@ -1,0 +1,64 @@
+package multifile_lib_regress
+
+// Generic sealed types whose match subject's type is INFERRED from a variant
+// constructor rather than declared, exercised through the multi-file
+// BatchAnalyzer path.
+//
+// The subject's type comes from the variant companion's `Apply` return type. A
+// package-qualified base name there only resolves when the qualifier is also
+// the registry key — true for a named package like this one, but not for
+// `main`/`test`, whose types are registered unqualified. Batch analysis merges
+// sibling metadata on a different route than single-file analysis, so the
+// named-package direction is worth pinning too: it is what proves the fix did
+// not simply drop the qualifier everywhere.
+
+sealed type Reply[T any] {
+    case Answered(Body T)
+    case Silent
+}
+
+sealed type Outcome[A any, B any] {
+    case Ok(Value A)
+    case Bad(Err B)
+}
+
+// Subject type inferred from the constructor.
+func InferredReply() string {
+    val r = Answered("hi")
+    return r match {
+        case Answered(b) => s"reply-answered $b"
+        case Silent()    => "reply-silent"
+    }
+}
+
+func InferredSilent() string {
+    val r = Silent[string]()
+    return r match {
+        case Answered(b) => s"reply-answered $b"
+        case Silent()    => "reply-silent"
+    }
+}
+
+// Declared parameter type — the control that always worked.
+func DescribeReply(r Reply[int]) string = r match {
+    case Answered(b) => s"reply-int $b"
+    case Silent()    => "reply-silent"
+}
+
+func MakeAnsweredInt(v int) Reply[int] = Answered(v)
+
+// Two type parameters.
+func InferredOutcome() string {
+    val o = Ok[int, string](3)
+    return o match {
+        case Ok(v)  => s"outcome-ok $v"
+        case Bad(e) => s"outcome-bad $e"
+    }
+}
+
+func DescribeOutcome(o Outcome[int, string]) string = o match {
+    case Ok(v)  => s"outcome-ok $v"
+    case Bad(e) => s"outcome-bad $e"
+}
+
+func MakeBad(e string) Outcome[int, string] = Bad(e)

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -371,4 +371,17 @@ func main() {
     Println(multifile_lib_regress.ScopeLambdaCapture(3))
     Println(multifile_lib_regress.ScopeQualifiedImport("gamma"))
     Println(multifile_lib_regress.ScopeSnapshotLabel())
+
+    // --- Regression: a generic sealed type must be recognized as sealed when
+    // the match subject's type is INFERRED from a variant constructor. The
+    // subject's type comes from the companion's Apply return type, and a
+    // qualified base name there only resolves when the qualifier is also the
+    // registry key. A miss made every check keyed on the matched type stand
+    // down, so an exhaustive match was rejected with "must have a default
+    // case". See multifile_lib_regress/generic_sealed.gala.
+    Println(multifile_lib_regress.InferredReply())
+    Println(multifile_lib_regress.InferredSilent())
+    Println(multifile_lib_regress.DescribeReply(multifile_lib_regress.MakeAnsweredInt(9)))
+    Println(multifile_lib_regress.InferredOutcome())
+    Println(multifile_lib_regress.DescribeOutcome(multifile_lib_regress.MakeBad("nope")))
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -83,3 +83,8 @@ scope:dana:v2,v3,v4:ok
 5
 gamma
 scope-7-ok
+reply-answered hi
+reply-silent
+reply-int 9
+outcome-ok 3
+outcome-bad nope

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -1935,9 +1935,24 @@ func (a *galaAnalyzer) analyzeSealedType(ctx *grammar.SealedTypeDeclarationConte
 		for _, f := range vi.fields {
 			applyMeta.ParamTypes = append(applyMeta.ParamTypes, a.resolveTypeWithParams(f.typeName, pkgName, typeParams))
 		}
-		// Return type is the parent sealed type
+		// Return type is the parent sealed type.
+		//
+		// The package qualifier follows the same rule the whole analyzer uses
+		// (see resolveBaseName): types declared in `main` or `test` are keyed
+		// and referenced by their bare name, because those package names never
+		// become an import qualifier. Qualifying them here produced a base name
+		// (`main.Maybe`) that matches no key in the type registry, so every
+		// lookup keyed on the Apply return type's base silently missed — most
+		// visibly exhaustiveness checking, which saw a `val m = Just(42)` as a
+		// non-sealed subject and demanded a default case for a match that
+		// already listed every variant.
 		if len(typeParams) > 0 {
-			baseType := transpiler.NamedType{Package: pkgName, Name: typeName}
+			var baseType transpiler.Type
+			if pkgName != "" && pkgName != "main" && pkgName != "test" {
+				baseType = transpiler.NamedType{Package: pkgName, Name: typeName}
+			} else {
+				baseType = transpiler.BasicType{Name: typeName}
+			}
 			var params []transpiler.Type
 			for _, tp := range typeParams {
 				params = append(params, transpiler.BasicType{Name: tp})

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -82,6 +82,7 @@ go_test(
         "func_phantom_typearg_test.go",
         "functions_test.go",
         "generated_format_test.go",
+        "generic_sealed_exhaustive_test.go",
         "generics_test.go",
         "immutable_test.go",
         "immutable_unwrapping_test.go",

--- a/internal/transpiler/transformer/generic_sealed_exhaustive_test.go
+++ b/internal/transpiler/transformer/generic_sealed_exhaustive_test.go
@@ -1,0 +1,196 @@
+package transformer_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"martianoff/gala/galaerr"
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+
+	"github.com/stretchr/testify/require"
+)
+
+// transpileGenericSealed compiles src through the full pipeline.
+func transpileGenericSealed(t *testing.T, src string) (string, error) {
+	t.Helper()
+	p := transpiler.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzer(p, getStdSearchPath())
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	return transpiler.NewGalaToGoTranspiler(p, a, tr, g).Transpile(src, "main.gala")
+}
+
+// TestGenericSealedTypeIsRecognizedAsSealed covers a whole class of checks that
+// silently stood down for a generic sealed type declared in `main` (or `test`).
+//
+// Every one of them keys off `getTypeMeta(matchedType.BaseName())`. The matched
+// type came from the variant constructor's `Apply` return type, which the
+// analyzer built as `NamedType{Package: "main", Name: "Maybe"}` — base name
+// `main.Maybe`. Types in `main`/`test` are registered under their BARE name, so
+// that lookup matched nothing and every caller concluded "not a sealed type".
+//
+// The visible symptom was exhaustiveness: a match listing every variant was
+// rejected with GALA-E0003 ("must have a default case"). But the same miss also
+// disabled GALA-E0002 and GALA-E0004, so each is pinned here — a fix that only
+// silenced E0003 (say, by treating an unresolvable subject as exhaustive) would
+// pass the first case and fail the rest.
+func TestGenericSealedTypeIsRecognizedAsSealed(t *testing.T) {
+	const maybeDecl = `package main
+
+sealed type Maybe[T any] {
+    case Just(V T)
+    case Nothing
+}
+
+`
+
+	t.Run("exhaustive match needs no default", func(t *testing.T) {
+		out, err := transpileGenericSealed(t, maybeDecl+`func main() {
+    val m = Just(42)
+    val r = m match {
+        case Just(v)   => s"just $v"
+        case Nothing() => "nothing"
+    }
+    Println(r)
+}`)
+		require.NoError(t, err)
+		// An exhaustive sealed match lowers with a synthetic unreachable
+		// default rather than a user-supplied one.
+		require.Contains(t, out, `panic("unreachable")`)
+	})
+
+	// The BARE zero-field spelling (`case Nothing` rather than `case Nothing()`)
+	// is deliberately not covered here. It is a separate defect with its own
+	// fix: a bare identifier naming a zero-field variant of a GENERIC parent
+	// falls through to a variable binding. The two compose — that spelling over
+	// an inferred generic subject needs both fixes — but pinning it from this
+	// side would make this test fail for a reason it does not own.
+
+	t.Run("missing variant reports E0002, not E0003", func(t *testing.T) {
+		_, err := transpileGenericSealed(t, maybeDecl+`func main() {
+    val m = Just(42)
+    val r = m match {
+        case Just(v) => s"just $v"
+    }
+    Println(r)
+}`)
+		require.Error(t, err)
+		var se *galaerr.SemanticError
+		require.ErrorAs(t, err, &se)
+		require.Equal(t, galaerr.CodeNonExhaustiveMatch, se.Code,
+			"a recognized sealed subject must name the missing variant, "+
+				"not fall back to the generic missing-default error")
+		require.Contains(t, se.Msg, "Nothing")
+	})
+
+	t.Run("variant arity is validated", func(t *testing.T) {
+		_, err := transpileGenericSealed(t, `package main
+
+sealed type Pair[T any] {
+    case Both(A T, B T)
+    case Neither
+}
+
+func main() {
+    val m = Both(1, 2)
+    val r = m match {
+        case Both(a)   => s"both $a"
+        case Neither() => "neither"
+    }
+    Println(r)
+}`)
+		require.Error(t, err)
+		var se *galaerr.SemanticError
+		require.ErrorAs(t, err, &se)
+		require.Equal(t, galaerr.CodeVariantArityMismatch, se.Code)
+	})
+
+	t.Run("non-generic control", func(t *testing.T) {
+		_, err := transpileGenericSealed(t, `package main
+
+sealed type Sh {
+    case Circle(R float64)
+    case Empty
+}
+
+func main() {
+    val m = Circle(1.0)
+    val r = m match {
+        case Circle(v) => s"circle $v"
+        case Empty()   => "empty"
+    }
+    Println(r)
+}`)
+		require.NoError(t, err)
+	})
+
+	t.Run("std Option control", func(t *testing.T) {
+		_, err := transpileGenericSealed(t, `package main
+
+func main() {
+    val m = Some(42)
+    val r = m match {
+        case Some(v) => s"some $v"
+        case None()  => "none"
+    }
+    Println(r)
+}`)
+		require.NoError(t, err)
+	})
+}
+
+// TestGenericSealedTypeInNamedPackage is the control that answers "why did
+// std.Option work when a structurally identical user type did not".
+//
+// Nothing special-cases std. `std` is simply a NAMED package, so the qualified
+// base name its Apply return type carries (`std.Option`) is also the key that
+// type is registered under, and the lookup hit. A user-declared generic sealed
+// type in any named package behaves identically — the defect was scoped to
+// `main`/`test`, whose types are registered unqualified.
+//
+// This case also guards the fix's blast radius in the other direction: the
+// qualifier must still be emitted for named packages, or cross-package sealed
+// resolution would break instead.
+func TestGenericSealedTypeInNamedPackage(t *testing.T) {
+	searchRoot := t.TempDir()
+	pkgDir := filepath.Join(searchRoot, "boxpkg")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o755))
+
+	libSrc := `package boxpkg
+
+sealed type Box[T any] {
+    case Full(V T)
+    case Empty
+}
+
+func MakeFull(v int) Box[int] = Full(v)
+`
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "box.gala"), []byte(libSrc), 0o600))
+
+	mainDir := filepath.Join(searchRoot, "main")
+	require.NoError(t, os.MkdirAll(mainDir, 0o755))
+	mainSrc := `package main
+
+import . "martianoff/gala/boxpkg"
+
+func main() {
+    val b = MakeFull(7)
+    val r = b match {
+        case Full(v) => s"full $v"
+        case Empty() => "empty"
+    }
+    Println(r)
+}
+`
+	mainPath := filepath.Join(mainDir, "main.gala")
+	require.NoError(t, os.WriteFile(mainPath, []byte(mainSrc), 0o600))
+
+	out, err := newDocGuardTranspilerWithPaths(searchRoot).Transpile(mainSrc, mainPath)
+	require.NoError(t, err)
+	require.Contains(t, out, `panic("unreachable")`,
+		"a named-package generic sealed type must also be recognized as exhaustive")
+}


### PR DESCRIPTION
## Summary

Fixes **FIX-004**: a user-declared **generic** sealed type in a `main`/`test` package got no exhaustiveness recognition. A match listing every variant in the correct parenthesized form was still rejected:

```gala
sealed type Maybe[T any] {
    case Just(V T)
    case Nothing
}

val m = Just(42)
val r = m match {
    case Just(v)   => s"just $v"
    case Nothing() => "nothing"
}
```
→ `error[GALA-E0003]: match expression must have a default case`

**Category**: TRANSPILER_BUG
**Priority**: P1
**Found in**: flagged as an uninvestigated adjacent observation while validating the gala-kv design document; confirmed and isolated separately

This one matters because exhaustive matching over sealed types is the language's flagship safety feature, and it was absent for a whole class of types.

## Root Cause

`analyzeSealedType` builds the variant companion's `Apply` return type in two branches. Only the **non-generic** branch applied the analyzer-wide rule that `main`/`test` types are referenced **bare**. The generic branch qualified unconditionally, so `Just`'s `Apply` returned `main.Maybe[T]` — base name `main.Maybe`, a key nothing is registered under. The lookup missed, and the type was never recognised as sealed.

### It was not std special-casing

The obvious hypothesis — that generic `std.Option` works because something special-cases `std` — is **wrong**, and no special-casing was found or removed. The asymmetry is `main`/`test` vs. *named package*, not user vs. std. `std` is a named package, so the qualified base its `Apply` return type carries (`std.Option`) **is** its registry key and the lookup hits.

Verified with an on-disk control: a user-declared `sealed type Box[T any]` in a named package `boxpkg` behaves exactly like `std.Option`, before and after the fix. There is no CLAUDE.md rule-2 violation here. A named-package control is included in the test file to keep that distinction pinned.

## Exhaustiveness was only the visible symptom

The same missed lookup **silently disabled two further checks** for these types:

- `GALA-E0002` — naming the missing variant
- `GALA-E0004` — variant arity

Both now fire, and both are pinned by tests. A narrower fix that merely silenced `GALA-E0003` would fail the suite.

## Changes

- `internal/transpiler/analyzer/analyzer.go` — one branch.
- `examples/BUILD.bazel`, `internal/transpiler/transformer/BUILD.bazel`.

## Verification

- `internal/transpiler/transformer/generic_sealed_exhaustive_test.go` (new, 6 cases + the named-package control)
- `examples/generic_sealed_exhaustive.{gala,out}` (new)
- `examples/multifile_lib_regress/generic_sealed.gala` (new), plus 5 new assertions in `multifile_lib_regress_test`
- `bazel build //...` green (1433 targets); `bazel run //:gazelle` produced no further changes
- `bazel test //...` — 387/389. Both failures are pre-existing/environmental: `TestGorootFromGoBinarySymlink` (the known-benign Windows symlink test) and `TestDiagnostics_IntentionalSyntaxErrorThenFix`, an LSP debounce-timing test that fails only under parallel load — it passed in the FIX-003 run and passes **5/5** in isolation.

## Dependencies

None — branches from `master`. Composes with FIX-003 (#458): `case Nothing` in *bare* form over a generic user sealed type needs both fixes — FIX-003 to stop it binding, FIX-004 to recognise the subject as sealed. That spelling was deliberately kept out of this PR's tests so this suite doesn't fail for a defect it doesn't own (there is a comment at the omission site). Whichever PR lands second should add one assertion for the combined shape.

## Note on the original triage

The triage brief pointed at `analyzer.go:1092` as a likely site. That was a red herring — that region (`len(meta.FieldNames) == 0 || len(meta.TypeParams) == 0`, now ~line 1154) is the struct-field-collides-with-type check for `GALA-E0016`, unrelated to exhaustiveness.

## Report Reference

Not in the original report set. Flagged as an uninvestigated adjacent observation in `docs/private/BUG_BARE_VARIANT_PATTERN_SILENTLY_BINDS.md` ("One adjacent observation, not investigated"), then confirmed and isolated as its own defect.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aZRWH39EXTXVALyxALJut