### PR TITLE
fix(parser): slice, map and func types rejected inside explicit type arguments

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -2175,7 +2175,9 @@ val empty = SliceEmpty[int]()            // Creates Go []int{}
 | `SliceDrop(s, n)` | Drop first n elements |
 | `SliceTake(s, n)` | Take first n elements |
 
-**Note:** Slice types (`[]T`) are still valid in function signatures and struct fields.
+**Note:** Slice types (`[]T`) are still valid in function signatures and struct
+fields — and, like every other type, inside explicit type-argument brackets:
+`EmptyHashMap[string, []byte]()`, `Array[[]byte]`, `zero[map[string]int]()`.
 
 ### Maps
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2806,6 +2806,7 @@ gala_library(
         "multifile_lib_regress/proc_session.gala",
         "multifile_lib_regress/symbol_scope.gala",
         "multifile_lib_regress/team_lookup.gala",
+        "multifile_lib_regress/type_args_slice_map.gala",
         "multifile_lib_regress/types.gala",
     ],
     go_srcs = [
@@ -2819,6 +2820,7 @@ gala_library(
         ":multifile_lib_regress_team_pkg",
         "//collection_immutable",
         "//examples/go_struct_bridge",
+        "//go_interop",
     ],
 )
 
@@ -2833,6 +2835,7 @@ gala_exec_test(
         ":multifile_lib_regress_shadow_func",
         "//collection_immutable",
         "//examples/go_struct_bridge",
+        "//go_interop",
     ],
 )
 
@@ -3010,5 +3013,15 @@ gala_exec_test(
     deps = [
         ":cross_pkg_try_chain_proc",
         ":cross_pkg_try_chain_session",
+    ],
+)
+
+gala_exec_test(
+    name = "type_args_slice_map",
+    src = "type_args_slice_map.gala",
+    expected = "type_args_slice_map.out",
+    deps = [
+        "//collection_immutable",
+        "//go_interop",
     ],
 )

