### PR TITLE
docs: document multi-package project layout; correct the internal/ package tree

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -94,8 +94,19 @@ GALA has two categories of tests:
 gala/
   cmd/gala/                        # CLI entry point (Cobra)
   internal/
+    build/                         # `gala build` / `gala test` driver: transpile into a
+                                   #   workspace, generate its go.mod, invoke the Go toolchain
+    depman/                        # Module resolution and the gala.mod reader/writer
+    lsp/                           # Language server (diagnostics, hover, completion)
+    stdlib/                        # Embedded standard-library snapshot + extraction
     parser/grammar/                # ANTLR4 grammar and generated parser
     transpiler/
+      analyzer/                    # Package metadata extraction; Go type info via the Go SDK
+      infer/                       # Hindley-Milner inference (Layer 2)
+      module/                      # Module/import path resolution
+      profiler/                    # Optional phase timing (GALA_PROFILE)
+      registry/                    # Type and function registries
+      resolver/                    # Symbol resolution
       generator/                   # Go source code generation from Go AST
       transformer/                 # GALA parse tree -> Go AST transformation
   std/                             # Standard library (Option, Either, Try, etc.)

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -99,6 +99,35 @@ gala_binary(
 
 The transpiler automatically passes sibling file information so that each file can resolve types, sealed types, and methods defined in other files of the same package.
 
+### Multi-Package Projects
+
+A project can contain many packages. One directory is one package, and a package imports another in the same module by its **full module path plus the directory path** — the same spelling Go uses:
+
+```
+myapp/
+  gala.mod                     module example.com/myapp
+  cmd/myapp/main.gala          package main
+  internal/greet/greet.gala    package greet
+```
+
+```gala
+package main
+
+import "example.com/myapp/internal/greet"
+
+func main() {
+    Println(greet.Hello("world"))
+}
+```
+
+Only `gala.mod` is required. A `go.mod` is not needed — the build generates one for its workspace.
+
+There is no restriction on nesting depth or on directory names: `internal/`, `pkg/foo/`, and `lib/a/b/` all work, and an intermediate directory (`internal/` above) need not contain any source files of its own.
+
+> **Version note.** Projects where *no* top-level directory directly contains `.gala` files require a build containing the fix from PR #465. Earlier versions failed with `cannot find module providing package …: 404 Not Found`, because the project's own module path was not redirected into the build workspace. Bazel builds were never affected.
+
+Bazel builds the same layout with one `gala_library` per directory; `bazel run //:gazelle` generates and maintains them. See [DEPENDENCY_MANAGEMENT.MD](DEPENDENCY_MANAGEMENT.MD) for depending on *other* modules, which is a separate mechanism from importing your own packages.
+
 ## 2. Variable Declarations
 
 GALA distinguishes between immutable and mutable variables.


### PR DESCRIPTION
## Summary

Follow-up to #465. That PR fixed the mechanism; this documents the layout it enables, and corrects a contributor-facing map that omitted the package the fix landed in.

## Why

`GALA.MD` had **no** guidance on projects containing more than one package. §1 covered multi-*file* packages within a single directory, and only via Bazel. Nothing stated:

- how a package imports another package of the same module
- that one directory is one package
- that only `gala.mod` is required (no `go.mod`)
- that a project laid out this way is a supported shape at all

That gap is causally linked to #465. A project whose top-level directories all hold their sources one level down could not be built by the CLI, and nothing documented the layout as supported — so the only projects exercising it were Bazel-built, and the CLI path went unexercised.

## Changes

**`docs/GALA.MD` §1 — new "Multi-Package Projects" subsection.** Import spelling (`<module path>/<dir>`), the `gala.mod`-only requirement, no restriction on nesting depth or directory names, and a version note for layouts with no shallow top-level package. The example is **compile-verified**: `cmd/myapp/main.gala` importing `internal/greet` builds and prints `hello world` — deliberately the exact shape that failed before #465.

**`CONTRIBUTING.MD` — architecture tree corrected.** It listed 3 of the 14 packages under `internal/`, omitting `build/` (where #465 landed), `depman/`, `lsp/`, `stdlib/`, and six `transpiler/` subpackages. Every package on disk is now present, verified programmatically.

## Not included

`internal/` visibility semantics are deliberately left out — being handled separately.

## Verification

- Documented example compiled and run.
- `CONTRIBUTING.MD` tree checked against `ls internal/` and `ls internal/transpiler/` — all 14 present.
- `//internal/transpiler/transformer:transformer_test` passes (contains the error-docs guard).
- Diff is **purely additive**: 40 insertions, 0 deletions.

## Note for reviewers

An earlier attempt at this branch would have silently reverted 104 lines of `docs/GALA.MD` — the E0039 bare-variant rule, the E0037 `Sendable` note, the E0032 dot-import note, and the "Where Go slice and map types may be written" section from #463 — because it was authored against a checkout predating those merges. Caught by the diff stat showing deletions on a supposedly additive change. This branch is built directly on `origin/master`; the zero-deletion count above is the check.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aZRWH39EXTXVALyxALJut