### PR TITLE
fix(transpiler): don't probe a function name for an Immutable wrapper

### DIFF
--- a/internal/transpiler/transformer/expressions.go
+++ b/internal/transpiler/transformer/expressions.go
@@ -959,6 +959,19 @@ func (t *galaASTTransformer) unwrapImmutable(expr ast.Expr) ast.Expr {
 			if !t.getType(ident.Name).IsNil() {
 				return expr
 			}
+			// Nor a function name, for the same reason. This arrives via
+			// resolveIndexAccess: `ArrayOf[Tuple[bool, string]](...)` parses as
+			// an index access, so the base is probed for an Immutable wrapper
+			// on the way past. Asking is not free — a generic function's ident
+			// resolves to NilType, which getExprTypeNameManual declines to
+			// cache, so getExprTypeName re-runs manual inference and then falls
+			// through to Hindley-Milner on every such query.
+			//
+			// getFunction is checked last: it builds a resolver and an imports
+			// slice per call, so the cheap scope and type lookups go first.
+			if t.getFunction(ident.Name) != nil {
+				return expr
+			}
 		}
 	}
 	if sel, ok := expr.(*ast.SelectorExpr); ok {

--- a/internal/transpiler/transformer/unresolved_corpus_test.go
+++ b/internal/transpiler/transformer/unresolved_corpus_test.go
@@ -23,22 +23,32 @@ import (
 // previously unresolved, lower it in the same commit so the slack is not
 // silently available to the next regression.
 //
-// The current inventory is dominated by three shapes, which is what makes it a
-// worklist rather than a wall:
+// What is left is dominated by four shapes, which is what makes it a worklist
+// rather than a wall:
 //
-//   - bare references to a function passed as a value (tickerAdvance,
-//     splitGeneric, consList, FutureOf, New)
-//   - vals and Option chains that lose their type partway along
-//     (arr, arr.Get(), d1.Get().Age.Get())
-//   - a method named but not called, as the receiver of a further call
-//     (.FlatMap, .GetOrElse, .Get)
+//   - a val that loses its type, and every read through it
+//     (arr, arr.Get(), copied, copied.Get())
+//   - an Option or Immutable chain that stops resolving partway
+//     (result.Get().Get, m.Get().Get, opt.Get().Map, ptr.Get().Deref)
+//   - a method on a Go value, named through an interface
+//     (err.Error(), e.Error(), node.Ptr)
+//   - a generic function passed as a value (tickerAdvance, splitGeneric),
+//     which has to be instantiated against the parameter it is passed to
+//
+// The first is the one to pull on: an unresolved val makes every later use of
+// it unresolved too, so these counts are not independent.
+//
+// The fourth is small — about a dozen — but it is the one to leave alone in the
+// count. Those idents were briefly filtered out as "a generic function has no
+// standalone type", which is true, and it hid the reports that would show an
+// instantiation failing. See hasNoTypeByConstruction.
 //
 // This is a ceiling rather than an equality check on purpose. Go type info is
 // unavailable when the Go SDK is not on the path, and without it some
 // expressions that would otherwise resolve do not. A run with more type
 // information available resolves more and comes in under the ceiling; it
 // should not have to move the number to stay green.
-const unresolvedBudget = 735
+const unresolvedBudget = 541
 
 // TestUnresolvedTypeInventory transpiles the single-file example corpus with
 // the unresolved-type inventory enabled and holds the total to a budget.

--- a/internal/transpiler/transformer/unresolved_types.go
+++ b/internal/transpiler/transformer/unresolved_types.go
@@ -122,16 +122,23 @@ func dedupeUnresolved(in []UnresolvedType) []UnresolvedType {
 // inventory — they were the majority of the first run — and none is a place
 // inference could be improved.
 //
-// Deliberately narrow. Anything genuinely value-shaped stays in, even when the
-// transformer has a good reason to fail on it, because "we have a reason" is
-// how a real gap gets filtered out and stops being counted.
+// Deliberately narrow, and it stays that way. Generic function names were also
+// most of an early inventory, and filtering them here looked equally
+// justified — but the filter resolved names better than the instantiation path
+// it deferred to, so in a package other than main it would have suppressed
+// exactly the reports that matter. They are kept out at the source instead, by
+// not asking: see the function-name early-out in unwrapImmutable.
+//
+// The lesson generalises. Anything genuinely value-shaped stays in, even when
+// the transformer has a good reason to fail on it, because "we have a reason"
+// is how a real gap gets filtered out and stops being counted.
 func (t *galaASTTransformer) hasNoTypeByConstruction(expr ast.Expr) bool {
 	ident, ok := expr.(*ast.Ident)
 	if !ok {
 		return false
 	}
-	// A local val or param shadowing a package name is a value; the scope
-	// lookup wins over the package-name check.
+	// A local val or param shadowing a package or function name is a value; the
+	// scope lookup wins over the checks below.
 	if !t.getValType(ident.Name).IsNil() {
 		return false
 	}


### PR DESCRIPTION
First pass over the worklist #479 established.

## The change

`ArrayOf[Tuple[bool, string]](...)` parses as an **index access**, so `resolveIndexAccess` routes the base through `unwrapImmutable` to ask whether it needs a `.Get()` before indexing. `unwrapImmutable` already declines to unwrap a *type* name; a *function* name is the same case and was missing:

```go
if !t.isVal(ident.Name) && !t.isVar(ident.Name) {
    if !t.getType(ident.Name).IsNil() { return expr }      // existing
    if t.getFunction(ident.Name) != nil { return expr }    // added
}
```

Asking is not free. A generic function's ident resolves to `NilType` — there is no signature until its type parameters are bound — and `getExprTypeNameManual` **declines to cache a nil result**, so `getExprTypeName` re-runs manual inference and then falls through to Hindley-Milner on every such query, for every generic instantiation in the file. `getFunction` is checked last because it builds a resolver per call; the cheap scope and type lookups go first.

It also removes the largest category of noise from the unresolved-type inventory: **719 → 541**.

## Why not filter it in the diagnostics layer

The first version of this PR did exactly that — skipped generic function idents in `hasNoTypeByConstruction`, on the grounds that a generic function has no standalone type. That is true, and it would have been a mistake. `/simplify`'s altitude pass caught it and I verified each step:

- The filter resolved names through `getFunction`: bare → `std.` → current package → dot imports → named imports (`resolver.go:38-78`).
- The paths that instantiate a generic function *passed as a value* look it up by **bare key** — `calls.go:562` (`t.functions[id.Name]`) and `lookupBareFuncRefMeta` (`type_inference.go:414`).
- Functions are keyed `"pkg.Name"` for every package except `main` and `test` (`analyzer.go:1393-1395`).

So in a **named package**, a bare same-package generic function passed as a value is *not* instantiated by the argument path — and the filter would have found it and suppressed the report. The corpus structurally cannot catch this: **301 of its 303 examples are `package main`**, the one kind where the bare-key lookup happens to work. The claim was validated on the only configuration where it is true.

Not asking is both narrower and deeper. It removes only the *incidental* queries and leaves the dozen genuine passed-as-value references visible — **541 rather than 529** — and it saves the wasted inference on the production path rather than only in diagnostics.

That residue is now called out in the budget comment as the shape *not* to filter, so the next person to look at those twelve entries doesn't repeat the reasoning.

## Effect on the worklist

| Count | Shape | |
|---|---|---|
| 15 | `nil` | untyped literal whose context supplied nothing |
| 7 | `result.Get().Get` | Option/Immutable chain stops resolving partway |
| 4 | `arr`, `arr.Get()` | a val that loses its type, and every read through it |
| 4 | `err.Error()` | method named through a Go interface |
| ~12 | `tickerAdvance` | generic function passed as a value — **keep visible** |

The val case is the one to pull on next: an unresolved val makes every later use of it unresolved too, so those counts are not independent.

## Verification

`bazel test //...` — 398 pass. One failure, `TestGorootFromGoBinarySymlink`, is the Windows symlink-privilege test that fails on clean master too.

`541` was measured independently twice. `expressions.go` is left unformatted-as-found; it does not pass `gofmt` on master either, and reformatting it would bury a 12-line change in a whole-file diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)