--- a/examples/multifile_lib_regress/type_args_slice_map.gala
+++ b/examples/multifile_lib_regress/type_args_slice_map.gala
@@ -1,0 +1,39 @@
+package multifile_lib_regress
+
+import (
+    . "martianoff/gala/collection_immutable"
+    . "martianoff/gala/std"
+    "martianoff/gala/go_interop"
+)
+
+// --- Regression: a slice (`[]T`) or map (`map[K]V`) type written inside
+// explicit type-argument brackets. Those types are legal in every other type
+// position — parameters, return types, struct fields, `val` annotations — so
+// they have to be legal between `[` and `]` as well. Otherwise the idiomatic
+// collection cannot be instantiated at a byte slice at all, and the workaround
+// (declare a named type) is the only way to write byte-oriented generic code.
+//
+// Exercised here from a library package so the consumer below can instantiate
+// the same generics across a package boundary.
+
+struct Envelope[T any](Payload T)
+
+func EmptyOf[T any]() Option[T] = None[T]()
+
+// Slice type argument on a stdlib collection constructor.
+func BytesBucketSize() int = EmptyHashMap[string, []byte]().Size()
+
+// Map type argument, nested inside another instantiation.
+func CountsBucketSize() int = EmptyHashMap[string, map[string]int]().Size()
+
+// Slice type argument on a sibling-declared generic function.
+func MissingBytes() bool = EmptyOf[[]byte]().IsEmpty()
+
+// Slice type argument on a generic struct constructor.
+func WrapBytes(s string) Envelope[[]byte] =
+    Envelope[[]byte](Payload = go_interop.ToBytes(s))
+
+func EnvelopeText(e Envelope[[]byte]) string = go_interop.ToString(e.Payload)
+
+// Slice-of-slice element type.
+func ChunkCount() int = EmptyArray[[]byte]().Size()

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -371,4 +371,16 @@ func main() {
     Println(multifile_lib_regress.ScopeLambdaCapture(3))
     Println(multifile_lib_regress.ScopeQualifiedImport("gamma"))
     Println(multifile_lib_regress.ScopeSnapshotLabel())
+
+    // --- Regression: slice and map types inside explicit type-argument
+    // brackets, both inside the library and across the package boundary from
+    // here. See multifile_lib_regress/type_args_slice_map.gala.
+    Println(multifile_lib_regress.BytesBucketSize())
+    Println(multifile_lib_regress.CountsBucketSize())
+    Println(multifile_lib_regress.MissingBytes())
+    Println(multifile_lib_regress.ChunkCount())
+    Println(multifile_lib_regress.EnvelopeText(multifile_lib_regress.WrapBytes("payload")))
+    Println(multifile_lib_regress.EmptyOf[[]byte]().IsEmpty())
+    Println(multifile_lib_regress.EmptyOf[map[string]int]().IsEmpty())
+    Println(EmptyHashMap[string, []byte]().Size())
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -83,3 +83,11 @@ scope:dana:v2,v3,v4:ok
 5
 gamma
 scope-7-ok
+0
+0
+true
+0
+payload
+true
+true
+0

--- a/examples/type_args_slice_map.gala
+++ b/examples/type_args_slice_map.gala
@@ -1,0 +1,50 @@
+package main
+
+// Explicit type arguments accept the full type grammar. A slice (`[]T`), a map
+// (`map[K]V`) or a function type is as legal between `[` and `]` at a call site
+// as it is in a parameter list, a return type, a struct field, or a `val`
+// annotation.
+import "martianoff/gala/collection_immutable"
+import "martianoff/gala/go_interop"
+
+struct Box[T any](Value T)
+
+func zero[T any]() Option[T] = None[T]()
+
+func describe[T any](f func(T) string) string = "fn"
+
+func main() {
+    // Slice type argument on a user-declared generic function.
+    val noBytes = zero[[]byte]()
+    Println(noBytes.IsEmpty())
+
+    // Map type argument on the same function.
+    val noCounts = zero[map[string]int]()
+    Println(noCounts.IsEmpty())
+
+    // Function type argument.
+    Println(describe[[]byte]((b) => go_interop.ToString(b)))
+
+    // Slice type argument on a user-declared generic struct.
+    val boxed = Box[[]byte](Value = go_interop.ToBytes("gala"))
+    Println(go_interop.ToString(boxed.Value))
+
+    // Slice type argument on a stdlib collection constructor — the idiomatic
+    // collection has to be instantiable at a byte slice too.
+    val m = collection_immutable.EmptyHashMap[string, []byte]()
+    Println(m.Size())
+
+    val filled = m.Put("k", go_interop.ToBytes("v"))
+    Println(go_interop.ToString(filled.Get("k").Get()))
+
+    // Nested: a slice of slices, and a map whose value is a slice.
+    val nested = collection_immutable.EmptyArray[[]byte]()
+    Println(nested.Size())
+
+    val byName = collection_immutable.EmptyHashMap[string, map[string]int]()
+    Println(byName.Size())
+
+    // ... and on a Go-interop constructor.
+    val raw = go_interop.MapEmpty[string, []byte]()
+    Println(go_interop.MapLen(raw))
+}

--- a/examples/type_args_slice_map.out
+++ b/examples/type_args_slice_map.out
@@ -1,0 +1,9 @@
+true
+true
+fn
+gala
+0
+v
+0
+0
+0

--- a/internal/parser/BUILD.bazel
+++ b/internal/parser/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
         "grammar_test.go",
         "parser_concurrent_test.go",
         "parser_test.go",
+        "type_arguments_test.go",
     ],
     embed = [":parser"],
     deps = [

--- a/internal/parser/grammar/gala.g4
+++ b/internal/parser/grammar/gala.g4
@@ -169,10 +169,21 @@ postfixExpr
     : primaryExpr postfixSuffix* ('match' '{' caseClause+ '}')?
     ;
 
+// `[ ... ]` after a primary is either an index (`arr[i]`, `m[k]`) or explicit
+// type arguments (`zero[int]()`, `EmptyHashMap[string, int]()`). Most type
+// arguments also parse as expressions — `int`, `pkg.T`, `*P`, `Box[T]` — so the
+// expressionList alternative covers them and the transformer reinterprets the
+// index as an instantiation. Types that have no expression spelling (`[]byte`,
+// `map[K]V`, `func(...)`) need the real `type` production; that is what the
+// typeArguments alternative supplies. It is listed last so ANTLR's
+// lowest-alternative ambiguity resolution keeps every shape that parses as an
+// expression on the existing path — only input that cannot be an expression
+// reaches it.
 postfixSuffix
     : '.' identifier
     | '(' argumentList? ')'
     | '[' expressionList ']'
+    | typeArguments
     ;
 
 primaryExpr

--- a/internal/parser/type_arguments_test.go
+++ b/internal/parser/type_arguments_test.go
@@ -1,0 +1,101 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Explicit type arguments accept the full `type` production. Slice, map and
+// function types have no expression spelling, so they used to be rejected
+// between `[` and `]` even though the same types are legal in every other type
+// position (parameters, return types, struct fields, `val` annotations).
+//
+// The index/subscript cases are here for the other half of the contract: `[`
+// after a primary still parses as an index when its contents are expressions,
+// so widening type arguments must not steal ordinary subscripting.
+func TestTypeArgumentsAcceptFullTypeGrammar(t *testing.T) {
+	p := NewAntlrGalaParser()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "slice type argument on a generic function",
+			body: `val x = zero[[]byte]()`,
+		},
+		{
+			name: "map type argument on a generic function",
+			body: `val x = zero[map[string]int]()`,
+		},
+		{
+			name: "function type argument",
+			body: `val x = zero[func(int) string]()`,
+		},
+		{
+			name: "pointer type argument still parses",
+			body: `val x = zero[*Node]()`,
+		},
+		{
+			name: "named type argument still parses",
+			body: `val x = zero[Bytes]()`,
+		},
+		{
+			name: "slice among several type arguments",
+			body: `val x = EmptyHashMap[string, []byte]()`,
+		},
+		{
+			name: "map among several type arguments",
+			body: `val x = EmptyHashMap[string, map[string]int]()`,
+		},
+		{
+			name: "slice of slices",
+			body: `val x = EmptyArray[[][]byte]()`,
+		},
+		{
+			name: "slice type argument on a package-qualified generic",
+			body: `val x = collection_immutable.EmptyHashMap[string, []byte]()`,
+		},
+		{
+			name: "slice type argument on a generic struct constructor",
+			body: `val x = Box[[]byte](Value = payload)`,
+		},
+		{
+			name: "slice type argument on a generic type instantiation",
+			body: `val x Box[[]byte] = boxed`,
+		},
+		{
+			name: "index with an identifier subscript",
+			body: `val x = arr[i]`,
+		},
+		{
+			name: "index with a computed subscript",
+			body: `val x = arr[i + 1]`,
+		},
+		{
+			name: "index with a string subscript",
+			body: `val x = m["key"]`,
+		},
+		{
+			name: "index with a pointer-deref subscript",
+			body: `val x = arr[*p]`,
+		},
+		{
+			name: "index on a call result",
+			body: `val x = items()[0]`,
+		},
+		{
+			name: "chained index",
+			body: `val x = grid[r][c]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := "package main\n\nfunc main() {\n    " + tt.body + "\n}\n"
+			_, err := p.Parse(src)
+			assert.NoError(t, err, "unexpected parse error for: %s", tt.body)
+		})
+	}
+}

--- a/internal/transpiler/scopewalk/scopewalk.go
+++ b/internal/transpiler/scopewalk/scopewalk.go
@@ -557,8 +557,9 @@ func classifySuffixes(suffixes []grammar.IPostfixSuffixContext, hasMatch bool) (
 			parts = append(parts, id.GetText())
 			continue
 		}
-		if sc.ExpressionList() != nil {
-			// Index `[...]` — a value-position use of the whole receiver.
+		if sc.ExpressionList() != nil || sc.TypeArguments() != nil {
+			// Index or explicit type arguments `[...]` — a value-position use of
+			// the whole receiver either way.
 			return "", true
 		}
 		// A call `(...)`. Tolerate a SINGLE trailing method call on a

--- a/internal/transpiler/transformer/expressions.go
+++ b/internal/transpiler/transformer/expressions.go
@@ -495,13 +495,17 @@ func (t *galaASTTransformer) getCallPatternWithTypeArgsFromExpression(ctx gramma
 		typeArgsSuffix = suffixes[0].(*grammar.PostfixSuffixContext)
 		callSuffix = suffixes[1].(*grammar.PostfixSuffixContext)
 
-		// Verify first suffix is type args (starts with '[')
-		if typeArgsSuffix.GetChildCount() < 2 {
-			return nil, nil, nil
-		}
-		firstChild := typeArgsSuffix.GetChild(0).(antlr.ParseTree).GetText()
-		if firstChild != "[" {
-			return nil, nil, nil
+		// Verify first suffix is type args: either the bracketed expression list
+		// (`Unwrap[int](v)`) or the `typeArguments` production the grammar uses
+		// for types with no expression spelling (`Unwrap[[]byte](v)`).
+		if typeArgsSuffix.TypeArguments() == nil {
+			if typeArgsSuffix.GetChildCount() < 2 {
+				return nil, nil, nil
+			}
+			firstChild := typeArgsSuffix.GetChild(0).(antlr.ParseTree).GetText()
+			if firstChild != "[" {
+				return nil, nil, nil
+			}
 		}
 	}
 

--- a/internal/transpiler/transformer/postfix.go
+++ b/internal/transpiler/transformer/postfix.go
@@ -65,6 +65,14 @@ func (t *galaASTTransformer) applyPostfixSuffix(base ast.Expr, suffix *grammar.P
 		return t.resolveFieldAccess(base, suffix.Identifier().GetText())
 	}
 
+	// Explicit type arguments whose types have no expression spelling — e.g.
+	// `f[[]byte]()`, `EmptyHashMap[string, map[string]int]()`. The grammar routes
+	// those through `typeArguments` instead of the index suffix, so transform the
+	// real type productions here.
+	if ta := suffix.TypeArguments(); ta != nil {
+		return t.applyTypeArgumentSuffix(base, ta)
+	}
+
 	childCount := suffix.GetChildCount()
 	if childCount >= 2 {
 		firstChild := suffix.GetChild(0).(antlr.ParseTree).GetText()
@@ -335,6 +343,31 @@ func (t *galaASTTransformer) callExprReturnType(ce *ast.CallExpr) transpiler.Typ
 		}
 	}
 	return transpiler.NilType{}
+}
+
+// applyTypeArgumentSuffix instantiates a generic function or type at explicit
+// type arguments written with the full `type` production. Go spells generic
+// instantiation the same way an index reads, so the result is the same
+// IndexExpr/IndexListExpr shape the expression-list path produces — the rest of
+// the pipeline needs no special case.
+func (t *galaASTTransformer) applyTypeArgumentSuffix(base ast.Expr, ta grammar.ITypeArgumentsContext) (ast.Expr, error) {
+	typeList := ta.TypeList()
+	if typeList == nil {
+		return nil, galaerr.NewSemanticErrorAt(ta.GetStart().GetLine(), ta.GetStart().GetColumn(), "type arguments require at least one type")
+	}
+	types := typeList.(*grammar.TypeListContext).AllType_()
+	args := make([]ast.Expr, 0, len(types))
+	for _, typ := range types {
+		arg, err := t.transformType(typ)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, arg)
+	}
+	if len(args) == 1 {
+		return &ast.IndexExpr{X: base, Index: args[0]}, nil
+	}
+	return &ast.IndexListExpr{X: base, Indices: args}, nil
 }
 
 // resolveIndexAccess handles index/subscript expressions with Immutable unwrapping.

--- a/internal/transpiler/transformer/type_inference.go
+++ b/internal/transpiler/transformer/type_inference.go
@@ -1101,6 +1101,20 @@ func (t *galaASTTransformer) exprToTypeString(expr ast.Expr) string {
 		}
 	case *ast.StarExpr:
 		return "*" + t.exprToTypeString(e.X)
+	case *ast.ArrayType:
+		// Slices only — GALA has no fixed-size array type, so a non-nil Len
+		// cannot come from GALA source and has no string spelling here.
+		if e.Len != nil {
+			return ""
+		}
+		if elem := t.exprToTypeString(e.Elt); elem != "" {
+			return "[]" + elem
+		}
+	case *ast.MapType:
+		key, val := t.exprToTypeString(e.Key), t.exprToTypeString(e.Value)
+		if key != "" && val != "" {
+			return "map[" + key + "]" + val
+		}
 	case *ast.IndexExpr:
 		return t.exprToTypeString(e.X) + "[" + t.exprToTypeString(e.Index) + "]"
 	case *ast.IndexListExpr:


### PR DESCRIPTION
## Summary

Fixes **FIX-006**: a slice (`[]T`), map (`map[K]V`) or func type inside explicit type arguments failed to parse, while the same types are legal in every other type position.

**Category**: PARSER
**Priority**: P2
**Found in**: validating GALA code samples for the gala-kv design document

```
go_interop.MapEmpty[string, []byte]()
→ no viable alternative at input '(MapEmpty[string,[]byte('
```

Reproduces on a user generic function, a user generic struct, and `collection_immutable.EmptyHashMap[string, []byte]()`.

## Root Cause

Explicit type arguments in *expression* position were never parsed by a type production at all — they were parsed by the **index suffix**, `postfixSuffix: '[' expressionList ']'`, with the transformer reinterpreting the index as a generic instantiation (Go spells both the same way).

Named, qualified, pointer and nested-instantiation types all happen to have an *expression* spelling — `int`, `pkg.T`, `*P` as unary deref, `Box[T]` as a nested index — which is exactly why the report's scoping table showed those working. Slice, map and func types have no expression spelling, so the parser fell through to `primary → compositeLiteral: type ('{' … '}')`, matched `[]byte` as a type, then demanded the `{` — producing `missing '{' at '('`, pointing at the wrong token.

## Grammar change

One alternative added to `postfixSuffix`, pointing type-argument brackets at the `typeArguments` production that type positions already use:

```antlr
postfixSuffix
    : '.' identifier
    | '(' argumentList? ')'
    | '[' expressionList ']'
    | typeArguments          // NEW  (typeArguments: '[' typeList ']')
    ;
```

**Placement is load-bearing.** It is last, so ANTLR's lowest-alternative ambiguity resolution keeps every input that parses as an expression on the existing path. Only input that *cannot* be an expression reaches the new alternative. **No previously-parsing program changes its parse tree** — that is the safety property that made this the minimal option.

## Ambiguity and cost — measured, not assumed

- **ANTLR tool diagnostics: zero, before and after.** Verified by running the same `antlr4` jar the genrule uses over baseline and new `gala.g4`; both exit 0 with empty stdout/stderr.
- **Runtime ambiguity is real and was measured** with a throwaway diagnostic (since removed) parsing a 294-file corpus (`examples/`, `std/`, `collection_immutable/`) under `PredictionModeLLExactAmbigDetection`:

| | baseline | after |
|---|---|---|
| total ambiguity reports | 4007 | 4609 |
| `postfixSuffix` | **0** | **594** |
| `postfixExpr` | 3132 | 3137 |
| full-context predictions | 10872 | 11494 |

The 594 are exactly the predicted overlap: for `[Ident]`, `[pkg.T]`, `[*P]` both alternatives are viable, ANTLR reports it and resolves to the lower-numbered (existing) one. Deterministic, and the resolution preserves the old tree.

- **Parse-time cost:** best-of-5 over the same corpus, two samples per side — baseline 1.70s / 1.78s, after 1.87s / 2.25s. Tightest-sample delta ≈ **+10%**, ~0.6 ms per file. Small because parsing is a minor slice of transpile time, but not zero.

### The alternative, and why it was rejected

`'[' elemList ']'` with `elem: expression | type` removes the ambiguity entirely — but changes the parse-tree shape of *every index expression in the language* and needs ~5 transformer/scopewalk call-site changes. The additive version was chosen because no existing parse changes at all. **If you would rather pay that blast radius to get ambiguity back to zero, that is a real option** — flagging it rather than burying it.

## This is a consistency fix, not a widening — verified independently

- `docs/GALA.MD` already declares slice types valid in signatures and struct fields; `transformType` has had `ArrayType`/`MapType`/func-type branches all along; the `type` production in `gala.g4` has carried slice and map forms from the start. **Nothing new became a type.**
- "Use the idiomatic collection instead" is unavailable here — the idiomatic collection (`EmptyHashMap`) is what could not be instantiated.
- The change is confined to type-argument brackets. It does **not** make `[]byte` a valid expression anywhere. An alternative adding slice/map to `primary` was cheaper on ambiguity and was rejected precisely because it *would* be a widening: `val x = []byte` would start parsing.

## Non-grammar changes, and what broke without each

- **`transformer/postfix.go`** — *load-bearing, observed.* `applyPostfixSuffix` dispatches on child 0 being `[`; for the new shape child 0 is the `typeArguments` context, so it fell through to `unknown postfix suffix type`. Added `applyTypeArgumentSuffix`, emitting the *same* `IndexExpr`/`IndexListExpr` as the expression path, so nothing downstream needs a special case.
- **`transformer/type_inference.go`** — *load-bearing, observed, and a CLAUDE.md rule-3 issue.* `exprToTypeString` had no `ast.ArrayType`/`ast.MapType` case, so type-param substitution got an empty string and gave up, emitting `func(b any) string`. It now emits `func(b []byte) string`. **This change removes an `any` leak rather than adding one.** Fixed-size arrays explicitly excluded (GALA has no such type).
- **`transformer/expressions.go`** — *load-bearing, verified by experiment.* `getCallPatternWithTypeArgsFromExpression` gates on the same child-0 text test. With the guard temporarily disabled and rebuilt, `case Some[[]byte](b) =>` degraded from a constructor pattern to a binding and failed with `unused variable 'Some' in match branch`. With it, lowers correctly to `std.Some[[]byte]{}.Unapply(obj)`.
- **`scopewalk/scopewalk.go`** — ⚠️ *defensive, 2 lines, NOT load-bearing today — reviewer's call.* `classifySuffixes` uses an expression-list presence test as its "this is a bracketed suffix" discriminator, which is now factually incomplete. Every reachable shape was traced and the fall-through reaches the same result, so no input could be constructed where it changes behaviour. It was kept because leaving a knowingly-wrong discriminator is a landmine for the next edit of that function. **Happy to drop it if the strictly minimal diff is preferred.**
- **`internal/parser/BUILD.bazel`** — registers the new `type_arguments_test.go` in the existing `go_test` srcs. `bazel run //:gazelle` after all edits produced **zero** diff across the repo.

## Tests

- `internal/parser/type_arguments_test.go` — 17-case table (slice / map / func / nested slice-of-slice / multi-arg / package-qualified / generic-struct-ctor / type-annotation), **plus 6 index-expression cases** (`arr[i]`, `arr[i+1]`, `m["key"]`, `arr[*p]`, `items()[0]`, `grid[r][c]`) guarding the other half of the contract — that widening type args did not steal ordinary subscripting.
- `examples/type_args_slice_map.gala` / `.out` — all three shapes from the report, plus `go_interop.MapEmpty`, a `map[K]V` type arg, `EmptyArray[[]byte]`, and a func-type arg.
- `examples/multifile_lib_regress/type_args_slice_map.gala` + consumer additions — same shapes inside a library package *and* instantiated across the package boundary.
- `docs/GALA.MD` slice note updated.

## IDE / LSP sync: not needed

No new tokens, keywords or rule names — `typeArguments` and `typeList` already existed; `map` and `func` were already lexer literals. The IntelliJ Java parser regenerates from the same `gala.g4` via the existing `gala_grammar_java` genrule into a gitignored directory, so nothing checked in is stale. The LSP's only postfix-shape consumer (`internal/lsp/signature_help.go`) matches on terminal text and is unaffected. The sync skill was not run.

## Verification

- `bazel build //...` green (1433 targets)
- `bazel test //...` — 388/389; sole failure the known-benign `TestGorootFromGoBinarySymlink` (Windows symlink privilege)
- `internal/parser/grammar/*.go` were **not** hand-edited — they do not exist on disk in this worktree; the directory holds only `BUILD.bazel`, `copy_java_to_ide.sh` and `gala.g4`, with the `.go` files as pure genrule outputs in `bazel-bin`

## Dependencies

None — branches from `master`.

## Report Reference

Originally reported as **BUG-KV-1** in `docs/private/gala-kv-findings/REPORT.md`; detail in `docs/private/BUG_SLICE_TYPE_IN_EXPLICIT_TYPE_ARGS.md`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aZRWH39EXTXVALyxALJut
