### PR TITLE
fix(transpiler): instantiate bare generic function refs passed to generic methods

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -345,6 +345,22 @@ gala_exec_test(
     ],
 )
 
+# Regression: bare reference to a GENERIC function (same-package and
+# cross-package) passed to Array.Map, with the result consumed by something
+# that must write the element type down (a ForEach lambda parameter, a chained
+# Map). The function's own type parameter must be instantiated from the
+# expected parameter type, otherwise Map's result type parameter never binds
+# and its sentinel leaks into the generated Go.
+gala_exec_test(
+    name = "generic_funcref_chain",
+    src = "generic_funcref_chain.gala",
+    expected = "generic_funcref_chain.out",
+    deps = [
+        "//collection_immutable",
+        "//examples/generic_funcref_lib",
+    ],
+)
+
 # Regression: placeholder-lambda `_.Field` must be equivalent to the explicit
 # lambda `(p) => p.Field`, including the Immutable field auto-unwrap. Prior to
 # the fix `_.Name` bound `_` to `any`, hiding the struct metadata from the

--- a/examples/generic_funcref_chain.gala
+++ b/examples/generic_funcref_chain.gala
@@ -1,0 +1,33 @@
+package main
+
+import (
+    . "martianoff/gala/collection_immutable"
+    "martianoff/gala/examples/generic_funcref_lib"
+)
+
+// A bare reference to a GENERIC function — same-package AND cross-package —
+// passed to Array.Map, whose result is then consumed by something that must
+// WRITE the element type down (a ForEach lambda parameter, a chained Map).
+// Unless the referenced function's own type parameter is instantiated from the
+// expected parameter type, Map's result type parameter never binds and its
+// sentinel leaks into the generated Go.
+//
+// Consuming the result with only `.String()` hides the leak, which is why every
+// case below feeds a consumer that names the element type.
+
+func ident[T any](x T) T = x
+
+func main() {
+    // Same-package generic bare ref -> type-writing consumer.
+    ArrayOf("a", "b").Map(ident).ForEach((g) => Println(g))
+
+    // Same-package generic bare ref on a different element type, chained into
+    // a second generic method.
+    Println(ArrayOf(1, 2).Map(ident).Map(_ * 2).String())
+
+    // Cross-package generic bare ref -> type-writing consumer.
+    ArrayOf("c").Map(generic_funcref_lib.Identity).ForEach((g) => Println(g))
+
+    // Cross-package generic bare ref whose result type has a different shape.
+    ArrayOf(3).Map(generic_funcref_lib.Repeat).ForEach((g) => Println(g.String()))
+}

--- a/examples/generic_funcref_chain.out
+++ b/examples/generic_funcref_chain.out
@@ -1,0 +1,5 @@
+a
+b
+Array(2, 4)
+c
+Array(3)

--- a/examples/generic_funcref_lib/BUILD.bazel
+++ b/examples/generic_funcref_lib/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_gala//gala:defs.bzl", "gala_library")
+
+gala_library(
+    name = "generic_funcref_lib",
+    src = "identity.gala",
+    importpath = "martianoff/gala/examples/generic_funcref_lib",
+    visibility = ["//visibility:public"],
+    deps = ["//collection_immutable"],
+)

--- a/examples/generic_funcref_lib/identity.gala
+++ b/examples/generic_funcref_lib/identity.gala
@@ -1,0 +1,15 @@
+package generic_funcref_lib
+
+import . "martianoff/gala/collection_immutable"
+
+// Identity is a GENERIC function that lives in a DIFFERENT package from its
+// caller. Passing a bare reference to it (`generic_funcref_lib.Identity`) into
+// a generic method such as Array.Map requires the transpiler to instantiate the
+// function's OWN type parameter from the expected parameter type before the
+// method's result type parameter can be bound.
+func Identity[T any](x T) T = x
+
+// Repeat is a generic function whose result type has a different SHAPE from its
+// parameter, so the consuming method's type parameter cannot accidentally fall
+// back to the receiver's element type.
+func Repeat[T any](x T) Array[T] = ArrayOf(x)

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "func_phantom_typearg_test.go",
         "functions_test.go",
         "generated_format_test.go",
+        "generic_funcref_chain_test.go",
         "generic_sealed_exhaustive_test.go",
         "generics_test.go",
         "go_generic_return_instantiation_test.go",

