### PR TITLE
fix(diagnostics,docs): GALA-E0040 for Go slice/map types in expression position; correct the positional rule

### DIFF
--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -2177,7 +2177,73 @@ val empty = SliceEmpty[int]()            // Creates Go []int{}
 | `SliceDrop(s, n)` | Drop first n elements |
 | `SliceTake(s, n)` | Take first n elements |
 
-**Note:** Slice types (`[]T`) are still valid in function signatures and struct fields.
+<a id="where-go-slice-and-map-types-may-be-written"></a>
+
+#### Where Go slice and map types may be written
+
+Go slice (`[]T`) and map (`map[K]V`) types are an **interop surface**, not
+first-class GALA types. The rule is positional, and it is exhaustive: a Go slice
+or map type may be written **only where a type is expected, and never inside an
+expression.**
+
+These are every position where a type is expected, and a Go slice or map type is
+valid in all of them:
+
+| Position | Example |
+|----------|---------|
+| Function / method parameter | `func f(xs []int)` |
+| Function / method return type | `func f() map[string]int` |
+| Struct field | `type B struct { data []byte }` |
+| Interface method result | `type R interface { Read() []byte }` |
+| `val` / `var` annotation | `val b []byte = ToBytes("hi")` |
+| Lambda parameter annotation | `(xs []int) => xs` |
+| Type alias | `type Bytes []byte` |
+| Inside a `func` type | `func([]byte) string` |
+| Type argument of a generic **type** in any position above | `func take(m HashMap[string, []byte])` |
+
+Everywhere else — that is, anywhere a value is expected — is an expression, and a
+Go slice or map type may not appear there. The three shapes Go allows and GALA
+does not:
+
+```gala
+val m = EmptyHashMap[string, []byte]()   // NO: explicit type argument on a call
+val b = []byte("hi")                     // NO: conversion
+val xs = []int{1, 2, 3}                  // NO: composite literal
+```
+
+The first two are [GALA-E0040](errors/GALA-E0040.md); the literal forms are
+[GALA-E0007](errors/GALA-E0007.md) and [GALA-E0008](errors/GALA-E0008.md).
+
+Note the last row of the table against the first bad line: `HashMap[string,
+[]byte]` is fine as a parameter type, a struct field type, a `val` annotation or
+a type alias, because those are type positions. The identical text after
+`EmptyHashMap` is not, because that is an expression.
+
+**Write it the GALA way instead.** `[]T` is `Array[T]`, and `map[K]V` is
+`HashMap[K, V]`:
+
+```gala
+import . "martianoff/gala/collection_immutable"
+
+val m = EmptyHashMap[string, Array[byte]]()
+```
+
+For `[]byte` in particular, ask what the bytes are: text is `string` in GALA, and
+that is usually the type wanted.
+
+```gala
+val m = EmptyHashMap[string, string]()
+```
+
+When the value genuinely has to be a Go `[]T` — because it crosses into a Go API
+— keep the Go type out of the expression by giving it a name, which puts it back
+in a type position:
+
+```gala
+type Bytes []byte
+
+val m = EmptyHashMap[string, Bytes]()
+```
 
 ### Maps
 
@@ -2219,11 +2285,16 @@ MapForEach(goMap, (k string, v int) => {
     fmt.Println(k, v)
 })
 
-// Iterate Go maps with complex value types (e.g., map[string][]string)
-// V can be any type including slices — MapForEach[K comparable, V any] handles it
-var headers = MapEmpty[string, []string]()
+// Iterate Go maps with complex value types (e.g., map[string][]string).
+// V can be any type including slices — MapForEach[K comparable, V any] handles
+// it. The value type needs a NAME here: MapEmpty's type arguments sit in an
+// expression, and a Go slice type cannot be written there (GALA-E0040). A type
+// alias puts it back in a type position.
+type StrList []string
+
+var headers = MapEmpty[string, StrList]()
 headers = MapPut(headers, "Accept", SliceOf("text/html", "application/json"))
