### PR TITLE
Resolve hover by context, and surface documentation

### DIFF
--- a/internal/lsp/BUILD.bazel
+++ b/internal/lsp/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "definition_project_module_test.go",
         "error_lines_test.go",
         "hover_coverage_test.go",
+        "hover_internal_test.go",
         "repro_gala_mcp_test.go",
         "server_test.go",
         "signature_help_test.go",
@@ -46,7 +47,6 @@ go_test(
         "size_sugar_test.go",
         "string_escape_diagnostics_test.go",
         "typeatpos_test.go",
-        "hover_internal_test.go",
         "uri_internal_test.go",
     ],
     data = [

--- a/internal/lsp/BUILD.bazel
+++ b/internal/lsp/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "size_sugar_test.go",
         "string_escape_diagnostics_test.go",
         "typeatpos_test.go",
+        "hover_internal_test.go",
         "uri_internal_test.go",
     ],
     data = [

--- a/internal/lsp/BUILD.bazel
+++ b/internal/lsp/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "bom_test.go",
         "definition_project_module_test.go",
         "error_lines_test.go",
+        "hover_coverage_test.go",
         "repro_gala_mcp_test.go",
         "server_test.go",
         "signature_help_test.go",

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/owenrumney/go-lsp/lsp"
@@ -10,24 +11,31 @@ import (
 	"martianoff/gala/internal/transpiler"
 )
 
+// Hover resolves the symbol under the cursor and renders its signature and
+// documentation.
+//
+// Resolution is context-aware rather than a bare-word lookup: `Map` means
+// something different in `arr.Map(...)`, `im.Map`, and a top-level `func Map`,
+// and a bare-word search over the type table answers all three the same way (or,
+// for a method, not at all). The dispatcher below therefore establishes what the
+// word is qualified by before it looks anything up, reusing the same resolvers
+// completion uses (resolveChainTypeN / resolveReceiverType / findType), so hover
+// and completion cannot disagree about what an expression's type is.
 func (h *GalaHandler) Hover(ctx context.Context, params *lsp.HoverParams) (*lsp.Hover, error) {
 	uri := string(params.TextDocument.URI)
 
 	h.mu.Lock()
 	text := h.documents[uri]
 	richAST := h.richASTs[uri]
+	varTypes := h.varTypes[uri]
 	h.mu.Unlock()
 
 	if text == "" || richAST == nil {
 		return nil, nil
 	}
 
-	word := wordAtPosition(text, int(params.Position.Line), int(params.Position.Character))
-	if word == "" {
-		return nil, nil
-	}
-
-	info := lookupSymbol(richAST, word)
+	line, char := int(params.Position.Line), int(params.Position.Character)
+	info := h.hoverInfo(text, richAST, varTypes, line, char)
 	if info == "" {
 		return nil, nil
 	}
@@ -40,7 +48,238 @@ func (h *GalaHandler) Hover(ctx context.Context, params *lsp.HoverParams) (*lsp.
 	}, nil
 }
 
+// hoverInfo renders the hover body for a position, or "" when nothing resolves.
+func (h *GalaHandler) hoverInfo(text string, richAST *transpiler.RichAST, varTypes map[string]string, line, char int) string {
+	lines := strings.Split(text, "\n")
+	if line >= len(lines) {
+		return ""
+	}
+	word := wordAtPosition(text, line, char)
+	if word == "" {
+		return ""
+	}
+	funcScope := findEnclosingFunc(lines, line)
+
+	// An import line names a package rather than a symbol; the word under the
+	// cursor is a path segment, not something in the type table.
+	if isImportLine(lines[line]) {
+		return packageHover(richAST, word, lines[line])
+	}
+
+	// `qualifier.word` — the qualifier decides where to look.
+	if qualifier, wordStart, ok := qualifierBefore(lines[line], char); ok {
+		if pkg := resolvePackageQualifier(richAST, qualifier); pkg != "" {
+			if info := packageMemberHover(richAST, pkg, word); info != "" {
+				return info
+			}
+		}
+		// typeAtDot expects the cursor just past the dot, which is where the
+		// word starts.
+		if recv := typeAtDot(text, line, wordStart, richAST, varTypes); recv != "" {
+			if info := memberHover(richAST, recv, word); info != "" {
+				return info
+			}
+		}
+	}
+
+	// A method or field declaration: the receiver is the enclosing type, not
+	// anything to the left of the cursor.
+	if info := declarationSiteHover(richAST, lines, line, word); info != "" {
+		return info
+	}
+
+	// A local val/var carries no metadata entry — its type comes from the
+	// transformer's resolved scope, the same source inlay hints read.
+	if typStr := lookupVarType(varTypes, funcScope, word); typStr != "" {
+		return localHover(richAST, word, typStr, lines[line])
+	}
+
+	if pkg := resolvePackageQualifier(richAST, word); pkg != "" {
+		return packageHover(richAST, word, lines[line])
+	}
+
+	return lookupSymbol(richAST, word)
+}
+
+// qualifierBefore returns the identifier chain qualifying the word at `char`,
+// the column the word starts at, and whether the word was dot-qualified at all.
+func qualifierBefore(line string, char int) (qualifier string, wordStart int, ok bool) {
+	if char > len(line) {
+		return "", 0, false
+	}
+	start := char
+	for start > 0 && isIdentChar(line[start-1]) {
+		start--
+	}
+	if start == 0 || line[start-1] != '.' {
+		return "", start, false
+	}
+	end := start - 1
+	i := end - 1
+	for i >= 0 && (isIdentChar(line[i]) || line[i] == '.') {
+		i--
+	}
+	return line[i+1 : end], start, true
+}
+
+// resolvePackageQualifier maps an import alias or package name to its package
+// name, or "" when the qualifier is a value rather than a package.
+func resolvePackageQualifier(richAST *transpiler.RichAST, qualifier string) string {
+	if qualifier == "" || strings.Contains(qualifier, ".") {
+		return ""
+	}
+	if pkg, ok := richAST.ImportAliases[qualifier]; ok {
+		return pkg
+	}
+	for _, pkg := range richAST.Packages {
+		if pkg == qualifier {
+			return pkg
+		}
+	}
+	return ""
+}
+
+// packageMemberHover renders a symbol accessed through a package qualifier.
+func packageMemberHover(richAST *transpiler.RichAST, pkg, name string) string {
+	qualified := pkg + "." + name
+	if variant, parent := findSealedVariant(richAST, name); variant != nil {
+		return formatVariant(variant, parent)
+	}
+	if tm, ok := richAST.Types[qualified]; ok {
+		return formatTypeMeta(tm)
+	}
+	if fm, ok := richAST.Functions[qualified]; ok {
+		return formatFuncMeta(fm)
+	}
+	return ""
+}
+
+// memberHover renders a method or field selected on a receiver of known type.
+func memberHover(richAST *transpiler.RichAST, recvType, name string) string {
+	tm := findType(richAST, recvType)
+	if tm == nil {
+		return ""
+	}
+	if m, ok := tm.Methods[name]; ok {
+		return formatMethodMeta(tm, m)
+	}
+	if ft, ok := tm.Fields[name]; ok {
+		return formatField(tm, name, ft)
+	}
+	return ""
+}
+
+// declarationSiteHover handles the cursor sitting on a declaration rather than a
+// use: a method name in `func (r Recv) Name(...)`, or a field in a struct body.
+// Neither has a receiver expression to the cursor's left, so the enclosing
+// declaration supplies it.
+func declarationSiteHover(richAST *transpiler.RichAST, lines []string, line int, word string) string {
+	if recv := receiverTypeOnLine(lines[line], word); recv != "" {
+		if tm := findType(richAST, recv); tm != nil {
+			if m, ok := tm.Methods[word]; ok {
+				return formatMethodMeta(tm, m)
+			}
+		}
+	}
+	if enclosing := enclosingTypeDecl(lines, line); enclosing != "" {
+		if tm := findType(richAST, enclosing); tm != nil {
+			if ft, ok := tm.Fields[word]; ok && isFieldDeclLine(lines[line], word) {
+				return formatField(tm, word, ft)
+			}
+			for _, v := range tm.SealedVariants {
+				if v.Name == word {
+					return formatVariant(&v, tm)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// receiverTypeOnLine extracts `Recv` from `func (r Recv) word(...)`, or "" when
+// the line is not that method's declaration.
+func receiverTypeOnLine(line, word string) string {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "func (") {
+		return ""
+	}
+	close := strings.Index(trimmed, ")")
+	if close < 0 {
+		return ""
+	}
+	after := strings.TrimSpace(trimmed[close+1:])
+	if !strings.HasPrefix(after, word) {
+		return ""
+	}
+	recv := strings.Fields(trimmed[len("func ("):close])
+	if len(recv) < 2 {
+		return ""
+	}
+	return stripTypeParams(recv[1])
+}
+
+// enclosingTypeDecl scans upward for the `type`/`sealed type` header whose body
+// the given line sits in.
+func enclosingTypeDecl(lines []string, line int) string {
+	for i := line; i >= 0; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if i != line && trimmed == "}" {
+			return ""
+		}
+		rest, ok := strings.CutPrefix(trimmed, "sealed type ")
+		if !ok {
+			rest, ok = strings.CutPrefix(trimmed, "type ")
+		}
+		if !ok {
+			continue
+		}
+		name := rest
+		for j := 0; j < len(name); j++ {
+			if !isIdentChar(name[j]) {
+				name = name[:j]
+				break
+			}
+		}
+		return name
+	}
+	return ""
+}
+
+// isFieldDeclLine reports whether the line declares `word` as a struct field.
+func isFieldDeclLine(line, word string) bool {
+	trimmed := strings.TrimSpace(line)
+	for _, kw := range []string{"val ", "var "} {
+		if rest, ok := strings.CutPrefix(trimmed, kw); ok {
+			return strings.HasPrefix(rest, word)
+		}
+	}
+	return false
+}
+
+// findSealedVariant locates a `case` by name across every sealed type.
+func findSealedVariant(richAST *transpiler.RichAST, name string) (*transpiler.SealedVariant, *transpiler.TypeMetadata) {
+	for _, tm := range richAST.Types {
+		if !tm.IsSealed {
+			continue
+		}
+		for i := range tm.SealedVariants {
+			if tm.SealedVariants[i].Name == name {
+				return &tm.SealedVariants[i], tm
+			}
+		}
+	}
+	return nil, nil
+}
+
 func lookupSymbol(richAST *transpiler.RichAST, name string) string {
+	// Sealed cases are checked before the type table, not after. The transpiler
+	// generates a standalone type per variant, carrying Apply and Unapply, and
+	// registers it under the variant's own name — so an exact-key lookup finds
+	// that lowering artifact first and reports `type Circle` with plumbing the
+	// user never wrote, instead of `case Circle(radius float64)`.
+	if variant, parent := findSealedVariant(richAST, name); variant != nil {
+		return formatVariant(variant, parent)
+	}
 	if typeMeta, ok := richAST.Types[name]; ok {
 		return formatTypeMeta(typeMeta)
 	}
@@ -84,6 +323,22 @@ var builtinFuncDocs = map[string]string{
 	"recover": "```gala\nrecover() any\n```\n\n*Go built-in* — regains control of a panicking goroutine.\n",
 }
 
+// renderHover assembles the standard hover body: a fenced signature, the doc
+// comment, then the owning package.
+func renderHover(signature, doc, pkg string) string {
+	var b strings.Builder
+	b.WriteString("```gala\n")
+	b.WriteString(signature)
+	b.WriteString("\n```\n")
+	if doc != "" {
+		b.WriteString("\n" + doc + "\n")
+	}
+	if pkg != "" {
+		b.WriteString(fmt.Sprintf("\n*Package: %s*\n", pkg))
+	}
+	return b.String()
+}
+
 func formatTypeMeta(meta *transpiler.TypeMetadata) string {
 	var b strings.Builder
 	b.WriteString("```gala\n")
@@ -96,6 +351,10 @@ func formatTypeMeta(meta *transpiler.TypeMetadata) string {
 		b.WriteString("[" + strings.Join(meta.TypeParams, ", ") + "]")
 	}
 	b.WriteString("\n```\n")
+
+	if meta.Doc != "" {
+		b.WriteString("\n" + meta.Doc + "\n")
+	}
 
 	if len(meta.FieldNames) > 0 {
 		b.WriteString("\n**Fields:**\n")
@@ -111,24 +370,13 @@ func formatTypeMeta(meta *transpiler.TypeMetadata) string {
 	if len(meta.SealedVariants) > 0 {
 		b.WriteString("\n**Cases:**\n")
 		for _, v := range meta.SealedVariants {
-			if len(v.FieldNames) > 0 {
-				var fields []string
-				for j, fn := range v.FieldNames {
-					if j < len(v.FieldTypes) {
-						fields = append(fields, fn+" "+v.FieldTypes[j].String())
-					} else {
-						fields = append(fields, fn)
-					}
-				}
-				b.WriteString(fmt.Sprintf("- `case %s(%s)`\n", v.Name, strings.Join(fields, ", ")))
-			} else {
-				b.WriteString(fmt.Sprintf("- `case %s()`\n", v.Name))
-			}
+			b.WriteString(fmt.Sprintf("- `%s`\n", variantSignature(&v)))
 		}
 	}
 	if len(meta.Methods) > 0 {
 		b.WriteString("\n**Methods:**\n")
-		for name, m := range meta.Methods {
+		for _, name := range sortedMethodNames(meta.Methods) {
+			m := meta.Methods[name]
 			b.WriteString(fmt.Sprintf("- `%s(%s) %s`\n", name, formatMethodParams(m), m.ReturnType))
 		}
 	}
@@ -138,9 +386,20 @@ func formatTypeMeta(meta *transpiler.TypeMetadata) string {
 	return b.String()
 }
 
+// sortedMethodNames keeps the method list stable across hovers; Go map order is
+// randomized, so an unsorted list reshuffles every time the popup opens.
+func sortedMethodNames(methods map[string]*transpiler.MethodMetadata) []string {
+	names := make([]string, 0, len(methods))
+	for name := range methods {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 func formatFuncMeta(meta *transpiler.FunctionMetadata) string {
 	var b strings.Builder
-	b.WriteString("```gala\nfunc " + meta.Name)
+	b.WriteString("func " + meta.Name)
 	if len(meta.TypeParams) > 0 {
 		b.WriteString("[" + strings.Join(meta.TypeParams, ", ") + "]")
 	}
@@ -157,11 +416,136 @@ func formatFuncMeta(meta *transpiler.FunctionMetadata) string {
 	if meta.ReturnType != nil && !meta.ReturnType.IsNil() {
 		b.WriteString(" " + meta.ReturnType.String())
 	}
-	b.WriteString("\n```\n")
-	if meta.Package != "" {
-		b.WriteString(fmt.Sprintf("\n*Package: %s*\n", meta.Package))
+	return renderHover(b.String(), meta.Doc, meta.Package)
+}
+
+// formatMethodMeta renders a method with its receiver, so the popup says which
+// type the method belongs to.
+func formatMethodMeta(owner *transpiler.TypeMetadata, m *transpiler.MethodMetadata) string {
+	var b strings.Builder
+	b.WriteString("func (" + owner.Name + ") " + m.Name)
+	if len(m.TypeParams) > 0 {
+		b.WriteString("[" + strings.Join(m.TypeParams, ", ") + "]")
 	}
-	return b.String()
+	b.WriteString("(" + formatMethodParams(m) + ")")
+	if m.ReturnType != nil && !m.ReturnType.IsNil() {
+		b.WriteString(" " + m.ReturnType.String())
+	}
+	pkg := m.Package
+	if pkg == "" {
+		pkg = owner.Package
+	}
+	return renderHover(b.String(), m.Doc, pkg)
+}
+
+func formatField(owner *transpiler.TypeMetadata, name string, ft transpiler.Type) string {
+	mut := "val"
+	for i, fn := range owner.FieldNames {
+		if fn == name && i < len(owner.ImmutFlags) && !owner.ImmutFlags[i] {
+			mut = "var"
+		}
+	}
+	sig := fmt.Sprintf("%s %s %s", mut, name, ft)
+	doc := owner.FieldDocs[name]
+	body := renderHover(sig, doc, owner.Package)
+	return body + fmt.Sprintf("\n*Field of `%s`*\n", owner.Name)
+}
+
+// formatVariant renders a sealed case as a case of its parent type. The
+// transpiler also generates a standalone type per variant, carrying Apply and
+// Unapply; that is lowering detail, and surfacing it as though the user wrote it
+// misrepresents the language.
+func formatVariant(v *transpiler.SealedVariant, parent *transpiler.TypeMetadata) string {
+	pkg := ""
+	parentName := ""
+	if parent != nil {
+		pkg = parent.Package
+		parentName = parent.Name
+		if len(parent.TypeParams) > 0 {
+			parentName += "[" + strings.Join(parent.TypeParams, ", ") + "]"
+		}
+	}
+	body := renderHover(variantSignature(v), v.Doc, pkg)
+	if parentName != "" {
+		body += fmt.Sprintf("\n*Case of `%s`*\n", parentName)
+	}
+	return body
+}
+
+func variantSignature(v *transpiler.SealedVariant) string {
+	var fields []string
+	for i, fn := range v.FieldNames {
+		if i < len(v.FieldTypes) {
+			fields = append(fields, fn+" "+v.FieldTypes[i].String())
+		} else {
+			fields = append(fields, fn)
+		}
+	}
+	return fmt.Sprintf("case %s(%s)", v.Name, strings.Join(fields, ", "))
+}
+
+// localHover renders a local val/var. The declaration keyword comes from the
+// source line so `val` and `var` are not conflated.
+func localHover(richAST *transpiler.RichAST, name, typStr, line string) string {
+	kw := "val"
+	if trimmed := strings.TrimSpace(line); strings.HasPrefix(trimmed, "var ") {
+		kw = "var"
+	}
+	body := renderHover(fmt.Sprintf("%s %s %s", kw, name, typStr), "", "")
+	// Carry the type's own documentation, so hovering a binding explains what it
+	// holds rather than only naming it.
+	if tm := findType(richAST, stripTypeParams(typStr)); tm != nil && tm.Doc != "" {
+		body += "\n" + tm.Doc + "\n"
+	}
+	return body
+}
+
+// packageHover renders an import alias or a package named in an import line.
+func packageHover(richAST *transpiler.RichAST, word, line string) string {
+	pkg := resolvePackageQualifier(richAST, word)
+	path := importPathOnLine(line)
+	if pkg == "" {
+		// On an import line the word is a path segment; the package is whatever
+		// that path resolves to.
+		if path != "" {
+			if p, ok := richAST.Packages[path]; ok {
+				pkg = p
+			}
+		}
+		if pkg == "" {
+			return ""
+		}
+	}
+	if path == "" {
+		for p, name := range richAST.Packages {
+			if name == pkg {
+				path = p
+				break
+			}
+		}
+	}
+	sig := "package " + pkg
+	if path != "" {
+		sig += "\nimport \"" + path + "\""
+	}
+	return renderHover(sig, richAST.PackageDoc, "")
+}
+
+func isImportLine(line string) bool {
+	return strings.HasPrefix(strings.TrimSpace(line), "import ")
+}
+
+func importPathOnLine(line string) string {
+	first := strings.Index(line, `"`)
+	if first < 0 {
+		return ""
+	}
+	rest := line[first+1:]
+	last := strings.Index(rest, `"`)
+	if last < 0 {
+		return ""
+	}
+	return rest[:last]
 }
 
 func formatMethodParams(m *transpiler.MethodMetadata) string {

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -116,26 +116,46 @@ func declarationAt(richAST *transpiler.RichAST, path string, line, char int, wor
 	if path == "" {
 		return ""
 	}
+
+	// Members first, across every type — sealed cases, fields, then methods.
+	//
+	// The order is load-bearing, not stylistic. For each sealed case the
+	// analyzer registers a companion TypeMetadata named after the case and
+	// carrying the SAME Pos as the parent's SealedVariant, so a case
+	// declaration matches two entries at once: the case, and a generated type
+	// whose only methods are Apply and Unapply. Resolving members in their own
+	// pass means the case always wins; interleaved with the type-name check,
+	// Go's map order decided it, and roughly one hover in ten showed the
+	// plumbing instead.
 	for _, tm := range richAST.Types {
 		if !sameSourceFile(tm.DefinedIn, path) {
 			continue
 		}
-		if tm.Name == word && posCovers(tm.Pos, line, char, word) {
-			return formatTypeMeta(tm)
+		for i := range tm.SealedVariants {
+			if v := &tm.SealedVariants[i]; v.Name == word && posCovers(v.Pos, line, char, word) {
+				return formatVariant(v, tm)
+			}
 		}
 		if pos, ok := tm.FieldPositions[word]; ok && posCovers(pos, line, char, word) {
 			if ft, ok := tm.Fields[word]; ok {
 				return formatField(tm, word, ft)
 			}
 		}
-		for i := range tm.SealedVariants {
-			v := &tm.SealedVariants[i]
-			if v.Name == word && posCovers(v.Pos, line, char, word) {
-				return formatVariant(v, tm)
-			}
-		}
+	}
+
+	// Methods are matched on the METHOD's own DefinedIn, not the type's: a
+	// method may be declared in a different file from the type it extends, and
+	// gating on the type's file skipped it entirely — after which the bare-name
+	// fallback could answer with an unrelated same-named type from any package.
+	for _, tm := range richAST.Types {
 		if m, ok := tm.Methods[word]; ok && sameSourceFile(m.DefinedIn, path) && posCovers(m.Pos, line, char, word) {
 			return formatMethodMeta(tm, m)
+		}
+	}
+
+	for _, tm := range richAST.Types {
+		if tm.Name == word && sameSourceFile(tm.DefinedIn, path) && posCovers(tm.Pos, line, char, word) {
+			return formatTypeMeta(tm)
 		}
 	}
 	for _, fm := range richAST.Functions {
@@ -163,9 +183,16 @@ func packageMemberHover(richAST *transpiler.RichAST, pkg, name string) string {
 	if variant, parent := findSealedVariant(richAST, name, pkg); variant != nil && parent != nil && parent.Package == pkg {
 		return formatVariant(variant, parent)
 	}
-	if tm := findType(richAST, qualified); tm != nil {
+	// findType falls back to a simple-name match across every package, in map
+	// order, so it must be re-checked against pkg: otherwise `mypkg.Some`, where
+	// mypkg has no Some, renders std's Some — the precise wrong answer the
+	// qualifier exists to prevent — and varies between hovers when two packages
+	// share a type name.
+	if tm := findType(richAST, qualified); tm != nil && tm.Package == pkg {
 		return formatTypeMeta(tm)
 	}
+	// findFunction is safe unchecked: a qualified name never matches its
+	// simple-name loop.
 	if fm := findFunction(richAST, qualified); fm != nil {
 		return formatFuncMeta(fm)
 	}
@@ -492,17 +519,17 @@ func isExported(name string) bool {
 // `import ( ... )` form as well as single-line imports; hand-scanning the cursor
 // line for a quoted path silently went dead inside a group.
 func packageHover(richAST *transpiler.RichAST, text, word string) string {
+	// Resolved from the file's OWN import table. richAST.Packages holds every
+	// package the analyzer loaded, including merely transitive ones, and is
+	// keyed path -> name — so consulting it first would claim an import the file
+	// never wrote, and would pick between two paths sharing a name in map order.
 	path, ok := parseGalaImports(text)[word]
 	if !ok {
-		// Not an alias — it may be the package's own name.
-		for p, name := range richAST.Packages {
-			if name == word {
-				path, ok = p, true
-				break
-			}
+		// The file's own package name is the one legitimate non-import case, and
+		// PackageDoc describes exactly that package.
+		if word == richAST.PackageName {
+			return renderHover("package "+word, richAST.PackageDoc, "")
 		}
-	}
-	if !ok {
 		return ""
 	}
 	pkg := word

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -3,7 +3,10 @@ package lsp
 import (
 	"context"
 	"fmt"
-	"sort"
+	"maps"
+	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/owenrumney/go-lsp/lsp"
@@ -35,7 +38,7 @@ func (h *GalaHandler) Hover(ctx context.Context, params *lsp.HoverParams) (*lsp.
 	}
 
 	line, char := int(params.Position.Line), int(params.Position.Character)
-	info := h.hoverInfo(text, richAST, varTypes, line, char)
+	info := h.hoverInfo(text, uriToPath(uri), richAST, varTypes, line, char)
 	if info == "" {
 		return nil, nil
 	}
@@ -49,7 +52,11 @@ func (h *GalaHandler) Hover(ctx context.Context, params *lsp.HoverParams) (*lsp.
 }
 
 // hoverInfo renders the hover body for a position, or "" when nothing resolves.
-func (h *GalaHandler) hoverInfo(text string, richAST *transpiler.RichAST, varTypes map[string]string, line, char int) string {
+//
+// path is the on-disk path of the document being hovered; it is what the
+// analyzer recorded as DefinedIn, and is how a declaration in this file is told
+// apart from a same-named one elsewhere in the package.
+func (h *GalaHandler) hoverInfo(text, path string, richAST *transpiler.RichAST, varTypes map[string]string, line, char int) string {
 	lines := strings.Split(text, "\n")
 	if line >= len(lines) {
 		return ""
@@ -58,97 +65,108 @@ func (h *GalaHandler) hoverInfo(text string, richAST *transpiler.RichAST, varTyp
 	if word == "" {
 		return ""
 	}
-	funcScope := findEnclosingFunc(lines, line)
 
-	// An import line names a package rather than a symbol; the word under the
-	// cursor is a path segment, not something in the type table.
-	if isImportLine(lines[line]) {
-		return packageHover(richAST, word, lines[line])
-	}
-
-	// `qualifier.word` — the qualifier decides where to look.
-	if qualifier, wordStart, ok := qualifierBefore(lines[line], char); ok {
-		if pkg := resolvePackageQualifier(richAST, qualifier); pkg != "" {
-			if info := packageMemberHover(richAST, pkg, word); info != "" {
-				return info
-			}
-		}
-		// typeAtDot expects the cursor just past the dot, which is where the
-		// word starts.
-		if recv := typeAtDot(text, line, wordStart, richAST, varTypes); recv != "" {
-			if info := memberHover(richAST, recv, word); info != "" {
-				return info
-			}
-		}
-	}
-
-	// A method or field declaration: the receiver is the enclosing type, not
-	// anything to the left of the cursor.
-	if info := declarationSiteHover(richAST, lines, line, word); info != "" {
+	// The cursor sits ON a declaration: a method name, a struct field, a sealed
+	// case, or a type. Resolved by position against the metadata the analyzer
+	// already recorded rather than by re-reading the source — the same anchor
+	// go-to-definition uses.
+	if info := declarationAt(richAST, path, line, char, word); info != "" {
 		return info
+	}
+
+	// `qualifier.word`. typeAtDot resolves the qualifier for us, returning a
+	// packagePrefix-marked name for a package and a type name otherwise — the
+	// same single call completion dispatches on, so the two cannot disagree
+	// about what an expression is.
+	if recv := typeAtDot(text, line, char, richAST, varTypes); recv != "" {
+		// Both branches return unconditionally. A selector whose receiver resolved
+		// but whose member did not must produce nothing, not fall through to a
+		// global name search — that answers `resp.Body` with whatever unrelated
+		// type happens to be called Body. Go-to-definition guards the same class
+		// of wrong answer.
+		if pkg, isPkg := strings.CutPrefix(recv, packagePrefix); isPkg {
+			return packageMemberHover(richAST, pkg, word)
+		}
+		return memberHover(richAST, recv, word)
 	}
 
 	// A local val/var carries no metadata entry — its type comes from the
 	// transformer's resolved scope, the same source inlay hints read.
+	funcScope := findEnclosingFunc(lines, line)
 	if typStr := lookupVarType(varTypes, funcScope, word); typStr != "" {
-		return localHover(richAST, word, typStr, lines[line])
+		return localHover(richAST, word, typStr)
 	}
 
-	if pkg := resolvePackageQualifier(richAST, word); pkg != "" {
-		return packageHover(richAST, word, lines[line])
+	if info := packageHover(richAST, text, word); info != "" {
+		return info
 	}
 
 	return lookupSymbol(richAST, word)
 }
 
-// qualifierBefore returns the identifier chain qualifying the word at `char`,
-// the column the word starts at, and whether the word was dot-qualified at all.
-func qualifierBefore(line string, char int) (qualifier string, wordStart int, ok bool) {
-	if char > len(line) {
-		return "", 0, false
-	}
-	start := char
-	for start > 0 && isIdentChar(line[start-1]) {
-		start--
-	}
-	if start == 0 || line[start-1] != '.' {
-		return "", start, false
-	}
-	end := start - 1
-	i := end - 1
-	for i >= 0 && (isIdentChar(line[i]) || line[i] == '.') {
-		i--
-	}
-	return line[i+1 : end], start, true
-}
-
-// resolvePackageQualifier maps an import alias or package name to its package
-// name, or "" when the qualifier is a value rather than a package.
-func resolvePackageQualifier(richAST *transpiler.RichAST, qualifier string) string {
-	if qualifier == "" || strings.Contains(qualifier, ".") {
+// declarationAt resolves the cursor against declaration positions recorded
+// during analysis, returning "" when the cursor is not on one.
+//
+// Text-scanning for `func (r Recv) Name(` and friends is the thing this package
+// tells itself not to do: the shapes are ambiguous (generic receivers, one-line
+// bodies, comments, string literals) and the transpiler has already resolved
+// them exactly. SourcePos is 1-based line, 0-based column, matching
+// definition.go's locationAt.
+func declarationAt(richAST *transpiler.RichAST, path string, line, char int, word string) string {
+	if path == "" {
 		return ""
 	}
-	if pkg, ok := richAST.ImportAliases[qualifier]; ok {
-		return pkg
+	for _, tm := range richAST.Types {
+		if !sameSourceFile(tm.DefinedIn, path) {
+			continue
+		}
+		if tm.Name == word && posCovers(tm.Pos, line, char, word) {
+			return formatTypeMeta(tm)
+		}
+		if pos, ok := tm.FieldPositions[word]; ok && posCovers(pos, line, char, word) {
+			if ft, ok := tm.Fields[word]; ok {
+				return formatField(tm, word, ft)
+			}
+		}
+		for i := range tm.SealedVariants {
+			v := &tm.SealedVariants[i]
+			if v.Name == word && posCovers(v.Pos, line, char, word) {
+				return formatVariant(v, tm)
+			}
+		}
+		if m, ok := tm.Methods[word]; ok && sameSourceFile(m.DefinedIn, path) && posCovers(m.Pos, line, char, word) {
+			return formatMethodMeta(tm, m)
+		}
 	}
-	for _, pkg := range richAST.Packages {
-		if pkg == qualifier {
-			return pkg
+	for _, fm := range richAST.Functions {
+		if fm.Name == word && sameSourceFile(fm.DefinedIn, path) && posCovers(fm.Pos, line, char, word) {
+			return formatFuncMeta(fm)
 		}
 	}
 	return ""
 }
 
+// posCovers reports whether an analyzer SourcePos names the identifier under an
+// LSP cursor.
+func posCovers(pos transpiler.SourcePos, line, char int, name string) bool {
+	if pos.Line == 0 {
+		return false
+	}
+	return pos.Line-1 == line && char >= pos.Column && char <= pos.Column+len(name)
+}
+
 // packageMemberHover renders a symbol accessed through a package qualifier.
 func packageMemberHover(richAST *transpiler.RichAST, pkg, name string) string {
 	qualified := pkg + "." + name
-	if variant, parent := findSealedVariant(richAST, name); variant != nil {
+	// Scoped to pkg: an unscoped variant search here would answer `mypkg.Some`
+	// with std's Some, defeating the qualifier the user typed.
+	if variant, parent := findSealedVariant(richAST, name, pkg); variant != nil && parent != nil && parent.Package == pkg {
 		return formatVariant(variant, parent)
 	}
-	if tm, ok := richAST.Types[qualified]; ok {
+	if tm := findType(richAST, qualified); tm != nil {
 		return formatTypeMeta(tm)
 	}
-	if fm, ok := richAST.Functions[qualified]; ok {
+	if fm := findFunction(richAST, qualified); fm != nil {
 		return formatFuncMeta(fm)
 	}
 	return ""
@@ -169,118 +187,54 @@ func memberHover(richAST *transpiler.RichAST, recvType, name string) string {
 	return ""
 }
 
-// declarationSiteHover handles the cursor sitting on a declaration rather than a
-// use: a method name in `func (r Recv) Name(...)`, or a field in a struct body.
-// Neither has a receiver expression to the cursor's left, so the enclosing
-// declaration supplies it.
-func declarationSiteHover(richAST *transpiler.RichAST, lines []string, line int, word string) string {
-	if recv := receiverTypeOnLine(lines[line], word); recv != "" {
-		if tm := findType(richAST, recv); tm != nil {
-			if m, ok := tm.Methods[word]; ok {
-				return formatMethodMeta(tm, m)
-			}
-		}
-	}
-	if enclosing := enclosingTypeDecl(lines, line); enclosing != "" {
-		if tm := findType(richAST, enclosing); tm != nil {
-			if ft, ok := tm.Fields[word]; ok && isFieldDeclLine(lines[line], word) {
-				return formatField(tm, word, ft)
-			}
-			for _, v := range tm.SealedVariants {
-				if v.Name == word {
-					return formatVariant(&v, tm)
-				}
-			}
-		}
-	}
-	return ""
-}
-
-// receiverTypeOnLine extracts `Recv` from `func (r Recv) word(...)`, or "" when
-// the line is not that method's declaration.
-func receiverTypeOnLine(line, word string) string {
-	trimmed := strings.TrimSpace(line)
-	if !strings.HasPrefix(trimmed, "func (") {
-		return ""
-	}
-	close := strings.Index(trimmed, ")")
-	if close < 0 {
-		return ""
-	}
-	after := strings.TrimSpace(trimmed[close+1:])
-	if !strings.HasPrefix(after, word) {
-		return ""
-	}
-	recv := strings.Fields(trimmed[len("func ("):close])
-	if len(recv) < 2 {
-		return ""
-	}
-	return stripTypeParams(recv[1])
-}
-
-// enclosingTypeDecl scans upward for the `type`/`sealed type` header whose body
-// the given line sits in.
-func enclosingTypeDecl(lines []string, line int) string {
-	for i := line; i >= 0; i-- {
-		trimmed := strings.TrimSpace(lines[i])
-		if i != line && trimmed == "}" {
-			return ""
-		}
-		rest, ok := strings.CutPrefix(trimmed, "sealed type ")
-		if !ok {
-			rest, ok = strings.CutPrefix(trimmed, "type ")
-		}
-		if !ok {
-			continue
-		}
-		name := rest
-		for j := 0; j < len(name); j++ {
-			if !isIdentChar(name[j]) {
-				name = name[:j]
-				break
-			}
-		}
-		return name
-	}
-	return ""
-}
-
-// isFieldDeclLine reports whether the line declares `word` as a struct field.
-func isFieldDeclLine(line, word string) bool {
-	trimmed := strings.TrimSpace(line)
-	for _, kw := range []string{"val ", "var "} {
-		if rest, ok := strings.CutPrefix(trimmed, kw); ok {
-			return strings.HasPrefix(rest, word)
-		}
-	}
-	return false
-}
-
-// findSealedVariant locates a `case` by name across every sealed type.
-func findSealedVariant(richAST *transpiler.RichAST, name string) (*transpiler.SealedVariant, *transpiler.TypeMetadata) {
-	for _, tm := range richAST.Types {
-		if !tm.IsSealed {
+// findSealedVariant locates a `case` by name, preferring one declared in
+// preferPkg.
+//
+// Iteration is over sorted keys, not Go map order: `std` alone contributes the
+// case names Some, None, Success, Failure, Left and Right, so a file with a
+// sealed type of its own reusing one of those would otherwise get a parent —
+// and a rendered hover — that changed between invocations.
+func findSealedVariant(richAST *transpiler.RichAST, name, preferPkg string) (*transpiler.SealedVariant, *transpiler.TypeMetadata) {
+	var anyV *transpiler.SealedVariant
+	var anyT *transpiler.TypeMetadata
+	for _, key := range slices.Sorted(maps.Keys(richAST.Types)) {
+		tm := richAST.Types[key]
+		if tm == nil || !tm.IsSealed {
 			continue
 		}
 		for i := range tm.SealedVariants {
-			if tm.SealedVariants[i].Name == name {
+			if tm.SealedVariants[i].Name != name {
+				continue
+			}
+			if tm.Package == preferPkg {
 				return &tm.SealedVariants[i], tm
+			}
+			if anyV == nil {
+				anyV, anyT = &tm.SealedVariants[i], tm
 			}
 		}
 	}
-	return nil, nil
+	return anyV, anyT
 }
 
 func lookupSymbol(richAST *transpiler.RichAST, name string) string {
-	// Sealed cases are checked before the type table, not after. The transpiler
-	// generates a standalone type per variant, carrying Apply and Unapply, and
-	// registers it under the variant's own name — so an exact-key lookup finds
-	// that lowering artifact first and reports `type Circle` with plumbing the
-	// user never wrote, instead of `case Circle(radius float64)`.
-	if variant, parent := findSealedVariant(richAST, name); variant != nil {
-		return formatVariant(variant, parent)
+	typeMeta, hasType := richAST.Types[name]
+	// The transpiler generates a standalone companion type per sealed case,
+	// carrying Apply and Unapply, and registers it under the case's own name. When
+	// the exact-key type IS that artifact, the case is what the user actually
+	// wrote and should win — reporting `type Circle` with plumbing nobody wrote
+	// misrepresents the language.
+	//
+	// A same-named type from a DIFFERENT package is not an artifact and must not
+	// be shadowed: `std` exports cases called Success, Failure, Some, Left and
+	// Right, and a user's own `type Success struct` has to keep answering for
+	// itself.
+	if variant, parent := findSealedVariant(richAST, name, richAST.PackageName); variant != nil {
+		if !hasType || (parent != nil && parent.Package == typeMeta.Package) {
+			return formatVariant(variant, parent)
+		}
 	}
-	if typeMeta, ok := richAST.Types[name]; ok {
+	if hasType {
 		return formatTypeMeta(typeMeta)
 	}
 	for key, typeMeta := range richAST.Types {
@@ -375,7 +329,7 @@ func formatTypeMeta(meta *transpiler.TypeMetadata) string {
 	}
 	if len(meta.Methods) > 0 {
 		b.WriteString("\n**Methods:**\n")
-		for _, name := range sortedMethodNames(meta.Methods) {
+		for _, name := range slices.Sorted(maps.Keys(meta.Methods)) {
 			m := meta.Methods[name]
 			b.WriteString(fmt.Sprintf("- `%s(%s) %s`\n", name, formatMethodParams(m), m.ReturnType))
 		}
@@ -384,17 +338,6 @@ func formatTypeMeta(meta *transpiler.TypeMetadata) string {
 		b.WriteString(fmt.Sprintf("\n*Package: %s*\n", meta.Package))
 	}
 	return b.String()
-}
-
-// sortedMethodNames keeps the method list stable across hovers; Go map order is
-// randomized, so an unsorted list reshuffles every time the popup opens.
-func sortedMethodNames(methods map[string]*transpiler.MethodMetadata) []string {
-	names := make([]string, 0, len(methods))
-	for name := range methods {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
 }
 
 func formatFuncMeta(meta *transpiler.FunctionMetadata) string {
@@ -484,68 +427,23 @@ func variantSignature(v *transpiler.SealedVariant) string {
 	return fmt.Sprintf("case %s(%s)", v.Name, strings.Join(fields, ", "))
 }
 
-// localHover renders a local val/var. The declaration keyword comes from the
-// source line so `val` and `var` are not conflated.
-func localHover(richAST *transpiler.RichAST, name, typStr, line string) string {
-	kw := "val"
-	if trimmed := strings.TrimSpace(line); strings.HasPrefix(trimmed, "var ") {
-		kw = "var"
-	}
-	body := renderHover(fmt.Sprintf("%s %s %s", kw, name, typStr), "", "")
-	// Carry the type's own documentation, so hovering a binding explains what it
-	// holds rather than only naming it.
+// localHover renders a local binding: its name and inferred type.
+//
+// Mutability is deliberately not claimed. The transformer knows whether a
+// binding was `val` or `var` (scope.go's addVal/addVar), but that fact is not
+// carried into the LSP's var channel, and deriving it from the cursor's line
+// reports `val` at every reference to a `var` that is not its own declaration.
+// Saying nothing beats saying something false; formatField gets this right
+// because ImmutFlags is real metadata.
+func localHover(richAST *transpiler.RichAST, name, typStr string) string {
+	body := renderHover(name+" "+typStr, "", "")
+	// The binding's own doc comment is not available, so the type's doc is
+	// offered instead — attributed, so it does not read as documentation of the
+	// binding itself.
 	if tm := findType(richAST, stripTypeParams(typStr)); tm != nil && tm.Doc != "" {
-		body += "\n" + tm.Doc + "\n"
+		body += fmt.Sprintf("\n*Type* `%s` — %s\n", tm.Name, tm.Doc)
 	}
 	return body
-}
-
-// packageHover renders an import alias or a package named in an import line.
-func packageHover(richAST *transpiler.RichAST, word, line string) string {
-	pkg := resolvePackageQualifier(richAST, word)
-	path := importPathOnLine(line)
-	if pkg == "" {
-		// On an import line the word is a path segment; the package is whatever
-		// that path resolves to.
-		if path != "" {
-			if p, ok := richAST.Packages[path]; ok {
-				pkg = p
-			}
-		}
-		if pkg == "" {
-			return ""
-		}
-	}
-	if path == "" {
-		for p, name := range richAST.Packages {
-			if name == pkg {
-				path = p
-				break
-			}
-		}
-	}
-	sig := "package " + pkg
-	if path != "" {
-		sig += "\nimport \"" + path + "\""
-	}
-	return renderHover(sig, richAST.PackageDoc, "")
-}
-
-func isImportLine(line string) bool {
-	return strings.HasPrefix(strings.TrimSpace(line), "import ")
-}
-
-func importPathOnLine(line string) string {
-	first := strings.Index(line, `"`)
-	if first < 0 {
-		return ""
-	}
-	rest := line[first+1:]
-	last := strings.Index(rest, `"`)
-	if last < 0 {
-		return ""
-	}
-	return rest[:last]
 }
 
 func formatMethodParams(m *transpiler.MethodMetadata) string {
@@ -586,4 +484,51 @@ func isIdentChar(c byte) bool {
 
 func isExported(name string) bool {
 	return len(name) > 0 && name[0] >= 'A' && name[0] <= 'Z'
+}
+
+// packageHover renders an import alias or package name.
+//
+// The import table comes from parseGalaImports, which understands the grouped
+// `import ( ... )` form as well as single-line imports; hand-scanning the cursor
+// line for a quoted path silently went dead inside a group.
+func packageHover(richAST *transpiler.RichAST, text, word string) string {
+	path, ok := parseGalaImports(text)[word]
+	if !ok {
+		// Not an alias — it may be the package's own name.
+		for p, name := range richAST.Packages {
+			if name == word {
+				path, ok = p, true
+				break
+			}
+		}
+	}
+	if !ok {
+		return ""
+	}
+	pkg := word
+	if name, found := richAST.Packages[path]; found {
+		pkg = name
+	}
+	return renderHover("package "+pkg+"\nimport \""+path+"\"", "", "")
+}
+
+// sameSourceFile compares two paths for identity the way the analyzer does when
+// it records DefinedIn: absolute, cleaned, and case-insensitively on Windows,
+// where the client's URI casing need not match the analyzer's.
+func sameSourceFile(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(filepath.Clean(absA), filepath.Clean(absB))
+	}
+	return filepath.Clean(absA) == filepath.Clean(absB)
 }

--- a/internal/lsp/hover_coverage_test.go
+++ b/internal/lsp/hover_coverage_test.go
@@ -86,35 +86,39 @@ func TestHoverCoverage(t *testing.T) {
 	settle(t, h, uri, hoverSrc, "type Greeter", "Greeter")
 
 	tests := []struct {
-		name   string
-		anchor string
-		word   string
-		want   []string // all must appear
+		name    string
+		anchor  string
+		word    string
+		want    []string // all must appear
+		notWant []string // none may appear
 	}{
-		{"type declaration carries its doc", "type Greeter", "Greeter",
-			[]string{"Greeter", "Greeter greets people politely."}},
-		{"function declaration carries its doc", "func makeGreeter", "makeGreeter",
-			[]string{"makeGreeter", "makeGreeter builds a Greeter with the default prefix."}},
-		{"method declaration", ") Greet(", "Greet",
-			[]string{"Greet", "string", "Greet builds a greeting for name."}},
-		{"method call on a local", "gr.Greet", "Greet",
-			[]string{"Greet", "Greet builds a greeting for name."}},
-		{"field declaration", "val prefix", "prefix",
-			[]string{"prefix", "string", "prefix is placed before the name."}},
-		{"field access", "gr.prefix", "prefix",
-			[]string{"prefix", "string"}},
-		{"local val shows inferred type", "val gr =", "gr",
-			[]string{"gr", "Greeter"}},
-		{"stdlib method carries stdlib doc", "opt.GetOrElse", "GetOrElse",
-			[]string{"GetOrElse", "returns the option's value"}},
-		{"stdlib collection method", "arr.Size", "Size",
-			[]string{"Size"}},
-		{"package alias", "= im.", "im",
-			[]string{"collection_immutable"}},
-		{"sealed variant reads as a case, not a type", "= Circle", "Circle",
-			[]string{"Circle", "radius", "Shape"}},
-		{"sealed type declaration", "sealed type Shape", "Shape",
-			[]string{"Shape", "Shape is a closed set of drawable things."}},
+		{name: "type declaration carries its doc", anchor: "type Greeter", word: "Greeter",
+			want: []string{"Greeter", "Greeter greets people politely."}},
+		{name: "function declaration carries its doc", anchor: "func makeGreeter", word: "makeGreeter",
+			want: []string{"makeGreeter", "makeGreeter builds a Greeter with the default prefix."}},
+		{name: "method declaration", anchor: ") Greet(", word: "Greet",
+			want: []string{"Greet", "string", "Greet builds a greeting for name."}},
+		{name: "method call on a local", anchor: "gr.Greet", word: "Greet",
+			want: []string{"Greet", "Greet builds a greeting for name."}},
+		{name: "field declaration", anchor: "val prefix", word: "prefix",
+			want: []string{"prefix", "string", "prefix is placed before the name."}},
+		{name: "field access", anchor: "gr.prefix", word: "prefix",
+			want: []string{"prefix", "string"}},
+		{name: "local val shows inferred type", anchor: "val gr =", word: "gr",
+			want: []string{"gr", "Greeter"}},
+		{name: "stdlib method carries stdlib doc", anchor: "opt.GetOrElse", word: "GetOrElse",
+			want: []string{"GetOrElse", "returns the option's value"}},
+		{name: "stdlib collection method", anchor: "arr.Size", word: "Size",
+			want: []string{"Size"}},
+		{name: "package alias", anchor: "= im.", word: "im",
+			want: []string{"collection_immutable"}},
+		{name: "sealed variant reads as a case, not a type", anchor: "= Circle", word: "Circle",
+			want: []string{"Circle", "radius", "Shape"},
+			// The transpiler generates a companion type per case carrying Apply
+			// and Unapply; that lowering detail must never reach the popup.
+			notWant: []string{"Unapply", "_variant"}},
+		{name: "sealed type declaration", anchor: "sealed type Shape", word: "Shape",
+			want: []string{"Shape", "Shape is a closed set of drawable things."}},
 	}
 
 	for _, tt := range tests {
@@ -129,21 +133,6 @@ func TestHoverCoverage(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-// A sealed variant must not be presented as a bare type with the transpiler's
-// Apply/Unapply plumbing on show.
-func TestHoverVariantHidesInternals(t *testing.T) {
-	h := newHarness(t)
-	uri := openFileOnDisk(t, h, hoverSrc)
-	settle(t, h, uri, hoverSrc, "type Greeter", "Greeter")
-
-	got := hoverAt(t, h, uri, "= Circle", "Circle")
-	for _, leak := range []string{"Unapply", "_variant"} {
-		if strings.Contains(got, leak) {
-			t.Errorf("hover leaks transpiler internal %q\n--- got ---\n%s", leak, got)
-		}
 	}
 }
 

--- a/internal/lsp/hover_coverage_test.go
+++ b/internal/lsp/hover_coverage_test.go
@@ -1,0 +1,147 @@
+package lsp_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/owenrumney/go-lsp/lsp"
+)
+
+const hoverSrc = `package main
+
+import "martianoff/gala/std"
+import im "martianoff/gala/collection_immutable"
+
+// Greeter greets people politely.
+type Greeter struct {
+    // prefix is placed before the name.
+    val prefix string
+}
+
+// Greet builds a greeting for name.
+// name: who to greet.
+func (g Greeter) Greet(name string) string = s"${g.prefix} ${name}"
+
+// makeGreeter builds a Greeter with the default prefix.
+func makeGreeter() Greeter = Greeter(prefix = "Hello")
+
+// Shape is a closed set of drawable things.
+sealed type Shape {
+    // Circle is round.
+    case Circle(radius float64)
+    case Square(side float64)
+}
+
+func main() {
+    val gr = makeGreeter()
+    val opt = std.Some(5)
+    val arr = im.ArrayOf(1, 2, 3)
+    val c = Circle(radius = 1.0)
+    Println(gr.Greet("world"), gr.prefix, opt.GetOrElse(0), arr.Size(), c)
+}
+`
+
+// hoverAt hovers on `word` inside the first line containing `anchor`.
+//
+// Anchors rather than line numbers: hardcoded line numbers silently drift as the
+// fixture is edited, and a stale one either panics or, worse, quietly hovers
+// somewhere else and still passes.
+func hoverAt(t *testing.T, h hoverHarness, uri lsp.DocumentURI, anchor, word string) string {
+	t.Helper()
+	line, ai := -1, -1
+	for i, l := range strings.Split(hoverSrc, "\n") {
+		if idx := strings.Index(l, anchor); idx >= 0 {
+			line, ai = i, idx
+			break
+		}
+	}
+	if line < 0 {
+		t.Fatalf("anchor %q not found in fixture", anchor)
+	}
+	wi := strings.Index(anchor, word)
+	if wi < 0 {
+		t.Fatalf("word %q not inside anchor %q", word, anchor)
+	}
+	col := ai + wi + 1
+
+	hv, err := h.Hover(uri, line, col)
+	if err != nil {
+		t.Fatalf("hover: %v", err)
+	}
+	if hv == nil {
+		return ""
+	}
+	return hv.Contents.Value
+}
+
+type hoverHarness interface {
+	Hover(uri lsp.DocumentURI, line, char int) (*lsp.Hover, error)
+}
+
+func TestHoverCoverage(t *testing.T) {
+	h := newHarness(t)
+	uri := openFileOnDisk(t, h, hoverSrc)
+	time.Sleep(2500 * time.Millisecond)
+
+	tests := []struct {
+		name   string
+		anchor string
+		word   string
+		want   []string // all must appear
+	}{
+		{"type declaration carries its doc", "type Greeter", "Greeter",
+			[]string{"Greeter", "Greeter greets people politely."}},
+		{"function declaration carries its doc", "func makeGreeter", "makeGreeter",
+			[]string{"makeGreeter", "makeGreeter builds a Greeter with the default prefix."}},
+		{"method declaration", ") Greet(", "Greet",
+			[]string{"Greet", "string", "Greet builds a greeting for name."}},
+		{"method call on a local", "gr.Greet", "Greet",
+			[]string{"Greet", "Greet builds a greeting for name."}},
+		{"field declaration", "val prefix", "prefix",
+			[]string{"prefix", "string", "prefix is placed before the name."}},
+		{"field access", "gr.prefix", "prefix",
+			[]string{"prefix", "string"}},
+		{"local val shows inferred type", "val gr =", "gr",
+			[]string{"gr", "Greeter"}},
+		{"stdlib method carries stdlib doc", "opt.GetOrElse", "GetOrElse",
+			[]string{"GetOrElse", "returns the option's value"}},
+		{"stdlib collection method", "arr.Size", "Size",
+			[]string{"Size"}},
+		{"package alias", "= im.", "im",
+			[]string{"collection_immutable"}},
+		{"sealed variant reads as a case, not a type", "= Circle", "Circle",
+			[]string{"Circle", "radius", "Shape"}},
+		{"sealed type declaration", "sealed type Shape", "Shape",
+			[]string{"Shape", "Shape is a closed set of drawable things."}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hoverAt(t, h, uri, tt.anchor, tt.word)
+			if got == "" {
+				t.Fatalf("hover returned nothing")
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("hover missing %q\n--- got ---\n%s", want, got)
+				}
+			}
+		})
+	}
+}
+
+// A sealed variant must not be presented as a bare type with the transpiler's
+// Apply/Unapply plumbing on show.
+func TestHoverVariantHidesInternals(t *testing.T) {
+	h := newHarness(t)
+	uri := openFileOnDisk(t, h, hoverSrc)
+	time.Sleep(2500 * time.Millisecond)
+
+	got := hoverAt(t, h, uri, "= Circle", "Circle")
+	for _, leak := range []string{"Unapply", "_variant"} {
+		if strings.Contains(got, leak) {
+			t.Errorf("hover leaks transpiler internal %q\n--- got ---\n%s", leak, got)
+		}
+	}
+}

--- a/internal/lsp/hover_coverage_test.go
+++ b/internal/lsp/hover_coverage_test.go
@@ -145,3 +145,131 @@ func TestHoverVariantHidesInternals(t *testing.T) {
 		}
 	}
 }
+
+// A selector whose receiver resolves but whose member does not must render
+// nothing, rather than falling through to a global name search and answering
+// with an unrelated same-named type.
+func TestHoverUnresolvedMemberDoesNotFallThrough(t *testing.T) {
+	h := newHarness(t)
+	src := `package main
+
+// Body is a top-level type that must not be used to answer a member lookup.
+type Body struct {
+    val text string
+}
+
+type Resp struct {
+    val code int
+}
+
+func main() {
+    val r = Resp(code = 1)
+    Println(r.Body, Body(text = "x"))
+}
+`
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(2500 * time.Millisecond)
+
+	lines := strings.Split(src, "\n")
+	var line, col int
+	for i, l := range lines {
+		if idx := strings.Index(l, "r.Body"); idx >= 0 {
+			line, col = i, idx+len("r.")+1
+			break
+		}
+	}
+	hv, err := h.Hover(uri, line, col)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hv != nil && strings.Contains(hv.Contents.Value, "type Body") {
+		t.Errorf("member lookup fell through to an unrelated top-level type\n--- got ---\n%s", hv.Contents.Value)
+	}
+}
+
+// Mutability must not be guessed from the cursor's line: every reference to a
+// `var` that is not its declaration would be reported as `val`.
+func TestHoverLocalDoesNotClaimMutability(t *testing.T) {
+	h := newHarness(t)
+	src := `package main
+
+func main() {
+    var count = 1
+    count = count + 1
+    Println(count)
+}
+`
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(2500 * time.Millisecond)
+
+	lines := strings.Split(src, "\n")
+	var line, col int
+	for i, l := range lines {
+		if idx := strings.Index(l, "count = count + 1"); idx >= 0 {
+			line, col = i, idx+1
+			break
+		}
+	}
+	hv, err := h.Hover(uri, line, col)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hv == nil {
+		t.Skip("local not resolved in this harness")
+	}
+	if strings.Contains(hv.Contents.Value, "val count") {
+		t.Errorf("a var was reported as val at a non-declaration reference\n--- got ---\n%s", hv.Contents.Value)
+	}
+}
+
+// Grouped imports must resolve; scanning only the cursor line for a quoted path
+// went dead inside `import ( ... )`.
+func TestHoverGroupedImportAlias(t *testing.T) {
+	h := newHarness(t)
+	src := `package main
+
+import (
+    im "martianoff/gala/collection_immutable"
+)
+
+func main() {
+    val arr = im.ArrayOf(1, 2, 3)
+    Println(arr)
+}
+`
+	uri := openFileOnDisk(t, h, src)
+	time.Sleep(2500 * time.Millisecond)
+
+	lines := strings.Split(src, "\n")
+	var line, col int
+	for i, l := range lines {
+		if idx := strings.Index(l, "= im."); idx >= 0 {
+			line, col = i, idx+2+1
+			break
+		}
+	}
+	hv, err := h.Hover(uri, line, col)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hv == nil || !strings.Contains(hv.Contents.Value, "collection_immutable") {
+		got := ""
+		if hv != nil {
+			got = hv.Contents.Value
+		}
+		t.Errorf("grouped-import alias did not resolve\n--- got ---\n%s", got)
+	}
+}
+
+// locate returns the LSP position of `word` inside the first line of src
+// containing `anchor`.
+func locate(t *testing.T, src, anchor, word string) (line, col int) {
+	t.Helper()
+	for i, l := range strings.Split(src, "\n") {
+		if ai := strings.Index(l, anchor); ai >= 0 {
+			return i, ai + strings.Index(anchor, word) + 1
+		}
+	}
+	t.Fatalf("anchor %q not found", anchor)
+	return 0, 0
+}

--- a/internal/lsp/hover_coverage_test.go
+++ b/internal/lsp/hover_coverage_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/owenrumney/go-lsp/lsp"
+	"github.com/owenrumney/go-lsp/servertest"
 )
 
 const hoverSrc = `package main
@@ -82,7 +83,7 @@ type hoverHarness interface {
 func TestHoverCoverage(t *testing.T) {
 	h := newHarness(t)
 	uri := openFileOnDisk(t, h, hoverSrc)
-	time.Sleep(2500 * time.Millisecond)
+	settle(t, h, uri, hoverSrc, "type Greeter", "Greeter")
 
 	tests := []struct {
 		name   string
@@ -136,7 +137,7 @@ func TestHoverCoverage(t *testing.T) {
 func TestHoverVariantHidesInternals(t *testing.T) {
 	h := newHarness(t)
 	uri := openFileOnDisk(t, h, hoverSrc)
-	time.Sleep(2500 * time.Millisecond)
+	settle(t, h, uri, hoverSrc, "type Greeter", "Greeter")
 
 	got := hoverAt(t, h, uri, "= Circle", "Circle")
 	for _, leak := range []string{"Unapply", "_variant"} {
@@ -168,16 +169,8 @@ func main() {
 }
 `
 	uri := openFileOnDisk(t, h, src)
-	time.Sleep(2500 * time.Millisecond)
-
-	lines := strings.Split(src, "\n")
-	var line, col int
-	for i, l := range lines {
-		if idx := strings.Index(l, "r.Body"); idx >= 0 {
-			line, col = i, idx+len("r.")+1
-			break
-		}
-	}
+	settle(t, h, uri, src, "type Resp", "Resp")
+	line, col := locate(t, src, "r.Body", "Body")
 	hv, err := h.Hover(uri, line, col)
 	if err != nil {
 		t.Fatal(err)
@@ -200,22 +193,14 @@ func main() {
 }
 `
 	uri := openFileOnDisk(t, h, src)
-	time.Sleep(2500 * time.Millisecond)
-
-	lines := strings.Split(src, "\n")
-	var line, col int
-	for i, l := range lines {
-		if idx := strings.Index(l, "count = count + 1"); idx >= 0 {
-			line, col = i, idx+1
-			break
-		}
-	}
+	line, col := locate(t, src, "count = count + 1", "count")
+	settle(t, h, uri, src, "count = count + 1", "count")
 	hv, err := h.Hover(uri, line, col)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if hv == nil {
-		t.Skip("local not resolved in this harness")
+		t.Fatal("local did not resolve")
 	}
 	if strings.Contains(hv.Contents.Value, "val count") {
 		t.Errorf("a var was reported as val at a non-declaration reference\n--- got ---\n%s", hv.Contents.Value)
@@ -238,16 +223,8 @@ func main() {
 }
 `
 	uri := openFileOnDisk(t, h, src)
-	time.Sleep(2500 * time.Millisecond)
-
-	lines := strings.Split(src, "\n")
-	var line, col int
-	for i, l := range lines {
-		if idx := strings.Index(l, "= im."); idx >= 0 {
-			line, col = i, idx+2+1
-			break
-		}
-	}
+	line, col := locate(t, src, "= im.", "im")
+	settle(t, h, uri, src, "= im.", "im")
 	hv, err := h.Hover(uri, line, col)
 	if err != nil {
 		t.Fatal(err)
@@ -272,4 +249,24 @@ func locate(t *testing.T, src, anchor, word string) (line, col int) {
 	}
 	t.Fatalf("anchor %q not found", anchor)
 	return 0, 0
+}
+
+// settle waits until the document has been analyzed, by polling the position of
+// a symbol known to resolve.
+//
+// Analysis runs in a background goroutine, so a fixed sleep is wrong in both
+// directions: it wastes wall clock on a fast machine and still races on a loaded
+// one. Polling a known-good anchor is both faster in the common case and
+// deterministic.
+func settle(t *testing.T, h *servertest.Harness, uri lsp.DocumentURI, src, anchor, word string) {
+	t.Helper()
+	line, col := locate(t, src, anchor, word)
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if hv, err := h.Hover(uri, line, col); err == nil && hv != nil {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("document was not analyzed within the deadline (anchor %q)", anchor)
 }

--- a/internal/lsp/hover_internal_test.go
+++ b/internal/lsp/hover_internal_test.go
@@ -1,0 +1,113 @@
+package lsp
+
+import (
+	"strings"
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+)
+
+// richASTWithVariantClash builds a RichAST where the current package declares a
+// type whose name is also a sealed case in an imported package — the shape that
+// makes an unscoped variant lookup answer with the wrong symbol.
+func richASTWithVariantClash() *transpiler.RichAST {
+	return &transpiler.RichAST{
+		PackageName: "app",
+		Types: map[string]*transpiler.TypeMetadata{
+			"Marker": {
+				Name:    "Marker",
+				Package: "app",
+				Doc:     "Marker is the application's own type.",
+				Fields:  map[string]transpiler.Type{},
+			},
+			"dep.Flow": {
+				Name:     "Flow",
+				Package:  "dep",
+				IsSealed: true,
+				SealedVariants: []transpiler.SealedVariant{
+					{Name: "Marker", Doc: "Marker is a case of dep.Flow."},
+				},
+			},
+			"app.Signal": {
+				Name:     "Signal",
+				Package:  "app",
+				IsSealed: true,
+				SealedVariants: []transpiler.SealedVariant{
+					{Name: "Ping", Doc: "Ping is a case of app.Signal."},
+				},
+			},
+		},
+		Functions: map[string]*transpiler.FunctionMetadata{},
+	}
+}
+
+func TestLookupSymbolPrefersOwnTypeOverForeignVariant(t *testing.T) {
+	got := lookupSymbol(richASTWithVariantClash(), "Marker")
+	if !strings.Contains(got, "Marker is the application's own type.") {
+		t.Errorf("own type was shadowed by an imported package's sealed case\n--- got ---\n%s", got)
+	}
+	if strings.Contains(got, "Case of") {
+		t.Errorf("own type rendered as a sealed case\n--- got ---\n%s", got)
+	}
+}
+
+// A case with no same-named type still renders as a case.
+func TestLookupSymbolRendersVariantWhenNoTypeShadows(t *testing.T) {
+	got := lookupSymbol(richASTWithVariantClash(), "Ping")
+	if !strings.Contains(got, "case Ping()") || !strings.Contains(got, "Case of") {
+		t.Errorf("sealed case did not render as a case\n--- got ---\n%s", got)
+	}
+}
+
+// findSealedVariant must prefer the requested package and be deterministic:
+// Go map order would otherwise make the chosen parent differ between calls.
+func TestFindSealedVariantIsScopedAndDeterministic(t *testing.T) {
+	rich := &transpiler.RichAST{
+		PackageName: "app",
+		Types: map[string]*transpiler.TypeMetadata{
+			"app.Local":  {Name: "Local", Package: "app", IsSealed: true, SealedVariants: []transpiler.SealedVariant{{Name: "Dup", Doc: "app"}}},
+			"dep.Remote": {Name: "Remote", Package: "dep", IsSealed: true, SealedVariants: []transpiler.SealedVariant{{Name: "Dup", Doc: "dep"}}},
+			"zzz.Other":  {Name: "Other", Package: "zzz", IsSealed: true, SealedVariants: []transpiler.SealedVariant{{Name: "Dup", Doc: "zzz"}}},
+		},
+	}
+	for i := 0; i < 50; i++ {
+		if _, parent := findSealedVariant(rich, "Dup", "app"); parent == nil || parent.Package != "app" {
+			t.Fatalf("iteration %d: preferred package ignored, got %v", i, parent)
+		}
+		if _, parent := findSealedVariant(rich, "Dup", "dep"); parent == nil || parent.Package != "dep" {
+			t.Fatalf("iteration %d: preferred package ignored, got %v", i, parent)
+		}
+		// With no match in the preferred package the fallback must still be
+		// stable rather than whichever key the map yielded first.
+		_, parent := findSealedVariant(rich, "Dup", "nosuch")
+		if parent == nil || parent.Package != "app" {
+			t.Fatalf("iteration %d: fallback not deterministic, got %v", i, parent)
+		}
+	}
+}
+
+// posCovers translates the analyzer's 1-based line / 0-based column onto the
+// LSP's 0-based line, and must not claim a neighbouring identifier.
+func TestPosCovers(t *testing.T) {
+	pos := transpiler.SourcePos{Line: 10, Column: 5}
+	cases := []struct {
+		name       string
+		line, char int
+		want       bool
+	}{
+		{"start of identifier", 9, 5, true},
+		{"inside identifier", 9, 7, true},
+		{"end of identifier", 9, 9, true},
+		{"before identifier", 9, 4, false},
+		{"past identifier", 9, 10, false},
+		{"wrong line", 10, 5, false},
+	}
+	for _, tc := range cases {
+		if got := posCovers(pos, tc.line, tc.char, "abcd"); got != tc.want {
+			t.Errorf("%s: posCovers = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+	if posCovers(transpiler.SourcePos{}, 0, 0, "x") {
+		t.Error("an unset position must not match")
+	}
+}

--- a/internal/lsp/hover_internal_test.go
+++ b/internal/lsp/hover_internal_test.go
@@ -111,3 +111,74 @@ func TestPosCovers(t *testing.T) {
 		t.Error("an unset position must not match")
 	}
 }
+
+// A sealed case declaration matches two metadata entries at the same position:
+// the case itself, and the companion type the analyzer generates for it, whose
+// only methods are Apply and Unapply. Resolution must be stable and must always
+// pick the case — interleaved with the type-name check, Go's map order decided
+// it and roughly one hover in ten showed the generated plumbing.
+func TestDeclarationAtPrefersCaseOverGeneratedCompanion(t *testing.T) {
+	const path = "/proj/shapes.gala"
+	rich := &transpiler.RichAST{
+		PackageName: "main",
+		Types: map[string]*transpiler.TypeMetadata{
+			"Shape": {
+				Name: "Shape", Package: "main", DefinedIn: path, IsSealed: true,
+				Pos: transpiler.SourcePos{Line: 2, Column: 12},
+				SealedVariants: []transpiler.SealedVariant{
+					{Name: "Circle", Doc: "Circle is round.", Pos: transpiler.SourcePos{Line: 3, Column: 9}},
+				},
+			},
+			// The generated companion: same name, same position as the case.
+			"Circle": {
+				Name: "Circle", Package: "main", DefinedIn: path,
+				Pos: transpiler.SourcePos{Line: 3, Column: 9},
+				Methods: map[string]*transpiler.MethodMetadata{
+					"Apply":   {Name: "Apply"},
+					"Unapply": {Name: "Unapply"},
+				},
+				Fields: map[string]transpiler.Type{},
+			},
+		},
+		Functions: map[string]*transpiler.FunctionMetadata{},
+	}
+
+	for i := 0; i < 200; i++ {
+		got := declarationAt(rich, path, 2, 10, "Circle")
+		if !strings.Contains(got, "case Circle") {
+			t.Fatalf("iteration %d: case declaration resolved to the companion type\n--- got ---\n%s", i, got)
+		}
+		if strings.Contains(got, "Unapply") {
+			t.Fatalf("iteration %d: hover leaked generated plumbing\n--- got ---\n%s", i, got)
+		}
+	}
+}
+
+// A method may be declared in a different file from the type it extends. Gating
+// the method search on the TYPE's file skipped it, after which a bare-name
+// fallback could answer with an unrelated same-named type.
+func TestDeclarationAtFindsMethodDeclaredInAnotherFile(t *testing.T) {
+	const typePath, methodPath = "/proj/widget.gala", "/proj/fluent.gala"
+	rich := &transpiler.RichAST{
+		PackageName: "main",
+		Types: map[string]*transpiler.TypeMetadata{
+			"Widget": {
+				Name: "Widget", Package: "main", DefinedIn: typePath,
+				Pos: transpiler.SourcePos{Line: 1, Column: 5},
+				Methods: map[string]*transpiler.MethodMetadata{
+					"AsFixed": {
+						Name: "AsFixed", Package: "main", DefinedIn: methodPath,
+						Doc: "AsFixed pins the widget.",
+						Pos: transpiler.SourcePos{Line: 4, Column: 20},
+					},
+				},
+			},
+		},
+		Functions: map[string]*transpiler.FunctionMetadata{},
+	}
+
+	got := declarationAt(rich, methodPath, 3, 21, "AsFixed")
+	if !strings.Contains(got, "AsFixed pins the widget.") {
+		t.Errorf("method declared in another file than its type did not resolve\n--- got ---\n%s", got)
+	}
+}


### PR DESCRIPTION
Hover was a bare-word lookup: it took the identifier under the cursor and searched the type table, the function table, and a builtin map. That answers `Map` identically whether it appears in `arr.Map(...)`, `im.Map`, or a top-level `func Map` — and for a method, it answers not at all.

Probing the symbol kinds a developer actually points at, hover returned **nothing** for methods (both declaration and call site), struct fields, local bindings, package aliases, and import paths. Every method call in every GALA file hovered to nothing.

## What it does now

Hover establishes what the word is qualified by, then dispatches:

| Context | Resolution |
|---|---|
| declaration site | the analyzer's recorded position — type, field, sealed case, method, function |
| `qualifier.word` | package member, or method/field on the resolved receiver type |
| bare word | local binding, package, sealed case, type, function, builtin |

Declarations resolve **by position**, against `TypeMetadata.Pos`, `FieldPositions`, `SealedVariant.Pos`, `MethodMetadata.Pos` and `FunctionMetadata.Pos` — the same anchors go-to-definition navigates to — rather than by re-reading the source for shapes like `func (r Recv) Name(`.

Qualified expressions go through `typeAtDot`, the single call completion already dispatches on, so hover and completion cannot disagree about what an expression's type is. Multi-line chains resolve, and a local named after a package no longer loses to the package, because the shared resolver checks bindings first.

Every rendering carries the doc comment captured during parsing, so the standard library's own prose reaches the popup:

```
func (Option) GetOrElse(defaultValue T) T

GetOrElse returns the option's value if the option is Some, otherwise returns
the result of evaluating defaultValue.
defaultValue: the default value to return if the option is empty.

*Package: std*
```

## Corrections

**Sealed cases no longer show transpiler internals.** The analyzer generates a companion type per case, carrying `Apply` and `Unapply` and registered under the case's own name — so an exact-key lookup found the lowering artifact and reported `type Circle` with plumbing nobody wrote. A case now renders as `case Circle(radius float64)` with its parent named. The case wins only when the same-named type is its own artifact, so an imported package's case cannot shadow a local type of the same name.

**Resolution is deterministic.** A case declaration matches both the case and its companion at the same position; resolving type names in the same pass as members let Go's map order decide, and the generated plumbing surfaced in roughly one run in ten. Members now resolve in their own pass. The variant scan, the method list, and the package-member lookup were all similarly map-ordered and are now stable.

**Mutability is no longer guessed.** The `val`/`var` keyword was read from the cursor's line, so every reference to a `var` that was not its own declaration reported `val`. The transformer knows the answer but does not carry it into the LSP's variable channel; hover now says nothing rather than something false.

**A selector that resolves its receiver but not its member renders nothing**, instead of falling through to a global name search that answered `resp.Body` with any unrelated type called `Body`.

**Package hover reads the file's own import table**, so grouped `import ( ... )` blocks resolve, and it no longer claims a merely-transitive package or prints the open file's package doc as though it belonged to whichever package was hovered.

## Known gaps

Unchanged by this change, and each its own piece of work: Go interop symbols (`time.Now`, `os.Getenv`) still hover to nothing; named arguments are not covered; sealed-case field declarations need a position the analyzer does not record yet.

## Verification

`bazel build //...` and `bazel test //...` pass (399/400; the one failure is the pre-existing Windows-only `TestGorootFromGoBinarySymlink` symlink-privilege case, unrelated).

New coverage: twelve hover cases across types, functions, method declarations and call sites, fields, locals, package aliases and sealed cases; a 200-iteration determinism test for case-versus-companion resolution; scoping and determinism tests for the variant lookup; a method declared in a different file from its type; the unresolved-member guard; grouped-import aliases; and the position-matching boundary conditions. Fixed sleeps in the new tests were replaced with polling, making the suite both faster and deterministic.