### PR TITLE
gala doc shows documentation, and stops showing plumbing

### DIFF
--- a/cmd/gala/commands/BUILD.bazel
+++ b/cmd/gala/commands/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
 go_test(
     name = "commands_test",
     srcs = [
+        "doc_prose_test.go",
         "imports_test.go",
         "new_test.go",
         "project_test.go",

--- a/cmd/gala/commands/doc.go
+++ b/cmd/gala/commands/doc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/ast"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -111,7 +112,7 @@ func runDoc(cmd *cobra.Command, args []string) {
 		fmt.Println(string(out))
 		return
 	}
-	printPackageDoc(pkg)
+	renderPackageDoc(cmd.OutOrStdout(), pkg)
 }
 
 // splitDocTarget splits `pkg.Type` into its parts. A target with no dot is a
@@ -237,29 +238,31 @@ func buildDocType(name string, meta *transpiler.TypeMetadata) docType {
 		TypeParams: meta.TypeParams,
 		Sealed:     meta.IsSealed,
 	}
-	// A sealed type's Fields are the MERGED representation of every case, so a
-	// case's own fields would otherwise be listed twice: once under the case that
-	// declares them, and again as though the parent declared them itself.
-	variantFields := make(map[string]bool)
 	for _, v := range meta.SealedVariants {
 		dt.Variants = append(dt.Variants, docVariant{
 			Name:   v.Name,
 			Doc:    v.Doc,
 			Params: namedTypes(v.FieldNames, v.FieldTypes),
 		})
-		for _, fn := range v.FieldNames {
-			variantFields[fn] = true
-		}
 	}
