### PR TITLE
fix(transpiler): resolve cross-package bare function references to a FuncType

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -330,6 +330,21 @@ gala_exec_test(
     deps = ["//collection_immutable"],
 )
 
+# Regression: bare reference to a function in ANOTHER package passed to a
+# generic method (Array.Map) whose result feeds a second generic method. The
+# cross-package function's signature must be resolved so Map's type parameter
+# binds; otherwise the uninstantiated method type parameter leaks into the
+# generated Go.
+gala_exec_test(
+    name = "crosspkg_funcref_chain",
+    src = "crosspkg_funcref_chain.gala",
+    expected = "crosspkg_funcref_chain.out",
+    deps = [
+        "//collection_immutable",
+        "//examples/crosspkg_funcref_lib",
+    ],
+)
+
 # Regression: placeholder-lambda `_.Field` must be equivalent to the explicit
 # lambda `(p) => p.Field`, including the Immutable field auto-unwrap. Prior to
 # the fix `_.Name` bound `_` to `any`, hiding the struct metadata from the

--- a/examples/crosspkg_funcref_chain.gala
+++ b/examples/crosspkg_funcref_chain.gala
@@ -1,0 +1,27 @@
+package main
+
+import (
+    . "martianoff/gala/collection_immutable"
+    "martianoff/gala/examples/crosspkg_funcref_lib"
+)
+
+// A bare reference to a function in ANOTHER package, passed to a generic
+// method (Array.Map) whose result is then consumed by a SECOND generic method
+// (ForEach / Map). The transpiler must resolve the cross-package function's
+// signature to bind Map's result type parameter; otherwise the uninstantiated
+// method type parameter leaks into the generated Go.
+func main() {
+    // Cross-package bare ref chained into a generic consumer.
+    ArrayOf("a", "b").Map(crosspkg_funcref_lib.Shout).ForEach((g) => Println(g))
+
+    // Cross-package bare ref whose result type differs from the element type,
+    // chained into another generic method.
+    val lengths = ArrayOf("aa", "bbb").Map(crosspkg_funcref_lib.Length)
+    Println(lengths.Map((n) => n * 2).String())
+
+    // Cross-package bare ref with a non-generic consumer.
+    Println(ArrayOf("c").Map(crosspkg_funcref_lib.Shout).String())
+
+    // Explicit lambda over the same cross-package function.
+    ArrayOf("d").Map((s) => crosspkg_funcref_lib.Shout(s)).ForEach((g) => Println(g))
+}

