### PR TITLE
fix(inference): a GALA package imported by one file rebound that name for its siblings

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2917,6 +2917,8 @@ gala_library(
         "multifile_lib_regress/generic_sealed.gala",
         "multifile_lib_regress/go_interop.gala",
         "multifile_lib_regress/logic.gala",
+        "multifile_lib_regress/pkg_name_collision.gala",
+        "multifile_lib_regress/pkg_name_collision_go.gala",
         "multifile_lib_regress/pointer_method_field.gala",
         "multifile_lib_regress/proc_session.gala",
         "multifile_lib_regress/symbol_scope.gala",
@@ -2935,6 +2937,7 @@ gala_library(
         "//collection_immutable",
         "//examples/go_struct_bridge",
         "//go_interop",
+        "//strings",
     ],
 )
 

--- a/examples/multifile_lib_regress/pkg_name_collision.gala
+++ b/examples/multifile_lib_regress/pkg_name_collision.gala
@@ -1,0 +1,24 @@
+package multifile_lib_regress
+
+// Regression: a GALA package imported by ONE file of a package must not rebind
+// that package name for its SIBLING files.
+//
+// GALA ships packages whose names collide with Go stdlib ones — strings, io,
+// path, json, crypto, fs. Function metadata is keyed by package NAME
+// ("strings.SplitN") and merged across every file in a package, so once any file
+// imported GALA's `strings`, a sibling file's Go `strings.SplitN` resolved
+// against GALA's signature (returning Array[string]) while codegen still emitted
+// the Go import (returning []string). Inference and emission disagreed, and the
+// error surfaced in the innocent file naming types it never wrote.
+//
+// This file imports GALA's strings. Its sibling pkg_name_collision_go.gala
+// imports Go's. Both must resolve to their own.
+
+import gstr "martianoff/gala/strings"
+
+// GalaStringsUpper goes through GALA's strings package.
+func GalaStringsUpper(s string) string = gstr.ToUpper(s)
+
+// GalaStringsSplitSize proves GALA's SplitN returns an Array (element count via
+// .Size()), which is exactly the signature that used to leak into the sibling.
+func GalaStringsSplitSize(s string) int = gstr.SplitN(s, ":", 2).Size()

--- a/examples/multifile_lib_regress/pkg_name_collision_go.gala
+++ b/examples/multifile_lib_regress/pkg_name_collision_go.gala
@@ -1,0 +1,34 @@
+package multifile_lib_regress
+
+// Sibling of pkg_name_collision.gala. That file imports GALA's `strings`; this
+// one imports GO's. Before the fix, the sibling's import rebound the qualifier
+// package-wide and this file's strings.SplitN was typed as returning
+// Array[string] instead of []string — so `parts` below became
+// Array[Array[string]] and the match subject came out as an Array rather than a
+// string.
+//
+// The match matters: the failure only surfaced where a concrete type was
+// required. Assigning parts.Get(0) straight to a string return type happened to
+// compile, so a weaker test would pass while the bug was live.
+
+import . "martianoff/gala/collection_immutable"
+import "strings"
+
+// GoStringsClassify uses GO's strings.SplitN (returns []string), spreads it into
+// an Array, and matches on an element. Both the element type and the match arms
+// must be string.
+func GoStringsClassify(s string) string {
+    val parts = ArrayOf(strings.SplitN(s, ":", 2)...)
+    if parts.Size() != 2 {
+        return "malformed"
+    }
+    return parts.Get(0) match {
+        case "header" => s"header=${parts.Get(1)}"
+        case "query"  => s"query=${parts.Get(1)}"
+        case _        => "other"
+    }
+}
+
+// GoStringsUpper is the Go-side counterpart of GalaStringsUpper, so both
+// packages are exercised for the same operation in one build.
+func GoStringsUpper(s string) string = strings.ToUpper(s)

--- a/examples/multifile_lib_regress_test.gala
+++ b/examples/multifile_lib_regress_test.gala
@@ -464,4 +464,17 @@ func main() {
         case Off    => Println("flag-off")
         case On(lb) => Println(s"flag-on $lb")
     }
+    // --- Regression: a GALA package imported by one file of a package must not
+    // rebind that package name for its siblings. pkg_name_collision.gala imports
+    // GALA's strings; pkg_name_collision_go.gala imports Go's. Each must resolve
+    // to its own. The match in GoStringsClassify is load-bearing: the old bug only
+    // surfaced where a concrete type was required.
+    Println(multifile_lib_regress.GalaStringsUpper("gala"))
+    Println(s"${multifile_lib_regress.GalaStringsSplitSize("a:b")}")
+    Println(multifile_lib_regress.GoStringsClassify("header:X-Api-Key"))
+    Println(multifile_lib_regress.GoStringsClassify("query:q"))
+    Println(multifile_lib_regress.GoStringsClassify("nope"))
+    Println(multifile_lib_regress.GoStringsClassify("cookie:c"))
+    Println(multifile_lib_regress.GoStringsUpper("go"))
+
 }

