### PR TITLE
fix(analyzer): Go func returning a GALA type emitted "invalid type" into generated source

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -110,6 +110,16 @@ gala_exec_test(
 )
 
 gala_exec_test(
+    name = "go_generic_option_lambda_return",
+    src = "go_generic_option_lambda_return.gala",
+    expected = "go_generic_option_lambda_return.out",
+    deps = [
+        "//go_interop",
+        "//resource",
+    ],
+)
+
+gala_exec_test(
     name = "tco_factorial",
     src = "tco_factorial.gala",
     expected = "tco_factorial.out",

--- a/examples/go_generic_option_lambda_return.gala
+++ b/examples/go_generic_option_lambda_return.gala
@@ -1,0 +1,38 @@
+package main
+
+import "martianoff/gala/go_interop"
+import . "martianoff/gala/resource"
+
+// `resource.WithLock(mu, () => …)` is the prescribed way to hold a mutex, and
+// `go_interop.OptionFromMap` is the sanctioned nil-safe bridge for reading a
+// possibly-nil Go map into an Option. Composing them is the obvious way to write
+// a locked map read.
+//
+// OptionFromMap is a Go generic returning a GALA std sealed type
+// (`std.Option[V]`), so a lambda over it forces the transpiler to write that
+// return type down. It used to emit unparseable Go and abort the build.
+
+func apply[A any](body func() A) A = body()
+
+func main() {
+    val mu = go_interop.NewMutex()
+    val m = go_interop.MapPut(go_interop.MapEmpty[string, int](), "k", 7)
+
+    // The documented lock-combinator idiom
+    Println(WithLock(mu, () => go_interop.OptionFromMap(m, "k")))
+    Println(WithLock(mu, () => go_interop.OptionFromMap(m, "missing")))
+
+    // Bare lambda, no combinator
+    val look = () => go_interop.OptionFromMap(m, "k")
+    Println(look())
+
+    // Routed through a user generic combinator
+    Println(apply(() => go_interop.OptionFromMap(m, "missing")))
+
+    // The recovered type must be a real Option[int], not an opaque value:
+    // pattern matching over it has to bind a concrete `v`.
+    apply(() => go_interop.OptionFromMap(m, "k")) match {
+        case Some(v) => Println(s"found ${v}")
+        case None()  => Println("absent")
+    }
+}

--- a/examples/go_generic_option_lambda_return.out
+++ b/examples/go_generic_option_lambda_return.out
@@ -1,0 +1,5 @@
+Some(7)
+None()
+Some(7)
+None()
+found 7

--- a/examples/multifile_lib_regress/go_interop.gala
+++ b/examples/multifile_lib_regress/go_interop.gala
@@ -95,3 +95,25 @@ func GoGenericLambdaViaCombinator(extra int) int {
 }
 
 func applyThunk[A any](body func() A) A = body()
+
+// --- Regression: a Go generic whose return type is a GALA type.
+//
+// `go_interop.OptionFromMap[K, V](m map[K]V, key K) std.Option[V]` is the only
+// go_interop function returning a GALA std sealed type. `std.Option` exists as Go
+// only after the std package is transpiled, but the analyzer type-checks
+// hand-written .go against the UN-transpiled tree, so go/types resolved that
+// return to Invalid. The transpiler then wrote go/types' display string for it
+// into the lambda's result clause — `func() invalid type` — which is not even
+// parseable Go, so the build aborted with an internal error naming no user
+// construct.
+//
+// The recovered type must be a genuine Option[int]: matching over the result and
+// binding `v` proves the type argument survived, not just that the file compiled.
+func GoGenericOptionLambda(key string) string {
+    val m = go_interop.MapPut(go_interop.MapEmpty[string, int](), "k", 7)
+    val look = () => go_interop.OptionFromMap(m, key)
+    return applyThunk(look) match {
+        case Some(v) => s"found ${v}"
+        case None()  => "absent"
+    }
+}

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -398,6 +398,12 @@ func main() {
     Println(multifile_lib_regress.GoGenericLambdaMapSize("k", 7))
     Println(multifile_lib_regress.GoGenericLambdaSliceSize(4))
     Println(multifile_lib_regress.GoGenericLambdaViaCombinator(9))
+    // Same path, but the Go generic returns a GALA std type (Option[V]) that
+    // go/types cannot resolve against the un-transpiled tree. It must be
+    // recovered as a concrete Option[int], not degraded to `any` or to
+    // go/types' unparseable "invalid type" display string.
+    Println(multifile_lib_regress.GoGenericOptionLambda("k"))
+    Println(multifile_lib_regress.GoGenericOptionLambda("nope"))
 
     Println(multifile_lib_regress.ScopeReport(1))
     Println(multifile_lib_regress.ScopeLambdaCapture(3))

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -87,6 +87,8 @@ ledger=nina/ledger:nina
 1
 4
 3
+found 7
+absent
 scope:dana:v2,v3,v4:ok
 5
 gamma

--- a/internal/transpiler/analyzer/go_types.go
+++ b/internal/transpiler/analyzer/go_types.go
@@ -392,10 +392,243 @@ func AnalyzeGoFiles(dirPath string) *transpiler.GoTypeInfo {
 	}
 
 	extractPackageInfo(pkg, info)
+	repairUnresolvedSignatures(files, pkg.Name(), info)
 	goFilesCache.mu.Lock()
 	goFilesCache.cache[dirPath] = info
 	goFilesCache.mu.Unlock()
 	return info
+}
+
+// repairUnresolvedSignatures recovers signature slots go/types could not resolve
+// from the type as it is WRITTEN in the source.
+//
+// A hand-written .go file in a GALA package may name a GALA-defined type — e.g.
+// `func OptionFromMap[K comparable, V any](m map[K]V, key K) std.Option[V]`. That
+// type only exists as Go once the GALA package has been transpiled, but this
+// analysis deliberately runs against the un-transpiled tree (.gen.go files are
+// skipped so metadata comes from the .gala source). go/types therefore resolves
+// the reference to Invalid while the rest of the signature — including the type
+// parameters — resolves normally.
+//
+// Left alone, that unresolved slot degrades to `any` and silently erases a
+// concrete type. The AST still says `std.Option[V]`, and the file's import list
+// says which package `std` is, which together are exactly the GenericType the rest
+// of the pipeline needs. Recovery is therefore syntactic.
+//
+// Nothing here is specific to std, or even to GALA: any Go signature naming a type
+// the checker could not load is recovered the same way, and slots go/types DID
+// resolve are never touched.
+func repairUnresolvedSignatures(files []*ast.File, pkgName string, info *transpiler.GoTypeInfo) {
+	for _, f := range files {
+		imports := fileImportPaths(f)
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Recv != nil || fd.Type == nil || !fd.Name.IsExported() {
+				continue
+			}
+			sig := info.Functions[pkgName+"."+fd.Name.Name]
+			if sig == nil {
+				continue
+			}
+			typeParams := funcDeclTypeParams(fd)
+
+			astParams := flattenFieldTypes(fd.Type.Params)
+			for i := range sig.Params {
+				if i >= len(astParams) || !isUnresolvedType(sig.Params[i].Type) {
+					continue
+				}
+				if rec := syntacticGoType(astParams[i], imports, pkgName, typeParams); !rec.IsNil() {
+					sig.Params[i].Type = rec
+				}
+			}
+
+			astResults := flattenFieldTypes(fd.Type.Results)
+			for i := range sig.Returns {
+				if i >= len(astResults) || !isUnresolvedType(sig.Returns[i]) {
+					continue
+				}
+				if rec := syntacticGoType(astResults[i], imports, pkgName, typeParams); !rec.IsNil() {
+					sig.Returns[i] = rec
+				}
+			}
+		}
+	}
+}
+
+// isUnresolvedType reports whether a converted signature slot carries an
+// unresolved type anywhere inside it. goTypeToTranspilerType maps go/types'
+// Invalid to NilType precisely so this check has something to key on.
+//
+// The check must recurse: go/types resolves `[]box.Box[T]` to a slice whose
+// ELEMENT is Invalid, so a top-level-only test would leave `[]<nothing>` in place.
+func isUnresolvedType(t transpiler.Type) bool {
+	if t == nil || t.IsNil() {
+		return true
+	}
+	switch v := t.(type) {
+	case transpiler.ArrayType:
+		return isUnresolvedType(v.Elem)
+	case transpiler.PointerType:
+		return isUnresolvedType(v.Elem)
+	case transpiler.MapType:
+		return isUnresolvedType(v.Key) || isUnresolvedType(v.Elem)
+	case transpiler.GenericType:
+		if isUnresolvedType(v.Base) {
+			return true
+		}
+		for _, p := range v.Params {
+			if isUnresolvedType(p) {
+				return true
+			}
+		}
+	case transpiler.FuncType:
+		for _, p := range v.Params {
+			if isUnresolvedType(p) {
+				return true
+			}
+		}
+		for _, r := range v.Results {
+			if isUnresolvedType(r) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// fileImportPaths maps the name a file refers to each import by (its alias, or the
+// last path segment) to that import's path.
+func fileImportPaths(f *ast.File) map[string]string {
+	out := make(map[string]string, len(f.Imports))
+	for _, imp := range f.Imports {
+		if imp.Path == nil {
+			continue
+		}
+		path := strings.Trim(imp.Path.Value, `"`)
+		name := path
+		if idx := strings.LastIndex(name, "/"); idx != -1 {
+			name = name[idx+1:]
+		}
+		if imp.Name != nil && imp.Name.Name != "" && imp.Name.Name != "_" && imp.Name.Name != "." {
+			name = imp.Name.Name
+		}
+		out[name] = path
+	}
+	return out
+}
+
+// funcDeclTypeParams returns the declaration's type-parameter names as a set, so
+// syntactic recovery can tell `V` (a type parameter) from a local type name.
+func funcDeclTypeParams(fd *ast.FuncDecl) map[string]bool {
+	if fd.Type == nil || fd.Type.TypeParams == nil {
+		return nil
+	}
+	out := make(map[string]bool)
+	for _, field := range fd.Type.TypeParams.List {
+		for _, name := range field.Names {
+			out[name.Name] = true
+		}
+	}
+	return out
+}
+
+// flattenFieldTypes expands a parameter/result list into one AST type per slot,
+// repeating the type for grouped names (`a, b int` is two slots). This makes the
+// result index-aligned with GoFuncSignature's flat Params/Returns.
+func flattenFieldTypes(fl *ast.FieldList) []ast.Expr {
+	if fl == nil {
+		return nil
+	}
+	var out []ast.Expr
+	for _, field := range fl.List {
+		n := len(field.Names)
+		if n == 0 {
+			n = 1
+		}
+		for i := 0; i < n; i++ {
+			out = append(out, field.Type)
+		}
+	}
+	return out
+}
+
+// syntacticGoType converts a Go type expression to a transpiler.Type using only
+// syntax plus the file's import table — no go/types resolution. Returns NilType for
+// any shape it cannot represent, so callers can leave the original slot alone.
+func syntacticGoType(expr ast.Expr, imports map[string]string, pkgName string, typeParams map[string]bool) transpiler.Type {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		if typeParams[e.Name] || transpiler.IsPrimitiveType(e.Name) || e.Name == "any" || e.Name == "error" {
+			return transpiler.BasicType{Name: e.Name}
+		}
+		return transpiler.NamedType{Package: pkgName, Name: e.Name}
+
+	case *ast.SelectorExpr:
+		x, ok := e.X.(*ast.Ident)
+		if !ok {
+			return transpiler.NilType{}
+		}
+		return transpiler.NamedType{Package: x.Name, Name: e.Sel.Name, ImportPath: imports[x.Name]}
+
+	case *ast.ParenExpr:
+		return syntacticGoType(e.X, imports, pkgName, typeParams)
+
+	case *ast.Ellipsis:
+		// convertSignature stores a variadic parameter element-wise, so `...T`
+		// recovers as T to stay index-aligned with it.
+		return syntacticGoType(e.Elt, imports, pkgName, typeParams)
+
+	case *ast.StarExpr:
+		elem := syntacticGoType(e.X, imports, pkgName, typeParams)
+		if elem.IsNil() {
+			return transpiler.NilType{}
+		}
+		return transpiler.PointerType{Elem: elem}
+
+	case *ast.ArrayType:
+		elem := syntacticGoType(e.Elt, imports, pkgName, typeParams)
+		if elem.IsNil() {
+			return transpiler.NilType{}
+		}
+		return transpiler.ArrayType{Elem: elem}
+
+	case *ast.MapType:
+		key := syntacticGoType(e.Key, imports, pkgName, typeParams)
+		val := syntacticGoType(e.Value, imports, pkgName, typeParams)
+		if key.IsNil() || val.IsNil() {
+			return transpiler.NilType{}
+		}
+		return transpiler.MapType{Key: key, Elem: val}
+
+	case *ast.IndexExpr:
+		return syntacticGenericType(e.X, []ast.Expr{e.Index}, imports, pkgName, typeParams)
+
+	case *ast.IndexListExpr:
+		return syntacticGenericType(e.X, e.Indices, imports, pkgName, typeParams)
+
+	case *ast.InterfaceType:
+		if e.Methods == nil || len(e.Methods.List) == 0 {
+			return transpiler.BasicType{Name: "any"}
+		}
+	}
+	return transpiler.NilType{}
+}
+
+// syntacticGenericType builds a GenericType for `Base[Args...]`.
+func syntacticGenericType(base ast.Expr, args []ast.Expr, imports map[string]string, pkgName string, typeParams map[string]bool) transpiler.Type {
+	baseType := syntacticGoType(base, imports, pkgName, typeParams)
+	if baseType.IsNil() {
+		return transpiler.NilType{}
+	}
+	params := make([]transpiler.Type, 0, len(args))
+	for _, arg := range args {
+		p := syntacticGoType(arg, imports, pkgName, typeParams)
+		if p.IsNil() {
+			return transpiler.NilType{}
+		}
+		params = append(params, p)
+	}
+	return transpiler.GenericType{Base: baseType, Params: params}
 }
 
 // extractPackageInfo extracts all exported type information from a types.Package.
@@ -704,6 +937,15 @@ func goTypeToTranspilerType(t types.Type) transpiler.Type {
 	switch t := t.(type) {
 	case *types.Basic:
 		name := t.Name()
+		// An unresolved type is NOT a type. go/types names the Invalid basic
+		// "invalid type" — a display string, not a Go identifier — and emitting
+		// it produces Go that does not even parse (`func() invalid type`), which
+		// then surfaces as an opaque internal error naming no user construct.
+		// NilType is the pipeline's contract for "unknown", and it is what lets
+		// repairUnresolvedSignatures find the slot and recover it from source.
+		if t.Kind() == types.Invalid {
+			return transpiler.NilType{}
+		}
 		// Untyped constants (e.g., "untyped string", "untyped int") should
 		// resolve to their concrete Go type for code generation purposes.
 		if t.Info()&types.IsUntyped != 0 {

--- a/internal/transpiler/analyzer/go_types_test.go
+++ b/internal/transpiler/analyzer/go_types_test.go
@@ -43,6 +43,57 @@ func TestAnalyzeGoFiles_RegistersMapAndChanElementTypes(t *testing.T) {
 	}
 }
 
+// A Go signature naming a type the checker cannot load must be recovered from
+// source rather than degraded.
+//
+// This is the shape go_interop's `OptionFromMap(...) std.Option[V]` has: `std` is
+// a GALA package, so it exists as Go only after transpilation, while this analysis
+// runs against the un-transpiled tree. go/types resolves such a reference to
+// Invalid — whose display string, "invalid type", is not a Go identifier at all.
+// Emitting it produced Go that could not be parsed. The recovery must yield the
+// type as written, with its type argument intact, so a call site can instantiate it.
+//
+// The unresolvable import here is a nonexistent path, not a GALA one: the recovery
+// is a property of unresolved types in general, with nothing specific to GALA or
+// to std.
+func TestAnalyzeGoFiles_RecoversUnresolvedSignatureTypesFromSource(t *testing.T) {
+	skipIfNoGoSDK(t)
+	dir := t.TempDir()
+	src := "package sample\n\n" +
+		"import \"example.test/nonexistent/box\"\n\n" +
+		"func Wrap[K comparable, V any](m map[K]V, k K) box.Box[V] { panic(\"x\") }\n" +
+		"func WrapSlice[T any](xs []T) []box.Box[T] { panic(\"x\") }\n" +
+		"func Plain(s string) int { return len(s) }\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sample.go"), []byte(src), 0644))
+
+	info := analyzer.AnalyzeGoFiles(dir)
+	require.NotNil(t, info)
+
+	sig := info.GetFuncSignature("sample.Wrap")
+	require.NotNil(t, sig, "the function must still be registered")
+	require.Len(t, sig.Returns, 1)
+	assert.Equal(t, "box.Box[V]", sig.Returns[0].String(),
+		"the unresolvable return must be recovered as written, keeping its type argument")
+	assert.NotContains(t, sig.Returns[0].String(), "invalid",
+		"go/types' Invalid display string must never reach a transpiler.Type")
+	assert.Equal(t, []string{"K", "V"}, sig.TypeParams,
+		"type-parameter names are what make the recovered type instantiable")
+
+	sig = info.GetFuncSignature("sample.WrapSlice")
+	require.NotNil(t, sig)
+	require.Len(t, sig.Returns, 1)
+	assert.Equal(t, "[]box.Box[T]", sig.Returns[0].String(),
+		"recovery must descend through composite types")
+
+	// Signatures go/types DID resolve must be left exactly as they were.
+	sig = info.GetFuncSignature("sample.Plain")
+	require.NotNil(t, sig)
+	require.Len(t, sig.Returns, 1)
+	assert.Equal(t, "int", sig.Returns[0].String())
+	require.Len(t, sig.Params, 1)
+	assert.Equal(t, "string", sig.Params[0].Type.String())
+}
+
 func TestAnalyzeGoPackage_FmtPackage(t *testing.T) {
 	skipIfNoGoSDK(t)
 

--- a/internal/transpiler/line_directives_guard_test.go
+++ b/internal/transpiler/line_directives_guard_test.go
@@ -1,8 +1,10 @@
 package transpiler
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"martianoff/gala/galaerr"
@@ -68,8 +70,31 @@ func TestInsertLineDirectivesRejectsUnparseableCode(t *testing.T) {
 			assert.Contains(t, se.Error(), "demo.gala")
 			assert.Contains(t, se.Error(), LineMarkerPrefix)
 			assert.Contains(t, se.Hint, "transpiler bug")
+
+			// The Go that failed to parse is the one artifact needed to
+			// diagnose the bug, and this is the only place it exists — the
+			// output file is never written on this path. The diagnostic must
+			// name a dump of it rather than discard it.
+			dump := dumpPathFromMessage(t, se.Error())
+			t.Cleanup(func() { _ = os.Remove(dump) })
+			written, readErr := os.ReadFile(dump)
+			require.NoError(t, readErr, "the named dump must exist and be readable")
+			assert.Equal(t, tc.code, string(written),
+				"the dump must be the exact source that failed to parse")
 		})
 	}
