### PR TITLE
fix(intellij): PSI walks crash on newer IntelliJ platforms

### DIFF
--- a/ide/intellij/src/main/kotlin/org/gala/ide/intellij/psi/GalaPsiNodes.kt
+++ b/ide/intellij/src/main/kotlin/org/gala/ide/intellij/psi/GalaPsiNodes.kt
@@ -1,15 +1,42 @@
 package org.gala.ide.intellij.psi
 
+import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNameIdentifierOwner
 import com.intellij.psi.PsiReference
-import org.antlr.intellij.adaptor.psi.ANTLRPsiNode
+import com.intellij.psi.util.PsiUtilCore
 
 /**
  * Base PSI node for GALA elements backed by ANTLR parse tree nodes.
+ *
+ * Extends [ASTWrapperPsiElement] directly instead of the ANTLR adaptor's
+ * `ANTLRPsiNode`. The adaptor routes `getChildren()` and `getContext()` through
+ * `org.antlr.intellij.adaptor.psi.Trees` / `SymtabUtils`, and `Trees` can no
+ * longer be loaded: it holds an anonymous subclass of `WriteCommandAction`,
+ * which recent IntelliJ platforms made final, so the JVM rejects the class with
+ * `IncompatibleClassChangeError` and every PSI walk (go to definition,
+ * annotator, inspections, structure view) dies. The only adaptor behaviour the
+ * plugin actually relies on is reimplemented below.
  */
-open class GalaPsiNode(node: ASTNode) : ANTLRPsiNode(node)
+open class GalaPsiNode(node: ASTNode) : ASTWrapperPsiElement(node) {
+    /**
+     * All children, token leaves included.
+     *
+     * The platform default keeps composite nodes only; GALA declarations locate
+     * their name identifier and keywords by walking this list, so leaves must
+     * stay visible.
+     */
+    override fun getChildren(): Array<PsiElement> {
+        var child: PsiElement? = firstChild ?: return PsiElement.EMPTY_ARRAY
+        val result = ArrayList<PsiElement>()
+        while (child != null) {
+            result.add(child)
+            child = child.nextSibling
+        }
+        return PsiUtilCore.toPsiElementArray(result)
+    }
+}
 
 /**
  * PSI node for identifier references (usages, not declarations).


### PR DESCRIPTION
## Problem

On the 2026.2 platform (GoLand 262), opening any `.gala` file and using go to definition — or triggering the annotator, inspections, or structure view — blows up with:

```
com.intellij.diagnostic.PluginException: Cannot load class org.antlr.intellij.adaptor.psi.Trees$1 (
  error: class org.antlr.intellij.adaptor.psi.Trees$1 cannot inherit from final class
         com.intellij.openapi.command.WriteCommandAction
) [Plugin: org.gala.lang]
    at org.antlr.intellij.adaptor.psi.ANTLRPsiNode.getChildren(ANTLRPsiNode.java:42)
    at org.gala.ide.intellij.psi.GalaReference$Companion.findDeclarationInScope(GalaReference.kt:68)
```

## Cause

`Trees` holds an anonymous subclass of `WriteCommandAction` (`Trees$1`, inside `replacePsiFileFromText`). Recent IntelliJ platforms made `WriteCommandAction` final, so verifying `Trees` pulls in `Trees$1` and the JVM rejects the whole class with `IncompatibleClassChangeError`.

`ANTLRPsiNode.getChildren()` is nothing but `Trees.getChildren(this)`, and every PSI walk in the plugin goes through `.children` — so this was never limited to go to definition. `ANTLRPsiNode.getContext()` had the same problem via `SymtabUtils`.

Upgrading the library is not an option: `0.1` is the only release of `org.antlr:antlr4-intellij-adaptor` on Maven Central.

## Fix

`GalaPsiNode` extends `ASTWrapperPsiElement` directly and reimplements the one adaptor behaviour the plugin relies on — `getChildren()` returning token leaves as well as composite nodes. The platform default filters leaves out, which would break every `nameIdentifier` lookup. All 11 `.children` call sites filter by element type or PSI class, so the leaves stay inert where they are not wanted.

The lexer, parser and token-type adaptor classes are untouched; none of them reference `Trees`.

## Verification

- `bazel build //ide/intellij:plugin` succeeds.
- Grepping the compiled classes inside the produced `gala-intellij-plugin.zip` shows **zero** references to `org/antlr/intellij/adaptor/psi/` in plugin code, so the unloadable class can no longer be reached at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)