-MapForEach(headers, (k string, v []string) => {
+MapForEach(headers, (k string, v StrList) => {
     fmt.Printf("%s: %v\n", k, v)
 })
 
@@ -2253,7 +2324,16 @@ val backToGoMap = hashMap.ToGoMap()
 | `MapValues(m)` | Get all values as slice |
 | `MapCopy(m)` | Shallow copy |
 
-**Note:** Map types (`map[K]V`) are still valid in function signatures and struct fields, similar to slices.
+**Where map types may be written.** `map[K]V` follows exactly the same
+positional rule as `[]T`: valid wherever a type is expected — a signature, a
+struct field, a `val`/`var` annotation, a type alias, a lambda parameter
+annotation, or as a type argument of a generic type in one of those positions —
+and never inside an expression. See
+[Where Go slice and map types may be written](#where-go-slice-and-map-types-may-be-written)
+for the full table, the three shapes that are rejected, and the GALA spellings
+to use instead. Writing one in an expression is
+[GALA-E0040](errors/GALA-E0040.md); a `map[K]V{}` literal is
+[GALA-E0008](errors/GALA-E0008.md).
 
 ### HashMap
 

--- a/docs/GALA_BEST_PRACTICES.MD
+++ b/docs/GALA_BEST_PRACTICES.MD
@@ -47,6 +47,17 @@ Use `collection_immutable.{Array, List, HashMap}` for general work. Use `go_inte
 | Pass to Go libraries | `SliceOf(...)` from `go_interop`, or `.ToGoSlice()` |
 | Variadic call | Go slice (`[]T`) via `SliceOf` |
 
+- **Go slice/map types go in type positions only.** `[]T` and `map[K]V` may be
+  written wherever a type is expected — signature, struct field, `val`/`var`
+  annotation, lambda parameter annotation, type alias, or as a type argument of a
+  generic type in one of those — and **never inside an expression**. So
+  `func take(m HashMap[string, []byte])` is fine, but
+  `EmptyHashMap[string, []byte]()` is not: write `EmptyHashMap[string, Array[byte]]()`,
+  or `EmptyHashMap[string, string]()` when the bytes are text. Name the Go type
+  with a type alias (`type Bytes []byte`) if it really has to stay a Go slice.
+  ([GALA-E0040](errors/GALA-E0040.md),
+  [§9 positional rule](GALA.MD#where-go-slice-and-map-types-may-be-written))
+
 - **Use functional ops, not loops:** `arr.Map`, `arr.Filter`, `arr.FoldLeft`, `arr.ForEach`, `arr.MkString`, `arr.ZipWithIndex`, `arr.Collect`.
 - **Short-circuit ops still loop:** `Exists`, `ForAll`, `Find`, `Contains` — keep these.
 - **Safe access:** `arr.GetOption(i)` returns `Option[T]` instead of panicking.

--- a/docs/errors/GALA-E0040.md
+++ b/docs/errors/GALA-E0040.md
@@ -1,0 +1,145 @@
+# GALA-E0040 — Go slice or map type in an expression
+
+**When it fires.** A Go slice (`[]T`) or map (`map[K]V`) type was written
+somewhere GALA expects an **expression** rather than a type. The usual site is
+an explicit type argument on a call:
+
+```gala
+val m = collection_immutable.EmptyHashMap[string, []byte]()
+```
+
+The same code covers the other expression site where Go would allow the syntax
+and GALA does not — a conversion, `[]byte(s)`.
+
+**The rule.** A Go slice or map type may be written **only where a type is
+expected**:
+
+| Position | Example | Allowed |
+|----------|---------|---------|
+| Function / method parameter | `func f(xs []int)` | yes |
+| Function / method return type | `func f() map[string]int` | yes |
+| Struct field | `type B struct { data []byte }` | yes |
+| Interface method result | `type R interface { Read() []byte }` | yes |
+| `val` / `var` annotation | `val b []byte = …` | yes |
+| Lambda parameter annotation | `(xs []int) => …` | yes |
+| Type alias | `type Bytes []byte` | yes |
+| Inside a `func` type | `func([]byte) string` | yes |
+| Type argument of a generic **type** in any position above | `m HashMap[string, []byte]` | yes |
+| Explicit type argument on a **call** | `EmptyHashMap[string, []byte]()` | **no — GALA-E0040** |
+| Conversion | `[]byte(s)` | **no — GALA-E0040** |
+| Composite literal | `[]int{1, 2, 3}` | no — see [GALA-E0007](GALA-E0007.md) / [GALA-E0008](GALA-E0008.md) |
+
+The distinction is type context versus expression context, not "signatures and
+struct fields". `HashMap[string, []byte]` is fine as a parameter type, a struct
+field type, a `val` annotation or a type alias, because all of those are type
+positions. The identical text after `EmptyHashMap` in an expression is not,
+because bracketed arguments following an expression are parsed as an expression
+list, and `[]byte` is not an expression.
+
+**Minimal repro.**
+
+```gala
+package main
+
+import "martianoff/gala/collection_immutable"
+
+func main() {
+    val m = collection_immutable.EmptyHashMap[string, []byte]()
+    Println(m.Size())
+}
+```
+
+**Error output.**
+
+```
+error[GALA-E0040]: Go slice type []byte is not allowed in an expression
+  --> typearg.gala:6:55
+  |
+6 |     val m = collection_immutable.EmptyHashMap[string, []byte]()
+  |                                                       ^^^^^^ use Array[byte], or string for text, instead
+  |
+  = hint: use Array[byte], or string for text, instead; Go slice and map types are an interop surface, allowed only where a type is expected: a function signature, a struct field, a val/var annotation, or a type alias
+```
+
+A map type reports the same code and names the `HashMap` spelling:
+
+```
+error[GALA-E0040]: Go map type map[string]int is not allowed in an expression
+  --> maparg.gala:6:55
+  |
+6 |     val m = collection_immutable.EmptyHashMap[string, map[string]int]()
+  |                                                       ^^^^^^^^^^^^^^ use HashMap[string, int] instead
+  |
+  = hint: use HashMap[string, int] instead; Go slice and map types are an interop surface, allowed only where a type is expected: a function signature, a struct field, a val/var annotation, or a type alias
+```
+
+**Fix.** Name a GALA type. `[]T` becomes `Array[T]`, `map[K]V` becomes
+`HashMap[K, V]`:
+
+```gala
+import "martianoff/gala/collection_immutable"
+
+val m = collection_immutable.EmptyHashMap[string, collection_immutable.Array[byte]]()
+```
+
+For `[]byte` specifically, ask what the bytes are. Text is `string` in GALA, and
+that is almost always the type wanted:
+
+```gala
+val m = collection_immutable.EmptyHashMap[string, string]()
+```
+
+If the value genuinely has to be a Go `[]byte` — because it crosses into a Go
+API — keep the Go type out of the expression and put it in a type position
+instead. A type alias is the shortest route:
+
+```gala
+type Bytes []byte
+
+val m = collection_immutable.EmptyHashMap[string, Bytes]()
+```
+
+For a conversion, use the `go_interop` helpers rather than `[]byte(s)`:
+
+```gala
+import . "martianoff/gala/go_interop"
+
+val b = ToBytes("hi")      // string -> []byte
+val s = ToString(b)        // []byte -> string
+```
+
+**Rationale.** Go slices and maps are an interop surface in GALA, not
+first-class types. They exist so a GALA program can name the shape a Go API
+demands; they are deliberately not something a GALA program builds with, which
+is why the literal forms are rejected outright ([GALA-E0007](GALA-E0007.md),
+[GALA-E0008](GALA-E0008.md)) and `make` is not part of the surface
+([GALA-E0035](GALA-E0035.md)). Restricting them to type positions is what keeps
+that boundary narrow: a Go type can be *named* wherever a Go value has to be
+described, and nowhere else.
+
+This code exists because the restriction used to be enforced without being
+explained. The parser, unable to read `[]byte` as an expression, fell back to
+its composite-literal alternative — whose type *does* admit `[]T` — and then
+demanded the brace that alternative requires, reporting ANTLR's raw recovery
+text:
+
+```
+error: missing '{' at '('
+```
+
+That named no code, no file, no line and no type, and it pointed at the token
+*after* the offending one, so it read as an unbalanced brace. The rejection was
+correct; only the message was not.
+
+**Scope.** This code covers a Go slice or map type appearing in expression
+position. It does not cover:
+
+- slice and map **literals** — [GALA-E0007](GALA-E0007.md) and
+  [GALA-E0008](GALA-E0008.md), which fire on a well-formed `[]int{…}` /
+  `map[K]V{…}` after it parses;
+- `make`, `append` and the other bare Go builtins —
+  [GALA-E0035](GALA-E0035.md).
+
+A Go **func** type in expression position (`EmptyHashMap[string, func(int) int]()`)
+is rejected too, but as an ordinary syntax error: it is a different problem and
+has no GALA collection to suggest.

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -58,6 +58,7 @@ rather than inventing an example — trust the notice at the top of the page.
 | `GALA-E0036` | Bare Go statement keyword is not part of GALA's surface | [GALA-E0036.md](GALA-E0036.md) |
 | `GALA-E0037` | Unshareable capture across a concurrency boundary | [GALA-E0037.md](GALA-E0037.md) |
 | `GALA-E0038` | Invalid string escape sequence | [GALA-E0038.md](GALA-E0038.md) |
+| `GALA-E0040` | Go slice or map type in an expression | [GALA-E0040.md](GALA-E0040.md) |
 
 ## Adding a new code
 

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1774,6 +1774,18 @@ gala_exec_test(
     deps = ["//strings"],
 )
 
+# Verification: every position where a Go slice or map type may be written
+# (the accept half of the GALA-E0040 rule)
+gala_exec_test(
+    name = "go_type_positions",
+    src = "go_type_positions.gala",
+    expected = "go_type_positions.out",
+    deps = [
+        "//collection_immutable",
+        "//go_interop",
+    ],
+)
+
 # Verification: immutable struct fields with Go slice types
 gala_exec_test(
     name = "immutable_slice_field",

--- a/examples/go_type_positions.gala
+++ b/examples/go_type_positions.gala
@@ -1,0 +1,80 @@
+package main
+
+import . "martianoff/gala/go_interop"
+import "martianoff/gala/collection_immutable"
+
+// Verification: every position where a Go slice or map type may legitimately be
+// written. Go slices and maps are an interop surface, not first-class GALA
+// types: they are valid wherever a TYPE is expected, and never inside an
+// expression (an explicit type argument on a call, or a conversion — both
+// GALA-E0040; a composite literal — GALA-E0007 / GALA-E0008).
+//
+// This example pins the ACCEPT half of that rule. Its counterpart, the reject
+// half, lives in internal/parser/go_type_in_expression_test.go.
+
+// Position: type alias.
+type Bytes []byte
+
+type Counts map[string]int
+
+// Position: struct field.
+type Box struct {
+    data []byte
+    seen map[string]int
+}
+
+// Position: interface method result.
+type Reader interface {
+    Read() []byte
+}
+
+// Position: function parameter and function return type.
+func widen(b []byte) []byte = b
+
+// Position: map as a parameter and as a return type.
+func passthrough(m map[string]int) map[string]int = m
+
+// Position: inside a func type (both as a parameter of the func type and as its
+// result), alongside an ordinary slice parameter.
+func apply(f func([]byte) string, b []byte) string = f(b)
+
+// Position: type argument of a GENERIC TYPE, in a signature. This is the row
+// most easily mistaken for the rejected shape — `HashMap[string, []byte]` is
+// fine here because a parameter list is a type position.
+func countEntries(m collection_immutable.HashMap[string, []byte]) int = m.Size()
+
+// Position: type argument of a generic type, as a return type.
+func emptyByteMap() collection_immutable.HashMap[string, []byte] =
+    collection_immutable.EmptyHashMap[string, Bytes]()
+
+type Holder struct {}
+
+// Position: method parameter and method return type.
+func (h Holder) take(xs []int) map[string]int = MapEmpty[string, int]()
+
+func main() {
+    // Position: val/var annotation.
+    val b []byte = ToBytes("hi")
+    var m map[string]int = MapEmpty[string, int]()
+
+    Println(ToString(widen(b)))
+    Println(MapLen(passthrough(m)))
+
+    // Position: lambda parameter annotation.
+    val decode = (xs []byte) => ToString(xs)
+    Println(apply(decode, ToBytes("lambda")))
+
+    // The alias makes the Go slice type nameable in an EXPRESSION — the type
+    // argument below sits in a call, where `[]byte` itself may not be written.
+    val aliased = collection_immutable.EmptyHashMap[string, Bytes]()
+    Println(aliased.Size())
+
+    val counts Counts = MapPut(MapEmpty[string, int](), "a", 1)
+    Println(MapLen(counts))
+
+    val boxed = Box{data: ToBytes("field"), seen: m}
+    Println(ToString(boxed.data))
+
+    Println(countEntries(emptyByteMap()))
+    Println(MapLen(Holder{}.take(SliceOf(1, 2, 3))))
+}

--- a/examples/go_type_positions.out
+++ b/examples/go_type_positions.out
@@ -1,0 +1,8 @@
+hi
+0
+lambda
+0
+1
+field
+0
+0

--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -345,6 +345,25 @@ const (
 	// output that does not compile. Validating the literal at its GALA position
 	// reports the offending escape in the file the user actually wrote.
 	CodeInvalidStringEscape ErrorCode = "GALA-E0038"
+
+	// E0040: a Go slice (`[]T`) or map (`map[K]V`) type was written inside an
+	// EXPRESSION — most often as an explicit type argument
+	// (`EmptyHashMap[string, []byte]()`), but also as a conversion
+	// (`[]byte(s)`) or a bare composite-literal type. Go slice and map types
+	// are an interop surface, not first-class GALA types: they may be written
+	// only where a TYPE is expected (function signature, struct field, `val`/
+	// `var` annotation, type alias — including as a type argument of a generic
+	// type in one of those positions). Expression position is not one of them,
+	// and the grammar reflects that: bracketed arguments after an expression
+	// are parsed as an expression list, which `[]T` is not.
+	//
+	// Without this code the failure surfaced as ANTLR's raw recovery message,
+	// `missing '{' at '('` — the parser had fallen back to the composite-literal
+	// alternative (`type '{' … '}'`), whose type does admit `[]T`, and then
+	// demanded the brace. That message named neither the offending type nor the
+	// rule, and pointed at the token after it, which sent readers looking for an
+	// unbalanced brace instead of the Go type they had written.
+	CodeGoTypeInExpression ErrorCode = "GALA-E0040"
 )
 
 // MultiError collects multiple GALA errors.

--- a/internal/parser/BUILD.bazel
+++ b/internal/parser/BUILD.bazel
@@ -17,12 +17,14 @@ go_test(
     srcs = [
         "bom_test.go",
         "empty_line_unicode_test.go",
+        "go_type_in_expression_test.go",
         "grammar_test.go",
         "parser_concurrent_test.go",
         "parser_test.go",
     ],
     embed = [":parser"],
     deps = [
+        "//galaerr",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/internal/parser/go_type_in_expression_test.go
+++ b/internal/parser/go_type_in_expression_test.go
@@ -1,0 +1,346 @@
+package parser
+
+import (
+	"errors"
+	"testing"
+
+	"martianoff/gala/galaerr"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// firstSemanticError returns the single coded diagnostic in err, requiring that
+// exactly one error was reported. The count matters: ANTLR recovers from the
+// failure by inserting the brace it wanted and re-reports the rest of the file
+// against the same composite literal, so a second error here means the cascade
+// suppression regressed and the user is back to reading invented brace errors.
+func firstSemanticError(t *testing.T, err error) *galaerr.SemanticError {
+	t.Helper()
+	require.Error(t, err)
+
+	var multi *galaerr.MultiError
+	require.True(t, errors.As(err, &multi), "expected a MultiError, got %T", err)
+	require.Len(t, multi.Errors, 1, "expected exactly one diagnostic, got: %v", multi.Errors)
+
+	var se *galaerr.SemanticError
+	require.True(t, errors.As(multi.Errors[0], &se), "expected a SemanticError, got %v", multi.Errors[0])
+	return se
+}
+
+// TestGoTypeInExpressionDiagnostic pins GALA-E0040: a Go slice or map type
+// written in expression position is rejected with a coded diagnostic that names
+// the offending type, points at it, and states the GALA spelling.
+//
+// The rejection itself is not new — every input here was already a compile
+// error. What is asserted is the message, which used to be ANTLR's raw
+// "missing '{' at '('": no code, no named type, and a position on the token
+// AFTER the offending one.
+func TestGoTypeInExpressionDiagnostic(t *testing.T) {
+	p := NewAntlrGalaParser()
+
+	tests := []struct {
+		name string
+		// input is a whole source file so the reported line/column can be
+		// asserted against real coordinates rather than an offset into a
+		// fragment.
+		input      string
+		wantMsg    string
+		wantLine   int
+		wantColumn int // 0-based, as stored
+		wantEndCol int
+		wantHint   string
+	}{
+		{
+			name: "slice type as an explicit type argument",
+			input: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    val m = EmptyHashMap[string, []byte]()
+    Println(m.Size())
+}`,
+			wantMsg:    "Go slice type []byte is not allowed in an expression",
+			wantLine:   6,
+			wantColumn: 33,
+			wantEndCol: 39,
+			wantHint:   "use Array[byte], or string for text, instead; Go slice and map types are an interop surface, allowed only where a type is expected: a function signature, a struct field, a val/var annotation, or a type alias",
+		},
+		{
+			name: "non-byte slice type as an explicit type argument",
+			input: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    val m = EmptyHashMap[string, []int]()
+    Println(m.Size())
+}`,
+			wantMsg:    "Go slice type []int is not allowed in an expression",
+			wantLine:   6,
+			wantColumn: 33,
+			wantEndCol: 38,
+			wantHint:   "use Array[int] instead; Go slice and map types are an interop surface, allowed only where a type is expected: a function signature, a struct field, a val/var annotation, or a type alias",
+		},
+		{
+			name: "map type as an explicit type argument",
+			input: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    val m = EmptyHashMap[string, map[string]int]()
+    Println(m.Size())
+}`,
+			wantMsg:    "Go map type map[string]int is not allowed in an expression",
+			wantLine:   6,
+			wantColumn: 33,
+			wantEndCol: 47,
+			wantHint:   "use HashMap[string, int] instead; Go slice and map types are an interop surface, allowed only where a type is expected: a function signature, a struct field, a val/var annotation, or a type alias",
+		},
+		{
+			name: "slice type as an explicit type argument on a method call",
+			input: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    val a = ArrayOf(1, 2, 3)
+    val b = a.Map[[]byte]((x) => nil)
+    Println(b.Size())
+}`,
+			wantMsg:    "Go slice type []byte is not allowed in an expression",
+			wantLine:   7,
+			wantColumn: 18,
+			wantEndCol: 24,
+			wantHint:   "use Array[byte], or string for text, instead; Go slice and map types are an interop surface, allowed only where a type is expected: a function signature, a struct field, a val/var annotation, or a type alias",
+		},
+		{
+			name: "slice type used as a conversion",
+			input: `package main
+
+func main() {
+    val b = []byte("hi")
+    Println(b)
+}`,
+			wantMsg:    "Go slice type []byte is not allowed in an expression",
+			wantLine:   4,
+			wantColumn: 12,
+			wantEndCol: 18,
+			wantHint:   "use Array[byte], or string for text, instead; Go slice and map types are an interop surface, allowed only where a type is expected: a function signature, a struct field, a val/var annotation, or a type alias",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := p.Parse(tt.input)
+			se := firstSemanticError(t, err)
+
+			assert.Equal(t, galaerr.CodeGoTypeInExpression, se.Code)
+			assert.Equal(t, tt.wantMsg, se.Msg)
+			assert.Equal(t, tt.wantHint, se.Hint)
+			assert.Equal(t, tt.wantLine, se.Line)
+			assert.Equal(t, tt.wantColumn, se.Column)
+			assert.Equal(t, tt.wantEndCol, se.EndColumn, "caret should span the offending type exactly")
+		})
+	}
+}
+
+// TestGoTypeInExpressionLeavesLegalPositionsAlone is the accept half of the
+// accept/reject set: every position where a Go slice or map type is legitimate
+// must still parse. E0040 lives in the error listener, so a mis-scoped gate
+// would show up here as a parse error on code that has always been valid.
+func TestGoTypeInExpressionLeavesLegalPositionsAlone(t *testing.T) {
+	p := NewAntlrGalaParser()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "function parameter and return type",
+			input: `package main
+
+func total(xs []int) []int = xs`,
+		},
+		{
+			name: "struct field",
+			input: `package main
+
+type Box struct {
+    data []byte
+    seen map[string]int
+}`,
+		},
+		{
+			name: "val and var annotations",
+			input: `package main
+
+func main() {
+    val b []byte = nil
+    var m map[string]int = nil
+    Println(b, m)
+}`,
+		},
+		{
+			name: "type alias",
+			input: `package main
+
+type Bytes []byte
+
+type EntryMap map[string]int`,
+		},
+		{
+			name: "lambda parameter annotation",
+			input: `package main
+
+func main() {
+    val f = (xs []int) => xs
+    Println(f)
+}`,
+		},
+		{
+			name: "type argument of a generic type in a signature",
+			input: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+func take(m HashMap[string, []byte]) HashMap[string, []byte] = m`,
+		},
+		{
+			name: "type argument of a generic type in a struct field",
+			input: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+type Wrap struct {
+    m HashMap[string, []byte]
+}`,
+		},
+		{
+			name: "slice inside a func type",
+			input: `package main
+
+func apply(f func([]byte) string, b []byte) string = f(b)`,
+		},
+		{
+			name: "method parameter and interface method result",
+			input: `package main
+
+type Holder struct {}
+
+func (h Holder) take(xs []int) map[string]int = nil
+
+type Reader interface {
+    Read() []byte
+}`,
+		},
+		{
+			name: "variadic parameter",
+			input: `package main
+
+func total(xs ...int) int = 0`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := p.Parse(tt.input)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestGoTypeInExpressionDoesNotSwallowOtherSyntaxErrors is the reject half:
+// unrelated malformed input must keep producing its own syntax error, uncoded,
+// rather than being relabelled as a Go type in expression position.
+func TestGoTypeInExpressionDoesNotSwallowOtherSyntaxErrors(t *testing.T) {
+	p := NewAntlrGalaParser()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "unclosed call argument list",
+			input: `package main
+
+func main() {
+    Println("ok"
+}`,
+		},
+		{
+			name: "stray closing brace at top level",
+			input: `package main
+
+func main() {
+    Println("ok")
+}
+}`,
+		},
+		{
+			name: "empty explicit type argument",
+			input: `package main
+
+import . "martianoff/gala/collection_immutable"
+
+func main() {
+    val m = EmptyHashMap[string, ]()
+    Println("ok")
+}`,
+		},
+		{
+			name: "slice literal with an unterminated element list",
+			input: `package main
+
+func main() {
+    val xs = []int{1, 2,
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := p.Parse(tt.input)
+			require.Error(t, err)
+
+			var multi *galaerr.MultiError
+			require.True(t, errors.As(err, &multi))
+			for _, sub := range multi.Errors {
+				var se *galaerr.SemanticError
+				if errors.As(sub, &se) {
+					assert.NotEqual(t, galaerr.CodeGoTypeInExpression, se.Code,
+						"unrelated syntax error was relabelled as GALA-E0040: %v", sub)
+				}
+			}
+		})
+	}
+}
+
+// TestSliceLiteralStillReachesTheAnalyzer guards the boundary between E0040 and
+// GALA-E0007. A well-formed slice literal PARSES — it is rejected later, by the
+// analyzer, with the literal-specific code. E0040 must not intercept it, or the
+// user gets a message about type positions for a construct whose real problem
+// is the literal itself.
+func TestSliceLiteralStillReachesTheAnalyzer(t *testing.T) {
+	p := NewAntlrGalaParser()
+
+	for _, src := range []string{
+		`package main
+
+func main() {
+    val xs = []int{1, 2, 3}
+    Println(xs)
+}`,
+		`package main
+
+func main() {
+    val m = map[string]int{}
+    Println(m)
+}`,
+	} {
+		_, err := p.Parse(src)
+		assert.NoError(t, err, "literal should parse; rejection belongs to the analyzer")
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,7 +1,9 @@
 package parser
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 	"sync"
 
 	"martianoff/gala/galaerr"
@@ -221,8 +223,146 @@ func runeSpan(is *antlr.InputStream, start, end int) (string, bool) {
 type GalaErrorListener struct {
 	*antlr.DefaultErrorListener
 	Errors []error
+
+	// reportedGoType is the composite-literal context a GALA-E0040 has already
+	// been reported for, if any. See SyntaxError for why it is remembered.
+	reportedGoType *grammar.CompositeLiteralContext
 }
 
 func (l *GalaErrorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{}, line, column int, msg string, e antlr.RecognitionException) {
+	lit := currentCompositeLiteral(recognizer)
+
+	// Cascade suppression. Once E0040 is reported, ANTLR recovers by INSERTING
+	// the '{' it wanted and carries on parsing the rest of the file as that
+	// literal's element list, so every following token is re-reported against
+	// the same context ("mismatched input 'Println' expecting {',', '}'}").
+	// Those follow-ups describe a brace the user never wrote. Keyed on context
+	// identity, so an unrelated error elsewhere in the file is untouched.
+	if lit != nil && lit == l.reportedGoType {
+		return
+	}
+
+	if err := goTypeInExpressionError(lit); err != nil {
+		l.reportedGoType = lit
+		l.Errors = append(l.Errors, err)
+		return
+	}
+
 	l.Errors = append(l.Errors, galaerr.NewSyntaxError(line, column, msg))
+}
+
+// currentCompositeLiteral returns the rule the parser was inside when it
+// reported an error, if that rule is a compositeLiteral. Any other rule — and
+// any non-parser recognizer, i.e. the lexer — yields nil.
+func currentCompositeLiteral(recognizer antlr.Recognizer) *grammar.CompositeLiteralContext {
+	psr, ok := recognizer.(antlr.Parser)
+	if !ok {
+		return nil
+	}
+	lit, _ := psr.GetParserRuleContext().(*grammar.CompositeLiteralContext)
+	return lit
+}
+
+// goTypeInExpressionError turns the parse failure behind ANTLR's
+// "missing '{' at …" into GALA-E0040 when — and only when — its cause is a Go
+// slice or map type written in expression position. It returns nil for every
+// other failure, so the raw syntax error still reaches the user unchanged.
+//
+// The gate is structural rather than message-based, because ANTLR's recovery
+// wording is not part of any contract:
+//
+//   - the innermost rule is `compositeLiteral` (`type ('{' … '}')`). The parser
+//     only lands there for a bracketed expression when the bracket contents are
+//     not an expression list, which for `f[…](…)` means a type the expression
+//     grammar cannot spell;
+//   - that context has exactly one child, the `type` — so the parse died at the
+//     '{' slot, before consuming a brace. A malformed but genuine composite
+//     literal (`[]int{1, 2,`) has consumed its brace by the time it fails and
+//     is left to the ordinary syntax error;
+//   - and that `type` actually contains a Go slice or map type. Without this
+//     the code would fire on a func type, which is a different problem.
+func goTypeInExpressionError(lit *grammar.CompositeLiteralContext) error {
+	if lit == nil || lit.GetChildCount() != 1 {
+		return nil
+	}
+	typeCtx := lit.Type_()
+	if typeCtx == nil {
+		return nil
+	}
+	offender := findGoSliceOrMapType(typeCtx)
+	if offender == nil {
+		return nil
+	}
+
+	start := offender.GetStart()
+	stop := offender.GetStop()
+	if start == nil {
+		return nil
+	}
+
+	text := offender.GetText()
+	kind := "slice"
+	if strings.HasPrefix(text, "map[") {
+		kind = "map"
+	}
+
+	err := galaerr.NewCodedSemanticError(
+		galaerr.CodeGoTypeInExpression,
+		start.GetLine(),
+		start.GetColumn(),
+		fmt.Sprintf("Go %s type %s is not allowed in an expression", kind, text),
+		// The suggestion leads and is separated by "; " so the renderer's
+		// terse caret annotation — which cuts the hint at its first clause —
+		// shows the replacement rather than a truncated rule.
+		galaTypeSuggestion(offender, text)+"; Go slice and map types are an interop surface, allowed only where a type is expected: a function signature, a struct field, a val/var annotation, or a type alias",
+	)
+
+	// Span the offending type exactly, so the caret covers `[]byte` rather
+	// than the single token the renderer would otherwise scan out. Only when
+	// the type sits on one line; a multi-line type leaves the span unset and
+	// falls back to that scan.
+	if stop != nil && stop.GetLine() == start.GetLine() {
+		err = err.WithSpan(start.GetColumn() + len([]rune(text)))
+	}
+	return err
+}
+
+// galaTypeSuggestion spells the offending Go type the GALA way, so the message
+// leaves the reader with the replacement and not just the prohibition.
+func galaTypeSuggestion(offender grammar.ITypeContext, text string) string {
+	args := offender.AllType_()
+	switch {
+	case strings.HasPrefix(text, "map[") && len(args) >= 2:
+		return fmt.Sprintf("use HashMap[%s, %s] instead", args[0].GetText(), args[1].GetText())
+	case strings.HasPrefix(text, "[]") && len(args) >= 1:
+		// A byte slice is GALA's `string` far more often than it is a
+		// collection of numbers, so name both rather than send text handling
+		// through Array[byte].
+		if args[0].GetText() == "byte" {
+			return "use Array[byte], or string for text, instead"
+		}
+		return fmt.Sprintf("use Array[%s] instead", args[0].GetText())
+	}
+	return "use a GALA collection type (Array/HashMap) instead"
+}
+
+// findGoSliceOrMapType returns the first Go slice or map type at or below node,
+// in source order, or nil when there is none. Searching the whole subtree is
+// what lets the outer type be an ordinary generic — the offender in
+// `EmptyHashMap[string, []byte]` is the type argument, not the literal's type.
+func findGoSliceOrMapType(node antlr.Tree) grammar.ITypeContext {
+	if node == nil {
+		return nil
+	}
+	if ty, ok := node.(*grammar.TypeContext); ok {
+		if txt := ty.GetText(); strings.HasPrefix(txt, "[]") || strings.HasPrefix(txt, "map[") {
+			return ty
+		}
+	}
+	for _, child := range node.GetChildren() {
+		if found := findGoSliceOrMapType(child); found != nil {
+			return found
+		}
+	}
+	return nil
 }

--- a/internal/transpiler/transformer/error_codes_test.go
+++ b/internal/transpiler/transformer/error_codes_test.go
@@ -406,6 +406,35 @@ func main() {
 			expectCode:     galaerr.CodeUntypedParam,
 			expectContains: `parameter "X" has no declared type`,
 		},
+		{
+			// GALA-E0040 is the one code in this table raised during PARSING
+			// rather than analysis, so it also pins that a coded parse-phase
+			// diagnostic survives the pipeline with its code intact.
+			name: "GALA-E0040 Go slice type as an explicit type argument",
+			input: `package main
+
+import "martianoff/gala/collection_immutable"
+
+func main() {
+    val m = collection_immutable.EmptyHashMap[string, []byte]()
+    Println(m.Size())
+}`,
+			expectCode:     galaerr.CodeGoTypeInExpression,
+			expectContains: "Go slice type []byte is not allowed in an expression",
+		},
+		{
+			name: "GALA-E0040 Go map type as an explicit type argument",
+			input: `package main
+
+import "martianoff/gala/collection_immutable"
+
+func main() {
+    val m = collection_immutable.EmptyHashMap[string, map[string]int]()
+    Println(m.Size())
+}`,
+			expectCode:     galaerr.CodeGoTypeInExpression,
+			expectContains: "use HashMap[string, int] instead",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/transpiler/transformer/error_docs_guard_test.go
+++ b/internal/transpiler/transformer/error_docs_guard_test.go
@@ -400,6 +400,36 @@ func main() {
 			code:   galaerr.CodeInvalidStringEscape, // GALA-E0038
 			render: renderEscapeVariant(`val s = "it\'s"`),
 		},
+		{
+			name: "Go slice type as an explicit type argument",
+			code: galaerr.CodeGoTypeInExpression, // GALA-E0040
+			render: func(t *testing.T) string {
+				return renderRepro(t, "typearg.gala", `package main
+
+import "martianoff/gala/collection_immutable"
+
+func main() {
+    val m = collection_immutable.EmptyHashMap[string, []byte]()
+    Println(m.Size())
+}
+`)
+			},
+		},
+		{
+			name: "Go map type as an explicit type argument",
+			code: galaerr.CodeGoTypeInExpression, // GALA-E0040
+			render: func(t *testing.T) string {
+				return renderRepro(t, "maparg.gala", `package main
+
+import "martianoff/gala/collection_immutable"
+
+func main() {
+    val m = collection_immutable.EmptyHashMap[string, map[string]int]()
+    Println(m.Size())
+}
+`)
+			},
+		},
 		// The GALA-E0038 page also documents the rune-literal shape in prose
 		// (`'\d'`), but quotes no output for it, so there is nothing to pin.
 		// Its numeric forms (`'\x41'`) are not guardable here at all: GALA's

--- a/internal/transpiler/transpiler.go
+++ b/internal/transpiler/transpiler.go
@@ -432,7 +432,11 @@ func (t *GalaToGoTranspiler) Transpile(input string, filePath string) (string, e
 	tree, err := t.parser.Parse(input)
 	done()
 	if err != nil {
-		return "", err
+		// Same stamping the analyze phase does below: a coded parse-phase
+		// diagnostic carries a position but not the file it came from, and the
+		// CLI renderer needs the path to re-read the source for its snippet.
+		// Uncoded ANTLR syntax errors are not SemanticErrors and are untouched.
+		return "", galaerr.WithFilePath(err, filePath)
 	}
 
 	done = prof.Phase("analyze")


### PR DESCRIPTION
## Summary

Fixes **FIX-008**: writing a Go slice or map type in an *expression* position produced an unusable diagnostic, and the documentation stated the positional rule both incompletely and incorrectly.

**Category**: DOC_GAP + USABILITY (diagnostic)
**Priority**: P2

This is the follow-up to **#460, which was closed as INVALID**. That PR tried to make `EmptyHashMap[string, []byte]()` *compile*. It should not, and it still does not. This PR changes only the message and the docs.

Before:

```
error: missing '{' at '('
```

No code, no file, no line, no caret, no hint — and pointing at the wrong token. A user then consulted `docs/GALA.MD:2176` ("Slice types are still valid in function signatures and struct fields"), concluded the compiler was wrong, and wrote #460. That path is reproducible by anyone.

## The documentation was wrong, in the permissive direction

The positional rule was established empirically across ~96 scratch modules under full `gala build`, not inferred from the docs. **It is not "signatures and struct fields" — it is type context vs. expression context.**

**Accepted — every position where a type is expected:**

| Position | Slice | Map |
|---|---|---|
| Function / method parameter | yes | yes |
| Function / method return type | yes | yes |
| Struct field | yes | yes |
| Interface method result | yes | yes |
| `val` / `var` annotation | yes | yes |
| Lambda parameter annotation | yes | yes |
| Type alias (`type Bytes []byte`) | yes | yes |
| Inside a `func` type (`func([]byte) string`) | yes | yes |
| Nested (`[][]int`) | yes | n/a |
| **Type argument of a generic type, in any of the above** | **yes** | **yes** |

**Rejected — expression positions:** explicit type argument on a call (function, method, constructor), conversion (`[]byte(s)`), composite literal (`[]int{…}` → E0007 / E0008).

So line 2176 named two positions where eight-plus are legal. The last row is the one that matters: `func take(m HashMap[string, []byte])` compiles today as a parameter type, field type, `val` annotation and type alias — while the identical text after `EmptyHashMap` does not, because that is an expression. **Nothing in the docs distinguished those two**, which is exactly the gap #460 fell into.

The design rule is unchanged and now stated plainly: Go slices and maps are an interop surface for *naming* shapes at a Go boundary, not first-class GALA types. `Array[T]` / `HashMap[K,V]` remain the answer for everything else.

## A shipped doc example never compiled

`docs/GALA.MD` §Maps presented `var headers = MapEmpty[string, []string]()` as *the canonical Go-map interop example*. That is precisely the rejected shape — the docs were shipping the construct they forbid elsewhere. The new diagnostic catches it. Fixed to use a `type StrList []string` alias.

## Implementation: Option B, no grammar change

The grammar already explains the failure: `postfixSuffix: '[' expressionList ']'` parses bracketed arguments after an expression as *expressions*, which `[]byte` is not; the only surviving alternative is `compositeLiteral: type ('{' … '}')` — whose `type` **does** admit a slice — so the parser consumes the type and then demands the brace.

That yields an exact structural signature in the error listener: innermost rule is `compositeLiteral`, child count 1 (only the type consumed, so the parse died at the brace slot rather than inside a real literal), and the type subtree contains a slice or map. **No message-string matching and no grammar edit** — so none of #460's 594 `postfixSuffix` ambiguity reports and none of its ~10% parse-time cost. Follow-on errors from the same literal are suppressed by context identity, since ANTLR inserts the brace and re-reports the rest of the file as element-list garbage.

Files: `internal/parser/parser.go` (the single parser-error file), plus a one-line `galaerr.WithFilePath` stamp on the parse-error return in `internal/transpiler/transpiler.go` — without it the CLI renderer has no path from which to read source for the snippet. That stamp touches only `*SemanticError`, so uncoded ANTLR syntax errors are byte-identical.

## Error code: GALA-E0040

Master's highest is E0038. **E0039 is taken on the unmerged `fix/FIX-003-bare-variant-pattern-binds` (#458)** — verified by listing `docs/errors/` on that remote branch rather than only on master — so this took the next free number.

## The accept/reject set is unchanged, and that was verified rather than asserted

96 scratch modules covering every candidate position, plus deliberate controls (unclosed call, stray brace, empty type argument, unterminated slice literal), run under **both** the released 0.72.2 CLI and the branch CLI and compared verdict-by-verdict: **0 differences**.

Three test layers pin it:
- the diagnostic's exact code, message, hint, line, column and span
- an accept suite over all legal positions
- a reject suite asserting unrelated syntax errors keep their own messages

`docs/errors/GALA-E0040.md` is machine-checked by `error_docs_guard_test.go` (two rows). All eight remediation snippets in the docs were compile-verified. New `examples/go_type_positions` exercises all nine legal positions end-to-end.

`bazel test //...` — 388/389; the one failure is the known-benign `TestGorootFromGoBinarySymlink` (Windows symlink privilege).

## Not in this PR

`docs/private/BUG_SLICE_TYPE_IN_EXPLICIT_TYPE_ARGS.md` is gitignored (`.gitignore:135`), so its updated version — original analysis intact beneath a clearly-marked `STATUS: REJECTED AS INVALID` section — cannot be committed. It has been copied into the main checkout separately.

## Dependencies

None — branches from `master`. Coordinates with #458 only on error-code numbering.

## Report Reference

Reclassified from **BUG-KV-1** in `docs/private/gala-kv-findings/REPORT.md`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aZRWH39EXTXVALyxALJut