--- a/internal/transpiler/transformer/generic_funcref_chain_test.go
+++ b/internal/transpiler/transformer/generic_funcref_chain_test.go
@@ -1,0 +1,162 @@
+package transformer_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/generator"
+	"martianoff/gala/internal/transpiler/transformer"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// genericFuncRefFixture builds a module whose helper package exports a GENERIC
+// function, so tests can pass `helper.Identity` as a bare (unapplied) function
+// reference to a generic collection method.
+func genericFuncRefFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	write := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0644))
+	}
+
+	write("gala.mod", "module example.com/genericref\n\ngala dev\n")
+	write("helper/helper.gala", `package helper
+
+func Identity[T any](x T) T = x
+
+func Shout(s string) string = s"$s!"
+`)
+	return root
+}
+
+func transpileGenericFuncRef(t *testing.T, root, src string) (string, error) {
+	t.Helper()
+	p := transpiler.NewAntlrGalaParser()
+	searchPaths := append([]string{root}, getStdSearchPath()...)
+	a := analyzer.NewGalaAnalyzer(p, searchPaths, root)
+	tr := transformer.NewGalaASTTransformer()
+	g := generator.NewGoCodeGenerator()
+	return transpiler.NewGalaToGoTranspiler(p, a, tr, g).
+		Transpile(src, filepath.Join(root, "main.gala"))
+}
+
+// Case 1: same-package GENERIC bare function reference chained into a consumer
+// that must write the element type down (ForEach's lambda parameter).
+func TestSamePackageGenericFuncRef_ChainedIntoTypeWritingConsumer(t *testing.T) {
+	root := genericFuncRefFixture(t)
+
+	const src = `package main
+
+import . "martianoff/gala/collection_immutable"
+
+func ident[T any](x T) T = x
+
+func main() {
+    ArrayOf("a").Map(ident).ForEach((g) => Println(g))
+}`
+
+	out, err := transpileGenericFuncRef(t, root, src)
+	require.NoError(t, err, "transpiling a same-package generic bare function reference must not error")
+
+	assert.NotContains(t, out, "__mtp0",
+		"a same-package GENERIC bare function reference chained into a type-writing\n"+
+			"consumer leaked an uninstantiated method type parameter (__mtp0);\ngenerated:\n%s", out)
+}
+
+// Case 2: cross-package GENERIC bare function reference chained into a
+// type-writing consumer.
+func TestCrossPackageGenericFuncRef_ChainedIntoTypeWritingConsumer(t *testing.T) {
+	root := genericFuncRefFixture(t)
+
+	const src = `package main
+
+import (
+    . "martianoff/gala/collection_immutable"
+    "example.com/genericref/helper"
+)
+
+func main() {
+    ArrayOf("a").Map(helper.Identity).ForEach((g) => Println(g))
+}`
+
+	out, err := transpileGenericFuncRef(t, root, src)
+	require.NoError(t, err, "transpiling a cross-package generic bare function reference must not error")
+
+	assert.NotContains(t, out, "__mtp0",
+		"a cross-package GENERIC bare function reference chained into a type-writing\n"+
+			"consumer leaked an uninstantiated method type parameter (__mtp0);\ngenerated:\n%s", out)
+}
+
+// Case 3 (control): cross-package generic bare ref consumed by .String(), which
+// never names the element type.
+func TestCrossPackageGenericFuncRef_NonTypeWritingConsumer(t *testing.T) {
+	root := genericFuncRefFixture(t)
+
+	const src = `package main
+
+import (
+    . "martianoff/gala/collection_immutable"
+    "example.com/genericref/helper"
+)
+
+func main() {
+    Println(ArrayOf("a").Map(helper.Identity).String())
+}`
+
+	out, err := transpileGenericFuncRef(t, root, src)
+	require.NoError(t, err)
+	assert.NotContains(t, out, "__mtp0",
+		"cross-package generic bare ref with a non-type-writing consumer must not leak a type parameter:\n%s", out)
+}
+
+// Case 4 (control): cross-package NON-generic bare ref into a type-writing
+// consumer — this is what was fixed earlier and must stay working.
+func TestCrossPackageNonGenericFuncRef_ChainedIntoTypeWritingConsumer(t *testing.T) {
+	root := genericFuncRefFixture(t)
+
+	const src = `package main
+
+import (
+    . "martianoff/gala/collection_immutable"
+    "example.com/genericref/helper"
+)
+
+func main() {
+    ArrayOf("a").Map(helper.Shout).ForEach((g) => Println(g))
+}`
+
+	out, err := transpileGenericFuncRef(t, root, src)
+	require.NoError(t, err)
+	assert.NotContains(t, out, "__mtp0",
+		"cross-package NON-generic bare ref must not leak a type parameter:\n%s", out)
+}
+
+// Case 5 (control): explicit lambda wrapping the generic function.
+func TestCrossPackageGenericExplicitLambda_ChainedIntoTypeWritingConsumer(t *testing.T) {
+	root := genericFuncRefFixture(t)
+
+	const src = `package main
+
+import (
+    . "martianoff/gala/collection_immutable"
+    "example.com/genericref/helper"
+)
+
+func main() {
+    ArrayOf("a").Map((s) => helper.Identity(s)).ForEach((g) => Println(g))
+}`
+
+	out, err := transpileGenericFuncRef(t, root, src)
+	require.NoError(t, err)
+	assert.NotContains(t, out, "__mtp0",
+		"explicit lambda over a generic function must not leak a type parameter:\n%s", out)
+}

