### PR TITLE
fix(lsp): go to definition cannot reach a project's own packages

### DIFF
--- a/internal/lsp/BUILD.bazel
+++ b/internal/lsp/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//internal/transpiler",
         "//internal/transpiler/analyzer",
         "//internal/transpiler/generator",
+        "//internal/transpiler/module",
         "//internal/transpiler/transformer",
         "@com_github_antlr4_go_antlr_v4//:antlr",
         "@com_github_owenrumney_go_lsp//lsp",
@@ -35,6 +36,7 @@ go_test(
     name = "lsp_test",
     srcs = [
         "bom_test.go",
+        "definition_project_module_test.go",
         "error_lines_test.go",
         "repro_gala_mcp_test.go",
         "server_test.go",

--- a/internal/lsp/definition.go
+++ b/internal/lsp/definition.go
@@ -11,6 +11,7 @@ import (
 	"martianoff/gala/galaerr"
 	"martianoff/gala/internal/transpiler"
 	"martianoff/gala/internal/transpiler/analyzer"
+	"martianoff/gala/internal/transpiler/module"
 )
 
 func (h *GalaHandler) Definition(ctx context.Context, params *lsp.DefinitionParams) ([]lsp.Location, error) {
@@ -488,21 +489,46 @@ func addImportSpec(imports map[string]string, spec string) {
 	}
 }
 
-// resolveImportDir resolves an import path to a filesystem directory using the
-// same search-path strategy the analyzer's resolver applies: internal
-// martianoff/gala/* paths map to a directory relative to a search path with
-// the module prefix stripped; everything else is tried as-is.
+// galaModulePath is the GALA compiler's own module path — the prefix every
+// stdlib import carries. It is needed as a literal only for the search-path
+// sweep below, where a search path can be a bare tree of package directories
+// with no gala.mod to read a module path out of.
+const galaModulePath = "martianoff/gala"
+
+// resolveImportDir resolves an import path to the directory holding that
+// package's sources, in three steps: strip the prefix of whichever gala.mod
+// module owns the path and resolve the remainder under that module's own root;
+// failing that, join the path with each search path; failing that, fall back
+// to Go source directories. It deliberately shares no code with the analyzer's
+// resolver — that one fuzzy-matches by path suffix and caches negative results
+// forever, both wrong for navigation in a live editor.
 func (h *GalaHandler) resolveImportDir(uri, importPath string) string {
-	relPath := strings.TrimPrefix(importPath, "martianoff/gala/")
+	// Resolve against the module that owns the path, under that module's own
+	// root. Joining a module-relative path against an unrelated search path is
+	// how a project package ends up pointing into a dependency's cache.
+	for _, m := range h.moduleRoots {
+		rel, ok := module.StripModulePrefix(importPath, m.path)
+		if !ok && importPath != m.path {
+			continue
+		}
+		if dir := statDir(filepath.Join(m.dir, rel)); dir != "" {
+			return dir
+		}
+	}
+	// No owning module — either the project has no gala.mod at its root, or the
+	// package belongs to a module we never learned about. Search paths are then
+	// all we have: a stdlib import resolves against a search path that IS the
+	// stdlib source root, so it needs its module prefix off; anything else is
+	// tried verbatim.
+	stdlibRel := strings.TrimPrefix(importPath, galaModulePath+"/")
 	for _, sp := range h.getSearchPaths(uriToPath(uri)) {
-		for _, cand := range []string{relPath, importPath} {
-			dir := filepath.Join(sp, cand)
-			if info, err := os.Stat(dir); err == nil && info.IsDir() {
-				if abs, err := filepath.Abs(dir); err == nil {
-					return abs
-				}
+		if stdlibRel != importPath {
+			if dir := statDir(filepath.Join(sp, stdlibRel)); dir != "" {
 				return dir
 			}
+		}
+		if dir := statDir(filepath.Join(sp, importPath)); dir != "" {
+			return dir
 		}
 	}
 	// Not on a GALA search path. Try third-party Go modules wired from the
@@ -514,6 +540,19 @@ func (h *GalaHandler) resolveImportDir(uri, importPath string) string {
 		}
 	}
 	return analyzer.GoPackageSourceDir(importPath)
+}
+
+// statDir returns path made absolute when it names an existing directory, and
+// "" otherwise — so a caller can try candidate directories in priority order.
+func statDir(path string) string {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		return abs
+	}
+	return path
 }
 
 // packageMemberDefinition resolves a `pkg.Symbol` reference where `pkg` is an

--- a/internal/lsp/definition_project_module_test.go
+++ b/internal/lsp/definition_project_module_test.go
@@ -55,13 +55,11 @@ func TestDefinition_ModuleQualifiedImport(t *testing.T) {
 	// The project's own packages, and a GALA dependency's packages, resolve by
 	// the same mechanism against different module roots.
 	for _, project := range []struct {
-		name     string
-		setup    func(t *testing.T) (root string, wantDir string)
-		respPath string
+		name  string
+		setup func(t *testing.T) (root string, wantDir string)
 	}{
 		{
-			name:     "project's own package",
-			respPath: "github.com/example/kv/internal/resp",
+			name: "project's own package",
 			setup: func(t *testing.T) (string, string) {
 				root := createTestProject(t, []testProjectFile{
 					{Name: "gala.mod", Src: "module github.com/example/kv\n\ngala 0.74.1\n"},
@@ -72,8 +70,7 @@ func TestDefinition_ModuleQualifiedImport(t *testing.T) {
 			},
 		},
 		{
-			name:     "dependency's package",
-			respPath: "github.com/example/proto/internal/resp",
+			name: "dependency's package",
 			setup: func(t *testing.T) (string, string) {
 				// A GALA dependency's sources live in the version-keyed module
 				// cache under GALA_HOME, which the handler stats when reading

--- a/internal/lsp/definition_project_module_test.go
+++ b/internal/lsp/definition_project_module_test.go
@@ -1,0 +1,167 @@
+package lsp_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/owenrumney/go-lsp/lsp"
+
+	lspserver "martianoff/gala/internal/lsp"
+)
+
+// The signature under test in every case below. Line 4 of the dispatch file.
+const (
+	dispatchSigLine = 4
+	dispatchSig     = "func Reply() resp.RespValue = resp.NullBulk()"
+)
+
+const respValueSrc = "package resp\n" +
+	"\n" +
+	"sealed type RespValue {\n" +
+	"    case SimpleString(Text string)\n" +
+	"    case NullBulk\n" +
+	"}\n"
+
+// dispatchSrc imports respPath and returns a value from it.
+func dispatchSrc(respPath string) string {
+	return "package command\n" +
+		"\n" +
+		"import \"" + respPath + "\"\n" +
+		"\n" +
+		dispatchSig + "\n"
+}
+
+// Packages are imported by their module-qualified path
+// (github.com/you/proj/internal/resp) while living at internal/resp under the
+// owning module's root. Definition has to strip the prefix of the module that
+// owns the path — the project's own, or a dependency's, both read from
+// gala.mod — before the import names anything on disk. Without that step the
+// package name and every pkg.Symbol reference answered "cannot find
+// declaration".
+func TestDefinition_ModuleQualifiedImport(t *testing.T) {
+	// Cursor one character inside each identifier of interest.
+	cases := []struct {
+		what string
+		col  int
+	}{
+		{"package qualifier", strings.Index(dispatchSig, "resp.") + 1},
+		{"qualified type", strings.Index(dispatchSig, "RespValue") + 1},
+		{"qualified sealed-case constructor", strings.Index(dispatchSig, "NullBulk") + 1},
+	}
+
+	// The project's own packages, and a GALA dependency's packages, resolve by
+	// the same mechanism against different module roots.
+	for _, project := range []struct {
+		name     string
+		setup    func(t *testing.T) (root string, wantDir string)
+		respPath string
+	}{
+		{
+			name:     "project's own package",
+			respPath: "github.com/example/kv/internal/resp",
+			setup: func(t *testing.T) (string, string) {
+				root := createTestProject(t, []testProjectFile{
+					{Name: "gala.mod", Src: "module github.com/example/kv\n\ngala 0.74.1\n"},
+					{Name: "internal/resp/value.gala", Src: respValueSrc},
+					{Name: "internal/command/dispatch.gala", Src: dispatchSrc("github.com/example/kv/internal/resp")},
+				})
+				return root, filepath.Join(root, "internal", "resp")
+			},
+		},
+		{
+			name:     "dependency's package",
+			respPath: "github.com/example/proto/internal/resp",
+			setup: func(t *testing.T) (string, string) {
+				// A GALA dependency's sources live in the version-keyed module
+				// cache under GALA_HOME, which the handler stats when reading
+				// gala.mod's require list.
+				galaHome := t.TempDir()
+				t.Setenv("GALA_HOME", galaHome)
+				depDir := filepath.Join(galaHome, "pkg", "mod", "github.com", "example", "proto@v1.2.0", "internal", "resp")
+				if err := os.MkdirAll(depDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(depDir, "value.gala"), []byte(respValueSrc), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				root := createTestProject(t, []testProjectFile{
+					{Name: "gala.mod", Src: "module github.com/example/kv\n\ngala 0.74.1\n\nrequire github.com/example/proto v1.2.0\n"},
+					{Name: "internal/command/dispatch.gala", Src: dispatchSrc("github.com/example/proto/internal/resp")},
+				})
+				return root, depDir
+			},
+		},
+	} {
+		t.Run(project.name, func(t *testing.T) {
+			root, wantDir := project.setup(t)
+			h, handler := newHarnessWithHandler(t)
+			initializeAtRoot(t, handler, root)
+			uri := openProjectFile(t, h, root, "internal/command/dispatch.gala")
+
+			for _, tc := range cases {
+				t.Run(tc.what, func(t *testing.T) {
+					locs, err := h.Definition(uri, dispatchSigLine, tc.col)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if len(locs) == 0 {
+						t.Fatalf("no definition found for %s", tc.what)
+					}
+					want := strings.ToLower(filepath.ToSlash(filepath.Join(wantDir, "value.gala")))
+					got := strings.ToLower(filepath.ToSlash(string(locs[0].URI)))
+					if !strings.HasSuffix(got, want) {
+						t.Fatalf("%s: expected a location in %s, got %s", tc.what, want, locs[0].URI)
+					}
+				})
+			}
+		})
+	}
+}
+
+// The GALA compiler repo is itself a module (`module martianoff/gala`) whose
+// stdlib packages sit at the repo root, so when a gala.mod names it, stdlib
+// imports resolve through the same module-root mechanism as anyone else's —
+// no prefix literal involved. (The literal survives only for the case with no
+// owning module at all, covered by TestDefinition_GoInteropPackageAndFunc.)
+func TestDefinition_StdlibImportUsesTheSameModuleMechanism(t *testing.T) {
+	root := createTestProject(t, []testProjectFile{
+		{Name: "gala.mod", Src: "module martianoff/gala\n\ngala 0.74.1\n"},
+		{Name: "collection_immutable/array.gala", Src: "package collection_immutable\n\ntype Marker struct {}\n"},
+		{Name: "app/main.gala", Src: "package main\n\nimport \"martianoff/gala/collection_immutable\"\n\nfunc Run() = Println(collection_immutable.Marker())\n"},
+	})
+
+	h, handler := newHarnessWithHandler(t)
+	initializeAtRoot(t, handler, root)
+	uri := openProjectFile(t, h, root, "app/main.gala")
+
+	// Line 4, cursor inside the "collection_immutable" qualifier.
+	locs, err := h.Definition(uri, 4, strings.Index("func Run() = Println(collection_immutable.Marker())", "collection_immutable")+1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locs) == 0 {
+		t.Fatal("no definition found for the stdlib package qualifier")
+	}
+	// Assert the full temp-project path: the real GALA repo is on the test
+	// harness's search paths and has a collection_immutable/array.gala of its
+	// own, which a suffix-only check would happily accept.
+	want := strings.ToLower(filepath.ToSlash(filepath.Join(root, "collection_immutable", "array.gala")))
+	if got := strings.ToLower(filepath.ToSlash(string(locs[0].URI))); !strings.HasSuffix(got, want) {
+		t.Fatalf("expected %s, got %s", want, locs[0].URI)
+	}
+}
+
+// initializeAtRoot drives the Initialize handshake with a project root, the way
+// an IDE does — this is what makes the handler read the project's gala.mod.
+// The harness's own handshake (servertest.New) sends no root; go-lsp v0.1.4
+// has no option to supply one.
+func initializeAtRoot(t *testing.T, handler *lspserver.GalaHandler, root string) {
+	t.Helper()
+	rootURI := fileURIForPath(root)
+	if _, err := handler.Initialize(context.Background(), &lsp.InitializeParams{RootURI: &rootURI}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -24,6 +24,18 @@ import (
 	"martianoff/gala/internal/transpiler/transformer"
 )
 
+// moduleRoot pairs a module path with the directory its packages live under.
+// Imports name packages by their module-qualified path
+// (github.com/you/proj/internal/resp) while the sources sit at internal/resp
+// under the module's own root, so navigating to one means stripping the
+// matching module's prefix and resolving the remainder under *that* module's
+// directory — joining against an unrelated root is how a project package ends
+// up pointing into a dependency's cache.
+type moduleRoot struct {
+	path string // module path as written in gala.mod, e.g. github.com/you/proj
+	dir  string // directory the module's packages are rooted at
+}
+
 // GalaHandler implements all LSP handler interfaces for the GALA language.
 //
 // Diagnostic publishing follows the cancel-and-restart pattern (like gopls):
@@ -44,9 +56,10 @@ type GalaHandler struct {
 	parser    transpiler.GalaParser
 	generator transpiler.CodeGenerator
 
-	extraSearchPaths []string      // additional search paths (for testing)
+	extraSearchPaths []string          // additional search paths (for testing)
 	goSrcDirs        map[string]string // Go module import-path prefix -> on-disk .go source dir (third-party deps)
-	client           *golsp.Client // LSP client for sending notifications
+	moduleRoots      []moduleRoot      // modules whose packages this project can import, from gala.mod
+	client           *golsp.Client     // LSP client for sending notifications
 
 	mu              sync.Mutex
 	documents       map[string]string              // URI -> source text
@@ -75,7 +88,7 @@ func (h *GalaHandler) SetSearchPaths(paths []string) {
 
 // SetGoSrcDirs wires the Go module import-path -> source-directory table used to
 // resolve third-party Go types (for testing; in production it is populated from
-// the project's gala.mod by resolveProjectDeps).
+// the project's gala.mod by loadProjectModule).
 func (h *GalaHandler) SetGoSrcDirs(dirs map[string]string) {
 	h.goSrcDirs = dirs
 }
@@ -147,7 +160,7 @@ func (h *GalaHandler) Initialize(ctx context.Context, params *lsp.InitializePara
 
 	// Auto-resolve gala.mod dependencies from project root
 	if h.rootPath != "" {
-		h.resolveProjectDeps(h.rootPath)
+		h.loadProjectModule(h.rootPath)
 	}
 
 	openClose := true
@@ -418,19 +431,22 @@ func findSiblingGalaFiles(filePath string) []string {
 	return siblings
 }
 
-// resolveProjectDeps scans for gala.mod in the project root and adds
-// dependency paths to the search paths so imported packages resolve correctly.
-func (h *GalaHandler) resolveProjectDeps(rootPath string) {
+// loadProjectModule parses the project's gala.mod and wires everything derived
+// from it: the module roots imports resolve against, the dependency search
+// paths, and the Go source directories.
+func (h *GalaHandler) loadProjectModule(rootPath string) {
 	galaModPath := filepath.Join(rootPath, "gala.mod")
 	galaMod, err := mod.ParseFile(galaModPath)
 	if err != nil {
 		return
 	}
+	h.moduleRoots = []moduleRoot{{path: galaMod.Module.Path, dir: rootPath}}
 	config := build.DefaultConfig()
 	for _, req := range galaMod.GalaRequires() {
 		depDir := config.GalaModulePath(req.Path, req.Version)
 		if info, err := os.Stat(depDir); err == nil && info.IsDir() {
 			h.extraSearchPaths = append(h.extraSearchPaths, depDir)
+			h.moduleRoots = append(h.moduleRoots, moduleRoot{path: req.Path, dir: depDir})
 		}
 	}
 	// Wire third-party Go module source directories so the analyzer can resolve

--- a/internal/transpiler/module/resolver.go
+++ b/internal/transpiler/module/resolver.go
@@ -329,7 +329,7 @@ func (r *Resolver) resolvePackagePathUncached(importPath string) (string, error)
 
 	// Strategy 1: Module-relative resolution
 	if r.moduleRoot != "" && r.moduleName != "" {
-		if relPath, ok := hasModulePrefix(importPath, r.moduleName); ok {
+		if relPath, ok := StripModulePrefix(importPath, r.moduleName); ok {
 			// Full module path: "martianoff/gala/std" -> "{moduleRoot}/std"
 			dirPath := filepath.Join(r.moduleRoot, relPath)
 			if isValidPackageDir(dirPath) {
@@ -382,7 +382,7 @@ func (r *Resolver) resolvePackagePathUncached(importPath string) (string, error)
 				return spModRoot, nil
 			}
 		}
-		if relPath, ok := hasModulePrefix(importPath, spModName); ok {
+		if relPath, ok := StripModulePrefix(importPath, spModName); ok {
 			dirPath := filepath.Join(spModRoot, relPath)
 			if isValidPackageDir(dirPath) {
 				return dirPath, nil
@@ -410,7 +410,7 @@ func (r *Resolver) resolvePackagePathUncached(importPath string) (string, error)
 	// real on-disk path). Other paths use the full import path as the suffix.
 	suffixPath := importPath
 	if r.moduleName != "" {
-		if rel, ok := hasModulePrefix(importPath, r.moduleName); ok {
+		if rel, ok := StripModulePrefix(importPath, r.moduleName); ok {
 			suffixPath = rel
 		}
 	}
@@ -486,7 +486,7 @@ func (r *Resolver) subpackageDirForCachedModule(baseDir, importPath string) stri
 	if err != nil || depMod.Module.Path == "" {
 		return ""
 	}
-	rel, ok := hasModulePrefix(importPath, depMod.Module.Path)
+	rel, ok := StripModulePrefix(importPath, depMod.Module.Path)
 	if !ok || rel == "" {
 		return ""
 	}
@@ -516,10 +516,14 @@ func matchesModuleName(importPath, moduleName string) bool {
 	return false
 }
 
-// hasModulePrefix checks if importPath starts with moduleName+"/", accounting for
-// VCS host prefix differences. Returns the relative path after the module prefix,
-// or empty string if no match.
-func hasModulePrefix(importPath, moduleName string) (relPath string, ok bool) {
+// StripModulePrefix reports whether importPath names a package inside
+// moduleName, returning the package's path relative to the module root. It
+// tolerates VCS host prefix differences, so "github.com/you/proj/internal/x"
+// and "you/proj/internal/x" both match the module either way round.
+//
+// Exported because tooling outside the transpiler needs the same matching: the
+// LSP maps an import path back to a source directory for go-to-definition.
+func StripModulePrefix(importPath, moduleName string) (relPath string, ok bool) {
 	if strings.HasPrefix(importPath, moduleName+"/") {
 		return strings.TrimPrefix(importPath, moduleName+"/"), true
 	}
@@ -555,7 +559,7 @@ func (r *Resolver) ResolveGoImportPath(importPath string) string {
 			return spModName // Return the full Go module path
 		}
 		// Handle subpackage: "martianoff/gala-server/sub" → "github.com/martianoff/gala-server/sub"
-		if relPath, ok := hasModulePrefix(importPath, spModName); ok {
+		if relPath, ok := StripModulePrefix(importPath, spModName); ok {
 			if importPath != spModName+"/"+relPath {
 				return spModName + "/" + relPath
 			}
@@ -581,7 +585,7 @@ func stripVCSHost(path string) string {
 func (r *Resolver) IsGalaPackage(importPath string) bool {
 	// Check if it's the current module (root package or subpackage)
 	if r.moduleName != "" && (matchesModuleName(importPath, r.moduleName) || func() bool {
-		_, ok := hasModulePrefix(importPath, r.moduleName)
+		_, ok := StripModulePrefix(importPath, r.moduleName)
 		return ok
 	}()) {
 		return true
@@ -615,7 +619,7 @@ func (r *Resolver) IsGalaPackage(importPath string) bool {
 	if r.galaMod != nil {
 		for _, req := range r.galaMod.Require {
 			if matchesModuleName(importPath, req.Path) || func() bool {
-				_, ok := hasModulePrefix(importPath, req.Path)
+				_, ok := StripModulePrefix(importPath, req.Path)
 				return ok
 			}() {
 				// If explicitly marked as Go in gala.mod, it's not a GALA package
@@ -640,8 +644,8 @@ func (r *Resolver) IsGalaPackage(importPath string) bool {
 		if matchesModuleName(importPath, spModName) {
 			return isValidPackageDir(spModRoot)
 		}
-		if _, ok := hasModulePrefix(importPath, spModName); ok {
-			relPath, _ := hasModulePrefix(importPath, spModName)
+		if _, ok := StripModulePrefix(importPath, spModName); ok {
+			relPath, _ := StripModulePrefix(importPath, spModName)
 			return isValidPackageDir(filepath.Join(spModRoot, relPath))
 		}
 	}


### PR DESCRIPTION
## Problem

In any GALA project, Ctrl-clicking a package-qualified symbol answered **"Cannot find declaration to go to"**:

```gala
import "github.com/martianoff/gala-kv/internal/resp"

func Dispatch(st store.Store, c Command) resp.RespValue = c match { … }
//                                        ^^^^ ^^^^^^^^^  neither resolved
```

Not limited to types, and not limited to one package — the qualifier itself, qualified functions, and sealed-case constructors all failed, for every package a project imports from itself or from a GALA dependency.

## Cause

A package is imported by its module-qualified path (`github.com/you/proj/internal/resp`) but its sources live at `internal/resp` under the project root. `resolveImportDir` stripped exactly one hardcoded prefix:

```go
relPath := strings.TrimPrefix(importPath, "martianoff/gala/")
```

That is the compiler repo's own module path. For any other project nothing came off, so the resolver looked for `<root>/github.com/you/proj/internal/resp` and gave up. `packageMemberDefinition` then returned nil, and the `isDottedMemberAccess` guard correctly refused to fall through to the global by-name scan — hence a clean "cannot find declaration" rather than a wrong jump.

Dependencies were broken by the same mechanism one level up: `resolveProjectDeps` computed each require's `(module path, cache dir)` pair, then discarded the module path and kept an unkeyed list of search paths.

The analyzer resolves all of these fine — that is why the projects type-check and build. Only the LSP's navigation path had its own, cruder resolver.

## Fix

The handler keeps the pairing it already had in hand: `moduleRoots` = the project module at the project root, plus one entry per resolvable gala.mod require. `resolveImportDir` strips the prefix of whichever module *owns* the path and resolves the remainder under **that module's** root, before falling back to the search-path sweep and then Go source directories.

Two things this buys beyond the reported bug:
- Dependency subpackages resolve by the same mechanism, instead of needing their own special case later.
- A project-relative path is no longer joined against every search path, so it can no longer silently resolve into an unrelated dependency's cache.

`hasModulePrefix` is renamed to `StripModulePrefix` and exported rather than wrapped — the VCS-host-tolerant matching is the one piece of resolver logic that is pure, stateless, and legitimately shared.

### Two things deliberately *not* done

- **Reusing `module.Resolver` wholesale.** It is the obvious "make this structurally impossible" move and it is wrong here: its `resolveCache` is unbounded, never invalidated, and caches *negative* results — justified for a single Bazel invocation, wrong for a long-lived editor over a mutating tree. Its Strategy 6 is a full recursive walk that fuzzy-matches by path suffix, which would make go-to-definition jump into same-named directories elsewhere in the tree. And it has no notion of Go-only packages, so `go_interop`, third-party Go, and Go SDK stdlib would still need the existing tail. The right long-term move is extracting the shared `(module path → root dir)` table; this change is the first half of that, done LSP-side.
- **Deleting the `"martianoff/gala/"` literal.** It looked provably dead — the compiler repo's own gala.mod produces the identical candidate through the new generic path. It is not: a search path can be a bare tree of package directories with **no gala.mod at all** to read a module path out of, which is exactly what the stdlib source root looks like. Removing it turned `TestDefinition_GoInteropPackageAndFunc` red. It now survives only in the search-path fallback, documented for what it actually does.

## Tests

New hermetic tests in `internal/lsp/definition_project_module_test.go`:
- `TestDefinition_ModuleQualifiedImport` — package qualifier, qualified type, and qualified sealed-case constructor, for **both** a project's own package and a GALA dependency's package (the latter staged in a `GALA_HOME`-rooted module cache).
- `TestDefinition_StdlibImportUsesTheSameModuleMechanism` — a project whose module *is* `martianoff/gala` resolves stdlib imports through the generic module-root path, with no prefix literal involved.

All 7 subcases confirmed red without the change. Also verified against a real multi-package project outside this repo (scratch check, not committed): the package qualifier, the type, and a second package's qualifier and type all resolve to the right file and line.

`bazel test //...` → 374 pass, 1 fail: `TestGorootFromGoBinarySymlink`, which needs symlink privileges the local Windows account does not have. Unrelated and pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)