### PR TITLE
fix(transpiler): instantiate a Go generic's multi-value return at the binding

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -110,6 +110,13 @@ gala_exec_test(
 )
 
 gala_exec_test(
+    name = "go_generic_multireturn_destructure",
+    src = "go_generic_multireturn_destructure.gala",
+    expected = "go_generic_multireturn_destructure.out",
+    deps = ["//go_interop"],
+)
+
+gala_exec_test(
     name = "go_generic_option_lambda_return",
     src = "go_generic_option_lambda_return.gala",
     expected = "go_generic_option_lambda_return.out",

--- a/examples/go_generic_multireturn_destructure.gala
+++ b/examples/go_generic_multireturn_destructure.gala
@@ -1,0 +1,81 @@
+package main
+
+import "martianoff/gala/go_interop"
+
+// Destructuring a Go generic's multi-value return must bind each name to the
+// call's INSTANTIATED return type. The transpiler used to bind the callee's
+// DECLARED type parameter instead: `val v, ok = go_interop.MapGet(m, "a")` gave
+// `v` the type `V` from
+// `func MapGet[K comparable, V any](m map[K]V, k K) (V, bool)`.
+//
+// Nothing complained at the binding, and any use that does not pin a type —
+// string interpolation, Println — kept working. The build broke only once the
+// value reached a position needing a concrete type, naming a type parameter the
+// user never wrote (`undefined: V`) at a line that was not the cause.
+//
+// Reading a Go map and lifting the (value, found) pair into an Option is the
+// idiomatic thing to do with it, so this shape is the common one.
+//
+// Every route below reaches the map differently, because instantiation depends
+// on the ARGUMENT's type resolving: a map read out of a struct field also
+// needed `map[K]V` to survive the AST-to-type round trip, which it did not.
+
+type Index struct {
+    entries map[string]int
+}
+
+// The map comes from a receiver field.
+func (ix Index) Lookup(key string) Option[int] {
+    val v, ok = go_interop.MapGet(ix.entries, key)
+    if ok {
+        return Some(v)
+    }
+    return None[int]()
+}
+
+// The map is copied to a local first.
+func (ix Index) LookupViaLocal(key string) Option[int] {
+    val entries = ix.entries
+    val v, ok = go_interop.MapGet(entries, key)
+    return When(ok, v)
+}
+
+// The map comes from a struct passed as a parameter.
+func lookupField(ix Index, key string) Option[int] {
+    val v, ok = go_interop.MapGet(ix.entries, key)
+    return When(ok, v)
+}
+
+// The map itself is the parameter.
+func lookupIn(m map[string]int, key string) Option[int] {
+    val v, ok = go_interop.MapGet(m, key)
+    return When(ok, v)
+}
+
+func main() {
+    val m = go_interop.MapPut(go_interop.MapEmpty[string, int](), "a", 1)
+    val ix = Index{entries: m}
+
+    // The reported repro: bind, then box. Boxing is what used to fail.
+    val v, ok = go_interop.MapGet(m, "a")
+    Println(s"interpolated: $v ok=$ok")
+    Println(Some(v))
+
+    // Explicit type arguments at the call site must instantiate the same way.
+    val ev, eok = go_interop.MapGet[string, int](m, "a")
+    Println(s"${Some(ev)} $eok")
+
+    Println(ix.Lookup("a"))
+    Println(ix.Lookup("missing"))
+    Println(ix.LookupViaLocal("a"))
+    Println(lookupField(ix, "a"))
+    Println(lookupIn(m, "a"))
+    Println(lookupIn(m, "missing"))
+
+    // The bound value is a real int, not an opaque one: it has to match and
+    // arithmetic on it has to type-check.
+    Some(v) match {
+        case Some(n) => Println(s"found ${n + 41}")
+        case None()  => Println("absent")
+    }
+}

--- a/examples/go_generic_multireturn_destructure.out
+++ b/examples/go_generic_multireturn_destructure.out
@@ -1,0 +1,10 @@
+interpolated: 1 ok=true
+Some(1)
+Some(1) true
+Some(1)
+None()
+Some(1)
+Some(1)
+Some(1)
+None()
+found 42

--- a/examples/multifile_lib_regress/go_interop.gala
+++ b/examples/multifile_lib_regress/go_interop.gala
@@ -117,3 +117,39 @@ func GoGenericOptionLambda(key string) string {
         case None()  => "absent"
     }
 }