--- a/internal/transpiler/transformer/type_inference.go
+++ b/internal/transpiler/transformer/type_inference.go
@@ -392,6 +392,80 @@ func (t *galaASTTransformer) instantiateFuncMetaType(fm *transpiler.FunctionMeta
 	return raw
 }
 
+// lookupBareFuncRefMeta resolves an expression that is a bare (unapplied)
+// reference to a GALA function — either a plain identifier `fn` or a
+// package-qualified selector `pkg.Fn` — to its FunctionMetadata. Returns nil
+// when the expression is anything else.
+func (t *galaASTTransformer) lookupBareFuncRefMeta(expr ast.Expr) *transpiler.FunctionMetadata {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		if fm, ok := t.functions[e.Name]; ok {
+			return fm
+		}
+	case *ast.SelectorExpr:
+		x, ok := e.X.(*ast.Ident)
+		if !ok || t.importManager == nil || !t.importManager.IsPackage(x.Name) {
+			return nil
+		}
+		pkgName := x.Name
+		if actual, ok := t.importManager.ResolveAlias(pkgName); ok {
+			pkgName = actual
+		}
+		if fm, ok := t.functions[pkgName+"."+e.Sel.Name]; ok {
+			return fm
+		}
+	}
+	return nil
+}
+
+// bareGenericFuncRefType resolves a bare reference to a GENERIC GALA function
+// against the expected parameter type and returns the function's signature with
+// its OWN type parameters instantiated.
+//
+// unifyForInference only binds type params that appear on its *pattern* side,
+// so the function's declared signature is the pattern here and the expected
+// type is the concrete side (the reverse of the usual argument direction). That
+// is what binds e.g. the `T` of `func Identity[T any](x T) T` to `string` when
+// the expected param type is `func(string) U`.
+//
+// A binding is only accepted when it is fully concrete: `foreign` lists the
+// consumer's own (still unresolved) type-param names, and any binding that
+// mentions one of them would merely trade the function's type variable for the
+// consumer's, so the whole reference is rejected instead.
+func (t *galaASTTransformer) bareGenericFuncRefType(expr ast.Expr, expected transpiler.Type, foreign []string) (transpiler.FuncType, bool) {
+	expectedFT, isFT := expected.(transpiler.FuncType)
+	if !isFT {
+		return transpiler.FuncType{}, false
+	}
+	fm := t.lookupBareFuncRefMeta(expr)
+	if fm == nil || len(fm.TypeParams) == 0 {
+		return transpiler.FuncType{}, false
+	}
+	raw := t.funcMetaToRawType(fm)
+	if len(raw.Params) != len(expectedFT.Params) {
+		return transpiler.FuncType{}, false
+	}
+	inferred := make(map[string]transpiler.Type)
+	t.unifyForInference(raw, expectedFT, fm.TypeParams, inferred)
+
+	typeArgs := make([]transpiler.Type, 0, len(fm.TypeParams))
+	for _, tp := range fm.TypeParams {
+		bound, ok := inferred[tp]
+		if !ok || bound == nil || transpiler.IsUnusableOrAny(bound) {
+			return transpiler.FuncType{}, false
+		}
+		if len(foreign) > 0 {
+			mentions := make(map[string]bool)
+			t.collectReferencedParams(bound, foreign, mentions)
+			if len(mentions) > 0 {
+				return transpiler.FuncType{}, false
+			}
+		}
+		typeArgs = append(typeArgs, bound)
+	}
+	return t.instantiateFuncMetaType(fm, typeArgs), true
+}
+
 // substituteConcreteTypes substitutes type parameters in a type with concrete types.
 // For example, if returnType is Pair[B, A], typeParams is ["A", "B"], and concreteTypes is [int, string],
 // the result will be Pair[string, int].
