### PR TITLE
gala doc std: a package is not a redefinition of itself

### DIFF
--- a/internal/transpiler/analyzer/BUILD.bazel
+++ b/internal/transpiler/analyzer/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "internal_import_test.go",
         "multipackage_panic_test.go",
         "parallel_parse_test.go",
+        "prelude_selfanalysis_test.go",
         "parsedfile_cache_test.go",
         "redefinition_cross_file_test.go",
         "test_exports_test.go",

--- a/internal/transpiler/analyzer/analyzer.go
+++ b/internal/transpiler/analyzer/analyzer.go
@@ -646,17 +646,22 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, docs map[int]string, filePath st
 	// dedupe wastes cycles but never produces wrong results.
 	mergeVisited := make(map[string]bool)
 
-	// 0.25 Load std package metadata
-	// For non-std packages: add as implicit import
-	// For std package: still load for intra-package type resolution, but don't add to Packages
-	if cachedStd, ok := a.analyzedPkgs[registry.StdImportPath]; ok && cachedStd != nil {
+	// 0.25 Load std package metadata as an implicit import.
+	//
+	// Skipped entirely when the file being analyzed IS part of std. Merging a
+	// prebuilt copy of std into the RichAST of a std file puts every declaration
+	// in that file into the AST before the file's own walk reaches it, so each
+	// one meets itself and is reported as a redefinition of itself. std's own
+	// types resolve from the file and its siblings, the same way every other
+	// package's do — it needs no prebuilt copy of itself.
+	if pkgName == registry.StdPackageName {
+		// nothing to import: this file is std
+	} else if cachedStd, ok := a.analyzedPkgs[registry.StdImportPath]; ok && cachedStd != nil {
 		// Use cached std metadata — walk its closure to materialize transitive
 		// types (analyzedPkgs entries are own-only projections; see
 		// projectOwnRichAST + mergeAnalyzedClosureAt for rationale).
 		a.mergeAnalyzedClosureAt(richAST, registry.StdImportPath, mergeVisited)
-		if pkgName != registry.StdPackageName {
-			richAST.Packages[registry.StdImportPath] = registry.StdPackageName
-		}
+		richAST.Packages[registry.StdImportPath] = registry.StdPackageName
 	} else if _, inProgress := a.analyzedPkgs[registry.StdImportPath]; !inProgress {
 		// First time analyzing std - set placeholder to prevent infinite recursion
 		a.analyzedPkgs[registry.StdImportPath] = nil
@@ -664,9 +669,7 @@ func (a *galaAnalyzer) Analyze(tree antlr.Tree, docs map[int]string, filePath st
 		if err == nil {
 			a.storeAnalyzedPkg(registry.StdImportPath, stdAST)
 			a.mergeAnalyzedClosureAt(richAST, registry.StdImportPath, mergeVisited)
-			if pkgName != registry.StdPackageName {
-				richAST.Packages[registry.StdImportPath] = registry.StdPackageName
-			}
+			richAST.Packages[registry.StdImportPath] = registry.StdPackageName
 		}
 	}
 

--- a/internal/transpiler/analyzer/prelude_selfanalysis_test.go
+++ b/internal/transpiler/analyzer/prelude_selfanalysis_test.go
@@ -1,0 +1,141 @@
+package analyzer_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+
+	"martianoff/gala/internal/parser"
+	"martianoff/gala/internal/transpiler/analyzer"
+)
+
+// analyzePkgFile analyzes one file of a package with its siblings registered.
+func analyzePkgFile(t *testing.T, searchPaths []string, dir, primary string) error {
+	t.Helper()
+	files, err := filepath.Glob(filepath.Join(dir, "*.gala"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := parser.NewAntlrGalaParser()
+	a := analyzer.NewGalaAnalyzerWithPackageFiles(p, searchPaths, files)
+
+	path := filepath.Join(dir, primary)
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree, docs, perr := p.Parse(string(src))
+	if perr != nil {
+		t.Fatalf("parse %s: %v", primary, perr)
+	}
+	_, aerr := a.Analyze(tree, docs, path)
+	return aerr
+}
+
+// Analyzing a file that belongs to a package the analyzer ALSO loads
+// implicitly — which is every file in `std` — merges a prebuilt copy of that
+// package into the RichAST before the file's own declarations are walked. Each
+// declaration then meets itself, and was reported as a redefinition of itself:
+//
+//	[GALA-E0011] type "ConstPtr" in package "std" redefined (also declared at line 6)
+//
+// This is the only shape that reproduces it, because `std` is the package the
+// analyzer loads for every file. A synthetic package cannot stand in.
+func TestStdFileIsNotARedefinitionOfItself(t *testing.T) {
+	stdFile, err := bazel.Runfile("std/option.gala")
+	if err != nil {
+		t.Skipf("std sources not staged: %v", err)
+	}
+	stdDir := filepath.Dir(stdFile)
+
+	for _, primary := range []string{"option.gala", "constptr.gala", "try.gala"} {
+		t.Run(primary, func(t *testing.T) {
+			if _, err := os.Stat(filepath.Join(stdDir, primary)); err != nil {
+				t.Skipf("%s not staged", primary)
+			}
+			if err := analyzePkgFile(t, getStdSearchPath(), stdDir, primary); err != nil {
+				t.Errorf("std file reported as a duplicate of itself: %v", err)
+			}
+		})
+	}
+}
+
+func writeDupPkg(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "dup")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, src := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// Forgiving a package's merged copy of itself must not cost duplicate
+// detection. These six shapes have to keep failing.
+func TestDuplicateDeclarationsStillRejected(t *testing.T) {
+	cases := []struct {
+		name  string
+		files map[string]string
+		want  string
+	}{
+		{
+			name:  "type twice in one file",
+			files: map[string]string{"a.gala": "package dup\n\ntype Thing struct {\n    val A int\n}\n\ntype Thing struct {\n    val B int\n}\n"},
+			want:  "redefined",
+		},
+		{
+			name:  "function twice in one file",
+			files: map[string]string{"a.gala": "package dup\n\nfunc Twice() int = 1\n\nfunc Twice() int = 2\n"},
+			want:  "redeclared",
+		},
+		{
+			name:  "method twice in one file",
+			files: map[string]string{"a.gala": "package dup\n\ntype Box struct {\n    val V int\n}\n\nfunc (b Box) Get() int = b.V\n\nfunc (b Box) Get() int = 0\n"},
+			want:  "redefined",
+		},
+		{
+			name: "type across two files",
+			files: map[string]string{
+				"a.gala": "package dup\n\ntype Thing struct {\n    val A int\n}\n",
+				"b.gala": "package dup\n\ntype Thing struct {\n    val B int\n}\n",
+			},
+			want: "redefined",
+		},
+		{
+			name: "function across two files",
+			files: map[string]string{
+				"a.gala": "package dup\n\nfunc Once() int = 1\n",
+				"b.gala": "package dup\n\nfunc Once() int = 2\n",
+			},
+			want: "redeclared",
+		},
+		{
+			name: "method across two files",
+			files: map[string]string{
+				"a.gala": "package dup\n\ntype Thing struct {\n    val A int\n}\n\nfunc (t Thing) Get() int = t.A\n",
+				"b.gala": "package dup\n\nfunc (t Thing) Get() int = 0\n",
+			},
+			want: "redefined",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := writeDupPkg(t, tc.files)
+			err := analyzePkgFile(t, getStdSearchPath(), dir, "a.gala")
+			if err == nil {
+				t.Fatal("duplicate declaration was accepted")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error does not report a duplicate: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`gala doc std` failed on the first declaration it reached:

```
[GALA-E0011] type "ConstPtr" in package "std" redefined (also declared at line 6)
```

The diagnostic named the same line it was reporting, because the two declarations *were* the same declaration. `declSiteRef` prints a bare line number only when the other site is in the same file — which was the clue.

## Cause

`std` is loaded implicitly for every file the analyzer sees, including files that are themselves part of `std`. That merges a prebuilt copy of the package into the `RichAST` before the file's own declarations are walked, so each one meets itself.

A `std` file needs no prebuilt copy of `std`: its types resolve from the file and its siblings, exactly as every other package's do. The implicit import is skipped when the file being analyzed belongs to `std`, which removes the collision at its source — 13 lines, touching no duplicate-detection logic.

## The approach I abandoned

The first attempt relaxed the redefinition guards instead, so each would forgive an entry merged in before the walk. Those guards read

```go
!(existing.DefinedIn != filePath && isSameFile(existing.DefinedIn, absFilePath))
```

which only forgives the same file reached by a *different* path spelling — never the identical path, which is the common case. Patching them worked for types, then functions, then methods, then sealed types, and then failed at a fifth site in the sibling pass.

Widening a core correctness gate once per symptom is the signal that the fix is at the wrong level. Removing the collision instead means the guards are untouched.

## Verification

`bazel build //...` and `bazel test //...` pass (399/400; the one failure is the pre-existing Windows-only `TestGorootFromGoBinarySymlink` symlink-privilege case, unrelated).

Regression coverage analyzes **real `std` files**, because `std` is the only package the analyzer loads implicitly and a synthetic package cannot reproduce the shape. The earlier synthetic test passed with and without the fix — it proved nothing, and was replaced.

Alongside it, the six duplicate shapes are pinned — type, function and method, each within one file and across two. All six were additionally confirmed by hand to still fail *inside `std` itself*, by temporarily adding a duplicate declaration to the package and checking each diagnostic still fires with the correct file named.