--- a/examples/crosspkg_funcref_chain.gala
+++ b/examples/crosspkg_funcref_chain.gala
@@ -17,7 +17,7 @@ func main() {
     // Cross-package bare ref whose result type differs from the element type,
     // chained into another generic method.
     val lengths = ArrayOf("aa", "bbb").Map(crosspkg_funcref_lib.Length)
-    Println(lengths.Map((n) => n * 2).String())
+    Println(lengths.Map(_ * 2).String())
 
     // Cross-package bare ref with a non-generic consumer.
     Println(ArrayOf("c").Map(crosspkg_funcref_lib.Shout).String())

--- a/examples/crosspkg_funcref_chain.out
+++ b/examples/crosspkg_funcref_chain.out
@@ -1,0 +1,5 @@
+a!
+b!
+Array(4, 6)
+Array(c!)
+d!

--- a/examples/crosspkg_funcref_lib/BUILD.bazel
+++ b/examples/crosspkg_funcref_lib/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_gala//gala:defs.bzl", "gala_library")
+
+gala_library(
+    name = "crosspkg_funcref_lib",
+    src = "shout.gala",
+    importpath = "martianoff/gala/examples/crosspkg_funcref_lib",
+    visibility = ["//visibility:public"],
+)

--- a/examples/crosspkg_funcref_lib/shout.gala
+++ b/examples/crosspkg_funcref_lib/shout.gala
@@ -1,0 +1,13 @@
+package crosspkg_funcref_lib
+
+// Shout is a plain, non-generic function that lives in a DIFFERENT package
+// from its caller. Passing a bare reference to it (`crosspkg_funcref_lib.Shout`)
+// into a generic method such as Array.Map requires the transpiler to resolve
+// the function's signature across the package boundary so the method's own
+// type parameter can be bound.
+func Shout(s string) string = s"$s!"
+
+// Length is a second cross-package function whose result type differs from its
+// parameter type, so Map's type parameter cannot accidentally fall back to the
+// element type of the receiver.
+func Length(s string) int = s.Size()

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -70,6 +70,7 @@ go_test(
         "coverage_regression_test.go",
         "cross_module_matrix_test.go",
         "crossfile_package_val_test.go",
+        "crosspkg_funcref_chain_test.go",
         "default_immutability_test.go",
         "dot_import_generic_namedarg_test.go",
         "dot_import_test.go",

--- a/internal/transpiler/transformer/crosspkg_funcref_chain_test.go
+++ b/internal/transpiler/transformer/crosspkg_funcref_chain_test.go
@@ -1,0 +1,126 @@
+package transformer_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func crossPkgFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	write := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0644))
+	}
+
+	write("gala.mod", "module example.com/crosspkg\n\ngala dev\n")
+	write("helper/helper.gala", `package helper
+
+func Shout(s string) string = s"$s!"
+`)
+	return root
+}
+
+func transpileCrossPkg(t *testing.T, root, src string) (string, error) {
+	t.Helper()
+	p := transpiler.NewAntlrGalaParser()
+	searchPaths := append([]string{root}, getStdSearchPath()...)
+	a := analyzer.NewGalaAnalyzer(p, searchPaths, root)
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	return transpiler.NewGalaToGoTranspiler(p, a, tr, g).
+		Transpile(src, filepath.Join(root, "main.gala"))
+}
+
+func TestCrossPackageFuncRef_ChainedIntoGenericMethod(t *testing.T) {
+	root := crossPkgFixture(t)
+
+	const src = `package main
+
+import (
+    . "martianoff/gala/collection_immutable"
+    "example.com/crosspkg/helper"
+)
+
+func main() {
+    ArrayOf("a").Map(helper.Shout).ForEach((g) => Println(g))
+}`
+
+	out, err := transpileCrossPkg(t, root, src)
+	require.NoError(t, err, "transpiling a cross-package bare function reference must not error")
+
+	assert.NotContains(t, out, "__mtp0",
+		"a cross-package bare function reference chained into a generic method leaked an\n"+
+			"uninstantiated method type parameter (__mtp0) into the generated Go;\ngenerated:\n%s", out)
+}
+
+func TestSamePackageFuncRef_ChainedIntoGenericMethod(t *testing.T) {
+	root := crossPkgFixture(t)
+
+	const src = `package main
+
+import . "martianoff/gala/collection_immutable"
+
+func shout(s string) string = s"$s!"
+
+func main() {
+    ArrayOf("a").Map(shout).ForEach((g) => Println(g))
+}`
+
+	out, err := transpileCrossPkg(t, root, src)
+	require.NoError(t, err)
+	assert.NotContains(t, out, "__mtp0",
+		"same-package bare function reference must not leak a method type parameter:\n%s", out)
+}
+
+func TestCrossPackageFuncRef_NonGenericConsumer(t *testing.T) {
+	root := crossPkgFixture(t)
+
+	const src = `package main
+
+import (
+    . "martianoff/gala/collection_immutable"
+    "example.com/crosspkg/helper"
+)
+
+func main() {
+    Println(ArrayOf("a").Map(helper.Shout).String())
+}`
+
+	out, err := transpileCrossPkg(t, root, src)
+	require.NoError(t, err)
+	assert.NotContains(t, out, "__mtp0",
+		"cross-package bare ref with a non-generic consumer must not leak a type parameter:\n%s", out)
+}
+
+func TestCrossPackageExplicitLambda_ChainedIntoGenericMethod(t *testing.T) {
+	root := crossPkgFixture(t)
+
+	const src = `package main
+
+import (
+    . "martianoff/gala/collection_immutable"
+    "example.com/crosspkg/helper"
+)
+
+func main() {
+    ArrayOf("a").Map((s) => helper.Shout(s)).ForEach((g) => Println(g))
+}`
+
+	out, err := transpileCrossPkg(t, root, src)
+	require.NoError(t, err)
+	assert.NotContains(t, out, "__mtp0",
+		"explicit lambda must not leak a method type parameter:\n%s", out)
+}

--- a/internal/transpiler/transformer/type_inference_calls.go
+++ b/internal/transpiler/transformer/type_inference_calls.go
@@ -52,6 +52,20 @@ func (t *galaASTTransformer) inferSelectorExprType(e *ast.SelectorExpr) transpil
 			// Check if this is a Go constant or variable (not a type)
 			// e.g., runtime.GOOS is a string constant, not a type
 			qualName := pkgName + "." + e.Sel.Name