--- a/examples/multifile_lib_regress_test.out
+++ b/examples/multifile_lib_regress_test.out
@@ -112,3 +112,10 @@ slot-holds q
 slot-vacant
 flag-on lit
 flag-off
+GALA
+2
+header=X-Api-Key
+query=q
+malformed
+other
+GO

--- a/internal/transpiler/transformer/transformer.go
+++ b/internal/transpiler/transformer/transformer.go
@@ -41,6 +41,14 @@ type galaASTTransformer struct {
 	structFieldTypes      map[string]map[string]transpiler.Type // structName -> fieldName -> typeName
 	genericMethods        map[string]map[string]bool            // receiverType -> methodName -> isGeneric
 	functions             map[string]*transpiler.FunctionMetadata
+	// galaPkgPaths is the set of import paths that are GALA packages, taken from
+	// richAST.Packages (the analyzer fills that map only inside its GALA-package
+	// branch). It lets a qualified call tell whether its qualifier names a GALA
+	// package or a Go one. `functions` is keyed by package NAME and merged across
+	// every file in the package, so GALA's `strings` and Go's `strings` collide
+	// there — as do io, path, json, crypto and fs. Membership here is metadata,
+	// not an import-path heuristic.
+	galaPkgPaths          map[string]bool
 	typeMetas             map[string]*transpiler.TypeMetadata
 	companionObjects      map[string]*transpiler.CompanionObjectMetadata // companion name -> metadata
 	importManager         *ImportManager                                 // unified import tracking (includes transitive imports and dot-import usage)
@@ -95,6 +103,7 @@ func NewGalaASTTransformer() transpiler.ASTTransformer {
 		structFieldTypes:  make(map[string]map[string]transpiler.Type, 32),
 		genericMethods:    make(map[string]map[string]bool, 16),
 		functions:         make(map[string]*transpiler.FunctionMetadata, 64),
+		galaPkgPaths:      make(map[string]bool, 16),
 		typeMetas:         make(map[string]*transpiler.TypeMetadata, 64),
 		companionObjects:  make(map[string]*transpiler.CompanionObjectMetadata, 16),
 		importManager:     NewImportManager(),
@@ -183,6 +192,9 @@ func (t *galaASTTransformer) Transform(richAST *transpiler.RichAST) (fset *token
 
 	// Populate imports from richAST.Packages (includes implicit std import from analyzer)
 	t.importManager.AddFromPackages(richAST.Packages)
+	for path := range richAST.Packages {
+		t.galaPkgPaths[path] = true
+	}
 
 	// Populate metadata from RichAST
 	for typeName, meta := range richAST.Types {

--- a/internal/transpiler/transformer/type_inference_calls.go
+++ b/internal/transpiler/transformer/type_inference_calls.go
@@ -268,7 +268,7 @@ func (t *galaASTTransformer) inferCallSelectorType(e *ast.CallExpr, sel *ast.Sel
 	}
 
 	if id, ok := sel.X.(*ast.Ident); ok {
-		if t.importManager.IsPackage(id.Name) {
+		if t.importManager.IsPackage(id.Name) && t.qualifierIsGalaPackage(id.Name) {
 			pkgName := id.Name
 			if actual, ok := t.importManager.ResolveAlias(pkgName); ok {
 				pkgName = actual
@@ -721,4 +721,29 @@ func (t *galaASTTransformer) inferGetMethodType(e *ast.CallExpr, sel *ast.Select
 		return transpiler.NilType{}
 	}
 	return xType
+}
+
+// qualifierIsGalaPackage reports whether a package qualifier used in this file
+// refers to a GALA package rather than a Go one.
+//
+// It exists because `t.functions` is keyed by package NAME ("strings.SplitN")
+// and is merged across every file in the package. GALA ships packages whose
+// names collide with Go stdlib ones — strings, io, path, json, crypto, fs — so
+// once ANY file in a package imports GALA's `strings`, the key "strings.SplitN"
+// exists package-wide. A sibling file that imports Go's `strings` would then
+// resolve its calls against GALA's signature (Array[string]) while codegen
+// emits the Go import ([]string). Inference and emission disagree, and the
+// error surfaces in the innocent file naming types it never wrote.
+//
+// The check is per-file and metadata-driven: it resolves the qualifier through
+// this file's own ImportManager and asks whether that import path is one the
+// analyzer classified as GALA. It is not an import-path heuristic.
+func (t *galaASTTransformer) qualifierIsGalaPackage(alias string) bool {
+	entry, ok := t.importManager.GetByAlias(alias)
+	if !ok {
+		// No entry to judge by (transitive or synthesized qualifier) — keep the
+		// previous behaviour rather than silently dropping a valid lookup.
+		return true
+	}
+	return t.galaPkgPaths[entry.Path]
 }


### PR DESCRIPTION
## Summary

A GALA package imported by **one** file of a package silently rebound that package name for its **sibling** files, so an untouched file's Go stdlib calls were typed against the GALA package instead.

**Category**: TYPE_INFERENCE_BUG
**Priority**: P1 — wrong types, and the error names a file that is not at fault
**Found in**: adding a TCP layer to `gala-server`

## The symptom

Adding one new file to `gala-server` broke `filter.gala`, a file the change never touched:

```
filter.gala:158: invalid operation: obj == "header"
    (mismatched types collection_immutable.Array[string] and untyped string)
filter.gala:167: cannot use parts.Get().Get(0) (value of type string)
    as collection_immutable.Array[string] value ...
```

`filter.gala` imports **Go's** `strings`. The new file imported **GALA's**. GALA's `strings.SplitN` returns `Array[string]`; Go's returns `[]string`. So `parts` was inferred as `Array[Array[string]]` — while the generated `filter.gen.go` still imported Go's `strings`.

**Inference and codegen disagreed about what `strings` meant.**

## Root cause

`inferCallSelectorType` built `"pkg.Func"` from the qualifier and hit `t.functions` unconditionally:

```go
if t.importManager.IsPackage(id.Name) {
    pkgName := id.Name
    if actual, ok := t.importManager.ResolveAlias(pkgName); ok { pkgName = actual }
    fullName := pkgName + "." + sel.Sel.Name
    if fMeta, ok := t.functions[fullName]; ok {   // <-- GALA's entry, always
```

`t.functions` is keyed by package **name** and merged across every file in the package. So once any file imported GALA's `strings`, the key `strings.SplitN` existed package-wide and every sibling's Go call resolved to it.

This is not specific to `strings`. GALA ships `io`, `path`, `json`, `crypto` and `fs` — all colliding with Go stdlib names.

## The fix

Guard the lookup: the qualifier must name a GALA package **in this file**.

```go
if t.importManager.IsPackage(id.Name) && t.qualifierIsGalaPackage(id.Name) {
```

`qualifierIsGalaPackage` resolves the qualifier through the file's own `ImportManager` (per-file, carries each entry's real import path) and checks whether that path is one the analyzer classified as GALA. `richAST.Packages` is populated **only inside the analyzer's GALA-package branch**, so membership there is metadata — not an import-path heuristic, which CLAUDE.md rule 8 forbids.

A qualifier with no import entry (transitive or synthesized) keeps the previous behaviour rather than silently dropping a valid lookup.

## Verification

- **The case that surfaced it**: `gala-server` could not compile once any file imported GALA's `strings`; it now does (`ok (library compiled successfully)`).
- **Minimal repro** — two files, reduced from an 11-file package:

  `a.gala`
  ```gala
  package main
  import gs "martianoff/gala/strings"
  func Trim(s string) string = gs.TrimSuffix(s, "!")
  ```

  `b.gala`
  ```gala
  package main
  import . "martianoff/gala/collection_immutable"
  import "strings"

  func First(s string) string {
      val parts = ArrayOf(strings.SplitN(s, ":", 2)...)
      return parts.Get(0) match {
          case "header" => "H"
          case _        => "?"
      }
  }
  ```

  Deleting `a.gala` made `b.gala` compile and run — the tell that a sibling was the cause. Aliasing made no difference; an unaliased import failed identically.

- **Regression test** in `examples/multifile_lib_regress/`, because the bug needs two files to exist at all. `pkg_name_collision.gala` imports GALA's `strings`, `pkg_name_collision_go.gala` imports Go's, and each must resolve to its own. **Confirmed to fail without the guard** (fails to build) and pass with it.

- `bazel build //...` clean; `bazel test //...` 398/399 — the sole failure is the known-benign `analyzer_test :: TestGorootFromGoBinarySymlink` (Windows symlink privilege). `bazel run //:gazelle` produced no changes.

## Why the match in the regression test is load-bearing

The defect only surfaced where a **concrete type was required**. Assigning `parts.Get(0)` straight to a `string` return happened to compile even while the bug was live — an earlier draft of the repro did exactly that and passed. The test matches on the element so a reintroduction cannot slip through.

## Why this survived

It needs two files, a name collision between a GALA package and a Go stdlib package, and a use site that forces a concrete type. Every existing GALA project either avoids GALA's colliding packages or never mixes them with the Go originals in one package.

## Dependencies

None — branches from `master`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aZRWH39EXTXVALyxALJut