+}
+
+// dumpPathFromMessage extracts the dump path the unparseable-Go diagnostic names.
+func dumpPathFromMessage(t *testing.T, msg string) string {
+	t.Helper()
+	const prefix = "the generated Go was written to "
+	idx := strings.Index(msg, prefix)
+	require.NotEqual(t, -1, idx, "diagnostic must name the dump it wrote: %s", msg)
+	rest := msg[idx+len(prefix):]
+	end := strings.Index(rest, " for inspection)")
+	require.NotEqual(t, -1, end, "diagnostic must close the dump clause: %s", msg)
+	return rest[:end]
 }
 
 // TestInternalErrorRendersWithoutBogusFrame pins that the 0,0 position these

--- a/internal/transpiler/transpiler.go
+++ b/internal/transpiler/transpiler.go
@@ -6,6 +6,7 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -516,6 +517,35 @@ func InsertLineDirectives(code, sourceFile string) (string, error) {
 	return insertLineDirectives(code, sourceFile)
 }
 
+// describeUnparseableDump writes the Go the transpiler just produced to a temp
+// file and returns a fragment naming it, or "" if it could not be written.
+//
+// When the marker rewrite fails the generated source is otherwise discarded — it
+// never reaches disk, because writing the output file is downstream of this step.
+// That leaves the one artifact needed to diagnose the bug visible to nobody,
+// including whoever has to fix it: a report can quote the parser's complaint
+// ("missing ',' in argument list") but not the text that caused it. Naming a dump
+// turns that into a one-line diagnosis.
+//
+// Failure to write is deliberately silent. This path is already reporting a
+// transpiler bug; a temp-dir problem must not replace that diagnostic with a less
+// useful one.
+func describeUnparseableDump(code, sourceFile string) string {
+	base := strings.TrimSuffix(filepath.Base(sourceFile), filepath.Ext(sourceFile))
+	if base == "" {
+		base = "gala"
+	}
+	f, err := os.CreateTemp("", "gala-unparseable-"+base+"-*.go")
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	if _, err := f.WriteString(code); err != nil {
+		return ""
+	}
+	return fmt.Sprintf(" (the generated Go was written to %s for inspection)", filepath.ToSlash(f.Name()))
+}
+
 // insertLineDirectives rewrites the transformer's GALA line markers into Go
 // `//line <file>:<n>` directives. A `//line` directive re-maps the reported
 // position of the FOLLOWING source line, so each directive is emitted on its own
