### PR TITLE
fix(build): a top-level heuristic decided whether project-module imports were rewritten at all

### DIFF
--- a/internal/build/BUILD.bazel
+++ b/internal/build/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "deptranspiler_test.go",
         "go_toolchain_test.go",
         "gomod_test.go",
+        "nested_subpackage_test.go",
         "sourcehash_test.go",
         "sourcemap_stacktrace_test.go",
         "transpile_batch_static_test.go",

--- a/internal/build/builder.go
+++ b/internal/build/builder.go
@@ -863,34 +863,26 @@ func (b *Builder) copyEmbedFiles(patterns []string) error {
 //
 //	"github.com/user/project/httpcore" → "gala-build-workspace/gen/httpcore"
 //	"github.com/user/project"          → "gala-build-workspace/gen"
+//
+// The rewrite is driven entirely by what the generated code actually imports,
+// not by a guess about the project's directory layout. Anything that names the
+// project module must be redirected, so the only precondition is knowing that
+// module path.
+//
+// An earlier version skipped the rewrite unless an immediate child of the
+// project directory held .go or .gala files. That mis-classified every project
+// whose packages sit below a source-free directory — internal/greet/,
+// pkg/foo/, lib/a/b/ — leaving the project's own module path in the emitted
+// imports, which sent `go mod tidy` to the network for a package that was
+// sitting in gen/ the whole time. Detecting the layout is strictly harder than
+// doing the work: rewriteImportsInDir is already a no-op when nothing matches,
+// so a project with no subpackages just pays one walk of gen/ — a few
+// milliseconds against a build that spends seconds in transpile, `go mod tidy`
+// and `go build`.
 func (b *Builder) rewriteProjectModuleImports(dir string) error {
 	projectModule := b.projectGoModulePath()
 	if projectModule == "" {
 		return nil // No module path known, nothing to rewrite
-	}
-
-	// Check if there are any local subdirectories — whether Go or GALA —
-	// that could be imported under the project module path. Pure GALA
-	// subpackages still need rewriting because their imports are emitted
-	// using the project module path (e.g. "github.com/user/proj/sub") and
-	// must be redirected to the workspace gen/ layout before `go build`
-	// can resolve them.
-	hasSubDirs := false
-	entries, err := os.ReadDir(b.workspace.ProjectDir)
-	if err == nil {
-		for _, e := range entries {
-			if e.IsDir() && !strings.HasPrefix(e.Name(), ".") && e.Name() != "vendor" &&
-				!strings.HasPrefix(e.Name(), "bazel-") {
-				subPath := filepath.Join(b.workspace.ProjectDir, e.Name())
-				if hasGoFiles(subPath) || hasGalaFilesShallow(subPath) {
-					hasSubDirs = true
-					break
-				}
-			}
-		}
-	}
-	if !hasSubDirs {
-		return nil // No local subpackages, skip rewriting
 	}
 
 	if b.verbose {
@@ -928,37 +920,6 @@ func parseGoModModulePath(content string) string {
 		}
 	}
 	return ""
-}
-
-// hasGoFiles returns true if the directory contains any .go files.
-func hasGoFiles(dir string) bool {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".go") {
-			return true
-		}
-	}
-	return false
-}
-
-// hasGalaFilesShallow reports whether dir contains at least one .gala file at
-// its top level. Used when deciding whether the project module's import paths
-// need to be rewritten to point at the workspace gen/ directory — GALA
-// subpackages must be covered too, not just Go subpackages.
-func hasGalaFilesShallow(dir string) bool {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".gala") {
-			return true
-		}
-	}
-	return false
 }
 
 // rewriteImportsInDir recursively scans all .go files in dir and rewrites

