### PR TITLE
feat(transpiler): report internal-package visibility violations as GALA-E0041

### DIFF
--- a/docs/DEPENDENCY_MANAGEMENT.MD
+++ b/docs/DEPENDENCY_MANAGEMENT.MD
@@ -451,6 +451,26 @@ When you add a GALA dependency (without the `--go` flag), the source `.gala` fil
 
 GALA library packages with multiple `.gala` files are fully supported. The transpiler uses `NewGalaAnalyzerWithPackageFiles` to enable cross-file type resolution within the dependency.
 
+### What You Can Import From a Dependency
+
+Not every package in a dependency is part of its API. A package under a directory named `internal` is private to the module that ships it:
+
+```
+github.com/user/lib-a/
+  liba.gala                  package liba      — importable by you
+  internal/
+    detail/detail.gala       package detail    — private to github.com/user/lib-a
+```
+
+```gala
+import "github.com/user/lib-a"                    // OK
+import "github.com/user/lib-a/internal/detail"    // GALA-E0041
+```
+
+The dependency uses its own `internal` packages freely — you just cannot reach past its public surface to them. This is the same rule Go applies, stated in full in [Package Visibility](GALA.MD#package-visibility): `a/b/c/internal/d` is importable only from the tree rooted at `a/b/c`.
+
+It applies to your own project too. A package under `internal/` at your module root is visible anywhere in your module but to no one who depends on it, which is what makes it a safe place for code you are not ready to commit to supporting. See [GALA-E0041](errors/GALA-E0041.md) for the diagnostic and how to resolve it.
+
 ### Transitive Dependencies
 
 Dependencies of dependencies are handled automatically:

--- a/docs/GALA.MD
+++ b/docs/GALA.MD
@@ -124,6 +124,8 @@ Only `gala.mod` is required. A `go.mod` is not needed — the build generates on
 
 There is no restriction on nesting depth or on directory names: `internal/`, `pkg/foo/`, and `lib/a/b/` all work, and an intermediate directory (`internal/` above) need not contain any source files of its own.
 
+`internal` is the one directory name that carries meaning beyond layout: a package under it is importable only from the tree rooted at that directory's parent. The example above is legal because `cmd/myapp` sits inside `example.com/myapp`, the parent of `internal/`. Another module importing `example.com/myapp/internal/greet` is rejected with [GALA-E0041](errors/GALA-E0041.md). See [Package Visibility](#package-visibility).
+
 > **Version note.** Projects where *no* top-level directory directly contains `.gala` files require a build containing the fix from PR #465. Earlier versions failed with `cannot find module providing package …: 404 Not Found`, because the project's own module path was not redirected into the build workspace. Bazel builds were never affected.
 
 Bazel builds the same layout with one `gala_library` per directory; `bazel run //:gazelle` generates and maintains them. See [DEPENDENCY_MANAGEMENT.MD](DEPENDENCY_MANAGEMENT.MD) for depending on *other* modules, which is a separate mechanism from importing your own packages.
@@ -3171,6 +3173,56 @@ func main() {
     fmt.Println(w2.V)
 }
 ```
+
+### Package Visibility
+
+GALA controls visibility at two levels.
+
+**Identifier level** — casing, as in Go. A `PascalCase` type, function, field or method is exported from its package; a `camelCase` one is not. This is per-package: everything in a package sees everything else in that package, regardless of casing.
+
+**Package level** — `internal` directories. A package that lives under a directory named `internal` is importable only from within the tree rooted at that directory's parent:
+
+```
+mylib/
+  gala.mod                     module example.com/mylib
+  mylib.gala                   package mylib          — public
+  internal/
+    detail/detail.gala         package detail         — private to example.com/mylib
+  sub/
+    sub.gala                   package sub            — public
+    internal/
+      deep/deep.gala           package deep           — private to example.com/mylib/sub
+```
+
+The rule is Go's, applied to GALA import paths: `a/b/c/internal/d` is importable only from the tree rooted at `a/b/c`. Concretely, for the layout above:
+
+| Importer | `.../mylib/internal/detail` | `.../mylib/sub/internal/deep` |
+|---|---|---|
+| `example.com/mylib` | ✅ | ❌ — not under `sub/` |
+| `example.com/mylib/sub` | ✅ | ✅ |
+| `example.com/mylib/sub/other` | ✅ | ✅ |
+| another module | ❌ | ❌ |
+
+Only whole path elements count — a directory named `internalize` is an ordinary public package.
+
+This lets a library share code across its own packages without adding it to the API it has to keep supporting. Consumers of `example.com/mylib` can call whatever `mylib` exports; they cannot reach `internal/detail`, so it can be renamed, resplit or deleted without breaking them.
+
+A forbidden import is rejected at the `import` line with [GALA-E0041](errors/GALA-E0041.md):
+
+```
+error[GALA-E0041]: package "example.com/mylib/sub/internal/deep" is internal to
+"example.com/mylib/sub" and cannot be imported from "example.com/mylib"
+  --> main.gala:3:8
+  |
+3 | import "example.com/mylib/sub/internal/deep"
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ internal packages are private to their parent tree
+```
+
+There is no exemption for the standard library: `martianoff/gala/*` packages resolve through the same mechanism as any other GALA library and obey the same rule.
+
+To make an internal package public, move it out of the `internal` directory. Because visibility is directory layout, this changes the package's import path — so the decision to publish a package is worth making deliberately, and reversing it is a breaking change for anyone who has started importing it.
+
+> **When to reach for it.** `internal` earns its keep when you ship a library to consumers you do not control and want a small supported surface. For an application or a single-binary project, the whole module is already private to you, and an `internal` tree mostly adds a directory level. Use it where there is a real API boundary to defend, not as a default layout.
 
 ### Creating GALA Libraries
 

--- a/docs/GALA_BEST_PRACTICES.MD
+++ b/docs/GALA_BEST_PRACTICES.MD
@@ -166,6 +166,14 @@ func copyFile(src string, dst string) Try[Int] = Try(() => {
   GET("/", (req) => Ok("hello"))
   ```
 - **Avoid `any` in callback signatures** — it forces callers to annotate lambdas.
+- **Keep shared-but-unsupported code in `internal/`** when you ship a library to consumers you do not control. A package under `internal/` is importable only from the tree rooted at that directory's parent, so it can be split, renamed or deleted without breaking anyone:
+  ```
+  mylib/
+    mylib.gala             # public API
+    internal/
+      detail/detail.gala   # shared across mylib's packages, invisible to consumers
+  ```
+  Not a default layout — for an application the whole module is already private, and an `internal/` tree just adds a directory level. Reach for it where there is a real API boundary to defend. Publishing later means moving the directory, which changes the import path. See [Package Visibility](GALA.MD#package-visibility).
 
 ---
 

--- a/docs/errors/GALA-E0041.md
+++ b/docs/errors/GALA-E0041.md
@@ -1,0 +1,111 @@
+# GALA-E0041 — Import of an internal package from outside its tree
+
+**When it fires.** An `import` names a package that lives under a directory
+called `internal`, and the importing package is not inside the tree that is
+allowed to see it.
+
+GALA uses Go's rule, applied to GALA import paths:
+
+> `a/b/c/internal/d` is importable only from the tree rooted at `a/b/c`.
+
+Only whole path **elements** count. `a/b/internalize/c` contains no `internal`
+element and is an ordinary public package. When a path contains more than one
+`internal` element, the innermost is the binding one, matching `cmd/go`:
+`a/internal/b/internal/c` is importable from the tree rooted at
+`a/internal/b`.
+
+There is no exemption for the standard library. `martianoff/gala/*` resolves
+through the same mechanism as any other GALA library and obeys the same rule.
+
+**Minimal repro.** A module whose `sub/` subtree keeps a private helper:
+
+```
+myapp/
+  gala.mod                      module example.com/myapp
+  main.gala                     package main
+  sub/
+    internal/
+      deep/deep.gala            package deep — private to example.com/myapp/sub
+```
+
+```gala
+package main
+
+import "example.com/myapp/sub/internal/deep"
+
+func main() {
+    Println(deep.Deep())
+}
+```
+
+`main.gala` sits at `example.com/myapp`, which is *above* `example.com/myapp/sub`
+rather than inside it, so the import is rejected.
+
+**Error output.**
+
+```
+error[GALA-E0041]: package "example.com/myapp/sub/internal/deep" is internal to "example.com/myapp/sub" and cannot be imported from "example.com/myapp"
+  --> main.gala:3:8
+  |
+3 | import "example.com/myapp/sub/internal/deep"
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ internal packages are private to their parent tree
+  |
+  = hint: internal packages are private to their parent tree; import something "example.com/myapp/sub" exports instead, or move this package out of internal/ to make it public
+```
+
+The same code covers a dependency's private packages:
+
+```
+error[GALA-E0041]: package "example.com/lib/internal/secret" is internal to "example.com/lib" and cannot be imported from "example.com/myapp"
+```
+
+**Fix.** Pick whichever matches your intent:
+
+1. **Use the public API.** If the internal package is a dependency's, the
+   library author deliberately did not publish it — call something the parent
+   package exports instead.
+
+2. **Move the importer into the tree.** A file that genuinely belongs to the
+   `sub/` subsystem should live under `sub/`, at which point the import is
+   legal.
+
+3. **Publish the package.** Move it out of the `internal` directory. Note that
+   this changes its import path, so it is a breaking change for anyone already
+   importing it under the old path — which is the point of the mechanism.
+
+**Rationale.** The rule itself was always enforced, but by the **Go compiler**,
+against the **generated** code — long after the transpiler had already resolved
+and transpiled the forbidden package. What the user saw was:
+
+```
+package gala-build-workspace/gen
+        gen\main.gen.go:6:8: use of internal package gala-build-workspace/gen/sub/internal/deep not allowed
+```
+
+That message names a file nobody wrote (`gen\main.gen.go`) and an import path
+that exists only inside the build workspace (`gala-build-workspace/gen/...`) —
+neither of which appears anywhere in the user's source. Nothing in it points
+back to the `import` line that caused it.
+
+Checking at import-resolution time reports the violation at that `import` line,
+in the `.gala` file, using the path the user actually typed.
+
+**Why it takes two signals.** The check reports a violation only when the
+import paths *and* the directory layout on disk both say so. Import paths alone
+are not a faithful picture of the layout: under Bazel a `gala_library` declares
+its `importpath` explicitly, and it need not mirror where the sources live.
+This repository's own examples declare `martianoff/gala/greeting` for sources
+under `examples/internal_package/greeting/` — judging by the derived import
+path alone, that package importing its own `internal/format` subtree would look
+like a violation. The layout shows it plainly is not.
+
+The Go compiler remains the backstop. Whenever a violation cannot be
+established — the importing package's import path is unknown (no module root,
+or a file outside it, as happens for a cached dependency analyzed on the fly or
+an editor buffer with no `gala.mod`), or the imported package cannot be
+resolved to a directory — the check deliberately fails **open** rather than
+guessing, and the compiler still rejects the generated code as before.
+
+**See also.** [Package Visibility](../GALA.MD#package-visibility) in the
+language reference, for the full visibility model and guidance on when an
+`internal` tree is worth introducing.

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -60,6 +60,7 @@ rather than inventing an example — trust the notice at the top of the page.
 | `GALA-E0038` | Invalid string escape sequence | [GALA-E0038.md](GALA-E0038.md) |
 | `GALA-E0039` | Bare variant name in a match pattern | [GALA-E0039.md](GALA-E0039.md) |
 | `GALA-E0040` | Go slice or map type in an expression | [GALA-E0040.md](GALA-E0040.md) |
+| `GALA-E0041` | Import of an internal package from outside its tree | [GALA-E0041.md](GALA-E0041.md) |
 
 ## Adding a new code
 

--- a/examples/internal_package/BUILD.bazel
+++ b/examples/internal_package/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@rules_gala//gala:defs.bzl", "gala_exec_test")
+
+# Verifies that a public package can serve an API built on top of a package
+# under its own internal/ directory, while the consumer sees only the facade.
+gala_exec_test(
+    name = "internal_package",
+    src = "main.gala",
+    expected = "main.out",
+    gala_deps = ["//examples/internal_package/greeting"],
+    deps = ["//collection_immutable"],
+)

--- a/examples/internal_package/greeting/BUILD.bazel
+++ b/examples/internal_package/greeting/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_gala//gala:defs.bzl", "gala_library")
+
+gala_library(
+    name = "greeting",
+    srcs = ["greeting.gala"],
+    importpath = "martianoff/gala/greeting",
+    visibility = ["//visibility:public"],
+    gala_deps = ["//examples/internal_package/greeting/internal/format"],
+)

--- a/examples/internal_package/greeting/greeting.gala
+++ b/examples/internal_package/greeting/greeting.gala
@@ -1,0 +1,7 @@
+package greeting
+
+import "martianoff/gala/greeting/internal/format"
+
+// Greet is the package's public API. It is free to call into the private
+// format package because greeting is the parent of format's internal/ directory.
+func Greet(name string) string = s"Hello, ${format.Decorate(name)}!"

--- a/examples/internal_package/greeting/internal/format/BUILD.bazel
+++ b/examples/internal_package/greeting/internal/format/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@rules_gala//gala:defs.bzl", "gala_library")
+
+# Private to the greeting tree. The Bazel visibility mirrors the GALA rule:
+# only targets under examples/internal_package/greeting may depend on it.
+gala_library(
+    name = "format",
+    srcs = ["format.gala"],
+    importpath = "martianoff/gala/greeting/internal/format",
+    visibility = ["//examples/internal_package/greeting:__subpackages__"],
+)

--- a/examples/internal_package/greeting/internal/format/format.gala
+++ b/examples/internal_package/greeting/internal/format/format.gala
@@ -1,0 +1,9 @@
+package format
+
+// Decorate renders a name in the greeting package's house style.
+//
+// This package sits under greeting/internal/, so it is importable only from
+// the tree rooted at martianoff/gala/greeting. Consumers of the greeting
+// package cannot reach it, which is what lets the styling change without
+// breaking them.
+func Decorate(name string) string = s"[$name]"

--- a/examples/internal_package/main.gala
+++ b/examples/internal_package/main.gala
@@ -1,0 +1,15 @@
+package main
+
+import (
+    . "martianoff/gala/collection_immutable"
+    "martianoff/gala/greeting"
+)
+
+// Demonstrates package-level visibility. This file may import the public
+// greeting package, but NOT martianoff/gala/greeting/internal/format —
+// that import is rejected with GALA-E0041, because main sits outside the
+// tree rooted at martianoff/gala/greeting.
+func main() {
+    val names = ArrayOf("ada", "grace", "alan")
+    names.Map((n) => greeting.Greet(n)).ForEach((g) => Println(g))
+}

--- a/examples/internal_package/main.out
+++ b/examples/internal_package/main.out
@@ -1,0 +1,3 @@
+Hello, [ada]!
+Hello, [grace]!
+Hello, [alan]!

--- a/galaerr/errors.go
+++ b/galaerr/errors.go
@@ -374,6 +374,29 @@ const (
 	// rule, and pointed at the token after it, which sent readers looking for an
 	// unbalanced brace instead of the Go type they had written.
 	CodeGoTypeInExpression ErrorCode = "GALA-E0040"
+
+	// E0041: an import names a package under an `internal` directory that the
+	// importing package is not allowed to see. GALA uses Go's rule verbatim:
+	// `a/b/c/internal/d` is importable only from the tree rooted at `a/b/c`,
+	// so a dependency's internal packages are private to that dependency, and
+	// a nested `sub/internal/...` is private to `sub/`.
+	//
+	// The rule was always enforced — but by the Go compiler, against the
+	// GENERATED code, long after the transpiler had already resolved and
+	// transpiled the forbidden package. That produced errors like
+	//
+	//	gen\main.gen.go:6:8: use of internal package
+	//	gala-build-workspace/gen/sub/internal/deep not allowed
+	//
+	// naming a file the user never wrote and an import path that exists only
+	// inside the build workspace. Checking at import-resolution time reports
+	// the violation at the `import` line of the .gala file, in terms of the
+	// path the user actually typed.
+	//
+	// The check fails open when the importing package's own import path cannot
+	// be determined (no module root, or a file outside it), leaving the Go
+	// compiler as the backstop rather than guessing.
+	CodeInternalPackageImport ErrorCode = "GALA-E0041"
 )
 
 // MultiError collects multiple GALA errors.

--- a/internal/transpiler/analyzer/BUILD.bazel
+++ b/internal/transpiler/analyzer/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
         "go_src_dirs_test.go",
         "go_types_debug_test.go",
         "go_types_test.go",
+        "internal_import_test.go",
         "multipackage_panic_test.go",
         "parallel_parse_test.go",
         "parsedfile_cache_test.go",
@@ -66,6 +67,7 @@ go_test(
     ],
     embed = [":analyzer"],
     deps = [
+        "//galaerr",
         "//internal/transpiler",
         "//internal/transpiler/module",
         "//internal/transpiler/registry",

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -25,6 +25,67 @@ import (
 	"martianoff/gala/internal/transpiler/transformer"
 )
 
+// checkInternalImport rejects an import of a package under an `internal`
+// directory that the importing package is not inside the tree of, reporting it
+// at the import's own position in the .gala source.
+//
+// GALA applies Go's rule unchanged, including to the standard library: there
+// is no exemption for `martianoff/gala/...`, because std resolves through the
+// same mechanism as any other GALA library.
+//
+// TWO signals must agree before anything is reported:
+//
+//  1. the import path — importPath names an internal package that importerPath
+//     is outside of; and
+//  2. the layout on disk — the importing file really does sit outside the
+//     internal directory's parent.
+//
+// Requiring both is what keeps the check honest under Bazel, where a
+// gala_library's declared `importpath` need not mirror where its sources live.
+// This repository's own examples do exactly that, so signal 1 alone would
+// reject a package importing its own internal/ subtree.
+//
+// Every path that cannot establish a violation returns nil. The Go compiler
+// still rejects the generated code, so failing open costs a worse error
+// message rather than a missed violation.
+func (a *galaAnalyzer) checkInternalImport(importerPath, importPath string, spec *grammar.ImportSpecContext, filePath string) error {
+	if module.AllowsInternalImport(importerPath, importPath) {
+		return nil
+	}
+
+	// Signal 1 fired. Corroborate against the layout before reporting.
+	importedDir, err := a.resolver.ResolvePackagePath(importPath)
+	if err != nil || importedDir == "" {
+		return nil
+	}
+	if !module.DirContainsInternalViolation(filepath.Dir(filePath), importedDir) {
+		return nil
+	}
+
+	root, _ := module.InternalPackageRoot(importPath)
+	msg := fmt.Sprintf("package %q is internal to %q and cannot be imported from %q",
+		importPath, root, importerPath)
+	// The first clause becomes the inline caret annotation (see
+	// galaerr.terseHint), so it is kept short and free of interpolation —
+	// a long module path would push it past the 60-rune cap and be truncated
+	// mid-word. The specifics belong in the footer clause.
+	hint := fmt.Sprintf(
+		"internal packages are private to their parent tree; "+
+			"import something %q exports instead, or move this package out of internal/ to make it public",
+		root)
+
+	tok := spec.STRING().GetSymbol()
+	violation := galaerr.NewCodedSemanticError(
+		galaerr.CodeInternalPackageImport,
+		tok.GetLine(),
+		tok.GetColumn(),
+		msg,
+		hint,
+	)
+	violation.FilePath = filePath
+	return violation
+}
+
 // CheckStdConflict returns an error if the given name conflicts with std library exports.
 // This prevents user code from shadowing std types and functions.
 //
@@ -606,11 +667,23 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, filePath string) (*transpiler.Ri
 	phaseStart = time.Now()
 
 	// 0.5 Scan imports
+	//
+	// importerPath is this file's own package import path. It is computed once
+	// for the whole scan and is "" whenever the module is unknown or the file
+	// sits outside its root (a cached dependency being analyzed recursively,
+	// an editor buffer with no gala.mod) — which makes every internal-package
+	// check below fail open. See module.AllowsInternalImport.
+	importerPath := a.resolver.PackageImportPath(filePath)
+
 	for _, impDecl := range sourceFile.AllImportDeclaration() {
 		ctx := impDecl.(*grammar.ImportDeclarationContext)
 		for _, spec := range ctx.AllImportSpec() {
 			s := spec.(*grammar.ImportSpecContext)
 			path := strings.Trim(s.STRING().GetText(), "\"")
+
+			if err := a.checkInternalImport(importerPath, path, s, filePath); err != nil {
+				return nil, err
+			}
 
 			// Check if this is a GALA package (internal or external)
 			isInternalGala := strings.HasPrefix(path, "martianoff/gala/")

--- a/internal/transpiler/analyzer/internal_import_test.go
+++ b/internal/transpiler/analyzer/internal_import_test.go
@@ -1,0 +1,206 @@
+package analyzer_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"martianoff/gala/galaerr"
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+)
+
+// internalImportFixture builds a module rooted at tmp with the layout
+//
+//	gala.mod            module example.com/mod
+//	internal/hidden/    package hidden        (private to the module)
+//	sub/plain/          package plain         (public)
+//	sub/internal/deep/  package deep          (private to sub/)
+//
+// and returns the module root. Callers add the importing file themselves.
+func internalImportFixture(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+
+	write := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(tmp, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write("gala.mod", "module example.com/mod\n\ngala dev\n")
+	write("internal/hidden/hidden.gala", "package hidden\n\nfunc Hidden() string = \"h\"\n")
+	write("sub/plain/plain.gala", "package plain\n\nfunc Plain() string = \"p\"\n")
+	write("sub/internal/deep/deep.gala", "package deep\n\nfunc Deep() string = \"d\"\n")
+
+	return tmp
+}
+
+// analyzeFile writes src at relPath inside root and analyzes it, returning
+// whatever error the analyzer produced.
+func analyzeFile(t *testing.T, root, relPath, src string) error {
+	t.Helper()
+
+	full := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := transpiler.NewAntlrGalaParser()
+	searchPaths := append([]string{root}, getStdSearchPath()...)
+	a := analyzer.NewGalaAnalyzer(p, searchPaths, root)
+
+	tree, err := p.Parse(src)
+	if err != nil {
+		t.Fatalf("parse %s: %v", relPath, err)
+	}
+	_, analyzeErr := a.Analyze(tree, full)
+	return analyzeErr
+}
+
+// requireE0041 asserts the error is a coded internal-import violation naming
+// the expected offending path.
+func requireE0041(t *testing.T, err error, wantPath string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected GALA-E0041 for import of %q, got no error", wantPath)
+	}
+	se, ok := err.(*galaerr.SemanticError)
+	if !ok {
+		t.Fatalf("expected *galaerr.SemanticError, got %T: %v", err, err)
+	}
+	if se.Code != galaerr.CodeInternalPackageImport {
+		t.Fatalf("expected code %s, got %s: %v", galaerr.CodeInternalPackageImport, se.Code, err)
+	}
+	if !strings.Contains(se.Error(), wantPath) {
+		t.Errorf("error should name the offending import %q, got: %v", wantPath, err)
+	}
+	if se.Line == 0 {
+		t.Errorf("error must carry a source line, got 0: %v", err)
+	}
+	if se.FilePath == "" {
+		t.Errorf("error must carry the .gala file path, got empty: %v", err)
+	}
+}
+
+// A package outside the internal parent's tree cannot reach in, even though
+// both live in the same module.
+func TestInternalImport_RejectedFromSiblingSubtree(t *testing.T) {
+	root := internalImportFixture(t)
+	err := analyzeFile(t, root, "main.gala", `package main
+
+import "example.com/mod/sub/internal/deep"
+
+func main() {
+    Println(deep.Deep())
+}
+`)
+	requireE0041(t, err, "example.com/mod/sub/internal/deep")
+}
+
+// The module root may import its own top-level internal/ tree.
+func TestInternalImport_AllowedFromModuleRoot(t *testing.T) {
+	root := internalImportFixture(t)
+	err := analyzeFile(t, root, "main.gala", `package main
+
+import "example.com/mod/internal/hidden"
+
+func main() {
+    Println(hidden.Hidden())
+}
+`)
+	if err != nil {
+		t.Fatalf("importing the module's own internal/ package must be allowed, got: %v", err)
+	}
+}
+
+// A package inside the internal parent's tree may reach in.
+func TestInternalImport_AllowedFromWithinParentTree(t *testing.T) {
+	root := internalImportFixture(t)
+	err := analyzeFile(t, root, "sub/consumer/consumer.gala", `package consumer
+
+import "example.com/mod/sub/internal/deep"
+
+func Use() string = deep.Deep()
+`)
+	if err != nil {
+		t.Fatalf("importing an internal package from inside its parent tree must be allowed, got: %v", err)
+	}
+}
+
+// A non-internal import is never touched by the check.
+func TestInternalImport_PublicPackageUnaffected(t *testing.T) {
+	root := internalImportFixture(t)
+	err := analyzeFile(t, root, "main.gala", `package main
+
+import "example.com/mod/sub/plain"
+
+func main() {
+    Println(plain.Plain())
+}
+`)
+	if err != nil {
+		t.Fatalf("importing a public package must be allowed, got: %v", err)
+	}
+}
+
+// "internalize" is not "internal" — only whole path elements count.
+func TestInternalImport_ElementBoundaryNotSubstring(t *testing.T) {
+	root := internalImportFixture(t)
+	pkgDir := filepath.Join(root, "internalize", "thing")
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "thing.gala"),
+		[]byte("package thing\n\nfunc Thing() string = \"t\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := analyzeFile(t, root, "main.gala", `package main
+
+import "example.com/mod/internalize/thing"
+
+func main() {
+    Println(thing.Thing())
+}
+`)
+	if err != nil {
+		t.Fatalf("a path element merely starting with \"internal\" must not be restricted, got: %v", err)
+	}
+}
+
+// The violation is reported at the import's own line and column, not at the
+// top of the file — that position is the whole point of checking here rather
+// than letting the Go compiler reject the generated code.
+func TestInternalImport_ReportsImportPosition(t *testing.T) {
+	root := internalImportFixture(t)
+	err := analyzeFile(t, root, "main.gala", `package main
+
+import "example.com/mod/sub/plain"
+import "example.com/mod/sub/internal/deep"
+
+func main() {
+    Println(deep.Deep())
+}
+`)
+	requireE0041(t, err, "example.com/mod/sub/internal/deep")
+
+	se := err.(*galaerr.SemanticError)
+	if se.Line != 4 {
+		t.Errorf("expected the offending import's line 4, got %d", se.Line)
+	}
+	// Column points at the opening quote of the import string (0-based, as
+	// ANTLR reports it): `import ` is 7 characters.
+	if se.Column != 7 {
+		t.Errorf("expected column 7 (the import path literal), got %d", se.Column)
+	}
+}

--- a/internal/transpiler/module/BUILD.bazel
+++ b/internal/transpiler/module/BUILD.bazel
@@ -14,7 +14,10 @@ go_library(
 
 go_test(
     name = "module_test",
-    srcs = ["resolver_test.go"],
+    srcs = [
+        "internal_visibility_test.go",
+        "resolver_test.go",
+    ],
     embed = [":module"],
     deps = [
         "@com_github_stretchr_testify//assert",

--- a/internal/transpiler/module/internal_visibility_test.go
+++ b/internal/transpiler/module/internal_visibility_test.go
@@ -1,0 +1,290 @@
+package module
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInternalPackageRoot(t *testing.T) {
+	cases := []struct {
+		name       string
+		importPath string
+		wantRoot   string
+		wantIsInt  bool
+	}{
+		{
+			name:       "no internal element",
+			importPath: "example.com/mod/sub/pkg",
+			wantIsInt:  false,
+		},
+		{
+			name:       "internal is only a prefix of an element",
+			importPath: "example.com/mod/internalize/pkg",
+			wantIsInt:  false,
+		},
+		{
+			name:       "internal is only a suffix of an element",
+			importPath: "example.com/mod/nointernal/pkg",
+			wantIsInt:  false,
+		},
+		{
+			name:       "top-level internal in a module",
+			importPath: "example.com/mod/internal/secret",
+			wantRoot:   "example.com/mod",
+			wantIsInt:  true,
+		},
+		{
+			name:       "nested internal binds to its own parent",
+			importPath: "example.com/mod/sub/internal/deep",
+			wantRoot:   "example.com/mod/sub",
+			wantIsInt:  true,
+		},
+		{
+			name:       "internal as the final element",
+			importPath: "example.com/mod/internal",
+			wantRoot:   "example.com/mod",
+			wantIsInt:  true,
+		},
+		{
+			name:       "unqualified internal yields the empty root",
+			importPath: "internal/secret",
+			wantRoot:   "",
+			wantIsInt:  true,
+		},
+		{
+			// cmd/go's findInternal takes the LAST internal element, so the
+			// binding root is the innermost — and narrowest — one.
+			name:       "doubly nested internal takes the innermost",
+			importPath: "a/internal/b/internal/c",
+			wantRoot:   "a/internal/b",
+			wantIsInt:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, isInternal := InternalPackageRoot(tc.importPath)
+			assert.Equal(t, tc.wantIsInt, isInternal, "isInternal for %q", tc.importPath)
+			if tc.wantIsInt {
+				assert.Equal(t, tc.wantRoot, root, "root for %q", tc.importPath)
+			}
+		})
+	}
+}
+
+func TestAllowsInternalImport(t *testing.T) {
+	cases := []struct {
+		name       string
+		importer   string
+		importPath string
+		want       bool
+	}{
+		{
+			name:       "non-internal import is always allowed",
+			importer:   "example.com/other",
+			importPath: "example.com/mod/sub",
+			want:       true,
+		},
+		{
+			name:       "the internal parent itself may import it",
+			importer:   "example.com/mod",
+			importPath: "example.com/mod/internal/secret",
+			want:       true,
+		},
+		{
+			name:       "a package below the parent may import it",
+			importer:   "example.com/mod/cmd/app",
+			importPath: "example.com/mod/internal/secret",
+			want:       true,
+		},
+		{
+			name:       "the internal package's own sibling may import it",
+			importer:   "example.com/mod/internal/other",
+			importPath: "example.com/mod/internal/secret",
+			want:       true,
+		},
+		{
+			name:       "a different module may not import it",
+			importer:   "example.com/consumer",
+			importPath: "example.com/mod/internal/secret",
+			want:       false,
+		},
+		{
+			name:       "the parent's parent may not import a nested internal",
+			importer:   "example.com/mod",
+			importPath: "example.com/mod/sub/internal/deep",
+			want:       false,
+		},
+		{
+			name:       "a sibling subtree may not import a nested internal",
+			importer:   "example.com/mod/other",
+			importPath: "example.com/mod/sub/internal/deep",
+			want:       false,
+		},
+		{
+			// "example.com/modular" must not be treated as living inside
+			// "example.com/mod" just because the string is a prefix.
+			name:       "prefix match must respect element boundaries",
+			importer:   "example.com/modular",
+			importPath: "example.com/mod/internal/secret",
+			want:       false,
+		},
+		{
+			name:       "unknown importer fails open",
+			importer:   "",
+			importPath: "example.com/mod/internal/secret",
+			want:       true,
+		},
+		{
+			// std resolves through the same mechanism as any other GALA
+			// library; there is no exemption for martianoff/gala/*.
+			name:       "std internal is not exempt",
+			importer:   "example.com/app",
+			importPath: "martianoff/gala/internal/detail",
+			want:       false,
+		},
+		{
+			name:       "std package may import std internal",
+			importer:   "martianoff/gala/collection_immutable",
+			importPath: "martianoff/gala/internal/detail",
+			want:       true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AllowsInternalImport(tc.importer, tc.importPath)
+			assert.Equal(t, tc.want, got,
+				"AllowsInternalImport(%q, %q)", tc.importer, tc.importPath)
+		})
+	}
+}
+
+func TestDirContainsInternalViolation(t *testing.T) {
+	root := t.TempDir()
+	j := func(parts ...string) string { return filepath.Join(append([]string{root}, parts...)...) }
+
+	cases := []struct {
+		name        string
+		importerDir string
+		importedDir string
+		want        bool
+	}{
+		{
+			name:        "importer above the internal parent is a violation",
+			importerDir: j("proj"),
+			importedDir: j("proj", "sub", "internal", "deep"),
+			want:        true,
+		},
+		{
+			name:        "importer in a sibling subtree is a violation",
+			importerDir: j("proj", "other"),
+			importedDir: j("proj", "sub", "internal", "deep"),
+			want:        true,
+		},
+		{
+			name:        "the internal parent itself is allowed",
+			importerDir: j("proj", "sub"),
+			importedDir: j("proj", "sub", "internal", "deep"),
+			want:        false,
+		},
+		{
+			name:        "a package below the internal parent is allowed",
+			importerDir: j("proj", "sub", "nested", "pkg"),
+			importedDir: j("proj", "sub", "internal", "deep"),
+			want:        false,
+		},
+		{
+			name:        "no internal directory on disk means nothing to enforce",
+			importerDir: j("proj"),
+			importedDir: j("proj", "sub", "public"),
+			want:        false,
+		},
+		{
+			name:        "unknown importer directory reports nothing",
+			importerDir: "",
+			importedDir: j("proj", "sub", "internal", "deep"),
+			want:        false,
+		},
+		{
+			name:        "unknown imported directory reports nothing",
+			importerDir: j("proj"),
+			importedDir: "",
+			want:        false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DirContainsInternalViolation(tc.importerDir, tc.importedDir)
+			assert.Equal(t, tc.want, got,
+				"DirContainsInternalViolation(%q, %q)", tc.importerDir, tc.importedDir)
+		})
+	}
+}
+
+// The Bazel case that motivated the two-signal design: a gala_library declares
+// importpath "martianoff/gala/greeting" for sources that live under
+// examples/internal_package/greeting/. The import path alone says "violation";
+// the layout says otherwise, and the layout is right.
+func TestDirContainsInternalViolation_DeclaredImportPathMayNotMirrorLayout(t *testing.T) {
+	root := t.TempDir()
+	greetingDir := filepath.Join(root, "examples", "internal_package", "greeting")
+	formatDir := filepath.Join(greetingDir, "internal", "format")
+
+	// Signal 1 (import paths) would reject this...
+	assert.False(t,
+		AllowsInternalImport("martianoff/gala/examples/internal_package/greeting",
+			"martianoff/gala/greeting/internal/format"),
+		"derived importer path disagrees with the declared importpath")
+
+	// ...but signal 2 (layout) shows the importer is the internal parent.
+	assert.False(t, DirContainsInternalViolation(greetingDir, formatDir),
+		"a package importing its own internal/ subtree must never be reported")
+}
+
+func TestPackageImportPath(t *testing.T) {
+	moduleRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(moduleRoot, "gala.mod"),
+		[]byte("module example.com/mod\n\ngala 1.0\n"), 0644))
+
+	subDir := filepath.Join(moduleRoot, "sub", "internal", "deep")
+	require.NoError(t, os.MkdirAll(subDir, 0755))
+
+	r := &Resolver{moduleRoot: moduleRoot, moduleName: "example.com/mod"}
+
+	t.Run("file at the module root", func(t *testing.T) {
+		got := r.PackageImportPath(filepath.Join(moduleRoot, "main.gala"))
+		assert.Equal(t, "example.com/mod", got)
+	})
+
+	t.Run("file in a nested package", func(t *testing.T) {
+		got := r.PackageImportPath(filepath.Join(subDir, "deep.gala"))
+		assert.Equal(t, "example.com/mod/sub/internal/deep", got)
+	})
+
+	t.Run("path need not exist on disk", func(t *testing.T) {
+		// PackageImportPath is pure path arithmetic — it must not stat.
+		got := r.PackageImportPath(filepath.Join(moduleRoot, "not", "created", "yet.gala"))
+		assert.Equal(t, "example.com/mod/not/created", got)
+	})
+
+	t.Run("file outside the module root yields unknown", func(t *testing.T) {
+		outside := filepath.Join(t.TempDir(), "stray.gala")
+		assert.Equal(t, "", r.PackageImportPath(outside))
+	})
+
+	t.Run("unknown module yields unknown", func(t *testing.T) {
+		bare := &Resolver{}
+		assert.Equal(t, "", bare.PackageImportPath(filepath.Join(moduleRoot, "main.gala")))
+	})
+
+	t.Run("empty path yields unknown", func(t *testing.T) {
+		assert.Equal(t, "", r.PackageImportPath(""))
+	})
+}

--- a/internal/transpiler/module/resolver.go
+++ b/internal/transpiler/module/resolver.go
@@ -129,6 +129,159 @@ func (r *Resolver) ModuleName() string {
 	return r.moduleName
 }
 
+// InternalPackageRoot reports whether importPath names a package that lives
+// under an "internal" directory, and if so returns the import path of the
+// subtree that is allowed to import it.
+//
+// The rule is Go's, applied to GALA import paths: a package
+// "a/b/c/internal/d/e" is importable only from the tree rooted at "a/b/c".
+// Only a whole path ELEMENT counts — "a/b/internalize/c" has no internal
+// element, and a leading "internal/d" yields the empty root, meaning the
+// module's own root tree.
+//
+// The LAST internal element wins, matching cmd/go's findInternal: for
+// "a/internal/b/internal/c" the binding root is "a/internal/b", the innermost
+// (and therefore narrowest) constraint.
+func InternalPackageRoot(importPath string) (root string, isInternal bool) {
+	elems := strings.Split(importPath, "/")
+	i := lastInternalElement(elems)
+	if i < 0 {
+		return "", false
+	}
+	return strings.Join(elems[:i], "/"), true
+}
+
+// lastInternalElement returns the index of the last path element equal to
+// "internal", or -1 when there is none. Shared by the import-path rule and the
+// on-disk rule so the two cannot drift apart on what counts as "internal".
+func lastInternalElement(elems []string) int {
+	for i := len(elems) - 1; i >= 0; i-- {
+		if elems[i] == "internal" {
+			return i
+		}
+	}
+	return -1
+}
+
+// relWithin reports the slash-separated path of target relative to root, and
+// whether target lies inside root (root itself counts as inside). Both
+// arguments must already be absolute.
+func relWithin(root, target string) (rel string, inside bool) {
+	r, err := filepath.Rel(root, target)
+	if err != nil {
+		return "", false
+	}
+	r = filepath.ToSlash(r)
+	if r == ".." || strings.HasPrefix(r, "../") {
+		return r, false
+	}
+	return r, true
+}
+
+// DirContainsInternalViolation reports whether importerDir sits outside the
+// tree that may import a package located at importedDir, judging by the
+// directory layout on disk rather than by import path.
+//
+// This is the corroborating signal for AllowsInternalImport. Import paths are
+// not always a faithful picture of the layout: under Bazel a gala_library
+// declares its `importpath` explicitly, and it need not mirror where the
+// sources live (this repository's own examples declare
+// "martianoff/gala/greeting" for sources under examples/internal_package/).
+// Judging visibility from the derived path alone would reject those builds.
+//
+// Returns false — no violation — whenever the layout does not clearly show
+// one, including when either path is unknown or the imported package has no
+// "internal" ancestor on disk.
+func DirContainsInternalViolation(importerDir, importedDir string) bool {
+	if importerDir == "" || importedDir == "" {
+		return false
+	}
+
+	absImporter, err := filepath.Abs(importerDir)
+	if err != nil {
+		return false
+	}
+	absImported, err := filepath.Abs(importedDir)
+	if err != nil {
+		return false
+	}
+
+	// Find the innermost "internal" element of the imported package's path and
+	// take its parent — the root of the tree allowed to import it.
+	elems := strings.Split(filepath.ToSlash(absImported), "/")
+	idx := lastInternalElement(elems)
+	if idx <= 0 {
+		return false // no internal ancestor on disk (or it is the filesystem root)
+	}
+	allowedRoot := filepath.FromSlash(strings.Join(elems[:idx], "/"))
+
+	_, inside := relWithin(allowedRoot, absImporter)
+	return !inside
+}
+
+// AllowsInternalImport reports whether a package whose own import path is
+// importerPath may import importPath.
+//
+// Non-internal imports are always allowed. An internal import is allowed only
+// when the importer sits inside the tree rooted at the internal directory's
+// parent — that is, when importerPath is that root or a package below it.
+//
+// An empty importerPath means the caller could not determine which package is
+// doing the importing (no module root, or a file outside it). The check then
+// fails OPEN and allows the import: reporting a visibility violation against
+// an unknown importer would turn "we don't know where this file lives" into a
+// hard compile error, and the Go compiler still backstops the real rule.
+func AllowsInternalImport(importerPath, importPath string) bool {
+	root, isInternal := InternalPackageRoot(importPath)
+	if !isInternal {
+		return true
+	}
+	if importerPath == "" {
+		return true
+	}
+	if root == "" {
+		// "internal/..." with no prefix: importable from anywhere in the
+		// module that declares it. The importer path alone cannot prove
+		// membership, so leave this to the resolver — an unqualified
+		// internal path never crosses a module boundary by import path.
+		return true
+	}
+	return importerPath == root || strings.HasPrefix(importerPath, root+"/")
+}
+
+// PackageImportPath returns the import path of the package that contains the
+// source file filePath, derived from the module root and module name.
+//
+// filePath names a FILE; its parent directory is the package. The function
+// touches no filesystem — it is pure path arithmetic.
+//
+// Returns "" when the module is unknown or filePath lies outside the module
+// root — callers treat that as "importer unknown" and skip visibility checks
+// rather than guessing.
+func (r *Resolver) PackageImportPath(filePath string) string {
+	if r.moduleName == "" || r.moduleRoot == "" || filePath == "" {
+		return ""
+	}
+
+	absDir, err := filepath.Abs(filepath.Dir(filePath))
+	if err != nil {
+		return ""
+	}
+	absRoot, err := filepath.Abs(r.moduleRoot)
+	if err != nil {
+		return ""
+	}
+
+	rel, inside := relWithin(absRoot, absDir)
+	if !inside {
+		return ""
+	}
+	if rel == "." {
+		return r.moduleName
+	}
+	return r.moduleName + "/" + rel
+}
+
 // ResolvePackagePath converts an import path to a filesystem path.
 //
 // Resolution strategy:

--- a/website/docs/errors.md
+++ b/website/docs/errors.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: "GALA Compiler Error Codes — Complete Reference (GALA-E0001 to GALA-E0038)"
-description: "Every GALA compile-time error code explained: what it means, the code that triggers it, the exact compiler message, and how to fix it. Searchable reference for GALA-E0001 through GALA-E0038."
-keywords: "gala error codes, gala compiler errors, gala-e0001, gala-e0038, gala semantic error, gala transpiler error, gala compile error reference, golang transpiler error codes"
+title: "GALA Compiler Error Codes — Complete Reference (GALA-E0001 to GALA-E0041)"
+description: "Every GALA compile-time error code explained: what it means, the code that triggers it, the exact compiler message, and how to fix it. Searchable reference for GALA-E0001 through GALA-E0041."
+keywords: "gala error codes, gala compiler errors, gala-e0001, gala-e0038, gala-e0041, gala semantic error, gala transpiler error, gala compile error reference, golang transpiler error codes"
 permalink: /docs/errors/
-last_modified_at: 2026-07-27
+last_modified_at: 2026-07-30
 ---
 
 <p class="breadcrumb"><a href="/">Home</a> / <a href="/docs/">Docs</a> / Error Codes</p>
@@ -93,6 +93,7 @@ Same code, same message; the column is zero-based in the terse form. See [Compil
 | [GALA-E0036](/docs/errors/gala-e0036/) | Bare Go statement keyword (`defer`, `go`, `select`, …) | Go surface |
 | [GALA-E0037](/docs/errors/gala-e0037/) | Non-shareable value crosses a goroutine boundary | Concurrency safety |
 | [GALA-E0038](/docs/errors/gala-e0038/) | Invalid escape sequence in a string literal | Literals |
+| [GALA-E0041](/docs/errors/gala-e0041/) | Import of an internal package from outside its tree | Packages |
 
 Every code the compiler can emit now has a page. Codes are never renumbered and never change meaning, so a code you find in an old build log still means the same thing here.
 
@@ -126,7 +127,7 @@ Five codes exist in the compiler but no valid source reaches them. Each still ha
 
 **Type inference** — [E0018](/docs/errors/gala-e0018/), [E0021](/docs/errors/gala-e0021/), [E0022](/docs/errors/gala-e0022/), [E0023](/docs/errors/gala-e0023/), [E0033](/docs/errors/gala-e0033/). See [Type Inference](/features/type-inference/).
 
-**Packages and imports** — [E0010](/docs/errors/gala-e0010/), [E0020](/docs/errors/gala-e0020/), [E0025](/docs/errors/gala-e0025/), [E0026](/docs/errors/gala-e0026/), [E0032](/docs/errors/gala-e0032/). See [Dependency Management](/docs/dependency-management/).
+**Packages and imports** — [E0010](/docs/errors/gala-e0010/), [E0020](/docs/errors/gala-e0020/), [E0025](/docs/errors/gala-e0025/), [E0026](/docs/errors/gala-e0026/), [E0032](/docs/errors/gala-e0032/), [E0041](/docs/errors/gala-e0041/) internal-package visibility. See [Dependency Management](/docs/dependency-management/).
 
 **Go constructs with no GALA surface** — [E0007](/docs/errors/gala-e0007/) slice literals · [E0008](/docs/errors/gala-e0008/) map literals · [E0035](/docs/errors/gala-e0035/) builtins like `len` and `panic` · [E0036](/docs/errors/gala-e0036/) statement keywords like `defer` and `go`. Each names its GALA replacement.
 

--- a/website/docs/errors/gala-e0041.md
+++ b/website/docs/errors/gala-e0041.md
@@ -1,0 +1,114 @@
+---
+layout: default
+title: "GALA-E0041 — Import of an Internal Package From Outside Its Tree"
+description: "\"package X is internal to Y and cannot be imported from Z\" — GALA-E0041 enforces Go's internal/ package rule on GALA import paths. See the real compiler output, the visibility table, and how to publish an internal package."
+keywords: "gala-e0041, gala internal package, gala private package, gala package visibility, gala internal directory, go internal rule, gala module private api"
+permalink: /docs/errors/gala-e0041/
+last_modified_at: 2026-07-30
+---
+
+<p class="breadcrumb"><a href="/">Home</a> / <a href="/docs/">Docs</a> / <a href="/docs/errors/">Error Codes</a> / GALA-E0041</p>
+
+# GALA-E0041 — Import of an internal package from outside its tree
+
+**What it means.** An `import` names a package that lives under a directory called `internal`, and the importing package is not inside the tree allowed to see it.
+
+GALA uses Go's rule, applied to GALA import paths:
+
+> `a/b/c/internal/d` is importable only from the tree rooted at `a/b/c`.
+
+Only whole path **elements** count — `a/b/internalize/c` contains no `internal` element and is an ordinary public package. When a path contains more than one `internal` element, the innermost is the binding one, matching `cmd/go`: `a/internal/b/internal/c` is importable from the tree rooted at `a/internal/b`.
+
+There is no exemption for the standard library. `martianoff/gala/*` resolves through the same mechanism as any other GALA library and obeys the same rule.
+
+---
+
+## Who can import what
+
+For a module laid out like this:
+
+```
+mylib/
+  gala.mod                     module example.com/mylib
+  mylib.gala                   package mylib          — public
+  internal/
+    detail/detail.gala         package detail         — private to example.com/mylib
+  sub/
+    sub.gala                   package sub            — public
+    internal/
+      deep/deep.gala           package deep           — private to example.com/mylib/sub
+```
+
+| Importer | `.../mylib/internal/detail` | `.../mylib/sub/internal/deep` |
+|---|---|---|
+| `example.com/mylib` | ✅ | ❌ — not under `sub/` |
+| `example.com/mylib/sub` | ✅ | ✅ |
+| `example.com/mylib/sub/other` | ✅ | ✅ |
+| another module | ❌ | ❌ |
+
+---
+
+## Minimal repro
+
+```gala
+package main
+
+import "example.com/myapp/sub/internal/deep"
+
+func main() {
+    Println(deep.Deep())
+}
+```
+
+`main.gala` sits at `example.com/myapp`, which is *above* `example.com/myapp/sub` rather than inside it.
+
+## Error output
+
+```
+error[GALA-E0041]: package "example.com/myapp/sub/internal/deep" is internal to "example.com/myapp/sub" and cannot be imported from "example.com/myapp"
+  --> main.gala:3:8
+  |
+3 | import "example.com/myapp/sub/internal/deep"
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ internal packages are private to their parent tree
+  |
+  = hint: internal packages are private to their parent tree; import something "example.com/myapp/sub" exports instead, or move this package out of internal/ to make it public
+```
+
+The same code covers a dependency's private packages:
+
+```
+error[GALA-E0041]: package "example.com/lib/internal/secret" is internal to "example.com/lib" and cannot be imported from "example.com/myapp"
+```
+
+---
+
+## How to fix it
+
+1. **Use the public API.** If the internal package belongs to a dependency, the library author deliberately did not publish it — call something the parent package exports instead.
+
+2. **Move the importer into the tree.** A file that genuinely belongs to the `sub/` subsystem should live under `sub/`, at which point the import is legal.
+
+3. **Publish the package.** Move it out of the `internal` directory. This changes its import path, so it is a breaking change for anyone already importing it under the old path — which is exactly the guarantee the mechanism buys you.
+
+---
+
+## Why the rule exists
+
+An `internal` tree lets a library share code across its own packages without adding it to the API it has to keep supporting. Consumers can call whatever the parent package exports; they cannot reach `internal/detail`, so it can be renamed, resplit or deleted without breaking them.
+
+This is worth reaching for when you ship a library to consumers you do not control and want a small supported surface. For an application or a single-binary project, the whole module is already private to you, and an `internal` tree mostly adds a directory level — use it where there is a real API boundary to defend, not as a default layout.
+
+## Why the check takes two signals
+
+The transpiler reports a violation only when the import paths *and* the directory layout on disk both indicate one. Import paths are not always a faithful picture of the layout: under Bazel a `gala_library` declares its `importpath` explicitly, and it need not mirror where the sources live. Judging by the derived import path alone would reject a package importing its own `internal/` subtree in those builds.
+
+Whenever a violation cannot be established — the importing package's import path is unknown (no module root, or a file outside it), or the imported package cannot be resolved to a directory — the check deliberately fails **open**. The Go compiler still rejects the generated code, so failing open costs a worse error message rather than a missed violation.
+
+---
+
+## See also
+
+- [Package Visibility](/docs/language-reference/#package-visibility) — the full visibility model, including identifier-level casing rules
+- [Dependency Management](/docs/dependency-management/) — what you can and cannot import from a dependency
+- [GALA-E0020](/docs/errors/gala-e0020/) — package not found (the import path does not resolve at all)
+- [GALA-E0025](/docs/errors/gala-e0025/) — unresolved cross-package symbol

--- a/website/docs/language-reference.md
+++ b/website/docs/language-reference.md
@@ -4,7 +4,7 @@ title: "GALA Language Reference - Complete Specification"
 description: "Complete GALA language specification. Variables, functions, structs, sealed types, pattern matching, generics, lambdas, interfaces, control flow, and standard library types — the full reference for the Go alternative language."
 keywords: "gala language reference, gala specification, gala syntax, gala language guide, go alternative language reference, gala documentation"
 permalink: /docs/language-reference/
-last_modified_at: 2026-07-05
+last_modified_at: 2026-07-30
 ---
 
 <p class="breadcrumb"><a href="/">Home</a> / <a href="/docs/">Docs</a> / Language Reference</p>
@@ -581,6 +581,28 @@ func main() {
     val sum = Add(10, 20) // from mathlib via dot import
 }
 ```
+
+### Package Visibility {#package-visibility}
+
+Visibility is controlled at two levels. **Identifiers** use casing, as in Go: a `PascalCase` type, function, field or method is exported from its package; a `camelCase` one is not.
+
+**Packages** use `internal` directories. A package under a directory named `internal` is importable only from the tree rooted at that directory's parent — Go's rule, applied to GALA import paths:
+
+```
+mylib/
+  mylib.gala                   package mylib    — public
+  internal/
+    detail/detail.gala         package detail   — private to example.com/mylib
+  sub/
+    internal/
+      deep/deep.gala           package deep     — private to example.com/mylib/sub
+```
+
+`a/b/c/internal/d` is importable only from the tree rooted at `a/b/c`. Only whole path elements count — a directory named `internalize` is an ordinary public package. There is no exemption for the standard library.
+
+This lets a library share code across its own packages without adding it to the API it must keep supporting: consumers call what the parent package exports and cannot reach `internal/detail`, so it can be renamed or deleted freely. A forbidden import is rejected with [GALA-E0041](/docs/errors/gala-e0041/).
+
+Publishing an internal package means moving it out of the `internal` directory, which changes its import path — so it is worth deciding deliberately. For an application, the whole module is already private to you; reach for `internal` where there is a real API boundary to defend, not as a default layout.
 
 See [Dependency Management](/docs/dependency-management/) for managing external packages.
 


### PR DESCRIPTION
## Summary

GALA already enforced Go's internal-package rule — but only via the **Go compiler**, against the **generated** code, long after the transpiler had resolved and transpiled the forbidden package. What a user saw was:

```
package gala-build-workspace/gen
        gen\main.gen.go:6:8: use of internal package gala-build-workspace/gen/sub/internal/deep not allowed
```

That names a file nobody wrote and an import path that exists only inside the build workspace. Nothing in it points back to the `import` line that caused it.

The rule is now checked at import-resolution time and reported at the import's own line, in the `.gala` file, using the path the user actually typed:

```
error[GALA-E0041]: package "example.com/myapp/sub/internal/deep" is internal to "example.com/myapp/sub" and cannot be imported from "example.com/myapp"
  --> main.gala:3:8
  |
3 | import "example.com/myapp/sub/internal/deep"
  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ internal packages are private to their parent tree
  |
  = hint: internal packages are private to their parent tree; import something "example.com/myapp/sub" exports instead, or move this package out of internal/ to make it public
```

## Design: the check takes two signals

A violation is reported only when the **import paths** *and* the **on-disk layout** both indicate one.

Import paths alone are not a faithful picture of the layout: under Bazel a `gala_library` declares its `importpath` explicitly, and it need not mirror where its sources live. This repository's own examples do exactly that — `martianoff/gala/greeting` for sources under `examples/internal_package/greeting/`. Judging by the derived path alone rejected a package importing *its own* `internal/` subtree, which broke the build during development of this PR.

Every case that cannot establish a violation **fails open**, leaving the Go compiler as the backstop rather than guessing: unknown module root, file outside it (a cached dependency analyzed on the fly, an editor buffer with no `gala.mod`), or an imported package that does not resolve to a directory.

The rule matches `cmd/go`'s `findInternal` exactly: whole path **elements** only (`internalize` is an ordinary package), and the **last** `internal` element wins. There is no exemption for the standard library — `martianoff/gala/*` resolves through the same mechanism as any other GALA library.

## Changes

- `galaerr/errors.go` — new `CodeInternalPackageImport` (`GALA-E0041`)
- `internal/transpiler/module/resolver.go` — `InternalPackageRoot`, `AllowsInternalImport`, `PackageImportPath`, `DirContainsInternalViolation` as pure, testable functions
- `internal/transpiler/analyzer/analyzer.go` — `checkInternalImport` fires during the import scan
- Docs — `GALA.MD` (new Package Visibility section, plus a cross-reference from the multi-package layout section added in #467), `DEPENDENCY_MANAGEMENT.MD`, `GALA_BEST_PRACTICES.MD`, `docs/errors/GALA-E0041.md` + index
- Website — error page, index, and a Package Visibility section in the language reference, which had none
- `examples/internal_package/` — a public facade over a private `internal/` package

Documented as *available and enforced*, deliberately **not** as a recommended default layout — the dominant criticism of `internal/` in the Go community is reflexive over-application, and there is no reason to import that.

## Verification

Five scenarios verified end to end with a branch-built CLI:

| Case | Result |
|---|---|
| Project imports its own `internal/hidden` | allowed |
| Package inside the internal parent's tree imports it | allowed |
| Dependency's public API backed by its own `internal/` | allowed |
| Sibling subtree imports `sub/internal/deep` | **GALA-E0041** |
| Consumer imports a dependency's `internal/secret` | **GALA-E0041** |

Plus 20+ unit tests across the module and analyzer packages. `bazel build //...` and `bazel test //...` green (the only failure is the pre-existing `TestGorootFromGoBinarySymlink`, which needs Windows symlink privilege and fails on pristine master too).

## Related

Companion change `gala_gazelle` [0.3.1](https://github.com/martianoff/rules-gala/releases/tag/0.3.1) makes gazelle emit matching Bazel visibility for `internal/` packages, so both layers agree. Picking it up here is a follow-up (`MODULE.bazel` currently pins `gala_gazelle` 0.2.4).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)