+			// A bare reference to a function in another GALA package
+			// (e.g. `helper.Shout` passed to Array.Map). The same-package
+			// form is resolved from FunctionMetadata in the *ast.Ident case
+			// of getExprTypeNameManualUncached; do the same here from the
+			// imported package's metadata so the reference carries a
+			// FuncType. Without it the reference resolves to a NamedType and
+			// unification cannot bind the consuming method's type parameter,
+			// leaving the method type-param sentinel in the emitted Go.
+			// Generic functions are excluded for the same reason as the
+			// Ident case: they need instantiation, not a raw signature whose
+			// type variables would leak.
+			if fm, ok := t.functions[qualName]; ok && fm != nil && len(fm.TypeParams) == 0 {
+				return t.funcMetaToRawType(fm)
+			}
 			if t.goTypeInfo != nil {
 				if constType, ok := t.goTypeInfo.Constants[qualName]; ok && constType != nil {
 					return constType


### PR DESCRIPTION
## Summary

A bare function reference to a function in **another package**, passed to a generic method (`Array.Map`), leaked an uninstantiated method type parameter into the generated Go when the result was consumed by a **second generic** method:

```gala
ArrayOf("a").Map(helper.Shout).ForEach((g) => Println(g))
// undefined: __mtp0
```

## Root cause

`inferSelectorExprType` (`internal/transpiler/transformer/type_inference_calls.go`) resolved a package-qualified selector like `helper.Shout` by consulting only `t.goTypeInfo` (Go constants/vars/func signatures), then falling through to `return transpiler.NamedType{Package: pkgName, Name: e.Sel.Name}`. It never consulted GALA `FunctionMetadata`.

So a cross-package GALA function reference carried a **NamedType**, not a **FuncType**. `unifyForInference(func(T) __mtp0, helper.Shout, …)` bound nothing, `inferMethodTypeParamsFromArgs` returned nil, and `Map`'s alpha-renamed sentinel `__mtp0` survived into the receiver type that the chained generic `.ForEach` then wrote down as its lambda parameter type.

Two asymmetries explain why this survived:

- the **same-package** form works because the `*ast.Ident` branch of `getExprTypeNameManualUncached` already builds a FuncType from `t.functions[name]`
- the **call** path `inferCallSelectorType` already looks up the exact same `pkg.Name` key — the bare-reference path was the only one that didn't

`examples/bare_funcref_map.gala` covers only same-package references, which is why CI never caught it.

## Fix

`type_inference_calls.go` — +14 lines: look up `t.functions[qualName]` and return `t.funcMetaToRawType(fm)` before the `goTypeInfo` checks. Gated on `len(fm.TypeParams) == 0`, mirroring the `*ast.Ident` branch (a generic function needs instantiation, not a raw signature whose type variables would leak). Pure metadata lookup — no import-path heuristics.

## Verification

`internal/transpiler/transformer/crosspkg_funcref_chain_test.go` — the failing shape plus three controls that pin the boundary. Neither cross-package-ness nor a chained generic consumer is sufficient alone; the combination is:

| Case | Before | After |
|---|---|---|
| cross-package bare ref + chained `.ForEach` | FAIL (`__mtp0`) | pass |
| same-package bare ref + chained `.ForEach` | pass | pass |
| cross-package bare ref + non-generic `.String()` | pass | pass |
| cross-package explicit lambda + chained `.ForEach` | pass | pass |

Also `examples/crosspkg_funcref_lib/` + `examples/crosspkg_funcref_chain.gala` / `.out`, closing the same-package-only gap in the existing coverage. The example was checked to be *real* coverage: with the fix stashed it fails to build with `undefined: __mtp0`.

`bazel build //...` green (1457 targets); `bazel test //...` 394/395, the only failure being the pre-existing `TestGorootFromGoBinarySymlink` (needs Windows symlink privilege, fails on pristine master too).

## Known remaining gap (not addressed here)

A bare reference to a **generic** function in another package is still not instantiated — the AST-rewrite path in `calls.go` only matches `*ast.Ident`, so `pkg.GenericFn` passed to `Map` gets no explicit type args. Out of scope for this defect and left untouched to keep the change minimal; worth its own issue.

## Repro (before fix)

```gala
package main

import (
    . "martianoff/gala/collection_immutable"
    "example.com/crosspkg/helper"
)

func main() {
    ArrayOf("a").Map(helper.Shout).ForEach((g) => Println(g))
}
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)