--- a/internal/build/nested_subpackage_test.go
+++ b/internal/build/nested_subpackage_test.go
@@ -1,0 +1,151 @@
+package build
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuild_ProjectSubpackageImportsRewrittenAtAnyDepth builds the *same*
+// two-package program at several directory depths and requires every one of
+// them to work. The layouts differ only in where the imported package sits:
+//
+//	greet/greet.gala           imported as example.com/layout/greet
+//	internal/greet/greet.gala  imported as example.com/layout/internal/greet
+//	lib/a/b/greet.gala         imported as example.com/layout/lib/a/b
+//
+// Why this shape
+// --------------
+// A package's own module path is not something the Go toolchain can fetch, so
+// every import naming it has to be redirected to the workspace gen/ tree before
+// `go mod tidy` and `go build` run. That redirection used to be skipped unless
+// an *immediate* child of the project directory contained .go or .gala files.
+// The nested layouts above fail that check — `internal/` and `lib/` hold only
+// more directories — so the imports were left naming the project module and the
+// build died trying to resolve example.com/layout/internal/greet over the
+// network. The flat layout passed the check and worked, which is why the gap
+// went unnoticed: depth was the only variable.
+//
+// The nested cases are the regression; the flat case is the control that proves
+// the harness itself builds a working program. `internal/` is spelled out
+// because it is the layout a Go developer reaches for first, but nothing about
+// the fix keys on that name — `lib/a/b` covers the general case and would fail
+// identically under the old gate.
+//
+// Two layers of proof
+// -------------------
+//  1. Import rewriting (always runs, needs no Go toolchain): after transpiling,
+//     the generated main.gen.go must import the workspace path and must not
+//     mention the project module. This is the assertion that actually pins the
+//     fix, and it is hermetic — no network, no `go` binary.
+//  2. End-to-end (when a usable Go toolchain is present): Builder.Build — the
+//     exact entry point `gala build` drives — produces a binary that runs and
+//     prints the expected greeting. Toolchain problems skip rather than fail,
+//     matching the convention already used for source-mapped stack traces.
+//
+// The build is offline in both layers: the generated workspace go.mod resolves
+// the GALA standard library through local `replace` directives into the
+// extracted stdlib cache, and the project's own packages through gen/.
+func TestBuild_ProjectSubpackageImportsRewrittenAtAnyDepth(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not on PATH")
+	}
+
+	const moduleName = "example.com/layout"
+
+	tests := []struct {
+		name string
+		// pkgDir is the package's location relative to the project root,
+		// in slash form.
+		pkgDir string
+		// pkgName is the GALA package clause, which must match the last
+		// path segment so the import qualifier below resolves.
+		pkgName string
+	}{
+		{
+			name:    "flat sibling directory (control)",
+			pkgDir:  "greet",
+			pkgName: "greet",
+		},
+		{
+			name:    "below a source-free internal directory",
+			pkgDir:  "internal/greet",
+			pkgName: "greet",
+		},
+		{
+			name:    "three levels below a source-free root",
+			pkgDir:  "lib/a/b",
+			pkgName: "b",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			projectDir := t.TempDir()
+			importPath := moduleName + "/" + tc.pkgDir
+
+			require.NoError(t, os.WriteFile(filepath.Join(projectDir, "gala.mod"),
+				[]byte("module "+moduleName+"\n\ngala 0.0.0\n"), 0o644))
+			// A real go.mod alongside gala.mod is what a Go developer writes,
+			// and it is the authoritative source for projectGoModulePath.
+			require.NoError(t, os.WriteFile(filepath.Join(projectDir, "go.mod"),
+				[]byte("module "+moduleName+"\n\ngo 1.22\n"), 0o644))
+
+			pkgPath := filepath.Join(projectDir, filepath.FromSlash(tc.pkgDir))
+			require.NoError(t, os.MkdirAll(pkgPath, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(pkgPath, "greet.gala"),
+				[]byte("package "+tc.pkgName+"\n\nfunc Hello(name string) string = s\"hello $name\"\n"), 0o644))
+
+			require.NoError(t, os.WriteFile(filepath.Join(projectDir, "main.gala"),
+				[]byte("package main\n\nimport \""+importPath+"\"\n\nfunc main() {\n    Println("+tc.pkgName+".Hello(\"world\"))\n}\n"), 0o644))
+
+			isolateUserState(t)
+			// Isolating HOME/USERPROFILE removes the default GOCACHE location,
+			// so point it at a throwaway dir — the `go build` inside
+			// Builder.Build needs a writable build cache.
+			setEnvForTest(t, "GOCACHE", filepath.Join(t.TempDir(), "gocache"))
+			alignGorootWithPathGo(t)
+			chdirForTest(t, projectDir)
+
+			b, err := NewBuilder(projectDir, "test", false)
+			require.NoError(t, err)
+			require.NoError(t, b.workspace.Ensure())
+
+			// --- Layer 1: the import rewrite itself. ---
+			require.NoError(t, b.ensureStdlib())
+			require.NoError(t, b.transpileDeps())
+			require.NoError(t, b.transpile())
+
+			// The subpackage must land in gen/ mirroring its source layout,
+			// otherwise the rewritten import would point at nothing.
+			genPkg := filepath.Join(b.workspace.GenDir, filepath.FromSlash(tc.pkgDir), "greet.gen.go")
+			require.FileExists(t, genPkg,
+				"the subpackage must be generated at gen/%s so the rewritten import resolves", tc.pkgDir)
+
+			mainGen := readFileString(t, filepath.Join(b.workspace.GenDir, "main.gen.go"))
+			assert.Contains(t, mainGen, "\"gala-build-workspace/gen/"+tc.pkgDir+"\"",
+				"the subpackage import must be redirected into the workspace gen/ tree:\n%s", mainGen)
+			assert.NotContains(t, mainGen, "\""+importPath+"\"",
+				"no import may still name the project module — the Go toolchain would try to fetch it:\n%s", mainGen)
+
+			// --- Layer 2: the whole `gala build` pipeline. ---
+			binPath, buildErr := b.Build("")
+			if buildErr != nil {
+				if isToolchainEnvError(buildErr.Error()) {
+					t.Skipf("skipping end-to-end check: Go toolchain unavailable/mismatched in this environment: %v", buildErr)
+				}
+				t.Fatalf("gala build failed for layout %s: %v", tc.pkgDir, buildErr)
+			}
+			require.NotEmpty(t, binPath)
+
+			out, runErr := runBuiltBinary(binPath)
+			require.NoError(t, runErr, "built binary failed to run; output:\n%s", out)
+			assert.Equal(t, "hello world", strings.TrimSpace(out))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **FIX-001**: whether the project-module import rewrite ran at all was decided by an unrelated heuristic, so some projects could not be built or tested by the CLI.

**Category**: TRANSPILER_BUG (build system)
**Priority**: P0 — blocks compilation
**Found in**: implementing P1 of the gala-kv design document

```
go: gala-build-workspace/gen imports
	example.com/flat/internal/greet: cannot find module providing package
	example.com/flat/internal/greet: unrecognized import path ...: 404 Not Found
```

## Root Cause

GALA transpiles into a workspace whose module is `gala-build-workspace`, with the project's code under `gen/`. Source still imports its own packages by the *project's* module path, so those imports must be redirected:

```
github.com/user/project/httpcore  →  gala-build-workspace/gen/httpcore
```

`rewriteProjectModuleImports` does this correctly. It was gated behind a scan of the project root's **immediate child directories**, looking for one that directly contained `.go` or `.gala` files. If none did, the function returned before rewriting anything, the project's own module path survived into the emitted imports, and `go mod tidy` went to the network for a package that was sitting in `gen/` the whole time.

### The gate was one global boolean, and that is the real defect

This is **not** "nested packages are broken" — that framing is wrong, and `gala_team` disproves it.

The scan set a single boolean for the whole project. One qualifying directory anywhere at the top level opened the gate for *every* package, at any depth:

| Project | Immediate children with direct sources | Result |
|---|---|---|
| `gala_team` | `cmd/` — 1 `.gala` file | **Gate opens.** All 22 packages under `app/` rewritten correctly, despite sitting 2 levels deep under a source-free `app/` |
| `gala-kv` | `bench/` 0, `cmd/` 0, `docs/` 0, `internal/` 0 | **Gate closes.** Nothing rewritten → 404 |

`gala_team` self-imports across 22 nested packages (`github.com/martianoff/gala_team/app/config`, …) and builds fine on the released CLI — verified, exit 0, zero resolution errors. It is rescued by a single file in `cmd/` that has nothing to do with any of them.

`gala-kv` fails only because it follows the *fully* conventional Go layout, where even the entry point is nested (`cmd/galakv/main.gala` rather than `cmd/main.gala`), leaving no shallow directory to trip the heuristic.

So the actual trigger is: **a project where no immediate child directory contains source files, while the project still imports its own packages.** Depth alone is harmless. Whether a correctness-critical rewrite ran was decided by an unrelated file in an unrelated directory.

## Changes

- `internal/build/builder.go` — remove the gate; the rewrite now runs whenever `projectGoModulePath()` is non-empty. Removes the two now-unused helpers `hasGoFiles` / `hasGalaFilesShallow`.
- `internal/build/nested_subpackage_test.go` (new) — regression test.
- `internal/build/BUILD.bazel` — register the test.

### Why remove the gate rather than fix the heuristic

Making the scan recursive would fix the reported symptom while leaving the same class of defect in place: a layout guess deciding whether required work happens. The gate was never a correctness mechanism — `rewriteImportsInDir` is already a no-op when nothing matches — it was an optimisation, and it was buying almost nothing:

- **Neither build-time budget touches this code.** `perf-real-build.yml` builds through rules-gala transpile actions and never reaches `internal/build.Builder`; `transpile_perf_test.go` drives `transpiler.Transpile` / `BatchAnalyzer` directly.
- **The walk is small and bounded.** It walks `workspace.GenDir`, which holds only the project's own generated `.go` — dependencies live in `deps/`, stdlib outside the workspace. Across ~170 build workspaces on the dev machine the largest `gen/` is 40 files / 623 KB. Measured walk + read + rewrite: **4.9 ms** there, **26 ms** on a synthetic tree 5× larger than anything real — against a build spending seconds in transpile, `go mod tidy` and `go build`.
- **Precedent:** the consumer-dir rewrite (builder.go ~757) is already called unconditionally whenever the module path is known.

## An unremarked property worth keeping deliberately

The rewrite touches **only the project's own module path**. A dependency's imports keep their real module path and resolve through `replace` into `deps/`.

That is what preserves Go's `internal/` visibility rule across module boundaries. Verified with two modules and a local `replace`:

```
app imports example.com/lib/pub              → builds and runs
app imports example.com/lib/internal/secret  → exit 1, no binary:
    use of internal package example.com/lib/internal/secret not allowed
```

A broader rewrite that also flattened dependency paths into `gen/` would silently make every project's `internal/` packages importable by anyone, with nothing failing to signal it. Worth stating so the narrow scope is defended rather than incidental.

## Verification

`TestBuild_ProjectSubpackageImportsRewrittenAtAnyDepth` builds the same two-package program at **three** depths — `greet/` (control), `internal/greet/`, `lib/a/b/` — through `Builder.Build`, the entry point `gala build` drives. Two layers per depth: assert the rewrite landed in generated source (hermetic), then full build and execute the binary asserting `hello world`.

- All three subtests genuinely **run** in the bazel sandbox rather than skipping — the generated workspace `go.mod` resolves through local `replace` directives into the extracted stdlib cache, so it is offline.
- Confirmed to be a real regression test by stashing the fix: the flat control passes, both nested cases fail.
- `lib/a/b` is present so the test pins the general problem rather than the literal name `internal`.

`bazel build //...` clean. `bazel test //...` — 393/394; the sole failure is the known-benign `analyzer_test :: TestGorootFromGoBinarySymlink` (Windows symlink privilege). `bazel run //:gazelle` produced no changes.

### Against the real blocked project

`gala-kv` (packages under `internal/`, main at `cmd/galakv`), measured with the workspace cleared so the incremental source-hash skip could not mask the result:

- **Before:** `go mod tidy` tries to `git ls-remote` `github.com/martianoff/gala-kv/internal/{resp,store,command}` → "Repository not found".
- **After:** import resolution fully past; the build proceeds to compiling `gala-build-workspace/gen/internal/command`, and the project now builds and serves RESP traffic.

## Repro (before fix)

A project with no immediate child directory holding sources, that imports its own package:

```
proj/
  gala.mod / go.mod     module example.com/flat
  main.gala             import "example.com/flat/internal/greet"
  internal/greet/greet.gala
```

Moving `internal/greet/` up to `greet/` — or adding any source file to a top-level directory — makes it build, which is the tell.

## Why this survived

`gala build` had, in practice, only ever been used on projects that happened to satisfy the heuristic. The repo's own multi-package coverage (`examples/multifile_lib_regress/`) is Bazel-built with an explicit `importpath`, a different code path that never exercised this gate. Nothing compared the two build paths' capabilities.

## Adjacent depth assumptions NOT covered here

Found while fixing, deliberately left alone to keep this to one gate. Both are separate latent bugs:

1. **`CollectImports` (`gomod.go:391`)** — `os.ReadDir` on the top level only. Called when generating a *dependency* module's `go.mod`, so a GALA dependency whose own packages are nested would have its `require`s under-generated.
2. **`Workspace.GenFiles()` (`workspace.go:123`)** — top-level only. Benign at its incremental-skip call site, but `isLibraryPackage` (`builder.go:1073`) reads the first top-level gen file to decide library-vs-executable, so a project with no root-level `.gala` would be misclassified as an executable.

## Dependencies

None — branches from `master`.

## Report Reference

Reported as **BUG-KVP1-1** in `docs/private/gala-kv-p1-findings/REPORT.md`; detail in `docs/private/BUG_NESTED_SUBPACKAGE_IMPORTS_NOT_REWRITTEN.md`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aZRWH39EXTXVALyxALJut