@@ -561,14 +591,17 @@ func InsertLineDirectives(code, sourceFile string) (string, error) {
 // the user never wrote. Both conditions mean a transpiler bug upstream, so the
 // error is reported as an internal failure and the transpile aborts; silently
 // shipping marker-laden Go with a success status is strictly worse.
+//
+// The unparseable case additionally dumps the offending Go (see
+// describeUnparseableDump) — it is the only copy that will ever exist.
 func insertLineDirectives(code, sourceFile string) (string, error) {
 	fset := token.NewFileSet()
 	astFile, err := parser.ParseFile(fset, "", code, parser.ParseComments)
 	if err != nil {
 		return "", galaerr.NewCodedSemanticError(
 			galaerr.CodeInternalTransformerPanic, 0, 0,
-			fmt.Sprintf("internal transpiler error: the generated Go for %s is not parseable, so its source-map markers (%s*) could not be rewritten into //line directives: %v",
-				sourceFile, LineMarkerPrefix, err),
+			fmt.Sprintf("internal transpiler error: the generated Go for %s is not parseable, so its source-map markers (%s*) could not be rewritten into //line directives: %v%s",
+				sourceFile, LineMarkerPrefix, err, describeUnparseableDump(code, sourceFile)),
 			markerRewriteBugHint,
 		)
 	}


### PR DESCRIPTION
## Summary

Fixes **FIX-002**: a lambda over `go_interop.OptionFromMap` — a Go generic returning a **GALA** type, `std.Option[V]` — emitted unparseable Go and aborted with `GALA-E0017`. Triggered by the documented `resource.WithLock(mu, () => …)` idiom.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P0 (blocks compilation)
**Found in**: validating GALA code samples for the gala-kv design document

## This was NOT the same defect as FIX-001

Both reports guessed these were one bug. They are not, and the guess was tested rather than assumed: FIX-002's repro was re-run on the FIX-001 branch **before any FIX-002 code was written**, and it still failed with the same `GALA-E0017`.

They are two independent defects that happen to surface at the same syntactic position — a lambda's synthesized result clause, the one place the transpiler is forced to write a Go type down.

The diagnostic dump added here is what proved it. The emitted Go was:

```go
func() invalid type
```

not `func() Option[V]` — a materially different failure from FIX-001's `func() map[K]V`.

## Root Cause

`OptionFromMap` returns `std.Option[V]`, which is a **GALA** type. `AnalyzeGoFiles` type-checks hand-written `.go` sources against the *un-transpiled* tree — `.gen.go` files are skipped — so `go/types` resolved `std.Option` to `Invalid`. `goTypeToTranspilerType` then passed `Invalid`'s **display string**, the literal `"invalid type"`, through as though it were a type name, and that string was written into the generated source.

## Changes

- `internal/transpiler/analyzer/go_types.go` — `goTypeToTranspilerType` / `AnalyzeGoFiles`: recover unresolved signature types from source instead of propagating `Invalid`'s display string.
- `internal/transpiler/transpiler.go` — the diagnostic improvement below.

## The diagnostic improvement (requested as optional; it was cheap)

When the source-map rewrite fails, the unparseable Go is now **written to a temp file and named in the diagnostic**. Previously the generated source was discarded, so nobody — including the fix team — could see what was actually emitted without instrumenting the transpiler.

This is what turned the investigation from guesswork into a one-line diagnosis. It was requested in the original bug report as an aside, and it earned its place: it is the reason the FIX-001/FIX-002 conflation was caught rather than inherited.

## Verification

- `examples/go_generic_option_lambda_return.gala` / `.out` (new target)
- `GoGenericOptionLambda` added to the multifile regression library
- `TestAnalyzeGoFiles_RecoversUnresolvedSignatureTypesFromSource`
- `TestInsertLineDirectivesRejectsUnparseableCode` extended to cover the dump
- `bazel build //...` and `bazel test //...` pass; only failure is the known-benign `TestGorootFromGoBinarySymlink` (Windows symlink privilege)

## Follow-up found, out of scope

**`std`'s own Go analysis is noisy.** Type-checking the `std` directory produces roughly 180 `undefined: Option` / `undefined: Try` errors per run, because `AnalyzeGoFiles` skips the `.gen.go` files that define those types. Currently harmless — the errors are ignored — but it is the *same* underlying "Go analysis sees the un-transpiled tree" tension that produced this bug, and it means `std`'s hand-written Go contributes almost no usable type metadata. Worth addressing on its own terms rather than as part of this fix.

## Dependencies

None remaining. This was originally stacked on #461 (FIX-001), which is now **merged** as `2ab0812`. This branch has been rebased onto `master` with FIX-001's commit dropped (it is present in `master` as a squash), so the diff here is FIX-002 only.

Supersedes **#462**, which GitHub auto-closed when #461's branch was deleted on merge — a closed PR whose base branch no longer exists cannot be reopened or retargeted.

## Report Reference

Originally reported as **BUG-KV-4** in `docs/private/gala-kv-findings/REPORT.md`; detail in `docs/private/BUG_GO_GENERIC_OPTION_RETURN_UNPARSEABLE.md`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aZRWH39EXTXVALyxALJut
