### PR TITLE
gala doc: document packages that have tests

### DIFF
--- a/cmd/gala/commands/doc.go
+++ b/cmd/gala/commands/doc.go
@@ -161,8 +161,22 @@ func findPackageDir(pkgName string) (string, error) {
 // the surface. The analyzer is given the sibling list so a type declared in one
 // file and extended in another reports its whole method set.
 func loadPackageDoc(pkgName, dir string) (*docPackage, error) {
-	files, err := filepath.Glob(filepath.Join(dir, "*.gala"))
-	if err != nil || len(files) == 0 {
+	found, err := filepath.Glob(filepath.Join(dir, "*.gala"))
+	if err != nil {
+		return nil, fmt.Errorf("no .gala files in %s", dir)
+	}
+	// Tests are not part of a package's documented API, and a `_test.gala` file
+	// declares `package main` by convention — it is a runnable program, not a
+	// member of the package under test. Including them made the analyzer reject
+	// the package for declaring two different names, so documenting any package
+	// that has tests — the standard library included — failed outright.
+	files := make([]string, 0, len(found))
+	for _, f := range found {
+		if !strings.HasSuffix(f, "_test.gala") {
+			files = append(files, f)
+		}
+	}
+	if len(files) == 0 {
 		return nil, fmt.Errorf("no .gala files in %s", dir)
 	}
 	sort.Strings(files)

--- a/cmd/gala/commands/doc_prose_test.go
+++ b/cmd/gala/commands/doc_prose_test.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -357,5 +359,33 @@ func TestDocHidesMergedSealedFields(t *testing.T) {
 	}
 	if !strings.Contains(got, "case Add(Left int, Right int)") {
 		t.Errorf("case fields not rendered\n--- got ---\n%s", got)
+	}
+}
+
+// A package's tests are not part of its documented API, and by convention a
+// `_test.gala` file declares `package main` — it is a runnable program, not a
+// member of the package under test. Globbing every .gala file made the analyzer
+// reject the package for declaring two different names, so `gala doc std`, the
+// single most likely thing to type, failed outright.
+func TestLoadPackageDocIgnoresTestFiles(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, src string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("shapes.gala", "package shapes\n\n// Box holds a size.\ntype Box struct {\n    val Size int\n}\n")
+	write("shapes_test.gala", "package main\n\nfunc main() {\n    Println(\"testing\")\n}\n")
+
+	pkg, err := loadPackageDoc("shapes", dir)
+	if err != nil {
+		t.Fatalf("a package with tests failed to document: %v", err)
+	}
+	if len(pkg.Types) != 1 || pkg.Types[0].Name != "Box" {
+		t.Fatalf("types = %+v", pkg.Types)
+	}
+	if pkg.Types[0].Doc != "Box holds a size." {
+		t.Errorf("Box.Doc = %q", pkg.Types[0].Doc)
 	}
 }


### PR DESCRIPTION
`gala doc` globbed every `*.gala` file in the package directory, including `_test.gala`. A GALA test file declares `package main` — it is a runnable program, not a member of the package under test — so the analyzer rejected the directory for declaring two package names and the command failed outright:

```
Error: [GALA-E0010] package file array_test.gala declares package "main"
but sibling files declare "collection_immutable"
```

That is every package with tests, which is to say every real project.

It was easy to miss: running `gala doc` from outside a project resolves against the installed stdlib snapshot, and that snapshot ships no test files. The failure only appears where the sources actually live — which is exactly where someone documenting their own package will be standing.

Tests are not part of a package's documented API, so they are excluded. This matches the build path, which already filters them out of sibling discovery.

## Not fixed here

`gala doc std` still fails, for an unrelated reason worth recording:

```
Error: [GALA-E0011] type "ConstPtr" in package "std" redefined (also declared at line 6)
```

Analyzing a file whose own package is `std` collides with the `std` the analyzer loads implicitly for every file, so each of its types is reported as a redefinition of itself. It reproduces with a directory containing nothing but `std/constptr.gala` — so it is not about siblings or test files, and sits in the analyzer's handling of a package that is also the prelude. Out of scope for a `gala doc` change.

## Verification

`bazel build //...` and `bazel test //...` pass (399/400; the one failure is the pre-existing Windows-only `TestGorootFromGoBinarySymlink` symlink-privilege case, unrelated).

Checked in-repo, where the sources have their tests: `collection_immutable`, `collection_mutable`, `concurrent` and `json` all document correctly and previously did not. A unit test covers a package whose test file declares `package main`.