+
+// --- Regression: destructuring a Go generic's MULTI-VALUE return.
+//
+// `go_interop.MapGet[K, V](m map[K]V, k K) (V, bool)` binds two names at once.
+// The binding used to take the callee's DECLARED return types, so `v` was typed
+// `V` — a type parameter that exists only inside the callee's signature. The
+// binding itself never complained and any use that does not pin a type kept
+// working; the build broke wherever the value was first boxed, naming `V` at a
+// line that was not the cause.
+//
+// Batch mode matters here for the same reason as the lambda case above: the
+// signature (and its type-parameter names) is rehydrated from the analysis
+// cache rather than a fresh go/types run.
+func GoGenericDestructureOption(key string) string {
+    val m = go_interop.MapPut(go_interop.MapEmpty[string, int](), "k", 7)
+    val v, ok = go_interop.MapGet(m, key)
+    return When(ok, v) match {
+        case Some(n) => s"found ${n}"
+        case None()  => "absent"
+    }
+}
+
+// Same binding, reached through a struct field rather than a local, and boxed
+// directly with Some rather than through When.
+func GoGenericDestructureFromField(key string) Option[int] {
+    val idx = GoMapIndex{entries: go_interop.MapPut(go_interop.MapEmpty[string, int](), "k", 7)}
+    val v, ok = go_interop.MapGet(idx.entries, key)
+    if ok {
+        return Some(v)
+    }
+    return None[int]()
+}
+
+type GoMapIndex struct {
+    entries map[string]int
+}

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -405,6 +405,14 @@ func main() {
     // go/types' unparseable "invalid type" display string.
     Println(multifile_lib_regress.GoGenericOptionLambda("k"))
     Println(multifile_lib_regress.GoGenericOptionLambda("nope"))
+    // Same instantiation gap, reached by destructuring a Go generic's
+    // MULTI-VALUE return (`val v, ok = go_interop.MapGet(m, k)`). Each bound
+    // name must take the call's instantiated return type; binding the declared
+    // `V` deferred the failure to the first use that pinned a type.
+    Println(multifile_lib_regress.GoGenericDestructureOption("k"))
+    Println(multifile_lib_regress.GoGenericDestructureOption("nope"))
+    Println(multifile_lib_regress.GoGenericDestructureFromField("k"))
+    Println(multifile_lib_regress.GoGenericDestructureFromField("nope"))
 
     Println(multifile_lib_regress.ScopeReport(1))
     Println(multifile_lib_regress.ScopeLambdaCapture(3))

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -89,6 +89,10 @@ ledger=nina/ledger:nina
 3
 found 7
 absent
+found 7
+absent
+Some(7)
+None()
 scope:dana:v2,v3,v4:ok
 5
 gamma

--- a/internal/transpiler/transformer/BUILD.bazel
+++ b/internal/transpiler/transformer/BUILD.bazel
@@ -87,6 +87,7 @@ go_test(
         "generic_funcref_chain_test.go",
         "generic_sealed_exhaustive_test.go",
         "generics_test.go",
+        "go_generic_multireturn_instantiation_test.go",
         "go_generic_return_instantiation_test.go",
         "immutable_test.go",
         "immutable_unwrapping_test.go",

--- a/internal/transpiler/transformer/calls.go
+++ b/internal/transpiler/transformer/calls.go
@@ -3,6 +3,7 @@ package transformer
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
 	"strings"
 
 	"github.com/antlr4-go/antlr/v4"
@@ -3584,7 +3585,8 @@ func (t *galaASTTransformer) resolveGoCallSignature(expr ast.Expr) *transpiler.G
 	if !ok {
 		return nil
 	}
-	switch fun := callExpr.Fun.(type) {
+	funExpr, _ := splitCallFunTypeArgs(callExpr.Fun)
+	switch fun := funExpr.(type) {
 	case *ast.SelectorExpr:
 		if id, ok := fun.X.(*ast.Ident); ok {
 			if sig := t.goTypeInfo.GetFuncSignature(id.Name + "." + fun.Sel.Name); sig != nil {
@@ -3600,6 +3602,51 @@ func (t *galaASTTransformer) resolveGoCallSignature(expr ast.Expr) *transpiler.G
 		}
 	}
 	return nil
+}
+
+// splitCallFunTypeArgs separates a call's function expression from any explicit
+// type arguments written at the call site, so `go_interop.MapGet[string, int]`
+// resolves against the same signature lookup as the bare `go_interop.MapGet`
+// while the type arguments stay available for instantiation.
+func splitCallFunTypeArgs(fun ast.Expr) (ast.Expr, []ast.Expr) {
+	switch idx := fun.(type) {
+	case *ast.IndexExpr:
+		return idx.X, []ast.Expr{idx.Index}
+	case *ast.IndexListExpr:
+		return idx.X, idx.Indices
+	}
+	return fun, nil
+}
+
+// resolveGoCallReturnTypes resolves a Go call's return types with the callee's
+// own type parameters instantiated to whatever the call binds them to. A
+// generic callee's recorded signature still names its declared type parameters
+// (`func MapGet[K comparable, V any](m map[K]V, k K) (V, bool)` returns `V`), so
+// every consumer that writes a return type down — rather than merely passing it
+// along — must go through here or it emits an identifier the user never wrote.
+func (t *galaASTTransformer) resolveGoCallReturnTypes(expr ast.Expr) []transpiler.Type {
+	callExpr, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return nil
+	}
+	sig := t.resolveGoCallSignature(callExpr)
+	if sig == nil {
+		return nil
+	}
+	return t.instantiateGoSignatureReturns(sig, callExpr.Args, t.callSiteTypeArgs(callExpr), callExpr.Ellipsis != token.NoPos)
+}
+
+// callSiteTypeArgs converts a call's explicit type arguments to transpiler types.
+func (t *galaASTTransformer) callSiteTypeArgs(callExpr *ast.CallExpr) []transpiler.Type {
+	_, typeArgExprs := splitCallFunTypeArgs(callExpr.Fun)
+	if len(typeArgExprs) == 0 {
+		return nil
+	}
+	typeArgs := make([]transpiler.Type, 0, len(typeArgExprs))
+	for _, ta := range typeArgExprs {
+		typeArgs = append(typeArgs, t.astTypeToTranspilerType(ta))
+	}
+	return typeArgs
 }
 
 // splitQualifiedName splits "pkg.Name" into ["pkg", "Name"], or returns nil for bare names.

--- a/internal/transpiler/transformer/declarations.go
+++ b/internal/transpiler/transformer/declarations.go
@@ -286,9 +286,14 @@ func (t *galaASTTransformer) transformValDeclaration(ctx *grammar.ValDeclaration
 		// no explicit annotation is given, so e.g. `val entries, err =
 		// os.ReadDir(p)` types `entries` as its `[]os.DirEntry` return (enabling
 		// `.Size()` and other receiver-typed inference) instead of NilType.
-		var callSig *transpiler.GoFuncSignature
+		//
+		// The returns are instantiated at the call site: a generic callee's
+		// declared returns still name its own type parameters, and binding one
+		// of those to a name defers the failure to wherever the name is next
+		// used in a position that needs a concrete type.
+		var callReturns []transpiler.Type
 		if ctx.Type_() == nil {
-			callSig = t.resolveGoCallSignature(callValue)
+			callReturns = t.resolveGoCallReturnTypes(callValue)
 		}
 
 		// Create specs for each named variable, wrapping the temp in NewImmutable
@@ -301,8 +306,8 @@ func (t *galaASTTransformer) transformValDeclaration(ctx *grammar.ValDeclaration
 				if t.isImmutableType(typeName) {
 					return nil, t.semanticErrorAt(ctx, "recursive Immutable wrapping is not allowed")
 				}
-			} else if callSig != nil && i < len(callSig.Returns) && callSig.Returns[i] != nil {
-				typeName = callSig.Returns[i]
+			} else if i < len(callReturns) && callReturns[i] != nil {
+				typeName = callReturns[i]
 			}
 
 			if qName := t.getType(typeName.String()); !qName.IsNil() {

--- a/internal/transpiler/transformer/go_generic_multireturn_instantiation_test.go
+++ b/internal/transpiler/transformer/go_generic_multireturn_instantiation_test.go
@@ -1,0 +1,177 @@
+package transformer
+
+import (
+	"go/ast"
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAstTypeToTranspilerTypeRoundTripsGoMaps guards the AST-to-type conversion
+// for Go map types.
+//
+// Go slices and Go maps are legal in exactly the same type positions — a struct
+// field, a parameter, a val annotation, a return. Slices converted; maps fell
+// through to NilType, so anything typed from a declared `map[K]V` lost its type
+// with no diagnostic. A struct field read (`ix.entries`) was the visible case:
+// the value came back untyped, which then defeated argument-driven inference at
+// any generic call it was passed to.
+func TestAstTypeToTranspilerTypeRoundTripsGoMaps(t *testing.T) {
+	tr, ok := NewGalaASTTransformer().(*galaASTTransformer)
+	require.True(t, ok)
+
+	cases := []struct {
+		name string
+		expr ast.Expr
+		want string
+	}{
+		{
+			name: "map with basic key and value",
+			expr: &ast.MapType{Key: ast.NewIdent("string"), Value: ast.NewIdent("int")},
+			want: "map[string]int",
+		},
+		{
+			name: "map whose value is a slice",
+			expr: &ast.MapType{
+				Key:   ast.NewIdent("string"),
+				Value: &ast.ArrayType{Elt: ast.NewIdent("byte")},
+			},
+			want: "map[string][]byte",
+		},
+		{
+			name: "map nested as a slice element",
+			expr: &ast.ArrayType{
+				Elt: &ast.MapType{Key: ast.NewIdent("string"), Value: ast.NewIdent("int")},
+			},
+			want: "[]map[string]int",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := tr.astTypeToTranspilerType(tc.expr)
+			require.False(t, got.IsNil(), "a Go map type position must not convert to NilType")
+			require.Equal(t, tc.want, got.String())
+		})
+	}
+}
+
+// TestInstantiateGoSignatureReturns guards the multi-value counterpart of the
+// call-site instantiation of a Go generic's return type.
+//
+// A Go generic signature records its returns exactly as declared, so
+// `func MapGet[K comparable, V any](m map[K]V, k K) (V, bool)` reports `V` for
+// the first slot. Consumers that bind more than the first return — a
+// destructuring `val v, ok = …` and the (T, error) auto-destructure wrapper —
+// write each slot's type down, so passing the declared types through gives a
+// name the type of a parameter that exists only inside the callee's signature.
+// The symptom is deferred: the binding succeeds, uses that do not pin a type
+// keep working, and the build breaks at the first use that does, reporting
+// `undefined: V` at a line that is not the cause.
+//
+// Hermetic: the signatures are built directly, so nothing here depends on the
+// Go SDK or on which stdlib generics happen to be reachable. Go's stdlib has no
+// generic function whose multi-value return mentions a type parameter, so the
+// end-to-end routes are covered by examples/go_generic_multireturn_destructure
+// and examples/multifile_lib_regress instead.
+func TestInstantiateGoSignatureReturns(t *testing.T) {
+	// func MapGet[K comparable, V any](m map[K]V, k K) (V, bool)
+	mapGet := &transpiler.GoFuncSignature{
+		Params: []transpiler.GoParam{
+			{Name: "m", Type: transpiler.MapType{
+				Key:  transpiler.BasicType{Name: "K"},
+				Elem: transpiler.BasicType{Name: "V"},
+			}},
+			{Name: "k", Type: transpiler.BasicType{Name: "K"}},
+		},
+		Returns:    []transpiler.Type{transpiler.BasicType{Name: "V"}, transpiler.BasicType{Name: "bool"}},
+		TypeParams: []string{"K", "V"},
+	}
+	// func Load[T any](path string) (T, error)
+	loadT := &transpiler.GoFuncSignature{
+		Params:     []transpiler.GoParam{{Name: "path", Type: transpiler.BasicType{Name: "string"}}},
+		Returns:    []transpiler.Type{transpiler.BasicType{Name: "T"}, transpiler.BasicType{Name: "error"}},
+		TypeParams: []string{"T"},
+	}
+	// func Cut(s, sep string) (string, string, bool) — not generic.
+	cut := &transpiler.GoFuncSignature{
+		Params: []transpiler.GoParam{
+			{Name: "s", Type: transpiler.BasicType{Name: "string"}},
+			{Name: "sep", Type: transpiler.BasicType{Name: "string"}},
+		},
+		Returns: []transpiler.Type{
+			transpiler.BasicType{Name: "string"},
+			transpiler.BasicType{Name: "string"},
+			transpiler.BasicType{Name: "bool"},
+		},
+	}
+
+	cases := []struct {
+		name     string
+		sig      *transpiler.GoFuncSignature
+		typeArgs []transpiler.Type
+		want     []string
+	}{
+		{
+			name:     "type params bound by explicit type arguments",
+			sig:      mapGet,
+			typeArgs: []transpiler.Type{transpiler.BasicType{Name: "string"}, transpiler.BasicType{Name: "int"}},
+			want:     []string{"int", "bool"},
+		},
+		{
+			name:     "slot returning a type param the call cannot determine is left alone",
+			sig:      mapGet,
+			typeArgs: nil,
+			want:     []string{"V", "bool"},
+		},
+		{
+			name:     "partial explicit prefix binds only its own positions",
+			sig:      mapGet,
+			typeArgs: []transpiler.Type{transpiler.BasicType{Name: "string"}},
+			want:     []string{"V", "bool"},
+		},
+		{
+			name:     "value slot of a (T, error) return is instantiated, error slot untouched",
+			sig:      loadT,
+			typeArgs: []transpiler.Type{transpiler.NamedType{Package: "bytes", Name: "Buffer"}},
+			want:     []string{"bytes.Buffer", "error"},
+		},
+		{
+			name:     "non-generic signature passes through unchanged",
+			sig:      cut,
+			typeArgs: nil,
+			want:     []string{"string", "string", "bool"},
+		},
+	}
+
+	tr, ok := NewGalaASTTransformer().(*galaASTTransformer)
+	require.True(t, ok, "instantiation is exercised on the concrete transformer")
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			declared := make([]string, len(tc.sig.Returns))
+			for i, ret := range tc.sig.Returns {
+				declared[i] = ret.String()
+			}
+
+			got := tr.instantiateGoSignatureReturns(tc.sig, nil, tc.typeArgs, false)
+			require.Len(t, got, len(tc.want))
+			for i, want := range tc.want {
+				require.NotNil(t, got[i], "return slot %d must stay populated", i)
+				require.Equal(t, want, got[i].String(), "return slot %d", i)
+			}
+
+			// Instantiation must not mutate the signature — the same cached
+			// *GoFuncSignature is handed to every call site, so writing the
+			// first call's type arguments into it would leak to the rest.
+			for i, want := range declared {
+				require.Equal(t, want, tc.sig.Returns[i].String(),
+					"declared return slot %d must survive instantiation", i)
+			}
+		})
+	}
+}

--- a/internal/transpiler/transformer/lambdas.go
+++ b/internal/transpiler/transformer/lambdas.go
@@ -474,7 +474,8 @@ func (t *galaASTTransformer) tryWrapGoMultiReturnWithErrorPanic(expr ast.Expr) (
 	// Case 1: simple pkg.Func() call — look up by qualified name.
 	// Case 2: chained call like expr.Method() — resolve receiver type, then look up method.
 	var sig *transpiler.GoFuncSignature
-	switch fun := callExpr.Fun.(type) {
+	funExpr, _ := splitCallFunTypeArgs(callExpr.Fun)
+	switch fun := funExpr.(type) {
 	case *ast.SelectorExpr:
 		if id, ok := fun.X.(*ast.Ident); ok {
 			// Simple case: pkg.Func() or receiver.Method() where receiver is an ident
@@ -494,14 +495,19 @@ func (t *galaASTTransformer) tryWrapGoMultiReturnWithErrorPanic(expr ast.Expr) (
 		return nil, nil
 	}
 
+	// The value types are written into the generated func literal's result
+	// clause, so a generic callee's declared returns have to be instantiated
+	// first — otherwise the emitted Go names the callee's own type parameters.
+	returns := t.instantiateGoSignatureReturns(sig, callExpr.Args, t.callSiteTypeArgs(callExpr), callExpr.Ellipsis != token.NoPos)
+
 	// Check that the LAST return is error
-	lastRet := sig.Returns[len(sig.Returns)-1]
+	lastRet := returns[len(returns)-1]
 	if lastRet == nil || lastRet.String() != "error" {
 		return nil, nil
 	}
 
 	// Number of non-error return values
-	valueCount := len(sig.Returns) - 1
+	valueCount := len(returns) - 1
 
 	// Build LHS variable names: _v0, _v1, ... _vN, _err
 	var lhsExprs []ast.Expr
@@ -516,7 +522,7 @@ func (t *galaASTTransformer) tryWrapGoMultiReturnWithErrorPanic(expr ast.Expr) (
 	if valueCount == 1 {
 		// (T, error) -> return _v0, type is T
 		returnExpr = ast.NewIdent("_v0")
-		returnTypeExpr = t.typeToExpr(sig.Returns[0])
+		returnTypeExpr = t.typeToExpr(returns[0])
 	} else {
 		// (A, B, error) -> return std.Tuple[A, B]{V1: _v0, V2: _v1}
 		// (A, B, C, error) -> return std.Tuple3[A, B, C]{V1: _v0, V2: _v1, V3: _v2}
@@ -526,7 +532,7 @@ func (t *galaASTTransformer) tryWrapGoMultiReturnWithErrorPanic(expr ast.Expr) (
 		// Build type args from the non-error return types
 		var typeArgs []ast.Expr
 		for i := 0; i < valueCount; i++ {
-			typeArgs = append(typeArgs, t.typeToExpr(sig.Returns[i]))
+			typeArgs = append(typeArgs, t.typeToExpr(returns[i]))
 		}
 
 		// Build tuple type expression: std.Tuple[A, B] or std.Tuple3[A, B, C]

--- a/internal/transpiler/transformer/type_inference.go
+++ b/internal/transpiler/transformer/type_inference.go
@@ -1246,41 +1246,40 @@ func (t *galaASTTransformer) getGoFuncReturnTypeForCall(qualifiedName string, e 
 	return t.instantiateGoSignatureReturn(sig, args, typeArgs, hasEllipsis)
 }
 
-// instantiateGoSignatureReturn substitutes a Go generic signature's type
-// parameters into its first return type, using explicit type arguments when the
-// call supplied them and otherwise unifying the DECLARED parameter types against
-// the actual argument types — the same inference inferFuncTypeParamsFromArgs
+// inferGoSignatureTypeArgs determines what a call site binds a Go generic
+// callee's own type parameters to, using explicit type arguments when the call
+// supplied them and otherwise unifying the DECLARED parameter types against the
+// actual argument types — the same inference inferFuncTypeParamsFromArgs
 // performs for GALA callees, driven off GoFuncSignature instead of
 // FunctionMetadata.
 //
-// Substitution is best-effort by design: a type parameter that no argument
-// determines is left alone, so the result is never worse than the un-instantiated
-// declared type, and getExprTypeName's existing "still has type params -> try
-// Hindley-Milner" fallback continues to apply.
-func (t *galaASTTransformer) instantiateGoSignatureReturn(
+// Inference is best-effort by design: a type parameter that neither an explicit
+// type argument nor an argument determines is simply absent from the returned
+// map, so substituting with it leaves that parameter alone and the result is
+// never worse than the un-instantiated declared type. Returns nil when the
+// callee is not generic or nothing could be determined.
+func (t *galaASTTransformer) inferGoSignatureTypeArgs(
 	sig *transpiler.GoFuncSignature,
 	args []ast.Expr,
 	typeArgs []transpiler.Type,
 	hasEllipsis bool,
-) transpiler.Type {
-	ret := sig.Returns[0]
+) map[string]transpiler.Type {
 	if len(sig.TypeParams) == 0 {
-		return ret
-	}
-
-	// A fully explicit instantiation (`go_interop.MapEmpty[string, int]()`)
-	// determines every type param on its own, arguments or not.
-	if len(typeArgs) == len(sig.TypeParams) {
-		return t.substituteConcreteTypes(ret, sig.TypeParams, typeArgs)
+		return nil
 	}
 
 	inferred := make(map[string]transpiler.Type, len(sig.TypeParams))
-	// A partial explicit prefix (`f[int](x)`) binds its positions; argument
-	// unification below fills in the rest.
+	// Explicit type arguments bind their positions directly; a partial prefix
+	// (`f[int](x)`) leaves the rest to the argument unification below.
 	for i, ta := range typeArgs {
 		if i < len(sig.TypeParams) && ta != nil && !ta.IsNil() {
 			inferred[sig.TypeParams[i]] = ta
 		}
+	}
+	// A fully explicit instantiation (`go_interop.MapEmpty[string, int]()`)
+	// determines every type param on its own, arguments or not.
+	if len(inferred) == len(sig.TypeParams) {
+		return inferred
 	}
 
 	for i, arg := range args {
@@ -1316,9 +1315,55 @@ func (t *galaASTTransformer) instantiateGoSignatureReturn(
 	}
 
 	if len(inferred) == 0 {
+		return nil
+	}
+	return inferred
+}
+
+// instantiateGoSignatureReturn substitutes a Go generic signature's type
+// parameters into its first return type. See inferGoSignatureTypeArgs for how
+// the substitution is derived and why it is best-effort; getExprTypeName's
+// existing "still has type params -> try Hindley-Milner" fallback continues to
+// apply to whatever is left un-substituted.
+func (t *galaASTTransformer) instantiateGoSignatureReturn(
+	sig *transpiler.GoFuncSignature,
+	args []ast.Expr,
+	typeArgs []transpiler.Type,
+	hasEllipsis bool,
+) transpiler.Type {
+	ret := sig.Returns[0]
+	subst := t.inferGoSignatureTypeArgs(sig, args, typeArgs, hasEllipsis)
+	if len(subst) == 0 {
 		return ret
 	}
-	return t.substituteInType(ret, inferred)
+	return t.substituteInType(ret, subst)
+}
+
+// instantiateGoSignatureReturns is the multi-value counterpart of
+// instantiateGoSignatureReturn: it instantiates EVERY return slot, for the
+// paths that consume more than the first one — a destructuring binding
+// (`val v, ok = go_interop.MapGet(m, k)`) and the (T, error) auto-destructure
+// wrapper. Those paths write each bound name's type down, so leaving the
+// callee's declared type parameters in place there materializes identifiers
+// like `V` that exist only inside the callee's signature.
+func (t *galaASTTransformer) instantiateGoSignatureReturns(
+	sig *transpiler.GoFuncSignature,
+	args []ast.Expr,
+	typeArgs []transpiler.Type,
+	hasEllipsis bool,
+) []transpiler.Type {
+	subst := t.inferGoSignatureTypeArgs(sig, args, typeArgs, hasEllipsis)
+	if len(subst) == 0 {
+		return sig.Returns
+	}
+	out := make([]transpiler.Type, len(sig.Returns))
+	for i, ret := range sig.Returns {
+		if ret == nil {
+			continue
+		}
+		out[i] = t.substituteInType(ret, subst)
+	}
+	return out
 }
 
 // getGoMethodReturnType returns the first return type of a method on a Go type.

--- a/internal/transpiler/transformer/types.go
+++ b/internal/transpiler/transformer/types.go
@@ -686,6 +686,16 @@ func (t *galaASTTransformer) astTypeToTranspilerType(expr ast.Expr) transpiler.T
 		return transpiler.PointerType{Elem: t.astTypeToTranspilerType(e.X)}
 	case *ast.ArrayType:
 		return transpiler.ArrayType{Elem: t.astTypeToTranspilerType(e.Elt)}
+	case *ast.MapType:
+		// A Go map is legal in every type position a Go slice is, so it has to
+		// round-trip here for the same reasons. Without this case a declared
+		// `map[K]V` collapsed to NilType, and anything typed from it — a struct
+		// field read, a val annotated with a map type — lost its type silently
+		// and only failed further downstream.
+		return transpiler.MapType{
+			Key:  t.astTypeToTranspilerType(e.Key),
+			Elem: t.astTypeToTranspilerType(e.Value),
+		}
 	case *ast.FuncType:
 		// Handle function types like func(S) Option[Tuple[T, S]]
 		var params []transpiler.Type


### PR DESCRIPTION
## Summary

Destructuring a Go generic's multi-value return bound each name to the callee's **declared** type parameter instead of the call's inferred type argument.

`go_interop.MapGet[K comparable, V any](m map[K]V, k K) (V, bool)` called with a `map[string]int` can only return `(int, bool)` — but `v` came out typed `V`, an identifier that exists only inside the callee's own signature.

**Category**: TYPE_INFERENCE_BUG / CODEGEN_BUG
**Priority**: P0 — a legal program does not build

## Why it was worse than a plain compile error

Nothing complained at the binding, and every use that does not pin a type kept working. The build broke only where the value first reached a position needing a concrete type — and the diagnostic named a type parameter the user never wrote, at the use rather than the cause:

```gala
val m = go_interop.MapEmpty[string, int]()
val v, ok = go_interop.MapGet(m, "a")

Println(s"interpolated: $v ok=$ok")   // compiles — interpolation masks it
val boxed = Some(v)                    // undefined: V
```

Reading a Go map and lifting the `(value, found)` pair into an `Option` is the idiomatic thing to do with it, so this shape is the common one:

```gala
func (ix Index) Lookup(key string) Option[int] {
    val v, ok = go_interop.MapGet(ix.entries, key)
    if ok {
        return Some(v)
    }
    return None[int]()
}
```

That function could not be written. The decisive control is that the identical destructure-then-box shape always worked when the Go callee was **not** generic (`val n, err = strconv.Atoi(s)`), which isolates it to generic callees.

## Root Cause

Two independent causes, both on the path from the call to the bound type.

**1. The destructuring path never instantiated the signature.** The single-return path already instantiates a Go generic's return at the call site, but multi-value `val` destructuring read `GoFuncSignature.Returns` verbatim. `tryWrapGoMultiReturnWithErrorPanic` — the `(T, error)` auto-destructure wrapper — had the same gap, and it writes each value type straight into a generated func literal's result clause, so a generic Go callee returning `(T, error)` leaked `T` the same way.

**2. `astTypeToTranspilerType` had no `*ast.MapType` case.** It handled `*ast.ArrayType`, so slices round-tripped, but a declared `map[K]V` converted to `NilType`. A map read out of a struct field therefore came back untyped, which then defeated the argument-driven inference in (1). This is why the receiver-field and local-copy routes failed even once (1) was fixed.

## Changes

- `internal/transpiler/transformer/type_inference.go` — split the substitution derivation out of `instantiateGoSignatureReturn` into `inferGoSignatureTypeArgs`, and add `instantiateGoSignatureReturns`, which applies it to **every** return slot. Behaviour of the existing single-return path is unchanged.
- `internal/transpiler/transformer/calls.go` — `resolveGoCallReturnTypes` resolves a call's return types already instantiated; `splitCallFunTypeArgs` lets `resolveGoCallSignature` see through explicit type arguments, so `MapGet[string, int](m, k)` resolves like the bare call.
- `internal/transpiler/transformer/declarations.go` — the destructuring binding uses the instantiated returns.
- `internal/transpiler/transformer/lambdas.go` — `tryWrapGoMultiReturnWithErrorPanic` instantiates before writing the result clause.
- `internal/transpiler/transformer/types.go` — `astTypeToTranspilerType` converts `*ast.MapType`.

Substitution stays best-effort by design: a type parameter that neither an explicit type argument nor an argument determines is left alone, so the result is never worse than the un-instantiated declared type and the existing Hindley-Milner fallback still applies.

## Verification

- `examples/go_generic_multireturn_destructure.gala` — the reported shape plus the receiver-field, local-copy, struct-parameter, map-parameter and explicit-type-argument routes, and a match over the boxed value to prove the bound value is a real `int`.
- `examples/multifile_lib_regress` — two functions on the batch path, where signatures are rehydrated from the on-disk analysis cache rather than a fresh `go/types` run.
- `internal/transpiler/transformer/go_generic_multireturn_instantiation_test.go` — hermetic guards for the multi-slot substitution (including that it does not mutate the shared cached signature) and the Go map round trip.
- `bazel build //...` passes.
- `bazel test //...` — 398/399 pass. The one failure is `TestGorootFromGoBinarySymlink`, which fails on `master` too: it needs symlink-creation privilege that this Windows environment does not grant.
- End to end with a branch-built CLI: the report's 8-line repro fails on released 0.73.0 with `undefined: V` and builds and runs correctly on this branch.

## Repro (before fix)

```gala
package main

import "martianoff/gala/go_interop"

func main() {
    val m = go_interop.MapEmpty[string, int]()
    val v, ok = go_interop.MapGet(m, "a")

    Println(s"interpolated: $v ok=$ok")
    val boxed = Some(v)
    Println(s"${boxed.IsEmpty()}")
}
```

```
main.gala:10: undefined: V
go build: exit status 1
```

## Dependencies

None — this PR can be reviewed and merged independently. It builds on the call-site instantiation added in #461 (which covered the lambda-return path) and is the multi-value counterpart of it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