-	for _, fieldName := range meta.FieldNames {
-		if !ast.IsExported(fieldName) || variantFields[fieldName] {
-			continue
+	// A sealed type has no fields of its own: the grammar gives it only cases,
+	// and the analyzer synthesises its struct fields by merging theirs, plus a
+	// `_variant` discriminator. Listing them would repeat what each case already
+	// shows — and when two cases declare the same field name with different
+	// types the merged field is prefixed with the case name, so `Add(Left int)`
+	// and `Scale(Left float64)` would surface as `AddLeft` and `ScaleLeft`,
+	// names nobody wrote.
+	if !meta.IsSealed {
+		for _, fieldName := range meta.FieldNames {
+			if !ast.IsExported(fieldName) {
+				continue
+			}
+			dt.Fields = append(dt.Fields, docField{
+				Name: fieldName,
+				Doc:  meta.FieldDocs[fieldName],
+				Type: typeString(meta.Fields[fieldName]),
+			})
 		}
-		dt.Fields = append(dt.Fields, docField{
-			Name: fieldName,
-			Doc:  meta.FieldDocs[fieldName],
-			Type: typeString(meta.Fields[fieldName]),
-		})
 	}
 	for methodName, m := range meta.Methods {
 		if m == nil || !ast.IsExported(methodName) {
@@ -310,21 +313,41 @@ func typeString(ty transpiler.Type) string {
 	return ty.String()
 }
 
-// narrowToType keeps only the named type, for `gala doc pkg.Type`.
+// narrowToType reduces the package to a single type.
+//
+// A sealed case resolves to the type that declares it. `Circle` is not a type a
+// user can name — the transpiler's companion for it is filtered out as
+// lowering detail — but asking about it is a reasonable thing to do, and the
+// answer is the sealed type it belongs to. Reporting "no type Circle" would be
+// literally true and useless.
 func narrowToType(pkg *docPackage, typeName string) (*docPackage, bool) {
 	for _, t := range pkg.Types {
 		if t.Name == typeName {
 			return &docPackage{Package: pkg.Package, Types: []docType{t}}, true
 		}
 	}
+	for _, t := range pkg.Types {
+		for _, v := range t.Variants {
+			if v.Name == typeName {
+				return &docPackage{Package: pkg.Package, Types: []docType{t}}, true
+			}
+		}
+	}
 	return nil, false
 }
 
-func printPackageDoc(pkg *docPackage) {
-	fmt.Printf("package %s\n", pkg.Package)
+// renderPackageDoc writes the human-readable form of a package's API.
+//
+// It takes a writer so the rendering is testable. It previously printed
+// straight to stdout, and the two things it silently failed to print — the
+// package's own documentation and every function's — went unnoticed precisely
+// because nothing could assert on the output.
+func renderPackageDoc(w io.Writer, pkg *docPackage) {
+	fmt.Fprintf(w, "package %s\n", pkg.Package)
+	renderProse(w, pkg.Doc, "    ")
 
 	for _, t := range pkg.Types {
-		fmt.Println()
+		fmt.Fprintln(w)
 		header := t.Name
 		if len(t.TypeParams) > 0 {
 			header += "[" + strings.Join(t.TypeParams, ", ") + "]"
@@ -334,45 +357,51 @@ func printPackageDoc(pkg *docPackage) {
 		} else {
 			header = "type " + header
 		}
-		fmt.Println(header)
-		printProse(t.Doc, "    ")
+		fmt.Fprintln(w, header)
+		renderProse(w, t.Doc, "    ")
 
 		for _, v := range t.Variants {
-			fmt.Printf("    case %s(%s)\n", v.Name, joinParams(v.Params))
-			printProse(v.Doc, "        ")
+			fmt.Fprintf(w, "    case %s\n", formatSignature(docSignat{Name: v.Name, Params: v.Params}))
+			renderProse(w, v.Doc, "        ")
 		}
 		for _, f := range t.Fields {
-			fmt.Printf("    %s %s\n", f.Name, f.Type)
-			printProse(f.Doc, "        ")
+			fmt.Fprintf(w, "    %s %s\n", f.Name, f.Type)
+			renderProse(w, f.Doc, "        ")
 		}
 		for _, m := range t.Methods {
-			fmt.Printf("    %s\n", formatSignature(m))
-			printProse(m.Doc, "        ")
+			fmt.Fprintf(w, "    %s\n", formatSignature(m))
+			renderProse(w, m.Doc, "        ")
 		}
 	}
 
 	if len(pkg.Functions) > 0 {
-		fmt.Println()
-		fmt.Println("functions")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "functions")
 		for _, f := range pkg.Functions {
-			fmt.Printf("    %s\n", formatSignature(f))
+			fmt.Fprintf(w, "    %s\n", formatSignature(f))
+			renderProse(w, f.Doc, "        ")
 		}
 	}
 }
 
-// printProse writes a doc comment under the declaration it documents, indented
-// to sit beneath it. Nothing is printed for an undocumented declaration — a
-// blank line there would suggest the documentation was empty rather than absent.
-func printProse(doc, indent string) {
+// renderProse writes a doc comment under the declaration it documents, indented
+// to sit beneath it.
+//
+// Nothing is written for an undocumented declaration: a blank line there would
+// read as documentation that exists and is empty. Surrounding blank lines are
+// trimmed too, since a doc comment ending in a bare `//` otherwise pushes a
+// stray gap between one member and the next.
+func renderProse(w io.Writer, doc, indent string) {
+	doc = strings.Trim(doc, "\n")
 	if doc == "" {
 		return
 	}
 	for _, line := range strings.Split(doc, "\n") {
 		if line == "" {
-			fmt.Println()
+			fmt.Fprintln(w)
 			continue
 		}
-		fmt.Printf("%s%s\n", indent, line)
+		fmt.Fprintf(w, "%s%s\n", indent, line)
 	}
 }
 
@@ -420,10 +449,3 @@ func generatedCaseCompanions(rich *transpiler.RichAST, pkgName string) map[strin
 }
 
 // joinParams renders a case's fields as they were declared.
-func joinParams(params []docField) string {
-	parts := make([]string, 0, len(params))
-	for _, p := range params {
-		parts = append(parts, p.Name+" "+p.Type)
-	}
-	return strings.Join(parts, ", ")
-}

--- a/cmd/gala/commands/doc.go
+++ b/cmd/gala/commands/doc.go
@@ -40,22 +40,32 @@ func init() {
 
 // docType is one type's public surface.
 type docType struct {
-	Name       string      `json:"name"`
-	TypeParams []string    `json:"typeParams,omitempty"`
-	Sealed     bool        `json:"sealed,omitempty"`
-	Variants   []string    `json:"variants,omitempty"`
-	Fields     []docField  `json:"fields,omitempty"`
-	Methods    []docSignat `json:"methods,omitempty"`
+	Name       string       `json:"name"`
+	Doc        string       `json:"doc,omitempty"`
+	TypeParams []string     `json:"typeParams,omitempty"`
+	Sealed     bool         `json:"sealed,omitempty"`
+	Variants   []docVariant `json:"variants,omitempty"`
+	Fields     []docField   `json:"fields,omitempty"`
+	Methods    []docSignat  `json:"methods,omitempty"`
+}
+
+// docVariant is one case of a sealed type.
+type docVariant struct {
+	Name   string     `json:"name"`
+	Doc    string     `json:"doc,omitempty"`
+	Params []docField `json:"params,omitempty"`
 }
 
 type docField struct {
 	Name string `json:"name"`
+	Doc  string `json:"doc,omitempty"`
 	Type string `json:"type"`
 }
 
 // docSignat is a callable: a method or a package-level function.
 type docSignat struct {
 	Name       string     `json:"name"`
+	Doc        string     `json:"doc,omitempty"`
 	TypeParams []string   `json:"typeParams,omitempty"`
 	Params     []docField `json:"params"`
 	Returns    string     `json:"returns,omitempty"`
@@ -63,6 +73,7 @@ type docSignat struct {
 
 type docPackage struct {
 	Package   string      `json:"package"`
+	Doc       string      `json:"doc,omitempty"`
 	Types     []docType   `json:"types,omitempty"`
 	Functions []docSignat `json:"functions,omitempty"`
 }
@@ -179,7 +190,8 @@ func loadPackageDoc(pkgName, dir string) (*docPackage, error) {
 // collectPackageDoc filters the analyzed metadata down to what this package
 // declares, dropping anything reached only because it was imported.
 func collectPackageDoc(pkgName string, rich *transpiler.RichAST) *docPackage {
-	out := &docPackage{Package: pkgName}
+	out := &docPackage{Package: pkgName, Doc: rich.PackageDoc}
+	companions := generatedCaseCompanions(rich, pkgName)
 
 	// Both maps are keyed by QUALIFIED name (`collection_immutable.Array`), so
 	// the export test has to run on the bare half — otherwise every entry is
@@ -188,6 +200,9 @@ func collectPackageDoc(pkgName string, rich *transpiler.RichAST) *docPackage {
 	for name, meta := range rich.Types {
 		bare := bareTypeName(name)
 		if meta == nil || !declaredBy(meta.Package, pkgName) || !ast.IsExported(bare) || seen[bare] {
+			continue
+		}
+		if companions[bare] {
 			continue
 		}
 		seen[bare] = true
@@ -203,6 +218,7 @@ func collectPackageDoc(pkgName string, rich *transpiler.RichAST) *docPackage {
 		}
 		out.Functions = append(out.Functions, docSignat{
 			Name:       bare,
+			Doc:        meta.Doc,
 			TypeParams: meta.TypeParams,
 			Params:     namedTypes(meta.ParamNames, meta.ParamTypes),
 			Returns:    typeString(meta.ReturnType),
@@ -217,17 +233,33 @@ func collectPackageDoc(pkgName string, rich *transpiler.RichAST) *docPackage {
 func buildDocType(name string, meta *transpiler.TypeMetadata) docType {
 	dt := docType{
 		Name:       bareTypeName(name),
+		Doc:        meta.Doc,
 		TypeParams: meta.TypeParams,
 		Sealed:     meta.IsSealed,
 	}
+	// A sealed type's Fields are the MERGED representation of every case, so a
+	// case's own fields would otherwise be listed twice: once under the case that
+	// declares them, and again as though the parent declared them itself.
+	variantFields := make(map[string]bool)
 	for _, v := range meta.SealedVariants {
-		dt.Variants = append(dt.Variants, v.Name)
+		dt.Variants = append(dt.Variants, docVariant{
+			Name:   v.Name,
+			Doc:    v.Doc,
+			Params: namedTypes(v.FieldNames, v.FieldTypes),
+		})
+		for _, fn := range v.FieldNames {
+			variantFields[fn] = true
+		}
 	}
 	for _, fieldName := range meta.FieldNames {
-		if !ast.IsExported(fieldName) {
+		if !ast.IsExported(fieldName) || variantFields[fieldName] {
 			continue
 		}
-		dt.Fields = append(dt.Fields, docField{Name: fieldName, Type: typeString(meta.Fields[fieldName])})
+		dt.Fields = append(dt.Fields, docField{
+			Name: fieldName,
+			Doc:  meta.FieldDocs[fieldName],
+			Type: typeString(meta.Fields[fieldName]),
+		})
 	}
 	for methodName, m := range meta.Methods {
 		if m == nil || !ast.IsExported(methodName) {
@@ -235,6 +267,7 @@ func buildDocType(name string, meta *transpiler.TypeMetadata) docType {
 		}
 		dt.Methods = append(dt.Methods, docSignat{
 			Name:       methodName,
+			Doc:        m.Doc,
 			TypeParams: m.TypeParams,
 			Params:     namedTypes(m.ParamNames, m.ParamTypes),
 			Returns:    typeString(m.ReturnType),
@@ -302,15 +335,19 @@ func printPackageDoc(pkg *docPackage) {
 			header = "type " + header
 		}
 		fmt.Println(header)
+		printProse(t.Doc, "    ")
 
-		if len(t.Variants) > 0 {
-			fmt.Printf("    variants: %s\n", strings.Join(t.Variants, ", "))
+		for _, v := range t.Variants {
+			fmt.Printf("    case %s(%s)\n", v.Name, joinParams(v.Params))
+			printProse(v.Doc, "        ")
 		}
 		for _, f := range t.Fields {
 			fmt.Printf("    %s %s\n", f.Name, f.Type)
+			printProse(f.Doc, "        ")
 		}
 		for _, m := range t.Methods {
 			fmt.Printf("    %s\n", formatSignature(m))
+			printProse(m.Doc, "        ")
 		}
 	}
 
@@ -320,6 +357,22 @@ func printPackageDoc(pkg *docPackage) {
 		for _, f := range pkg.Functions {
 			fmt.Printf("    %s\n", formatSignature(f))
 		}
+	}
+}
+
+// printProse writes a doc comment under the declaration it documents, indented
+// to sit beneath it. Nothing is printed for an undocumented declaration — a
+// blank line there would suggest the documentation was empty rather than absent.
+func printProse(doc, indent string) {
+	if doc == "" {
+		return
+	}
+	for _, line := range strings.Split(doc, "\n") {
+		if line == "" {
+			fmt.Println()
+			continue
+		}
+		fmt.Printf("%s%s\n", indent, line)
 	}
 }
 
@@ -344,4 +397,33 @@ func formatSignature(s docSignat) string {
 		b.WriteString(" " + s.Returns)
 	}
 	return b.String()
+}
+
+// generatedCaseCompanions names the types the transpiler synthesises for sealed
+// cases — one per case, registered under the case's own name and carrying only
+// Apply and Unapply.
+//
+// They are lowering detail, not API. Documenting them presents `type Circle`
+// with two methods nobody wrote, alongside the `case Circle(...)` the user
+// actually declared, and buries the real types among them.
+func generatedCaseCompanions(rich *transpiler.RichAST, pkgName string) map[string]bool {
+	companions := make(map[string]bool)
+	for _, meta := range rich.Types {
+		if meta == nil || !meta.IsSealed || !declaredBy(meta.Package, pkgName) {
+			continue
+		}
+		for _, v := range meta.SealedVariants {
+			companions[v.Name] = true
+		}
+	}
+	return companions
+}
+
+// joinParams renders a case's fields as they were declared.
+func joinParams(params []docField) string {
+	parts := make([]string, 0, len(params))
+	for _, p := range params {
+		parts = append(parts, p.Name+" "+p.Type)
+	}
+	return strings.Join(parts, ", ")
 }

--- a/cmd/gala/commands/doc_prose_test.go
+++ b/cmd/gala/commands/doc_prose_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -183,8 +184,8 @@ func TestDocHidesGeneratedCaseCompanions(t *testing.T) {
 	pkg := collectPackageDoc("shapes", rich)
 
 	names := make([]string, 0, len(pkg.Types))
-	for _, t := range pkg.Types {
-		names = append(names, t.Name)
+	for _, dt := range pkg.Types {
+		names = append(names, dt.Name)
 	}
 	for _, leaked := range []string{"Circle", "Square"} {
 		for _, got := range names {
@@ -221,5 +222,140 @@ func TestDocHidesGeneratedCaseCompanions(t *testing.T) {
 	}
 	if shape.Variants[0].Params[0].Name != "Radius" || shape.Variants[0].Params[0].Type != "float64" {
 		t.Errorf("case fields wrong: %+v", shape.Variants[0].Params)
+	}
+}
+
+// A sealed case is not a type a user can name — its companion is filtered as
+// lowering detail — but asking about one is reasonable, and the answer is the
+// type that declares it.
+func TestDocNarrowsCaseToItsSealedType(t *testing.T) {
+	rich := &transpiler.RichAST{
+		PackageName: "shapes",
+		Types: map[string]*transpiler.TypeMetadata{
+			"shapes.Shape": {
+				Name: "Shape", Package: "shapes", Doc: "Shape is drawable.", IsSealed: true,
+				SealedVariants: []transpiler.SealedVariant{{Name: "Circle", Doc: "Circle is round."}},
+			},
+			"shapes.Circle": {Name: "Circle", Package: "shapes"},
+		},
+		Functions: map[string]*transpiler.FunctionMetadata{},
+	}
+	pkg := collectPackageDoc("shapes", rich)
+
+	narrowed, ok := narrowToType(pkg, "Circle")
+	if !ok {
+		t.Fatal("asking about a sealed case reported no such type")
+	}
+	if len(narrowed.Types) != 1 || narrowed.Types[0].Name != "Shape" {
+		t.Fatalf("case did not resolve to its declaring type: %+v", narrowed.Types)
+	}
+
+	// A name that is neither a type nor a case still reports nothing.
+	if _, ok := narrowToType(pkg, "Nonexistent"); ok {
+		t.Error("an unknown name resolved to something")
+	}
+	// The declaring type still resolves by its own name.
+	if got, ok := narrowToType(pkg, "Shape"); !ok || got.Types[0].Name != "Shape" {
+		t.Error("the sealed type no longer resolves by its own name")
+	}
+}
+
+// The text rendering is the default, human-facing output. It previously
+// dropped the package's own documentation and every function's — collected,
+// present in --json, and invisible where people actually read it.
+func TestRenderPackageDocPrintsAllProse(t *testing.T) {
+	var buf bytes.Buffer
+	renderPackageDoc(&buf, collectPackageDoc("shapes", richWithDocs()))
+	got := buf.String()
+
+	for _, want := range []string{
+		"Package shapes draws things.",     // the package's own doc
+		"Box holds a width and a height.",  // a type
+		"Width is the horizontal extent.",  // a field
+		"Area returns width times height.", // a method
+		"Circle is round.",                 // a sealed case
+		"NewBox builds a Box.",             // a function
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered output missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+}
+
+// An undocumented declaration must not push a blank line into the output, and
+// neither must a doc comment that ends in a bare `//`.
+func TestRenderProseTrimsAndOmits(t *testing.T) {
+	var buf bytes.Buffer
+	renderProse(&buf, "", "    ")
+	if buf.String() != "" {
+		t.Errorf("an absent doc produced output: %q", buf.String())
+	}
+
+	buf.Reset()
+	renderProse(&buf, "\nCircle is round.\n", "    ")
+	if got, want := buf.String(), "    Circle is round.\n"; got != want {
+		t.Errorf("surrounding blank lines were not trimmed\n got: %q\nwant: %q", got, want)
+	}
+
+	buf.Reset()
+	renderProse(&buf, "First.\n\nSecond.", "  ")
+	if got, want := buf.String(), "  First.\n\n  Second.\n"; got != want {
+		t.Errorf("paragraph break not preserved\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// When two cases declare the same field name with different types, the analyzer
+// prefixes the merged struct field with the case name. Those synthesised names
+// must not surface as fields of the sealed type.
+func TestDocHidesMergedSealedFields(t *testing.T) {
+	rich := &transpiler.RichAST{
+		PackageName: "expr",
+		Types: map[string]*transpiler.TypeMetadata{
+			"expr.Expr": {
+				Name: "Expr", Package: "expr", IsSealed: true,
+				// What the analyzer actually produces for
+				//   case Add(Left int, Right int) / case Scale(Left float64)
+				FieldNames: []string{"AddLeft", "Right", "ScaleLeft", "_variant"},
+				Fields: map[string]transpiler.Type{
+					"AddLeft":   transpiler.BasicType{Name: "int"},
+					"Right":     transpiler.BasicType{Name: "int"},
+					"ScaleLeft": transpiler.BasicType{Name: "float64"},
+					"_variant":  transpiler.BasicType{Name: "uint8"},
+				},
+				SealedVariants: []transpiler.SealedVariant{
+					{
+						Name:       "Add",
+						FieldNames: []string{"Left", "Right"},
+						FieldTypes: []transpiler.Type{transpiler.BasicType{Name: "int"}, transpiler.BasicType{Name: "int"}},
+					},
+					{
+						Name:       "Scale",
+						FieldNames: []string{"Left"},
+						FieldTypes: []transpiler.Type{transpiler.BasicType{Name: "float64"}},
+					},
+				},
+			},
+		},
+		Functions: map[string]*transpiler.FunctionMetadata{},
+	}
+
+	pkg := collectPackageDoc("expr", rich)
+	if len(pkg.Types) != 1 {
+		t.Fatalf("types = %+v", pkg.Types)
+	}
+	if len(pkg.Types[0].Fields) != 0 {
+		t.Errorf("a sealed type reported fields of its own: %+v", pkg.Types[0].Fields)
+	}
+
+	var buf bytes.Buffer
+	renderPackageDoc(&buf, pkg)
+	got := buf.String()
+	for _, synthesised := range []string{"AddLeft", "ScaleLeft", "_variant"} {
+		if strings.Contains(got, synthesised) {
+			t.Errorf("synthesised field %q reached the output\n--- got ---\n%s", synthesised, got)
+		}
+	}
+	if !strings.Contains(got, "case Add(Left int, Right int)") {
+		t.Errorf("case fields not rendered\n--- got ---\n%s", got)
 	}
 }

--- a/cmd/gala/commands/doc_prose_test.go
+++ b/cmd/gala/commands/doc_prose_test.go
@@ -1,0 +1,225 @@
+package commands
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"martianoff/gala/internal/transpiler"
+)
+
+// richWithDocs is a package whose declarations all carry doc comments.
+func richWithDocs() *transpiler.RichAST {
+	return &transpiler.RichAST{
+		PackageName: "shapes",
+		PackageDoc:  "Package shapes draws things.",
+		Types: map[string]*transpiler.TypeMetadata{
+			"shapes.Box": {
+				Name:       "Box",
+				Package:    "shapes",
+				Doc:        "Box holds a width and a height.",
+				FieldNames: []string{"Width", "Height"},
+				Fields: map[string]transpiler.Type{
+					"Width":  transpiler.BasicType{Name: "int"},
+					"Height": transpiler.BasicType{Name: "int"},
+				},
+				FieldDocs: map[string]string{"Width": "Width is the horizontal extent."},
+				Methods: map[string]*transpiler.MethodMetadata{
+					"Area": {
+						Name:       "Area",
+						Doc:        "Area returns width times height.",
+						ReturnType: transpiler.BasicType{Name: "int"},
+					},
+				},
+			},
+			"shapes.Shape": {
+				Name:     "Shape",
+				Package:  "shapes",
+				Doc:      "Shape is a closed set of drawable things.",
+				IsSealed: true,
+				SealedVariants: []transpiler.SealedVariant{
+					{Name: "Circle", Doc: "Circle is round."},
+					{Name: "Square"},
+				},
+			},
+		},
+		Functions: map[string]*transpiler.FunctionMetadata{
+			"shapes.NewBox": {
+				Name:    "NewBox",
+				Package: "shapes",
+				Doc:     "NewBox builds a Box.",
+			},
+		},
+	}
+}
+
+func TestDocCarriesProse(t *testing.T) {
+	pkg := collectPackageDoc("shapes", richWithDocs())
+
+	if pkg.Doc != "Package shapes draws things." {
+		t.Errorf("package doc = %q", pkg.Doc)
+	}
+
+	var box, shape *docType
+	for i := range pkg.Types {
+		switch pkg.Types[i].Name {
+		case "Box":
+			box = &pkg.Types[i]
+		case "Shape":
+			shape = &pkg.Types[i]
+		}
+	}
+	if box == nil || shape == nil {
+		t.Fatalf("types missing: %+v", pkg.Types)
+	}
+
+	if box.Doc != "Box holds a width and a height." {
+		t.Errorf("Box.Doc = %q", box.Doc)
+	}
+	if len(box.Fields) == 0 || box.Fields[0].Doc != "Width is the horizontal extent." {
+		t.Errorf("field docs missing: %+v", box.Fields)
+	}
+	if len(box.Methods) == 0 || box.Methods[0].Doc != "Area returns width times height." {
+		t.Errorf("method doc missing: %+v", box.Methods)
+	}
+	if shape.Doc != "Shape is a closed set of drawable things." {
+		t.Errorf("Shape.Doc = %q", shape.Doc)
+	}
+	if len(shape.Variants) == 0 || shape.Variants[0].Doc != "Circle is round." {
+		t.Errorf("variant doc missing: %+v", shape.Variants)
+	}
+	if len(pkg.Functions) == 0 || pkg.Functions[0].Doc != "NewBox builds a Box." {
+		t.Errorf("function doc missing: %+v", pkg.Functions)
+	}
+}
+
+// The JSON form is a machine-readable contract; documentation has to be in it.
+func TestDocJSONCarriesProse(t *testing.T) {
+	pkg := collectPackageDoc("shapes", richWithDocs())
+	raw, err := json.Marshal(pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"Package shapes draws things.",
+		"Box holds a width and a height.",
+		"Area returns width times height.",
+		"Width is the horizontal extent.",
+		"Circle is round.",
+		"NewBox builds a Box.",
+	} {
+		if !strings.Contains(string(raw), want) {
+			t.Errorf("JSON missing %q", want)
+		}
+	}
+}
+
+// An undocumented declaration must not gain an empty "doc" key, and the text
+// rendering must not print a blank line where prose would be.
+func TestDocOmitsEmptyProse(t *testing.T) {
+	rich := &transpiler.RichAST{
+		PackageName: "bare",
+		Types: map[string]*transpiler.TypeMetadata{
+			"bare.Thing": {Name: "Thing", Package: "bare"},
+		},
+		Functions: map[string]*transpiler.FunctionMetadata{},
+	}
+	pkg := collectPackageDoc("bare", rich)
+	raw, err := json.Marshal(pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), `"doc"`) {
+		t.Errorf("undocumented package emitted a doc key: %s", raw)
+	}
+}
+
+// The transpiler generates a companion type per sealed case, carrying Apply and
+// Unapply and registered under the case's own name. It is lowering detail, not
+// something the user wrote, and must not appear in the documented API.
+func TestDocHidesGeneratedCaseCompanions(t *testing.T) {
+	rich := &transpiler.RichAST{
+		PackageName: "shapes",
+		Types: map[string]*transpiler.TypeMetadata{
+			"shapes.Shape": {
+				Name: "Shape", Package: "shapes", Doc: "Shape is drawable.", IsSealed: true,
+				FieldNames: []string{"Radius", "Side"},
+				Fields: map[string]transpiler.Type{
+					"Radius": transpiler.BasicType{Name: "float64"},
+					"Side":   transpiler.BasicType{Name: "float64"},
+				},
+				SealedVariants: []transpiler.SealedVariant{
+					{
+						Name: "Circle", Doc: "Circle is round.",
+						FieldNames: []string{"Radius"},
+						FieldTypes: []transpiler.Type{transpiler.BasicType{Name: "float64"}},
+					},
+					{
+						Name:       "Square",
+						FieldNames: []string{"Side"},
+						FieldTypes: []transpiler.Type{transpiler.BasicType{Name: "float64"}},
+					},
+				},
+			},
+			// The generated companions.
+			"shapes.Circle": {
+				Name: "Circle", Package: "shapes",
+				Methods: map[string]*transpiler.MethodMetadata{
+					"Apply": {Name: "Apply"}, "Unapply": {Name: "Unapply"},
+				},
+			},
+			"shapes.Square": {
+				Name: "Square", Package: "shapes",
+				Methods: map[string]*transpiler.MethodMetadata{
+					"Apply": {Name: "Apply"}, "Unapply": {Name: "Unapply"},
+				},
+			},
+			// A genuine type must survive the filter.
+			"shapes.Canvas": {Name: "Canvas", Package: "shapes", Doc: "Canvas is real."},
+		},
+		Functions: map[string]*transpiler.FunctionMetadata{},
+	}
+
+	pkg := collectPackageDoc("shapes", rich)
+
+	names := make([]string, 0, len(pkg.Types))
+	for _, t := range pkg.Types {
+		names = append(names, t.Name)
+	}
+	for _, leaked := range []string{"Circle", "Square"} {
+		for _, got := range names {
+			if got == leaked {
+				t.Errorf("generated companion %q documented as a type; types = %v", leaked, names)
+			}
+		}
+	}
+	var canvas, shape *docType
+	for i := range pkg.Types {
+		switch pkg.Types[i].Name {
+		case "Canvas":
+			canvas = &pkg.Types[i]
+		case "Shape":
+			shape = &pkg.Types[i]
+		}
+	}
+	if canvas == nil {
+		t.Fatalf("a real type was filtered out; types = %v", names)
+	}
+	if shape == nil {
+		t.Fatal("the sealed parent went missing")
+	}
+
+	// A case carries its own fields, so the parent must not also list them as
+	// its own — they are the merged representation, not Shape's API.
+	for _, f := range shape.Fields {
+		if f.Name == "Radius" || f.Name == "Side" {
+			t.Errorf("variant field %q listed on the sealed parent; fields = %+v", f.Name, shape.Fields)
+		}
+	}
+	if len(shape.Variants) != 2 || shape.Variants[0].Params == nil {
+		t.Fatalf("variants lack their fields: %+v", shape.Variants)
+	}
+	if shape.Variants[0].Params[0].Name != "Radius" || shape.Variants[0].Params[0].Type != "float64" {
+		t.Errorf("case fields wrong: %+v", shape.Variants[0].Params)
+	}
+}


### PR DESCRIPTION
`gala doc` answered "what can I call on this?" with signatures alone. The doc comments captured during parsing were already in the metadata it reads; it just never looked at them.

Packages, types, fields, methods, sealed cases and functions now carry their prose, in both the text and JSON forms. An undocumented declaration emits no `doc` key and prints no blank line, so absent documentation reads as absent rather than empty.

```
package shapes
    Package shapes draws things.

type Box
    Box holds a width and a height.
    Width int
        Width is the horizontal extent.
    Area() int
        Area returns width times height.

sealed type Shape
    Shape is a closed set of drawable things.
    case Circle(Radius float64)
        Circle is round.
    case Square(Side float64)

functions
    NewBox(w int, h int) shapes.Box
        NewBox builds a Box with the given dimensions.
        w: the width.
        h: the height.
```

The standard library gains this outright — `gala doc collection_immutable.Array` now explains every method, from documentation that has been in the source all along and unreadable outside it.

## Two things the output got wrong

Adding prose made both obvious.

**It published transpiler plumbing.** The transpiler generates a companion type per sealed case — named after the case, carrying only `Apply` and `Unapply`. Each was documented as a first-class exported type, so a three-case sealed type showed three types nobody wrote, with six methods nobody wrote, interleaved alphabetically among the real ones. Any name the filter removes is one that could not have compiled anyway: the analyzer registers companions unconditionally, so a user type sharing a case's name already produces a duplicate Go declaration.

**A sealed type reported fields that were not its own.** Its struct fields are the merged representation of every case, so `Radius` and `Side` appeared as fields of `Shape` while the cases they belong to showed nothing. Worse, when two cases declare the same field name with different types the analyzer prefixes the merged field with the case name, so `case Add(Left int)` and `case Scale(Left float64)` would have surfaced as `AddLeft` and `ScaleLeft`. The grammar gives a sealed type only cases, so it has no fields of its own to report; cases now carry theirs, rendered as `case Circle(Radius float64)`.

## Asking about a case

`gala doc pkg.Circle` used to show the companion. With companions filtered it would have dead-ended on "no type Circle" — literally true and useless, since the user asked about something that exists. It now answers with the sealed type that declares it.

## Verification

`bazel build //...` and `bazel test //...` pass (399/400; the one failure is the pre-existing Windows-only `TestGorootFromGoBinarySymlink` symlink-privilege case, unrelated).

The renderer previously wrote straight to stdout, so none of its behaviour was testable — which is why it went unnoticed that the package doc and every function doc were being dropped from the text output despite appearing in `--json`. It now takes a writer, and the output is asserted: all six kinds of prose present, blank lines omitted for undocumented declarations, surrounding newlines trimmed, paragraph breaks preserved, synthesised sealed fields absent, case fields rendered, and a case name resolving to its declaring type.