@@ -468,12 +542,27 @@ func (t *galaASTTransformer) inferMethodTypeParamsFromArgs(methodMeta *transpile
 	// Build a mapping from method type param names to inferred concrete types
 	inferredMap := make(map[string]transpiler.Type)
 
+	// Type-param names that are NOT resolved yet at this point: binding a
+	// referenced function's own type param to one of these would just swap one
+	// type variable for another.
+	foreign := append(append([]string{}, freshParamNames...), structTypeParams...)
+
 	// Try to infer type params from each argument
 	for i, arg := range args {
 		if i >= len(substitutedParamTypes) {
 			break
 		}
 		paramType := substitutedParamTypes[i]
+
+		// A bare (unapplied) reference to a GENERIC function has no type of its
+		// own: its signature still contains its own type variables, so neither
+		// getExprTypeNameManual nor inferExprType can hand back something that
+		// unifies usefully. Instantiate it against the expected parameter type
+		// first, then unify with the concrete signature.
+		if instFT, ok := t.bareGenericFuncRefType(arg, paramType, foreign); ok {
+			t.unifyForInference(paramType, instFT, freshParamNames, inferredMap)
+			continue
+		}
 
 		// Get the actual type of the argument
 		argType := t.getExprTypeNameManual(arg)


### PR DESCRIPTION
## Summary

Closes #471.

A bare reference to a **generic** function passed to `Array.Map` never bound `Map`'s result type parameter. The unresolved sentinel `__mtp0` leaked into the generated Go as soon as a downstream consumer had to write that element type down:

```gala
ArrayOf("a").Map(helper.Identity).ForEach((g) => Println(g))
// undefined: __mtp0
```

## The discriminator is not the package boundary

This was originally reported as a cross-package problem. It isn't — a **same-package** generic reference fails identically. Verified by hand against master before any code was written:

| Case | Before | After |
|---|---|---|
| **same**-package generic ref → `Map` → `.ForEach(lambda)` | **FAIL** `__mtp0` | pass |
| **cross**-package generic ref → `Map` → `.ForEach(lambda)` | **FAIL** `__mtp0` | pass |
| cross-package generic ref → `Map` → `.String()` | pass | pass |
| cross-package **non**-generic ref → `Map` → `.ForEach(lambda)` | pass | pass |
| explicit lambda `(s) => helper.Identity(s)` | pass | pass |

The real discriminator is **a generic bare reference plus a consumer that forces the element type to be emitted**. `.String()` never names the element type, so it hides the leak; a `ForEach` lambda parameter must be written down, so it surfaces.

That is exactly why this survived: `examples/bare_funcref_map.gala` *does* cover generic bare refs, but always consumes the result as `val zs = xs.Map(tickerAdvance); Println(zs.String())` — the one shape that hides it.

## Root cause

`inferMethodTypeParamsFromArgs` resolves each argument's type via `getExprTypeNameManual` → `inferExprType`. For a bare generic function reference neither can return anything usable: the same-package `*ast.Ident` case and the package-qualified selector case **both** gate on `len(fm.TypeParams) == 0`, because handing back the raw signature would leak the function's own type variables. The argument therefore contributed nothing to `unifyForInference`, so `Map`'s type param stayed as the sentinel from `resolveMethodCallTypeWithParams`.

The direction matters too: `unifyForInference` only binds type params appearing on its **pattern** side, so the existing forward unification (expected as pattern) could never bind the referenced function's own `T`.

No emit-side change was needed — Go 1.21+ infers the generic function's type args at the `Array_Map(xs, ident)` call site by itself. Only GALA's inference of the `Map` *result* was wrong.

## Changes

`internal/transpiler/transformer/type_inference.go` — **pure additions, no existing lines modified**:

- `lookupBareFuncRefMeta` — resolves a bare `fn` or `pkg.Fn` to its `FunctionMetadata` (via `importManager.IsPackage` + alias resolution and the `t.functions` table; no import-path heuristics)
- `bareGenericFuncRefType` — unifies with the function's declared signature as the **pattern** to bind its own type params, then instantiates
- hooked into `inferMethodTypeParamsFromArgs` ahead of the normal argument-typing path

It fails safe by construction: every rejection path returns `false` and falls through to the pre-existing logic, so it can only turn broken into working. A binding is accepted only when fully concrete — anything unusable/`any`, or mentioning one of the consumer's own still-unresolved type params, rejects the whole reference rather than trading one type variable for another.

## Verification

- 5 new tests in `internal/transpiler/transformer/generic_funcref_chain_test.go` — the 2 bug cases confirmed failing before the fix, the 3 controls passing throughout
- `examples/generic_funcref_lib/` + `examples/generic_funcref_chain.gala` close the uncovered **generic-ref × type-writing-consumer** quadrant, in both same- and cross-package form, including a generic whose result type has a different *shape* (`Repeat[T](x T) Array[T]`)
- **Revert check**: with only `type_inference.go` stashed, `//examples:generic_funcref_chain` fails to build with `undefined: __mtp0` at all four call sites — so the example is real coverage, not decoration
- `bazel build //...` clean; `bazel test //...` 397/398, the only failure being the pre-existing `TestGorootFromGoBinarySymlink` (needs Windows symlink privilege, fails on pristine master too)

## Follow-up noted, not addressed

The AST-rewrite block in `calls.go` that is meant to emit an explicit `fn[A]` instantiation is effectively dead for identity-shaped generics — its `unifyForInference` call can't bind the function's own type params for the same directionality reason, so `allBound` is never true. Harmless today (Go infers them), but it isn't doing what its comment claims. Left for a separate cleanup decision rather than folded in here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)